### PR TITLE
fix: SGP4 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Want to get started? This is the simplest and quickest way:
 
 The following command will start an [iPython](https://ipython.org/) shell within a container where the OSTk components are already installed:
 
-```bash
+```shell
 docker run -it openspacecollective/open-space-toolkit-astrodynamics-python
 ```
 
@@ -64,7 +64,7 @@ As a result, when running OSTk for the first time, it may take a minute to fetch
 
 The following command will start a [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) server within a container where the OSTk components are already installed:
 
-```bash
+```shell
 docker run --publish=8888:8888 openspacecollective/open-space-toolkit-astrodynamics-jupyter
 ```
 
@@ -84,7 +84,7 @@ The binary packages are hosted using [GitHub Releases](https://github.com/open-s
 
 After downloading the relevant `.deb` binary packages, install:
 
-```bash
+```shell
 apt install open-space-toolkit-astrodynamics-*.deb
 ```
 
@@ -92,7 +92,7 @@ apt install open-space-toolkit-astrodynamics-*.deb
 
 After downloading the relevant `.rpm` binary packages, install:
 
-```bash
+```shell
 dnf install open-space-toolkit-astrodynamics-*.rpm
 ```
 
@@ -100,7 +100,7 @@ dnf install open-space-toolkit-astrodynamics-*.rpm
 
 Install from [PyPI](https://pypi.org/project/open-space-toolkit-astrodynamics/):
 
-```bash
+```shell
 pip install open-space-toolkit-astrodynamics
 ```
 
@@ -157,7 +157,7 @@ Instructions on how to install Docker are available [here](https://docs.docker.c
 
 To start the development environment:
 
-```bash
+```shell
 make start-development
 ```
 
@@ -174,7 +174,7 @@ by following a procedure similar to the one described in the [Development Docker
 
 From the `./build` directory:
 
-```bash
+```shell
 cmake ..
 make
 ```
@@ -185,13 +185,13 @@ make
 
 To start a container to build and run the tests:
 
-```bash
+```shell
 make test
 ```
 
 Or to run them manually:
 
-```bash
+```shell
 ./bin/open-space-toolkit-astrodynamics.test
 ```
 
@@ -199,16 +199,17 @@ Or to run them manually:
 
 ## Dependencies
 
-| Name        | Version | License                | Link                                                                                                                                       |
-| ----------- | ------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Pybind11    | 2.6.1   | BSD-3-Clause           | [github.com/pybind/pybind11](https://github.com/pybind/pybind11)       |
-| Eigen       | 3.3.7   | MPL2                   | [eigen.tuxfamily.org](http://eigen.tuxfamily.org/index.php)                                                                                |
-| SGP4        | master  | Apache License 2.0     | [github.com/dnwrnr/sgp4](https://github.com/dnwrnr/sgp4)                                                                                   |
-| NLopt       | master  | LGPL                   | [github.com/stevengj/nlopt](https://github.com/stevengj/nlopt)                                                                             |
-| Core        | main    | Apache License 2.0     | [github.com/open-space-collective/open-space-toolkit-core](https://github.com/open-space-collective/open-space-toolkit-core)               |
-| I/O         | main    | Apache License 2.0     | [github.com/open-space-collective/open-space-toolkit-io](https://github.com/open-space-collective/open-space-toolkit-io)                   |
-| Mathematics | main    | Apache License 2.0     | [github.com/open-space-collective/open-space-toolkit-mathematics](https://github.com/open-space-collective/open-space-toolkit-mathematics) |
-| Physics     | main    | Apache License 2.0     | [github.com/open-space-collective/open-space-toolkit-physics](https://github.com/open-space-collective/open-space-toolkit-physics)         |
+| Name        | Version   | License                | Link                                                                                                                                       |
+| ----------- | --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Pybind11    | `2.6.1`   | BSD-3-Clause           | [github.com/pybind/pybind11](https://github.com/pybind/pybind11)                                                                           |
+| ordered-map | `0.6.0`   | MIT                    | [github.com/Tessil/ordered-map](https://github.com/Tessil/ordered-map)                                                                     |
+| Eigen       | `3.3.7`   | MPL2                   | [eigen.tuxfamily.org](http://eigen.tuxfamily.org/index.php)                                                                                |
+| SGP4        | `6a448b4` | Apache License 2.0     | [github.com/dnwrnr/sgp4](https://github.com/dnwrnr/sgp4)                                                                                   |
+| NLopt       | `2.5.0`   | LGPL                   | [github.com/stevengj/nlopt](https://github.com/stevengj/nlopt)                                                                             |
+| Core        | `main`    | Apache License 2.0     | [github.com/open-space-collective/open-space-toolkit-core](https://github.com/open-space-collective/open-space-toolkit-core)               |
+| I/O         | `main`    | Apache License 2.0     | [github.com/open-space-collective/open-space-toolkit-io](https://github.com/open-space-collective/open-space-toolkit-io)                   |
+| Mathematics | `main`    | Apache License 2.0     | [github.com/open-space-collective/open-space-toolkit-mathematics](https://github.com/open-space-collective/open-space-toolkit-mathematics) |
+| Physics     | `main`    | Apache License 2.0     | [github.com/open-space-collective/open-space-toolkit-physics](https://github.com/open-space-collective/open-space-toolkit-physics)         |
 
 ## Contribution
 

--- a/docker/development/debian/Dockerfile
+++ b/docker/development/debian/Dockerfile
@@ -7,7 +7,7 @@
 
 ################################################################################################################################################################
 
-ARG BASE_IMAGE_VERSION=latest
+ARG BASE_IMAGE_VERSION="latest"
 
 FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION}-debian
 
@@ -21,9 +21,11 @@ RUN apt-get update \
  && apt-get install -y unzip \
  && rm -rf /var/lib/apt/lists/*
 
-## {fmt} [5.2.0]
+## {fmt}
 
-RUN git clone --branch 5.2.0 --depth 1 https://github.com/fmtlib/fmt.git /tmp/fmt \
+ARG FMT_VERSION="5.2.0"
+
+RUN git clone --branch ${FMT_VERSION} --depth 1 https://github.com/fmtlib/fmt.git /tmp/fmt \
  && cd /tmp/fmt \
  && mkdir build \
  && cd build \
@@ -32,30 +34,37 @@ RUN git clone --branch 5.2.0 --depth 1 https://github.com/fmtlib/fmt.git /tmp/fm
  && make install \
  && rm -rf /tmp/fmt
 
-## ordered-map [0.6.0]
+## ordered-map
 
-RUN git clone --branch v0.6.0 --depth 1 https://github.com/Tessil/ordered-map.git /tmp/ordered-map \
+ARG ORDERED_MAP_VERSION="0.6.0"
+
+RUN git clone --branch v${ORDERED_MAP_VERSION} --depth 1 https://github.com/Tessil/ordered-map.git /tmp/ordered-map \
  && cd /tmp/ordered-map \
  && cp -r ./include/tsl /usr/local/include \
  && rm -rf /tmp/ordered-map
 
-## Eigen [3.3.7]
+## Eigen
+
+ARG EIGEN_VERSION="3.3.7"
 
 RUN mkdir /tmp/eigen \
  && cd /tmp/eigen \
- && wget --quiet https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz \
- && tar -xvf eigen-3.3.7.tar.gz \
- && cd eigen-3.3.7 \
+ && wget --quiet https://gitlab.com/libeigen/eigen/-/archive/${EIGEN_VERSION}/eigen-${EIGEN_VERSION}.tar.gz \
+ && tar -xvf eigen-${EIGEN_VERSION}.tar.gz \
+ && cd eigen-${EIGEN_VERSION} \
  && mkdir build \
  && cd build \
  && cmake .. \
  && make install \
  && rm -rf /tmp/eigen
 
-## SGP4 [master]
+## SGP4
+
+ARG SGP4_VERSION="6a448b4"
 
 RUN git clone https://github.com/dnwrnr/sgp4.git /tmp/sgp4 \
  && cd /tmp/sgp4 \
+ && git checkout ${SGP4_VERSION} \
  && mkdir build \
  && cd build \
  && cmake -DCMAKE_CXX_FLAGS="-fPIC" .. \
@@ -65,9 +74,11 @@ RUN git clone https://github.com/dnwrnr/sgp4.git /tmp/sgp4 \
  && cp libsgp4/*.a /usr/local/lib \
  && rm -rf /tmp/sgp4
 
-## NLopt [2.5.0]
+## NLopt
 
-RUN git clone --branch v2.5.0 --depth 1 https://github.com/stevengj/nlopt.git /tmp/nlopt \
+ARG NLOPT_VERSION="2.5.0"
+
+RUN git clone --branch v${NLOPT_VERSION} --depth 1 https://github.com/stevengj/nlopt.git /tmp/nlopt \
  && cd /tmp/nlopt \
  && mkdir build \
  && cd build \
@@ -78,7 +89,7 @@ RUN git clone --branch v2.5.0 --depth 1 https://github.com/stevengj/nlopt.git /t
 
 ## Open Space Toolkit ▸ Core
 
-ARG OSTK_CORE_VERSION=0.4.5
+ARG OSTK_CORE_VERSION="0.4.5"
 
 RUN mkdir -p /tmp/open-space-toolkit-core \
  && cd /tmp/open-space-toolkit-core \
@@ -89,7 +100,7 @@ RUN mkdir -p /tmp/open-space-toolkit-core \
 
 ## Open Space Toolkit ▸ I/O
 
-ARG OSTK_IO_VERSION=0.4.5
+ARG OSTK_IO_VERSION="0.4.5"
 
 RUN mkdir -p /tmp/open-space-toolkit-io \
  && cd /tmp/open-space-toolkit-io \
@@ -100,7 +111,7 @@ RUN mkdir -p /tmp/open-space-toolkit-io \
 
 ## Open Space Toolkit ▸ Mathematics
 
-ARG OSTK_MATHEMATICS_VERSION=0.5.1
+ARG OSTK_MATHEMATICS_VERSION="0.5.1"
 
 RUN mkdir -p /tmp/open-space-toolkit-mathematics \
  && cd /tmp/open-space-toolkit-mathematics \
@@ -111,7 +122,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 
 ## Open Space Toolkit ▸ Physics
 
-ARG OSTK_PHYSICS_VERSION=0.5.23
+ARG OSTK_PHYSICS_VERSION="0.5.23"
 
 RUN mkdir -p /tmp/open-space-toolkit-physics \
  && cd /tmp/open-space-toolkit-physics \

--- a/docker/development/fedora/Dockerfile
+++ b/docker/development/fedora/Dockerfile
@@ -7,7 +7,7 @@
 
 ################################################################################################################################################################
 
-ARG BASE_IMAGE_VERSION=latest
+ARG BASE_IMAGE_VERSION="latest"
 
 FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION}-fedora
 
@@ -15,9 +15,11 @@ LABEL maintainer="lucas@loftorbital.com"
 
 # Dependencies
 
-## {fmt} [5.2.0]
+## {fmt}
 
-RUN git clone --branch 5.2.0 --depth 1 https://github.com/fmtlib/fmt.git /tmp/fmt \
+ARG FMT_VERSION="5.2.0"
+
+RUN git clone --branch ${FMT_VERSION} --depth 1 https://github.com/fmtlib/fmt.git /tmp/fmt \
  && cd /tmp/fmt \
  && mkdir build \
  && cd build \
@@ -26,30 +28,37 @@ RUN git clone --branch 5.2.0 --depth 1 https://github.com/fmtlib/fmt.git /tmp/fm
  && make install \
  && rm -rf /tmp/fmt
 
-## ordered-map [0.6.0]
+## ordered-map
 
-RUN git clone --branch v0.6.0 --depth 1 https://github.com/Tessil/ordered-map.git /tmp/ordered-map \
+ARG ORDERED_MAP_VERSION="0.6.0"
+
+RUN git clone --branch v${ORDERED_MAP_VERSION} --depth 1 https://github.com/Tessil/ordered-map.git /tmp/ordered-map \
  && cd /tmp/ordered-map \
  && cp -r ./include/tsl /usr/local/include \
  && rm -rf /tmp/ordered-map
 
-## Eigen [3.3.7]
+## Eigen
+
+ARG EIGEN_VERSION="3.3.7"
 
 RUN mkdir /tmp/eigen \
  && cd /tmp/eigen \
- && wget --quiet https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz \
- && tar -xvf eigen-3.3.7.tar.gz \
- && cd eigen-3.3.7 \
+ && wget --quiet https://gitlab.com/libeigen/eigen/-/archive/${EIGEN_VERSION}/eigen-${EIGEN_VERSION}.tar.gz \
+ && tar -xvf eigen-${EIGEN_VERSION}.tar.gz \
+ && cd eigen-${EIGEN_VERSION} \
  && mkdir build \
  && cd build \
  && cmake .. \
  && make install \
  && rm -rf /tmp/eigen
 
-## SGP4 [master]
+## SGP4
+
+ARG SGP4_VERSION="6a448b4"
 
 RUN git clone https://github.com/dnwrnr/sgp4.git /tmp/sgp4 \
  && cd /tmp/sgp4 \
+ && git checkout ${SGP4_VERSION} \
  && mkdir build \
  && cd build \
  && cmake -DCMAKE_CXX_FLAGS="-fPIC" .. \
@@ -59,9 +68,11 @@ RUN git clone https://github.com/dnwrnr/sgp4.git /tmp/sgp4 \
  && cp libsgp4/*.a /usr/local/lib \
  && rm -rf /tmp/sgp4
 
-## NLopt [2.5.0]
+## NLopt
 
-RUN git clone --branch v2.5.0 --depth 1 https://github.com/stevengj/nlopt.git /tmp/nlopt \
+ARG NLOPT_VERSION="2.5.0"
+
+RUN git clone --branch v${NLOPT_VERSION} --depth 1 https://github.com/stevengj/nlopt.git /tmp/nlopt \
  && cd /tmp/nlopt \
  && mkdir build \
  && cd build \
@@ -72,7 +83,7 @@ RUN git clone --branch v2.5.0 --depth 1 https://github.com/stevengj/nlopt.git /t
 
 ## Open Space Toolkit ▸ Core
 
-ARG OSTK_CORE_VERSION=0.4.5
+ARG OSTK_CORE_VERSION="0.4.5"
 
 RUN mkdir -p /tmp/open-space-toolkit-core \
  && cd /tmp/open-space-toolkit-core \
@@ -83,7 +94,7 @@ RUN mkdir -p /tmp/open-space-toolkit-core \
 
 ## Open Space Toolkit ▸ IO
 
-ARG OSTK_IO_VERSION=0.4.5
+ARG OSTK_IO_VERSION="0.4.5"
 
 RUN mkdir -p /tmp/open-space-toolkit-io \
  && cd /tmp/open-space-toolkit-io \
@@ -94,7 +105,7 @@ RUN mkdir -p /tmp/open-space-toolkit-io \
 
 ## Open Space Toolkit ▸ Mathematics
 
-ARG OSTK_MATHEMATICS_VERSION=0.5.1
+ARG OSTK_MATHEMATICS_VERSION="0.5.1"
 
 RUN mkdir -p /tmp/open-space-toolkit-mathematics \
  && cd /tmp/open-space-toolkit-mathematics \
@@ -105,7 +116,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 
 ## Open Space Toolkit ▸ Physics
 
-ARG OSTK_PHYSICS_VERSION=0.5.23
+ARG OSTK_PHYSICS_VERSION="0.5.23"
 
 RUN mkdir -p /tmp/open-space-toolkit-physics \
  && cd /tmp/open-space-toolkit-physics \

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4.cpp
@@ -53,7 +53,7 @@ class SGP4::Impl
     private:
 
         const TLE&              tle_ ;
-        ::SGP4                  sgp4_ ;
+        libsgp4::SGP4           sgp4_ ;
 
         Shared<const Frame>     temeFrameOfEpochSPtr_ ;
 
@@ -63,7 +63,7 @@ class SGP4::Impl
 
                                 SGP4::Impl::Impl                            (   const   TLE&                        aTle                                        )
                                 :   tle_(aTle),
-                                    sgp4_(::Tle(tle_.getSatelliteName(), tle_.getFirstLine(), tle_.getSecondLine())),
+                                    sgp4_(libsgp4::Tle(tle_.getSatelliteName(), tle_.getFirstLine(), tle_.getSecondLine())),
                                     temeFrameOfEpochSPtr_(Frame::TEMEOfEpoch(tle_.getEpoch()))
 {
 
@@ -76,18 +76,18 @@ State                           SGP4::Impl::calculateStateAt                (   
 
     using ostk::physics::time::Duration ;
 
-    const Real durationFromEpoch_min = Duration::Between(tle_.getEpoch(), anInstant).inMinutes() ;
+    const Real durationFromEpoch_min = Duration::Between(this->tle_.getEpoch(), anInstant).inMinutes() ;
 
-    const ::Eci xv_TEME = sgp4_.FindPosition(durationFromEpoch_min) ;
+    const libsgp4::Eci xv_TEME = this->sgp4_.FindPosition(durationFromEpoch_min) ;
 
-    const ::Vector x_TEME_km = xv_TEME.Position() ;
-    const ::Vector v_TEME_kmps = xv_TEME.Velocity() ;
+    const libsgp4::Vector x_TEME_km = xv_TEME.Position() ;
+    const libsgp4::Vector v_TEME_kmps = xv_TEME.Velocity() ;
 
     const Vector3d x_TEME_m = Vector3d(x_TEME_km.x, x_TEME_km.y, x_TEME_km.z) * 1e3 ;
     const Vector3d v_TEME_mps = Vector3d(v_TEME_kmps.x, v_TEME_kmps.y, v_TEME_kmps.z) * 1e3 ;
 
-    const Position position_TEME = { x_TEME_m, Position::Unit::Meter, temeFrameOfEpochSPtr_ } ;
-    const Velocity velocity_TEME = { v_TEME_mps, Velocity::Unit::MeterPerSecond, temeFrameOfEpochSPtr_ } ;
+    const Position position_TEME = { x_TEME_m, Position::Unit::Meter, this->temeFrameOfEpochSPtr_ } ;
+    const Velocity velocity_TEME = { v_TEME_mps, Velocity::Unit::MeterPerSecond, this->temeFrameOfEpochSPtr_ } ;
 
     const State state_TEME = { anInstant, position_TEME, velocity_TEME } ;
 
@@ -130,9 +130,9 @@ SGP4&                           SGP4::operator =                            (   
 
         Model::operator = (aSGP4Model) ;
 
-        tle_ = aSGP4Model.tle_ ;
+        this->tle_ = aSGP4Model.tle_ ;
 
-        implUPtr_ = std::make_unique<SGP4::Impl>(tle_) ;
+        this->implUPtr_ = std::make_unique<SGP4::Impl>(tle_) ;
 
     }
 
@@ -153,7 +153,7 @@ bool                            SGP4::operator ==                           (   
         return false ;
     }
 
-    return tle_ == aSGP4Model.tle_ ;
+    return this->tle_ == aSGP4Model.tle_ ;
 
 }
 
@@ -174,7 +174,7 @@ std::ostream&                   operator <<                                 (   
 
 bool                            SGP4::isDefined                             ( ) const
 {
-    return tle_.isDefined() && (implUPtr_ != nullptr) ;
+    return this->tle_.isDefined() && (this->implUPtr_ != nullptr) ;
 }
 
 TLE                             SGP4::getTle                                ( ) const
@@ -185,7 +185,7 @@ TLE                             SGP4::getTle                                ( ) 
         throw ostk::core::error::runtime::Undefined("SGP4") ;
     }
 
-    return tle_ ;
+    return this->tle_ ;
 
 }
 
@@ -197,7 +197,7 @@ Instant                         SGP4::getEpoch                              ( ) 
         throw ostk::core::error::runtime::Undefined("SGP4") ;
     }
 
-    return tle_.getEpoch() ;
+    return this->tle_.getEpoch() ;
 
 }
 
@@ -209,7 +209,7 @@ Integer                         SGP4::getRevolutionNumberAtEpoch            ( ) 
         throw ostk::core::error::runtime::Undefined("SGP4") ;
     }
 
-    return tle_.getRevolutionNumberAtEpoch() ;
+    return this->tle_.getRevolutionNumberAtEpoch() ;
 
 }
 
@@ -226,7 +226,7 @@ State                           SGP4::calculateStateAt                      (   
         throw ostk::core::error::runtime::Undefined("SGP4") ;
     }
 
-    return implUPtr_->calculateStateAt(anInstant) ;
+    return this->implUPtr_->calculateStateAt(anInstant) ;
 
 }
 
@@ -243,12 +243,10 @@ Integer                         SGP4::calculateRevolutionNumberAt           (   
         throw ostk::core::error::runtime::Undefined("SGP4") ;
     }
 
-    if (anInstant == tle_.getEpoch())
+    if (anInstant == this->tle_.getEpoch())
     {
         return this->getRevolutionNumberAtEpoch() ;
     }
-
-    // aaaa
 
     return Integer::Undefined() ;
 


### PR DESCRIPTION
The SGP4 upstream repo introduced breaking changes today, and this repo was tracking the `master` branch. This PR adapts to these changes and locks the version.