### PR TITLE
feat: add maximum elevation field on Access

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -19,6 +19,7 @@ inline void                     OpenSpaceToolkitAstrodynamicsPy_Access      (   
     using namespace pybind11 ;
 
     using ostk::physics::time::Instant ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -26,7 +27,7 @@ inline void                     OpenSpaceToolkitAstrodynamicsPy_Access      (   
 
         class_<Access> access_class(aModule, "Access") ;
 
-        access_class.def(init<const Access::Type&, const Instant&, const Instant&, const Instant&>())
+        access_class.def(init<const Access::Type&, const Instant&, const Instant&, const Instant&, const Angle&>())
 
             .def(self == self)
             .def(self != self)
@@ -43,6 +44,7 @@ inline void                     OpenSpaceToolkitAstrodynamicsPy_Access      (   
             .def("get_loss_of_signal", &Access::getLossOfSignal)
             .def("get_interval", &Access::getInterval)
             .def("get_duration", &Access::getDuration)
+            .def("get_max_elevation", &Access::getMaxElevation)
 
             .def_static("undefined", &Access::Undefined)
 

--- a/bindings/python/test/test_access.py
+++ b/bindings/python/test/test_access.py
@@ -50,8 +50,9 @@ def test_access_constructors ():
     acquisition_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
     time_at_closest_approach = Instant.date_time(DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC)
     loss_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 2, 0), Scale.UTC)
+    max_elevation = Angle.degrees(54.3)
 
-    access: Access = Access(Access.Type.Complete, acquisition_of_signal, time_at_closest_approach, loss_of_signal)
+    access: Access = Access(Access.Type.Complete, acquisition_of_signal, time_at_closest_approach, loss_of_signal, max_elevation)
 
     assert access is not None
     assert isinstance(access, Access)
@@ -73,8 +74,9 @@ def test_access_getters ():
     acquisition_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
     time_at_closest_approach = Instant.date_time(DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC)
     loss_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 2, 0), Scale.UTC)
+    max_elevation = Angle.degrees(54.3)
 
-    access: Access = Access(Access.Type.Complete, acquisition_of_signal, time_at_closest_approach, loss_of_signal)
+    access: Access = Access(Access.Type.Complete, acquisition_of_signal, time_at_closest_approach, loss_of_signal, max_elevation)
 
     # get_type
     access_type: Access.Type = access.get_type()
@@ -114,6 +116,12 @@ def test_access_getters ():
 
     assert duration is not None
     assert isinstance(duration, Duration)
+
+    # get_max_elevation
+    max_el: Angle = access.get_max_elevation()
+
+    assert max_el is not None
+    assert isinstance(max_el, Angle)
 
 ################################################################################################################################################################
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Access.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Access.hpp
@@ -13,6 +13,7 @@
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Units/Derived/Angle.hpp>
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
@@ -32,6 +33,8 @@ using ostk::core::ctnr::Array ;
 using ostk::physics::time::Instant ;
 using ostk::physics::time::Duration ;
 using ostk::physics::time::Interval ;
+
+using ostk::physics::units::Angle ;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -54,7 +57,8 @@ class Access
                                 Access                                      (   const   Access::Type&               aType,
                                                                                 const   Instant&                    anAcquisitionOfSignal,
                                                                                 const   Instant&                    aTimeOfClosestApproach,
-                                                                                const   Instant&                    aLossOfSignal                               ) ;
+                                                                                const   Instant&                    aLossOfSignal,
+                                                                                const   Angle&                      aMaxElevation                               ) ;
 
         bool                    operator ==                                 (   const   Access&                     anAccess                                    ) const ;
 
@@ -79,6 +83,8 @@ class Access
 
         Duration                getDuration                                 ( ) const ;
 
+        Angle                   getMaxElevation                             ( ) const ;
+
         static Access           Undefined                                   ( ) ;
 
         static String           StringFromType                              (   const   Access::Type&               aType                                       ) ;
@@ -90,6 +96,7 @@ class Access
         Instant                 acquisitionOfSignal_ ;
         Instant                 timeOfClosestApproach_ ;
         Instant                 lossOfSignal_ ;
+        Angle                   maxElevation_ ;
 
 } ;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Access.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access.cpp
@@ -21,11 +21,13 @@ namespace astro
                                 Access::Access                              (   const   Access::Type&               aType,
                                                                                 const   Instant&                    anAcquisitionOfSignal,
                                                                                 const   Instant&                    aTimeOfClosestApproach,
-                                                                                const   Instant&                    aLossOfSignal                               )
+                                                                                const   Instant&                    aLossOfSignal,
+                                                                                const   Angle&                      aMaxElevation                               )
                                 :   type_(aType),
                                     acquisitionOfSignal_(anAcquisitionOfSignal),
                                     timeOfClosestApproach_(aTimeOfClosestApproach),
