### PR TITLE
Fix reference counting in converters

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Utilities/IterableConverter.hpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Utilities/IterableConverter.hpp
@@ -70,7 +70,17 @@ struct IterableConverter
 
     static void*                convertible                                 (           PyObject*                   anObject                                    )
     {
-        return PyObject_GetIter(anObject) ? anObject : nullptr ;
+
+        auto *iterator = PyObject_GetIter(anObject) ;
+
+        if (iterator != nullptr)
+        {
+            boost::python::decref(iterator) ;
+            return anObject ;
+        }
+
+        return nullptr ;
+
     }
 
     /// @brief Convert iterable PyObject to C++ container type.

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Utilities/MapConverter.hpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Utilities/MapConverter.hpp
@@ -74,7 +74,17 @@ struct MapConverter
 
     static void*                convertible                                 (           PyObject*                   anObject                                    )
     {
-        return PyObject_GetIter(anObject) ? anObject : nullptr ;
+
+        auto *iterator = PyObject_GetIter(anObject) ;
+
+        if (iterator != nullptr)
+        {
+            boost::python::decref(iterator) ;
+            return anObject ;
+        }
+
+        return nullptr ;
+
     }
 
     /// @brief Convert iterable PyObject to C++ container type.


### PR DESCRIPTION
This fixes a small memory leak in converters. 

Reference counting seems wrong in the `convertible` function: if the iterator from `PyObject_GetIter` is not null, it is never deleted. The change makes sure the new reference is decremented.

Resource: https://www.oreilly.com/library/view/python-cookbook/0596001673/ch16s04.html (cf. Discussion)
