### PR TITLE
feat: use VectorXd instead of std::vector for NumericalSolver

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
@@ -8,6 +8,8 @@
 #include <OpenSpaceToolkit/Core/Types/Real.hpp>
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
 
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
+
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
@@ -21,6 +23,8 @@ using ostk::core::types::Integer;
 using ostk::core::types::Real;
 using ostk::core::types::Size;
 using ostk::core::types::String;
+
+using ostk::math::obj::VectorXd;
 
 using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
@@ -45,7 +49,7 @@ class NumericalSolver
         LogAdaptive
     };
 
-    typedef std::vector<double> StateVector;  // Container used to hold the state vector
+    typedef VectorXd StateVector;  // Container used to hold the state vector
     typedef std::function<void(const StateVector&, StateVector&, const double)>
         SystemOfEquationsWrapper;  // Function pointer type for returning dynamical equation's pointers
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics.cpp
@@ -58,7 +58,7 @@ void Dynamics::DynamicalEquations(
     const Instant& anInstant
 )
 {
-    for (Index i = 0; i < dxdt.size(); ++i)
+    for (Index i = 0; i < (Size)dxdt.size(); ++i)
     {
         dxdt[i] = 0;
     }

--- a/src/OpenSpaceToolkit/Astrodynamics/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/NumericalSolver.cpp
@@ -1,11 +1,46 @@
 /// Apache License 2.0
 
 #include <boost/numeric/odeint.hpp>
+#include <boost/numeric/odeint/external/eigen/eigen_algebra.hpp>
 
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utilities.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp>
+
+// TBI: Move this to eigen.hpp when we move this file to ostk mathematics
+namespace boost::numeric::odeint
+{
+template <>
+struct resize_impl<ostk::astro::NumericalSolver::StateVector, ostk::astro::NumericalSolver::StateVector>
+{
+    static void resize(
+        ostk::astro::NumericalSolver::StateVector& x, const ostk::astro::NumericalSolver::StateVector& template_x
+    )
+    {
+        x.resize(template_x.size());
+    }
+};
+
+template <>
+struct is_resizeable<ostk::astro::NumericalSolver::StateVector>
+{
+    typedef boost::true_type type;
+    static const bool value = type::value;
+};
+
+template <>
+struct same_size_impl<ostk::astro::NumericalSolver::StateVector, ostk::astro::NumericalSolver::StateVector>
+{
+    static bool same_size(
+        const ostk::astro::NumericalSolver::StateVector& x, const ostk::astro::NumericalSolver::StateVector& template_x
+    )
+    {
+        return x.rows() == template_x.rows();
+    }
+};
+
+}  // namespace boost::numeric::odeint
 
 namespace ostk
 {
@@ -14,9 +49,22 @@ namespace astro
 
 using namespace boost::numeric::odeint;
 
-typedef runge_kutta4<NumericalSolver::StateVector> stepper_type_4;
-typedef runge_kutta_cash_karp54<NumericalSolver::StateVector> error_stepper_type_54;
-typedef runge_kutta_fehlberg78<NumericalSolver::StateVector> error_stepper_type_78;
+typedef runge_kutta4<NumericalSolver::StateVector, double, NumericalSolver::StateVector, double, vector_space_algebra>
+    stepper_type_4;
+typedef runge_kutta_cash_karp54<
+    NumericalSolver::StateVector,
+    double,
+    NumericalSolver::StateVector,
+    double,
+    vector_space_algebra>
+    error_stepper_type_54;
+typedef runge_kutta_fehlberg78<
+    NumericalSolver::StateVector,
+    double,
+    NumericalSolver::StateVector,
+    double,
+    vector_space_algebra>
+    error_stepper_type_78;
 
 NumericalSolver::NumericalSolver(
     const NumericalSolver::LogType& aLogType,
@@ -456,7 +504,7 @@ void NumericalSolver::observeNumericalIntegration(const NumericalSolver::StateVe
 
             std::cout.precision(10);
             std::cout.setf(std::ios::scientific, std::ios::floatfield);
-            for (Size i = 0; i < x.size(); i++)
+            for (Size i = 0; i < (Size)x.size(); i++)
             {
                 std::cout << std::internal << std::setw(16) << x[i] << "     ";
             }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
@@ -95,11 +95,7 @@ State Propagator::calculateStateAt(const State& aState, const Instant& anInstant
         throw ostk::core::error::runtime::Undefined("Propagator");
     }
 
-    const VectorXd stateCoordinates = aState.getCoordinates();
-
-    NumericalSolver::StateVector startStateVector(
-        stateCoordinates.data(), stateCoordinates.data() + stateCoordinates.size()
-    );
+    const NumericalSolver::StateVector startStateVector = aState.getCoordinates();
 
     const NumericalSolver::StateVector endStateVector = numericalSolver_.integrateStateFromInstantToInstant(
         startStateVector,
@@ -111,7 +107,8 @@ State Propagator::calculateStateAt(const State& aState, const Instant& anInstant
     return {
         anInstant,
         Position::Meters({endStateVector[0], endStateVector[1], endStateVector[2]}, gcrfSPtr),
-        Velocity::MetersPerSecond({endStateVector[3], endStateVector[4], endStateVector[5]}, gcrfSPtr)};
+        Velocity::MetersPerSecond({endStateVector[3], endStateVector[4], endStateVector[5]}, gcrfSPtr),
+    };
 }
 
 Array<State> Propagator::calculateStatesAt(const State& aState, const Array<Instant>& anInstantArray) const
@@ -139,13 +136,12 @@ Array<State> Propagator::calculateStatesAt(const State& aState, const Array<Inst
         }
     }
 
-    const VectorXd stateCoordinates = aState.getCoordinates();
-    NumericalSolver::StateVector startStateVector(
-        stateCoordinates.data(), stateCoordinates.data() + stateCoordinates.size()
-    );
+    const NumericalSolver::StateVector startStateVector = aState.getCoordinates();
 
     Array<Instant> forwardInstants;
+    forwardInstants.reserve(anInstantArray.getSize());
     Array<Instant> backwardInstants;
+    backwardInstants.reserve(anInstantArray.getSize());
 
     for (const Instant& anInstant : anInstantArray)
     {
@@ -197,7 +193,8 @@ Array<State> Propagator::calculateStatesAt(const State& aState, const Array<Inst
         State propagatedState = {
             anInstantArray[k],
             Position::Meters({stateVector[0], stateVector[1], stateVector[2]}, gcrfSPtr),
-            Velocity::MetersPerSecond({stateVector[3], stateVector[4], stateVector[5]}, gcrfSPtr)};
+            Velocity::MetersPerSecond({stateVector[3], stateVector[4], stateVector[5]}, gcrfSPtr),
+        };
 
         propagatedStates.add(propagatedState);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/AtmosphericDrag.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/AtmosphericDrag.test.cpp
@@ -228,7 +228,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_AtmosphericDrag, Ge
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_AtmosphericDrag, ApplyContribution)
 {
-    NumericalSolver::StateVector dxdt(6, 0.0);
+    NumericalSolver::StateVector dxdt(6);
+    dxdt.setZero();
     AtmosphericDrag atmosphericDrag(earthSPtr_, satelliteSystem_);
     atmosphericDrag.applyContribution(startStateVector_, dxdt, startInstant_);
     EXPECT_GT(1e-15, 0.0 - dxdt[0]);
@@ -251,14 +252,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_AtmosphericDrag, On
     stepper.do_step(Dynamics::GetDynamicalEquations(dynamics, startInstant_), startStateVector_, (0.0), 1.0);
 
     // Set reference pull values for the Earth
-    NumericalSolver::StateVector Earth_ReferencePull = {
-        7000000.0000000000000000,
-        0.0,
-        0.0,
-        0.0,
-        7546.0532621292200000,
-        -00000.0000000000197640,
-    };
+    NumericalSolver::StateVector Earth_ReferencePull(6);
+    Earth_ReferencePull << 7000000.0000000000000000, 0.0, 0.0, 0.0, 7546.0532621292200000, -00000.0000000000197640;
 
     EXPECT_GT(5e-11, startStateVector_[0] - Earth_ReferencePull[0]);
     EXPECT_GT(5e-11, startStateVector_[1] - Earth_ReferencePull[1]);
@@ -302,28 +297,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_AtmosphericDrag, On
     // Setup initial conditions
     const Instant startInstant = Instant::DateTime(DateTime(2023, 1, 1, 0, 0, 0), Scale::UTC);
 
-    NumericalSolver::StateVector startStateVector = {
-        6878137.0,
-        0.0,
-        0.0,
-        0.0,
-        7612.608170359118000,
-        0.0,
-    };
+    NumericalSolver::StateVector startStateVector(6);
+    startStateVector << 6878137.0, 0.0, 0.0, 0.0, 7612.608170359118000, 0.0;
 
     // Perform 1.0s integration step
     runge_kutta4<NumericalSolver::StateVector> stepper;
     stepper.do_step(Dynamics::GetDynamicalEquations(dynamics, startInstant), startStateVector, (0.0), 1.0);
 
     // Set reference pull values for the Earth
-    NumericalSolver::StateVector referenceValues = {
-        6878132.787246078000000,
-        7612.606615971900000,
-        -0.000000000000330,
-        -8.425506982847088,
-        7612.603507382901000,
-        -0.000000000000649,
-    };
+    NumericalSolver::StateVector referenceValues(6);
+    referenceValues << 6878132.787246078000000, 7612.606615971900000, -0.000000000000330, -8.425506982847088,
+        7612.603507382901000, -0.000000000000649;
 
     EXPECT_GT(1e-12, startStateVector[0] - referenceValues[0]);
     EXPECT_GT(1e-12, startStateVector[1] - referenceValues[1]);

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/CentralBodyGravity.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/CentralBodyGravity.test.cpp
@@ -192,7 +192,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_CentralBodyGravity,
 {
     CentralBodyGravity centralBodyGravity(sphericalEarthSPtr_);
 
-    NumericalSolver::StateVector dxdt(6, 0.0);
+    NumericalSolver::StateVector dxdt(6);
+    dxdt.setZero();
     centralBodyGravity.applyContribution(startStateVector_, dxdt, startInstant_);
     EXPECT_GT(1e-15, 0.0 - dxdt[0]);
     EXPECT_GT(1e-15, 0.0 - dxdt[1]);

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/PositionDerivative.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/PositionDerivative.test.cpp
@@ -17,13 +17,8 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_PositionDerivative :
    protected:
     void SetUp() override
     {
-        startStateVector_.resize(6);
-        startStateVector_[0] = 7000000.0;
-        startStateVector_[1] = 0.0;
-        startStateVector_[2] = 0.0;
-        startStateVector_[3] = 5000.12345;
-        startStateVector_[4] = 7546.05329;
-        startStateVector_[5] = 8000.5737;
+        startStateVector_ = NumericalSolver::StateVector(6);
+        startStateVector_ << 7000000.0, 0.0, 0.0, 5000.12345, 7546.05329, 8000.5737;
     }
 
     const PositionDerivative positionDerivative_;
@@ -68,7 +63,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_PositionDerivative,
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_PositionDerivative, ApplyContribution)
 {
-    NumericalSolver::StateVector dxdt(6, 0.0);
+    NumericalSolver::StateVector dxdt(6);
+    dxdt.setZero();
     positionDerivative_.applyContribution(startStateVector_, dxdt, startInstant_);
     EXPECT_GT(1e-15, startStateVector_[3] - dxdt[0]);
     EXPECT_GT(1e-15, startStateVector_[4] - dxdt[1]);

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/ThirdBodyGravity.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/ThirdBodyGravity.test.cpp
@@ -210,7 +210,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_ThirdBodyGravity, A
     const Shared<Celestial> earthSPtr = std::make_shared<Celestial>(Moon::Spherical());
     ThirdBodyGravity thirdBodyGravity(earthSPtr);
 
-    NumericalSolver::StateVector dxdt(6, 0.0);
+    NumericalSolver::StateVector dxdt(6);
+    dxdt.setZero();
     thirdBodyGravity.applyContribution(startStateVector_, dxdt, startInstant_);
 
     EXPECT_GT(1e-15, 0.0 - dxdt[0]);

--- a/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
@@ -350,7 +350,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStatesAtSortedInst
 
     // Performance test with RungeKutta4 in forward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
 
         const Instant startInstant = Instant::J2000();
 
@@ -392,7 +393,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStatesAtSortedInst
 
     // Performance test with RungeKutta4 in backward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
 
         const Instant startInstant = Instant::J2000();
 
@@ -434,7 +436,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStatesAtSortedInst
 
     // Performance test with RungeKuttaCashKarp54 and integrateStatesAtSortedInstants in forward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
 
         const Instant startInstant = Instant::J2000();
 
@@ -476,7 +479,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStatesAtSortedInst
 
     // Performance test with RungeKuttaCashKarp54 and integrateStateForDuration in backward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
 
         const Instant startInstant = Instant::J2000();
 
@@ -518,7 +522,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStatesAtSortedInst
 
     // Performance test with RungeKuttaFehlberg78 in forward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
 
         const Instant startInstant = Instant::J2000();
 
@@ -560,7 +565,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStatesAtSortedInst
 
     // Performance test with RungeKuttaFehlberg78 in backward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
 
         const Instant startInstant = Instant::J2000();
 
@@ -615,7 +621,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateForDuration)
 
     // Performance test with RungeKutta4 in forward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Duration propDuration = Duration::Seconds(10);
 
         // needs very small step size
@@ -640,7 +647,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateForDuration)
 
     // Performance test with RungeKutta4 in backward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Duration propDuration = Duration::Seconds(-10);
 
         // needs very small step size
@@ -665,7 +673,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateForDuration)
 
     // Performance test with RungeKuttaCashKarp54 and integrateStateForDuration in forward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
 
         const Duration propDuration = Duration::Seconds(10000);
 
@@ -690,7 +699,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateForDuration)
 
     // Performance test with RungeKuttaCashKarp54 and integrateStateForDuration in backward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Duration propDuration = Duration::Seconds(-10000);
 
         NumericalSolver numericalSolver = {
@@ -714,7 +724,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateForDuration)
 
     // Performance test with RungeKuttaFehlberg78 in forward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Duration propDuration = Duration::Seconds(10000);
 
         NumericalSolver numericalSolver = {
@@ -738,7 +749,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateForDuration)
 
     // Performance test with RungeKuttaFehlberg78 in backward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Duration propDuration = Duration::Seconds(-10000);
 
         NumericalSolver numericalSolver = {
@@ -762,7 +774,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateForDuration)
 
     // Performance test comparing results of integrate_adaptive and integrate_const for RungeKuttaCashKarp54
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Duration propDuration = Duration::Seconds(1000);
 
         NumericalSolver numericalSolver_1 = {
@@ -814,7 +827,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateForDuration)
 
     // Performance test comparing results of integrate_adaptive and integrate_const for RungeKuttaFehlberg78
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Duration propDuration = Duration::Seconds(1000);
 
         NumericalSolver numericalSolver_1 = {
@@ -877,7 +891,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
 
     // Performance test with RungeKutta4 in forwards time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(100);
 
@@ -904,7 +919,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
 
     // Performance test with RungeKutta4 in backwards time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(-100);
 
@@ -931,7 +947,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
 
     // Performance test with RungeKuttaCashKarp54 in forward time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(10000);
 
@@ -957,7 +974,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
 
     // Performance test with RungeKuttaCashKarp54 in backwards time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(-10000);
 
@@ -983,7 +1001,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
 
     // Performance test with RungeKuttaFehlberg78 in forwards time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(10000);
 
@@ -1009,7 +1028,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
 
     // Performance test with RungeKuttaFehlberg78 in backwards time
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(-10000);
 
@@ -1035,7 +1055,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
 
     // Performance test comparing results of integrate_adaptive and integrate_const for RungeKuttaCashKarp54
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(1000);
 
@@ -1090,7 +1111,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
 
     // Performance test comparing results of integrate_adaptive and integrate_const for RungeKuttaFehlberg78
     {
-        const NumericalSolver::StateVector currentStateVector = {0, 1};
+        NumericalSolver::StateVector currentStateVector(2);
+        currentStateVector << 0.0, 1.0;
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(1000);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
@@ -893,6 +893,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
     {
         NumericalSolver::StateVector currentStateVector(2);
         currentStateVector << 0.0, 1.0;
+
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(100);
 
@@ -921,6 +922,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
     {
         NumericalSolver::StateVector currentStateVector(2);
         currentStateVector << 0.0, 1.0;
+
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(-100);
 
@@ -949,6 +951,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
     {
         NumericalSolver::StateVector currentStateVector(2);
         currentStateVector << 0.0, 1.0;
+
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(10000);
 
@@ -976,6 +979,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
     {
         NumericalSolver::StateVector currentStateVector(2);
         currentStateVector << 0.0, 1.0;
+
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(-10000);
 
@@ -1003,6 +1007,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
     {
         NumericalSolver::StateVector currentStateVector(2);
         currentStateVector << 0.0, 1.0;
+
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(10000);
 
@@ -1030,6 +1035,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
     {
         NumericalSolver::StateVector currentStateVector(2);
         currentStateVector << 0.0, 1.0;
+
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(-10000);
 
@@ -1057,6 +1063,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
     {
         NumericalSolver::StateVector currentStateVector(2);
         currentStateVector << 0.0, 1.0;
+
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(1000);
 
@@ -1113,6 +1120,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateStateFromInstantTo
     {
         NumericalSolver::StateVector currentStateVector(2);
         currentStateVector << 0.0, 1.0;
+
         const Instant instant = Instant::J2000();
         const Duration propDuration = Duration::Seconds(1000);
 


### PR DESCRIPTION
Instead of having to convert back and forth between std:vector and VectorXd, we can just use VectorXd natively.