-                                    lossOfSignal_(aLossOfSignal)
+                                    lossOfSignal_(aLossOfSignal),
+                                    maxElevation_(aMaxElevation)
 {
 
     if (this->isDefined())
@@ -53,7 +55,7 @@ bool                            Access::operator ==                         (   
         return false ;
     }
 
-    return (type_ == anAccess.type_) && (acquisitionOfSignal_ == anAccess.acquisitionOfSignal_) && (timeOfClosestApproach_ == anAccess.timeOfClosestApproach_) && (lossOfSignal_ == anAccess.lossOfSignal_) ;
+    return (type_ == anAccess.type_) && (acquisitionOfSignal_ == anAccess.acquisitionOfSignal_) && (timeOfClosestApproach_ == anAccess.timeOfClosestApproach_) && (lossOfSignal_ == anAccess.lossOfSignal_) && (maxElevation_ == anAccess.maxElevation_) ;
 
 }
 
@@ -78,6 +80,8 @@ std::ostream&                   operator <<                                 (   
 
     ostk::core::utils::Print::Line(anOutputStream) << "Duration:"            << ((anAccess.acquisitionOfSignal_.isDefined() && anAccess.lossOfSignal_.isDefined()) ? Duration::Between(anAccess.acquisitionOfSignal_, anAccess.lossOfSignal_).toString() : "Undefined") ;
 
+    ostk::core::utils::Print::Line(anOutputStream) << "Maximum Elevation:"            << (anAccess.maxElevation_.isDefined() ? anAccess.maxElevation_.toString() : "Undefined") ;
+
     ostk::core::utils::Print::Footer(anOutputStream) ;
 
     return anOutputStream ;
@@ -86,7 +90,7 @@ std::ostream&                   operator <<                                 (   
 
 bool                            Access::isDefined                           ( ) const
 {
-    return (type_ != Access::Type::Undefined) && acquisitionOfSignal_.isDefined() && timeOfClosestApproach_.isDefined() && lossOfSignal_.isDefined() ;
+    return (type_ != Access::Type::Undefined) && acquisitionOfSignal_.isDefined() && timeOfClosestApproach_.isDefined() && lossOfSignal_.isDefined() && maxElevation_.isDefined() ;
 }
 
 bool                            Access::isComplete                          ( ) const
@@ -173,9 +177,21 @@ Duration                        Access::getDuration                         ( ) 
 
 }
 
+Angle                           Access::getMaxElevation                     ( ) const
+{
+
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Access") ;
+    }
+
+    return maxElevation_ ;
+
+}
+
 Access                          Access::Undefined                           ( )
 {
-    return Access(Access::Type::Undefined, Instant::Undefined(), Instant::Undefined(), Instant::Undefined()) ;
+    return Access(Access::Type::Undefined, Instant::Undefined(), Instant::Undefined(), Instant::Undefined(), Angle::Undefined()) ;
 }
 
 String                          Access::StringFromType                      (   const   Access::Type&               aType                                       )

--- a/test/OpenSpaceToolkit/Astrodynamics/Access.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access.test.cpp
@@ -12,6 +12,7 @@
 #include <OpenSpaceToolkit/Physics/Time/DateTime.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
+#include <OpenSpaceToolkit/Physics/Units/Derived/Angle.hpp>
 
 #include <Global.test.hpp>
 
@@ -23,6 +24,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, Constructor)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -32,8 +34,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, Constructor)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        EXPECT_NO_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal) ;) ;
+        EXPECT_NO_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation) ;) ;
 
     }
 
@@ -43,8 +46,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, Constructor)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        EXPECT_ANY_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal) ;) ;
+        EXPECT_ANY_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation) ;) ;
 
     }
 
@@ -54,8 +58,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, Constructor)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        EXPECT_ANY_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal) ;) ;
+        EXPECT_ANY_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation) ;) ;
 
     }
 
@@ -67,6 +72,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, EqualToOperator)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -76,8 +82,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, EqualToOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation} ;
 
         EXPECT_TRUE(access == access) ;
 
@@ -89,8 +96,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, EqualToOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_TRUE(access == access) ;
 
@@ -101,9 +109,10 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, EqualToOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access firstAccess = { Access::Type::Complete, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
-        const Access secondAccess = { Access::Type::Partial, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access firstAccess = { Access::Type::Complete, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
+        const Access secondAccess = { Access::Type::Partial, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_FALSE(firstAccess == secondAccess) ;
 
@@ -114,9 +123,10 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, EqualToOperator)
         const Access::Type type = Access::Type::Complete ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access firstAccess = { type, Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), timeOfClosestApproach, lossOfSignal } ;
-        const Access secondAccess = { type, Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC), timeOfClosestApproach, lossOfSignal } ;
+        const Access firstAccess = { type, Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), timeOfClosestApproach, lossOfSignal, maxElevation } ;
+        const Access secondAccess = { type, Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC), timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_FALSE(firstAccess == secondAccess) ;
 
