### PR TITLE
chore:  use spaces to pad revolution number for TLE sanitization

### DIFF
--- a/bindings/python/test/trajectory/orbit/models/sgp4/test_tle.py
+++ b/bindings/python/test/trajectory/orbit/models/sgp4/test_tle.py
@@ -150,6 +150,65 @@ class TestTLE:
 
         assert tle.get_second_line_checksum() == 6
 
+    def test_set_satellite_number (self, tle: TLE):
+
+        tle.set_satellite_number(99959)
+
+        assert tle.get_satellite_number() == 99959
+
+        tle.set_satellite_number(25544)
+
+        assert tle.get_satellite_number() == 25544
+
+    def test_set_epoch (self, tle: TLE):
+
+        tle.set_epoch(Instant.date_time(DateTime(2019, 9, 20, 5, 18, 28, 232, 361, 0), Scale.UTC))
+
+        assert tle.get_epoch() == Instant.date_time(DateTime(2019, 9, 20, 5, 18, 28, 231, 776, 0), Scale.UTC)
+
+        tle.set_epoch(Instant.date_time(DateTime(2018, 8, 19, 4, 17, 27, 231, 360, 0), Scale.UTC))
+
+        assert tle.get_epoch() == Instant.date_time(DateTime(2018, 8, 19, 4, 17, 27, 231, 360, 0), Scale.UTC)
+
+    def test_set_revolution_number_at_epoch (self, tle: TLE):
+
+        tle.set_revolution_number_at_epoch(2345)
+
+        assert tle.get_revolution_number_at_epoch() == 2345
+        assert tle.get_first_line() == '1 25544U 98067A   18231.17878740  .00000187  00000-0  10196-4 0  9994'
+        assert tle.get_second_line() == '2 25544  51.6447  64.7824 0005971  73.1467  36.4366 15.53848234 23455'
+
+        tle.set_revolution_number_at_epoch(6)
+
+        assert tle.get_revolution_number_at_epoch() == 6
+        assert tle.get_first_line() == '1 25544U 98067A   18231.17878740  .00000187  00000-0  10196-4 0  9994'
+        assert tle.get_second_line() == '2 25544  51.6447  64.7824 0005971  73.1467  36.4366 15.53848234    67'
+
+        other_tle = TLE(
+            '1 99993U 21990ZZZ 21182.62513889  .00000763  00000-0  42347-4 0 99995',
+            '2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975009992'
+        )
+
+        assert other_tle.get_revolution_number_at_epoch() == 999
+
+        other_tle.set_revolution_number_at_epoch(999)
+
+        assert other_tle.get_revolution_number_at_epoch() == 999
+        assert other_tle.get_first_line() == '1 99993U 21990ZZZ 21182.62513889  .00000763  00000-0  42347-4 0 99995'
+        assert other_tle.get_second_line() == '2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975  9992'
+
+        other_tle.set_revolution_number_at_epoch(9909)
+
+        assert other_tle.get_revolution_number_at_epoch() == 9909
+        assert other_tle.get_first_line() == '1 99993U 21990ZZZ 21182.62513889  .00000763  00000-0  42347-4 0 99995'
+        assert other_tle.get_second_line() == '2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975 99092'
+
+        other_tle.set_revolution_number_at_epoch(99)
+
+        assert other_tle.get_revolution_number_at_epoch() == 99
+        assert other_tle.get_first_line() == '1 99993U 21990ZZZ 21182.62513889  .00000763  00000-0  42347-4 0 99995'
+        assert other_tle.get_second_line() == '2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975   993'
+
     def test_can_parse (self, tle: TLE):
 
         assert TLE.can_parse(tle.get_first_line(), tle.get_second_line())

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4/TLE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4/TLE.cpp
@@ -468,7 +468,7 @@ void                            TLE::setRevolutionNumberAtEpoch             (   
     }
 
     const String revolutionNumberAtEpochString = aRevolutionNumberAtEpoch.toString() ;
-    const String sanitizedRevolutionNumberAtEpochString = String::Replicate("0", 5 - revolutionNumberAtEpochString.getLength()) + revolutionNumberAtEpochString ;
+    const String sanitizedRevolutionNumberAtEpochString = String::Replicate(" ", 5 - revolutionNumberAtEpochString.getLength()) + revolutionNumberAtEpochString ;
     const String newIntermediateSecondLine = secondLine_.getSubstring(0, 63) + sanitizedRevolutionNumberAtEpochString + secondLine_.getSubstring(68, 1) ;
 
     const Integer secondLineNewChecksum = TLE::GenerateChecksum(newIntermediateSecondLine) ;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4/TLE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4/TLE.test.cpp