@@ -128,8 +138,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, EqualToOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_FALSE(Access::Undefined() == Access::Undefined()) ;
         EXPECT_FALSE(Access::Undefined() == access) ;
@@ -145,6 +156,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, NotEqualToOperator)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -154,8 +166,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, NotEqualToOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_FALSE(access != access) ;
 
@@ -167,8 +180,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, NotEqualToOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_FALSE(access != access) ;
 
@@ -179,9 +193,10 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, NotEqualToOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access firstAccess = { Access::Type::Complete, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
-        const Access secondAccess = { Access::Type::Partial, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access firstAccess = { Access::Type::Complete, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
+        const Access secondAccess = { Access::Type::Partial, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_TRUE(firstAccess != secondAccess) ;
 
@@ -192,9 +207,10 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, NotEqualToOperator)
         const Access::Type type = Access::Type::Complete ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access firstAccess = { type, Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), timeOfClosestApproach, lossOfSignal } ;
-        const Access secondAccess = { type, Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC), timeOfClosestApproach, lossOfSignal } ;
+        const Access firstAccess = { type, Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), timeOfClosestApproach, lossOfSignal, maxElevation } ;
+        const Access secondAccess = { type, Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC), timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_TRUE(firstAccess != secondAccess) ;
 
@@ -206,8 +222,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, NotEqualToOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_TRUE(Access::Undefined() != Access::Undefined()) ;
         EXPECT_TRUE(Access::Undefined() != access) ;
@@ -223,6 +240,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, StreamOperator)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -232,8 +250,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, StreamOperator)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         testing::internal::CaptureStdout() ;
 
@@ -251,6 +270,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, IsDefined)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -260,8 +280,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, IsDefined)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_TRUE(access.isDefined()) ;
 
@@ -281,6 +302,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, IsComplete)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -290,8 +312,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, IsComplete)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_TRUE(access.isComplete()) ;
 
@@ -303,8 +326,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, IsComplete)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_FALSE(access.isComplete()) ;
 
@@ -324,6 +348,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetType)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -333,8 +358,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetType)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_EQ(type, access.getType()) ;
 
@@ -346,8 +372,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetType)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_EQ(type, access.getType()) ;
 
@@ -367,6 +394,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetAcquisitionOfSignal)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -376,8 +404,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetAcquisitionOfSignal)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_EQ(acquisitionOfSignal, access.getAcquisitionOfSignal()) ;
 
@@ -397,6 +426,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetTimeOfClosestApproach)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -406,8 +436,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetTimeOfClosestApproach)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_EQ(timeOfClosestApproach, access.getTimeOfClosestApproach()) ;
 
@@ -427,6 +458,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetLossOfSignal)
     using ostk::physics::time::Scale ;
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -436,8 +468,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetLossOfSignal)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_EQ(lossOfSignal, access.getLossOfSignal()) ;
 
@@ -458,6 +491,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetInterval)
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
     using ostk::physics::time::Interval ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -467,8 +501,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetInterval)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_EQ(Interval::Closed(acquisitionOfSignal, lossOfSignal), access.getInterval()) ;
 
@@ -489,6 +524,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetDuration)
     using ostk::physics::time::Instant ;
     using ostk::physics::time::DateTime ;
     using ostk::physics::time::Duration ;
+    using ostk::physics::units::Angle ;
 
     using ostk::astro::Access ;
 
@@ -498,8 +534,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetDuration)
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
         const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
 
-        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal } ;
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
 
         EXPECT_EQ(Duration::Minutes(2.0), access.getDuration()) ;
 
@@ -508,6 +545,39 @@ TEST (OpenSpaceToolkit_Astrodynamics_Access, GetDuration)
     {
 
         EXPECT_ANY_THROW(Access::Undefined().getDuration()) ;
+
+    }
+
+}
+
+TEST (OpenSpaceToolkit_Astrodynamics_Access, GetMaxElevation)
+{
+
+    using ostk::physics::time::Scale ;
+    using ostk::physics::time::Instant ;
+    using ostk::physics::time::DateTime ;
+    using ostk::physics::time::Duration ;
+    using ostk::physics::units::Angle ;
+
+    using ostk::astro::Access ;
+
+    {
+
+        const Access::Type type = Access::Type::Complete ;
+        const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC) ;
+        const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC) ;
+        const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC) ;
+        const Angle maxElevation = Angle::Degrees(54.3) ;
+
+        const Access access = { type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation } ;
+
+        EXPECT_EQ(Angle::Degrees(54.3), access.getMaxElevation()) ;
+
+    }
+
+    {
+
+        EXPECT_ANY_THROW(Access::Undefined().getMaxElevation()) ;
 
     }
 


### PR DESCRIPTION
- Add `maxElevation` `Angle` field on object `Access`. 
- Currently `maxElevation` value is computed using the elevation angular value obtained at TCA (approx.). 