@@ -905,9 +905,9 @@ TEST (OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_SGP4_TLE, SetRevolu
 
         tle.setRevolutionNumberAtEpoch(updatedRevolutionNumberAtEpoch) ;
 
-        EXPECT_EQ(56353, tle.getRevolutionNumberAtEpoch()) ;
+        EXPECT_EQ(6353, tle.getRevolutionNumberAtEpoch()) ;
 
-        const String newSecondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975 63537" ;
+        const String newSecondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975 63532" ;
 
         EXPECT_EQ(firstLine, tle.getFirstLine()) ;
         EXPECT_EQ(newSecondLine, tle.getSecondLine()) ;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4/TLE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4/TLE.test.cpp
@@ -662,7 +662,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_SGP4_TLE, SetSatell
     {
 
         const String firstLine = "1 99993U 21990ZZZ 21182.62513889  .00000763  00000-0  42347-4 0 99995" ;
-        const String secondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975009992" ;
+        const String secondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975  9992" ;
 
         TLE tle(firstLine, secondLine) ;
 
@@ -675,7 +675,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_SGP4_TLE, SetSatell
         EXPECT_EQ(99995, tle.getSatelliteNumber()) ;
 
         const String newFirstLine = "1 99995U 21990ZZZ 21182.62513889  .00000763  00000-0  42347-4 0 99997" ;
-        const String newSecondLine = "2 99995 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975009994" ;
+        const String newSecondLine = "2 99995 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975  9994" ;
 
         EXPECT_EQ(newFirstLine, tle.getFirstLine()) ;
         EXPECT_EQ(newSecondLine, tle.getSecondLine()) ;
@@ -841,7 +841,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_SGP4_TLE, SetRevolu
 
         EXPECT_EQ(10, tle.getRevolutionNumberAtEpoch()) ;
 
-        const String newSecondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975000106" ;
+        const String newSecondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975   106" ;
 
         EXPECT_EQ(firstLine, tle.getFirstLine()) ;
         EXPECT_EQ(newSecondLine, tle.getSecondLine()) ;
@@ -851,7 +851,7 @@ TEST (OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_SGP4_TLE, SetRevolu
     {
 
         const String firstLine = "1 99993U 21990ZZZ 21182.62513889  .00000763  00000-0  42347-4 0 99995" ;
-        const String secondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975009992" ;
+        const String secondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975  9992" ;
 
         TLE tle(firstLine, secondLine) ;
 
@@ -886,6 +886,28 @@ TEST (OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_SGP4_TLE, SetRevolu
         EXPECT_EQ(56353, tle.getRevolutionNumberAtEpoch()) ;
 
         const String newSecondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975563537" ;
+
+        EXPECT_EQ(firstLine, tle.getFirstLine()) ;
+        EXPECT_EQ(newSecondLine, tle.getSecondLine()) ;
+
+    }
+
+    {
+
+        const String firstLine = "1 99993U 21990ZZZ 21182.62513889  .00000763  00000-0  42347-4 0 99995" ;
+        const String secondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975  9992" ;
+
+        TLE tle(firstLine, secondLine) ;
+
+        EXPECT_EQ(999, tle.getRevolutionNumberAtEpoch()) ;
+
+        const Integer updatedRevolutionNumberAtEpoch = 6353 ;
+
+        tle.setRevolutionNumberAtEpoch(updatedRevolutionNumberAtEpoch) ;
+
+        EXPECT_EQ(56353, tle.getRevolutionNumberAtEpoch()) ;
+
+        const String newSecondLine = "2 99993 097.5132 311.4037 0016005 231.4378 006.3908 15.13696975 63537" ;
 
         EXPECT_EQ(firstLine, tle.getFirstLine()) ;
         EXPECT_EQ(newSecondLine, tle.getSecondLine()) ;


### PR DESCRIPTION
- Spaces and Zeroes are both valid to pad for revolution number. Aligning to use spaces to match SpaceTrack convention. 
- Zeroes are used for International Designator and Epoch. Already verified.