### PR TITLE
fix: add naming suggestions

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/NumericalSolver.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_NumericalSolver(pybind11::module& aM
 
         .def_readonly("solution", &NumericalSolver::ConditionSolution::solution)
         .def_readonly("condition_is_satisfied", &NumericalSolver::ConditionSolution::conditionIsSatisfied)
-        .def_readonly("number_of_iterations", &NumericalSolver::ConditionSolution::numberOfIterations)
+        .def_readonly("iteration_count", &NumericalSolver::ConditionSolution::iterationCount)
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
@@ -16,20 +16,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
     class_<RootSolver::Solution>(aModule, "RootSolverSolution")
 
         .def_readwrite("root", &RootSolver::Solution::root)
-        .def_readwrite("number_of_iterations", &RootSolver::Solution::numberOfIterations)
+        .def_readwrite("iteration_count", &RootSolver::Solution::iterationCount)
 
         ;
 
     {
         class_<RootSolver>(aModule, "RootSolver")
 
-            .def(init<const Size&, const Size&>(), arg("maximum_iterations_count"), arg("number_of_digits"))
+            .def(init<const Size&, const Size&>(), arg("maximum_iteration_count"), arg("digit_count"))
 
             .def("__str__", &(shiftToString<RootSolver>))
             .def("__repr__", &(shiftToString<RootSolver>))
 
-            .def("get_number_of_digits", &RootSolver::getNumberOfDigits)
-            .def("get_maximum_iterations_count", &RootSolver::getMaximumIterationsCount)
+            .def("get_digit_count", &RootSolver::getDigitCount)
+            .def("get_maximum_iteration_count", &RootSolver::getMaximumIterationCount)
 
             .def(
                 "solve",

--- a/bindings/python/test/test_numerical_solver.py
+++ b/bindings/python/test/test_numerical_solver.py
@@ -201,8 +201,8 @@ class TestNumericalSolver:
 
         assert condition_solution.condition_is_satisfied
         assert (
-            condition_solution.number_of_iterations
-            < numerical_solver_conditional.get_root_solver().get_maximum_iterations_count()
+            condition_solution.iteration_count
+            < numerical_solver_conditional.get_root_solver().get_maximum_iteration_count()
         )
 
         state_vector, time = condition_solution.solution
@@ -228,8 +228,8 @@ class TestNumericalSolver:
 
         assert condition_solution.condition_is_satisfied
         assert (
-            condition_solution.number_of_iterations
-            < numerical_solver_conditional.get_root_solver().get_maximum_iterations_count()
+            condition_solution.iteration_count
+            < numerical_solver_conditional.get_root_solver().get_maximum_iteration_count()
         )
 
         state_vector, time = condition_solution.solution

--- a/bindings/python/test/test_root_solver.py
+++ b/bindings/python/test/test_root_solver.py
@@ -11,23 +11,23 @@ def quadratic_function(x):
 
 
 @pytest.fixture
-def maximum_iterations_count() -> int:
+def maximum_iteration_count() -> int:
     return 100
 
 
 @pytest.fixture
-def number_of_digits() -> int:
+def digit_count() -> int:
     return 27
 
 
 @pytest.fixture
-def root_solver(maximum_iterations_count: int, number_of_digits: int) -> RootSolver:
-    return RootSolver(maximum_iterations_count, number_of_digits)
+def root_solver(maximum_iteration_count: int, digit_count: int) -> RootSolver:
+    return RootSolver(maximum_iteration_count, digit_count)
 
 
 class TestRootSolver:
-    def test_constructor(self, maximum_iterations_count: int, number_of_digits: int):
-        assert RootSolver(maximum_iterations_count, number_of_digits) is not None
+    def test_constructor(self, maximum_iteration_count: int, digit_count: int):
+        assert RootSolver(maximum_iteration_count, digit_count) is not None
 
     def test_solve_with_initial_guess(self, root_solver):
         solution = root_solver.solve(quadratic_function, 1.0, True)
@@ -39,8 +39,8 @@ class TestRootSolver:
     def test_getters(
         self,
         root_solver: RootSolver,
-        maximum_iterations_count: int,
-        number_of_digits: int,
+        maximum_iteration_count: int,
+        digit_count: int,
     ):
-        assert root_solver.get_maximum_iterations_count() == maximum_iterations_count
-        assert root_solver.get_number_of_digits() == number_of_digits
+        assert root_solver.get_maximum_iteration_count() == maximum_iteration_count
+        assert root_solver.get_digit_count() == digit_count

--- a/bindings/python/thirdparty/boost_numpy_eigen/eigen_numpy.cpp
+++ b/bindings/python/thirdparty/boost_numpy_eigen/eigen_numpy.cpp
@@ -1,5 +1,6 @@
-#include <Eigen/Eigen>
 #include <boost/numpy.hpp>
+
+#include <Eigen/Eigen>
 // #include <glog/logging.h>
 #include <numpy/arrayobject.h>
 
@@ -9,236 +10,311 @@ namespace np = boost::numpy;
 using namespace Eigen;
 
 template <typename SCALAR>
-struct NumpyEquivalentType {};
-
-template <> struct NumpyEquivalentType<double> {enum { type_code = NPY_DOUBLE };};
-template <> struct NumpyEquivalentType<int> {enum { type_code = NPY_INT };};
-template <> struct NumpyEquivalentType<float> {enum { type_code = NPY_FLOAT };};
-template <> struct NumpyEquivalentType<std::complex<double> > {enum { type_code = NPY_CDOUBLE };};
-
-template <typename SourceType, typename DestType >
-static void copy_array(const SourceType* source, DestType* dest,
-                       const npy_int &nb_rows, const npy_int &nb_cols,
-    const bool &isSourceTypeNumpy = false, const bool &isDestRowMajor = true,
-    const bool& isSourceRowMajor = true,
-    const npy_int &numpy_row_stride = 1, const npy_int &numpy_col_stride = 1)
+struct NumpyEquivalentType
 {
-  // determine source strides
-  int row_stride = 1, col_stride = 1;
-  if (isSourceTypeNumpy) {
-    row_stride = numpy_row_stride;
-    col_stride = numpy_col_stride;
-  } else {
-    if (isSourceRowMajor) {
-      row_stride = nb_cols;
-    } else {
-      col_stride = nb_rows;
-    }
-  }
-
-  if (isDestRowMajor) {
-    for (int r=0; r<nb_rows; r++) {
-      for (int c=0; c<nb_cols; c++) {
-        *dest = source[r*row_stride + c*col_stride];
-        dest++;
-      }
-    }
-  } else {
-    for (int c=0; c<nb_cols; c++) {
-      for (int r=0; r<nb_rows; r++) {
-        *dest = source[r*row_stride + c*col_stride];
-        dest++;
-      }
-    }
-  }
-}
-
-
-template<class MatType> // MatrixXf or MatrixXd
-struct EigenMatrixToPython {
-  static PyObject* convert(const MatType& mat) {
-    npy_intp shape[2] = { mat.rows(), mat.cols() };
-    PyArrayObject* python_array = (PyArrayObject*)PyArray_SimpleNew(
-        2, shape, NumpyEquivalentType<typename MatType::Scalar>::type_code);
-
-    copy_array(mat.data(),
-               (typename MatType::Scalar*)PyArray_DATA(python_array),
-               mat.rows(),
-               mat.cols(),
-               false,
-               true,
-               MatType::Flags & Eigen::RowMajorBit);
-    return (PyObject*)python_array;
-  }
 };
 
+template <>
+struct NumpyEquivalentType<double>
+{
+    enum
+    {
+        type_code = NPY_DOUBLE
+    };
+};
 
-template<typename MatType>
-struct EigenMatrixFromPython {
-  typedef typename MatType::Scalar T;
+template <>
+struct NumpyEquivalentType<int>
+{
+    enum
+    {
+        type_code = NPY_INT
+    };
+};
 
-  EigenMatrixFromPython() {
-    bp::converter::registry::push_back(&convertible,
-                                       &construct,
-                                       bp::type_id<MatType>());
-  }
+template <>
+struct NumpyEquivalentType<float>
+{
+    enum
+    {
+        type_code = NPY_FLOAT
+    };
+};
 
-  static void* convertible(PyObject* obj_ptr) {
-    if (!PyArray_Check(obj_ptr)) {
-      // LOG(ERROR) << "PyArray_Check failed";
-      return 0;
+template <>
+struct NumpyEquivalentType<std::complex<double>>
+{
+    enum
+    {
+        type_code = NPY_CDOUBLE
+    };
+};
+
+template <typename SourceType, typename DestType>
+static void copy_array(
+    const SourceType* source,
+    DestType* dest,
+    const npy_int& nb_rows,
+    const npy_int& nb_cols,
+    const bool& isSourceTypeNumpy = false,
+    const bool& isDestRowMajor = true,
+    const bool& isSourceRowMajor = true,
+    const npy_int& numpy_row_stride = 1,
+    const npy_int& numpy_col_stride = 1
+)
+{
+    // determine source strides
+    int row_stride = 1, col_stride = 1;
+    if (isSourceTypeNumpy)
+    {
+        row_stride = numpy_row_stride;
+        col_stride = numpy_col_stride;
     }
-    if (PyArray_NDIM(obj_ptr) > 2) {
-      // LOG(ERROR) << "dim > 2";
-      return 0;
-    }
-    if (PyArray_ObjectType(obj_ptr, 0) != NumpyEquivalentType<typename MatType::Scalar>::type_code) {
-      // LOG(ERROR) << "types not compatible";
-      return 0;
-    }
-    int flags = PyArray_FLAGS(obj_ptr);
-    if (!(flags & NPY_ARRAY_C_CONTIGUOUS)) {
-      // LOG(ERROR) << "Contiguous C array required";
-      return 0;
-    }
-    if (!(flags & NPY_ARRAY_ALIGNED)) {
-      // LOG(ERROR) << "Aligned array required";
-      return 0;
-    }
-    return obj_ptr;
-  }
-
-  static void construct(PyObject* obj_ptr,
-                        bp::converter::rvalue_from_python_stage1_data* data) {
-    const int R = MatType::RowsAtCompileTime;
-    const int C = MatType::ColsAtCompileTime;
-
-    using bp::extract;
-
-    PyArrayObject *array = reinterpret_cast<PyArrayObject*>(obj_ptr);
-    int ndims = PyArray_NDIM(obj_ptr);
-
-    int dtype_size = (PyArray_DESCR(obj_ptr))->elsize;
-    int s1 = PyArray_STRIDE(obj_ptr, 0);
-    // CHECK_EQ(0, s1 % dtype_size);
-    int s2 = 0;
-    if (ndims > 1) {
-      s2 = PyArray_STRIDE(obj_ptr, 1);
-      // CHECK_EQ(0, s2 % dtype_size);
-    }
-
-
-    int nrows = R;
-    int ncols = C;
-    if (ndims == 2) {
-      if (R != Eigen::Dynamic) {
-        // CHECK_EQ(R, array->dimensions[0]);
-      } else {
-        nrows = array->dimensions[0];
-      }
-
-      if (C != Eigen::Dynamic) {
-        // CHECK_EQ(C, array->dimensions[1]);
-      } else {
-        ncols = array->dimensions[1];
-      }
-    } else {
-      // CHECK_EQ(1, ndims);
-      // Vector are a somehow special case because for Eigen, everything is
-      // a 2D array with a dimension set to 1, but to numpy, vectors are 1D
-      // arrays
-      // So we could get a 1x4 array for a Vector4
-
-      // For a vector, at least one of R, C must be 1
-      // CHECK(R == 1 || C == 1);
-
-      if (R == 1) {
-        if (C != Eigen::Dynamic) {
-          // CHECK_EQ(C, array->dimensions[0]);
-        } else {
-          ncols = array->dimensions[0];
+    else
+    {
+        if (isSourceRowMajor)
+        {
+            row_stride = nb_cols;
         }
-        // We have received a 1xC array and want to transform to VectorCd,
-        // so we need to transpose
-        // TODO: An alternative is to add wrappers for RowVector, but maybe
-        // implicit transposition is more natural
-        std::swap(s1, s2);
-      } else {
-        if (R != Eigen::Dynamic) {
-          // CHECK_EQ(R, array->dimensions[0]);
-        } else {
-          nrows = array->dimensions[0];
+        else
+        {
+            col_stride = nb_rows;
         }
-      }
     }
 
-    T* raw_data = reinterpret_cast<T*>(PyArray_DATA(array));
+    if (isDestRowMajor)
+    {
+        for (int r = 0; r < nb_rows; r++)
+        {
+            for (int c = 0; c < nb_cols; c++)
+            {
+                *dest = source[r * row_stride + c * col_stride];
+                dest++;
+            }
+        }
+    }
+    else
+    {
+        for (int c = 0; c < nb_cols; c++)
+        {
+            for (int r = 0; r < nb_rows; r++)
+            {
+                *dest = source[r * row_stride + c * col_stride];
+                dest++;
+            }
+        }
+    }
+}
 
-    typedef Map<Matrix<T, Dynamic, Dynamic, RowMajor>, Aligned,
-                Stride<Dynamic, Dynamic>> MapType;
+template <class MatType>  // MatrixXf or MatrixXd
+struct EigenMatrixToPython
+{
+    static PyObject* convert(const MatType& mat)
+    {
+        npy_intp shape[2] = {mat.rows(), mat.cols()};
+        PyArrayObject* python_array =
+            (PyArrayObject*)PyArray_SimpleNew(2, shape, NumpyEquivalentType<typename MatType::Scalar>::type_code);
 
-    void* storage=((bp::converter::rvalue_from_python_storage<MatType>*)
-                   (data))->storage.bytes;
+        copy_array(
+            mat.data(),
+            (typename MatType::Scalar*)PyArray_DATA(python_array),
+            mat.rows(),
+            mat.cols(),
+            false,
+            true,
+            MatType::Flags & Eigen::RowMajorBit
+        );
+        return (PyObject*)python_array;
+    }
+};
 
-    new (storage) MatType;
-    MatType* emat = (MatType*)storage;
-    // TODO: This is a (potentially) expensive copy operation. There should
-    // be a better way
-    *emat = MapType(raw_data, nrows, ncols,
-                Stride<Dynamic, Dynamic>(s1/dtype_size, s2/dtype_size));
-    data->convertible = storage;
-  }
+template <typename MatType>
+struct EigenMatrixFromPython
+{
+    typedef typename MatType::Scalar T;
+
+    EigenMatrixFromPython()
+    {
+        bp::converter::registry::push_back(&convertible, &construct, bp::type_id<MatType>());
+    }
+
+    static void* convertible(PyObject* obj_ptr)
+    {
+        if (!PyArray_Check(obj_ptr))
+        {
+            // LOG(ERROR) << "PyArray_Check failed";
+            return 0;
+        }
+        if (PyArray_NDIM(obj_ptr) > 2)
+        {
+            // LOG(ERROR) << "dim > 2";
+            return 0;
+        }
+        if (PyArray_ObjectType(obj_ptr, 0) != NumpyEquivalentType<typename MatType::Scalar>::type_code)
+        {
+            // LOG(ERROR) << "types not compatible";
+            return 0;
+        }
+        int flags = PyArray_FLAGS(obj_ptr);
+        if (!(flags & NPY_ARRAY_C_CONTIGUOUS))
+        {
+            // LOG(ERROR) << "Contiguous C array required";
+            return 0;
+        }
+        if (!(flags & NPY_ARRAY_ALIGNED))
+        {
+            // LOG(ERROR) << "Aligned array required";
+            return 0;
+        }
+        return obj_ptr;
+    }
+
+    static void construct(PyObject* obj_ptr, bp::converter::rvalue_from_python_stage1_data* data)
+    {
+        const int R = MatType::RowsAtCompileTime;
+        const int C = MatType::ColsAtCompileTime;
+
+        using bp::extract;
+
+        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(obj_ptr);
+        int ndims = PyArray_NDIM(obj_ptr);
+
+        int dtype_size = (PyArray_DESCR(obj_ptr))->elsize;
+        int s1 = PyArray_STRIDE(obj_ptr, 0);
+        // CHECK_EQ(0, s1 % dtype_size);
+        int s2 = 0;
+        if (ndims > 1)
+        {
+            s2 = PyArray_STRIDE(obj_ptr, 1);
+            // CHECK_EQ(0, s2 % dtype_size);
+        }
+
+        int nrows = R;
+        int ncols = C;
+        if (ndims == 2)
+        {
+            if (R != Eigen::Dynamic)
+            {
+                // CHECK_EQ(R, array->dimensions[0]);
+            }
+            else
+            {
+                nrows = array->dimensions[0];
+            }
+
+            if (C != Eigen::Dynamic)
+            {
+                // CHECK_EQ(C, array->dimensions[1]);
+            }
+            else
+            {
+                ncols = array->dimensions[1];
+            }
+        }
+        else
+        {
+            // CHECK_EQ(1, ndims);
+            // Vector are a somehow special case because for Eigen, everything is
+            // a 2D array with a dimension set to 1, but to numpy, vectors are 1D
+            // arrays
+            // So we could get a 1x4 array for a Vector4
+
+            // For a vector, at least one of R, C must be 1
+            // CHECK(R == 1 || C == 1);
+
+            if (R == 1)
+            {
+                if (C != Eigen::Dynamic)
+                {
+                    // CHECK_EQ(C, array->dimensions[0]);
+                }
+                else
+                {
+                    ncols = array->dimensions[0];
+                }
+                // We have received a 1xC array and want to transform to VectorCd,
+                // so we need to transpose
+                // TODO: An alternative is to add wrappers for RowVector, but maybe
+                // implicit transposition is more natural
+                std::swap(s1, s2);
+            }
+            else
+            {
+                if (R != Eigen::Dynamic)
+                {
+                    // CHECK_EQ(R, array->dimensions[0]);
+                }
+                else
+                {
+                    nrows = array->dimensions[0];
+                }
+            }
+        }
+
+        T* raw_data = reinterpret_cast<T*>(PyArray_DATA(array));
+
+        typedef Map<Matrix<T, Dynamic, Dynamic, RowMajor>, Aligned, Stride<Dynamic, Dynamic>> MapType;
+
+        void* storage = ((bp::converter::rvalue_from_python_storage<MatType>*)(data))->storage.bytes;
+
+        new (storage) MatType;
+        MatType* emat = (MatType*)storage;
+        // TODO: This is a (potentially) expensive copy operation. There should
+        // be a better way
+        *emat = MapType(raw_data, nrows, ncols, Stride<Dynamic, Dynamic>(s1 / dtype_size, s2 / dtype_size));
+        data->convertible = storage;
+    }
 };
 
 #define EIGEN_MATRIX_CONVERTER(Type) \
-  EigenMatrixFromPython<Type>();  \
-  bp::to_python_converter<Type, EigenMatrixToPython<Type> >();
+    EigenMatrixFromPython<Type>();   \
+    bp::to_python_converter<Type, EigenMatrixToPython<Type>>();
 
-#define MAT_CONV(R, C, T) \
-  typedef Matrix<T, R, C> Matrix ## R ## C ## T; \
-  EIGEN_MATRIX_CONVERTER(Matrix ## R ## C ## T);
+#define MAT_CONV(R, C, T)                    \
+    typedef Matrix<T, R, C> Matrix##R##C##T; \
+    EIGEN_MATRIX_CONVERTER(Matrix##R##C##T);
 
 // This require a MAT_CONV for that Matrix type to be registered first
-#define MAP_CONV(R, C, T) \
-  typedef Map<Matrix ## R ## C ## T> Map ## R ## C ## T; \
-  EIGEN_MATRIX_CONVERTER(Map ## R ## C ## T);
+#define MAP_CONV(R, C, T)                      \
+    typedef Map<Matrix##R##C##T> Map##R##C##T; \
+    EIGEN_MATRIX_CONVERTER(Map##R##C##T);
 
-#define T_CONV(R, C, T) \
-  typedef Transpose<Matrix ## R ## C ## T> Transpose ## R ## C ## T; \
-  EIGEN_MATRIX_CONVERTER(Transpose ## R ## C ## T);
+#define T_CONV(R, C, T)                                    \
+    typedef Transpose<Matrix##R##C##T> Transpose##R##C##T; \
+    EIGEN_MATRIX_CONVERTER(Transpose##R##C##T);
 
-
-#define BLOCK_CONV(R, C, BR, BC, T) \
-  typedef Block<Matrix ## R ## C ## T, BR, BC> Block ## R ## C ## BR ## BC ## T; \
-  EIGEN_MATRIX_CONVERTER(Block ## R ## C ## BR ## BC ## T);
+#define BLOCK_CONV(R, C, BR, BC, T)                                \
+    typedef Block<Matrix##R##C##T, BR, BC> Block##R##C##BR##BC##T; \
+    EIGEN_MATRIX_CONVERTER(Block##R##C##BR##BC##T);
 
 static const int X = Eigen::Dynamic;
 
-void SetupEigenConverters() {
-  import_array();
+void SetupEigenConverters()
+{
+    import_array();
 
-  EIGEN_MATRIX_CONVERTER(Matrix2f);
-  EIGEN_MATRIX_CONVERTER(Matrix2d);
-  EIGEN_MATRIX_CONVERTER(Matrix3f);
-  EIGEN_MATRIX_CONVERTER(Matrix3d);
-  EIGEN_MATRIX_CONVERTER(Matrix4f);
-  EIGEN_MATRIX_CONVERTER(Matrix4d);
+    EIGEN_MATRIX_CONVERTER(Matrix2f);
+    EIGEN_MATRIX_CONVERTER(Matrix2d);
+    EIGEN_MATRIX_CONVERTER(Matrix3f);
+    EIGEN_MATRIX_CONVERTER(Matrix3d);
+    EIGEN_MATRIX_CONVERTER(Matrix4f);
+    EIGEN_MATRIX_CONVERTER(Matrix4d);
 
-  EIGEN_MATRIX_CONVERTER(Vector2f);
-  EIGEN_MATRIX_CONVERTER(Vector3f);
-  EIGEN_MATRIX_CONVERTER(Vector4f);
-  EIGEN_MATRIX_CONVERTER(Vector2d);
-  EIGEN_MATRIX_CONVERTER(Vector3d);
-  EIGEN_MATRIX_CONVERTER(Vector4d);
+    EIGEN_MATRIX_CONVERTER(Vector2f);
+    EIGEN_MATRIX_CONVERTER(Vector3f);
+    EIGEN_MATRIX_CONVERTER(Vector4f);
+    EIGEN_MATRIX_CONVERTER(Vector2d);
+    EIGEN_MATRIX_CONVERTER(Vector3d);
+    EIGEN_MATRIX_CONVERTER(Vector4d);
 
-  EIGEN_MATRIX_CONVERTER(VectorXi);
+    EIGEN_MATRIX_CONVERTER(VectorXi);
 
-  MAT_CONV(2, 3, double);
-  MAT_CONV(X, 3, double);
-  MAT_CONV(X, X, double);
-  MAT_CONV(X, 1, double);
-  MAT_CONV(1, 4, double);
-  MAT_CONV(1, X, double);
-  MAT_CONV(3, 4, double);
-  MAT_CONV(2, X, double);
+    MAT_CONV(2, 3, double);
+    MAT_CONV(X, 3, double);
+    MAT_CONV(X, X, double);
+    MAT_CONV(X, 1, double);
+    MAT_CONV(1, 4, double);
+    MAT_CONV(1, X, double);
+    MAT_CONV(3, 4, double);
+    MAT_CONV(2, X, double);
 }

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition.hpp
@@ -18,8 +18,8 @@ using ostk::core::types::String;
 
 using ostk::math::obj::VectorXd;
 
-/// @brief                      An Event Condition defines a criteria that can be evaluated based on a current/previous
-/// state vectors and times
+/// @brief                      An Event Condition defines a criteria that can be evaluated
+///                             based on a current/previous state vectors and times
 
 class EventCondition
 {
@@ -34,76 +34,76 @@ class EventCondition
         Undefined
     };
 
-    /// @brief              Constructor
+    /// @brief                  Constructor
     ///
     /// @code
-    ///                     EventCondition eventCondition = {aName, aCriteria};
+    ///                         EventCondition eventCondition = {aName, aCriteria};
     /// @endcode
     ///
-    /// @param              [in] aName A string representing the name of the Event Condition
-    /// @param              [in] aCriteria An enum indicating the criteria used to determine the Event Condition
+    /// @param                  [in] aName A string representing the name of the Event Condition
+    /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
 
     EventCondition(const String& aName, const Criteria& aCriteria);
 
-    /// @brief              Virtual destructor
+    /// @brief                  Virtual destructor
 
     virtual ~EventCondition();
 
-    /// @brief              Output stream operator
+    /// @brief                  Output stream operator
     ///
     /// @code
-    ///                     std::cout << EventCondition(...) ;
+    ///                         std::cout << EventCondition(...) ;
     /// @endcode
     ///
-    /// @param              [in] anOutputStream An output stream
-    /// @param              [in] anEventCondition An EventCondition
-    /// @return             A reference to output stream
+    /// @param                  [in] anOutputStream An output stream
+    /// @param                  [in] anEventCondition An EventCondition
+    /// @return                 A reference to output stream
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const EventCondition& anEventCondition);
 
-    /// @brief              Get name of the Event Condition
+    /// @brief                  Get name of the Event Condition
     ///
-    /// @return             String representing the name of the Event Condition
+    /// @return                 String representing the name of the Event Condition
 
     String getName() const;
 
-    /// @brief              Get the criteria of the Event Condition
+    /// @brief                  Get the criteria of the Event Condition
     ///
-    /// @return             Enum representing the criteria of the Event Condition
+    /// @return                 Enum representing the criteria of the Event Condition
 
     Criteria getCriteria() const;
 
-    /// @brief              Print the Event Condition
+    /// @brief                  Print the Event Condition
     ///
-    /// @param              [in, out] anOutputStream The output stream where the Event Condition will be printed
-    /// @param              [in] displayDecorator A boolean indicating whether or not to display decorator during
-    /// printing
+    /// @param                  [in, out] anOutputStream The output stream where the Event Condition will be printed
+    /// @param                  [in] displayDecorator A boolean indicating whether or not to display decorator during
+    ///                         printing
 
     virtual void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
-    /// @brief              Check if the Event Condition is satisfied based on current value and previous value
+    /// @brief                  Check if the Event Condition is satisfied based on current value and previous value
     ///
-    /// @param              [in] currentValue The current value
-    /// @param              [in] previousValue The previous value
+    /// @param                  [in] currentValue The current value
+    /// @param                  [in] previousValue The previous value
     ///
-    /// @return             Boolean value indicating if the Event Condition is met
+    /// @return                 Boolean value indicating if the Event Condition is met
 
     virtual bool isSatisfied(const Real& currentValue, const Real& previousValue) const;
 
-    /// @brief              Evaluate the Event Condition
+    /// @brief                  Evaluate the Event Condition
     ///
-    /// @param              [in] aStateVector The current state vector
-    /// @param              [in] aTime The current time
+    /// @param                  [in] aStateVector The current state vector
+    /// @param                  [in] aTime The current time
     ///
-    /// @return             Real number representing the evaluation result of the Event Condition
+    /// @return                 Real number representing the evaluation result of the Event Condition
 
     virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const = 0;
 
-    /// @brief              Convert criteria to string
+    /// @brief                  Convert criteria to string
     ///
-    /// @param              [in] aCriteria An enum representing the criteria
+    /// @param                  [in] aCriteria An enum representing the criteria
     ///
-    /// @return             String representing the given criteria
+    /// @return                 String representing the given criteria
 
     static String StringFromCriteria(const Criteria& aCriteria);
 

--- a/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
@@ -60,24 +60,24 @@ class NumericalSolver
     {
         Solution solution;
         bool conditionIsSatisfied;
-        Size numberOfIterations;
+        Size iterationCount;
     };
 
-    /// @brief              Constructor
+    /// @brief                  Constructor
     ///
     /// @code
-    ///                     NumericalSolver numericalSolver = { aLogType, aStepperType, aTimeStep, aRelativeTolerance,
-    ///                     anAbsoluteTolerance } ;
+    ///                         NumericalSolver numericalSolver = { aLogType, aStepperType, aTimeStep,
+    ///                         aRelativeTolerance, anAbsoluteTolerance } ;
     /// @endcode
     ///
-    /// @param              [in] aLogType An enum indicating the amount of verbosity wanted to be logged during
-    /// numerical integration
-    /// @param              [in] aStepperType An enum indicating the type of numerical stepper used to perform
-    /// integration
-    /// @param              [in] aTimeStep A number indicating the initial guess time step the numerical solver will
-    /// take
-    /// @param              [in] aRelativeTolerance A number indicating the relative integration tolerance
-    /// @param              [in] anAbsoluteTolerance A number indicating the absolute integration tolerance
+    /// @param                  [in] aLogType An enum indicating the amount of verbosity wanted to be logged during
+    ///                         numerical integration
+    /// @param                  [in] aStepperType An enum indicating the type of numerical stepper used to perform
+    ///                         integration
+    /// @param                  [in] aTimeStep A number indicating the initial guess time step the numerical solver will
+    ///                         take
+    /// @param                  [in] aRelativeTolerance A number indicating the relative integration tolerance
+    /// @param                  [in] anAbsoluteTolerance A number indicating the absolute integration tolerance
 
     NumericalSolver(
         const NumericalSolver::LogType& aLogType,
@@ -88,120 +88,120 @@ class NumericalSolver
         const RootSolver& aRootSolver = RootSolver::Default()
     );
 
-    /// @brief              Clone numerical solver
+    /// @brief                  Clone numerical solver
     ///
-    /// @return             Pointer to cloned numerical solver
+    /// @return                 Pointer to cloned numerical solver
 
     NumericalSolver* clone() const;
 
-    /// @brief              Equal to operator
+    /// @brief                  Equal to operator
     ///
-    /// @param              [in] aNumericalSolver A numerical solver
-    /// @return             True if numerical solver are equal
+    /// @param                  [in] aNumericalSolver A numerical solver
+    /// @return                 True if numerical solver are equal
 
     bool operator==(const NumericalSolver& aNumericalSolver) const;
 
-    /// @brief              Not equal to operator
+    /// @brief                  Not equal to operator
     ///
-    /// @param              [in] aNumericalSolver A numerical solver
-    /// @return             True if numerical solver are not equal
+    /// @param                  [in] aNumericalSolver A numerical solver
+    /// @return                 True if numerical solver are not equal
 
     bool operator!=(const NumericalSolver& aNumericalSolver) const;
 
-    /// @brief              Output stream operator
+    /// @brief                  Output stream operator
     ///
-    /// @param              [in] anOutputStream An output stream
-    /// @param              [in] aNumericalSolver A numerical solver
-    /// @return             A reference to output stream
+    /// @param                  [in] anOutputStream An output stream
+    /// @param                  [in] aNumericalSolver A numerical solver
+    /// @return                 A reference to output stream
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const NumericalSolver& aNumericalSolver);
 
-    /// @brief              Check if numerical solver is defined
+    /// @brief                  Check if numerical solver is defined
     ///
-    /// @return             True if numerical solver is defined
+    /// @return                 True if numerical solver is defined
 
     bool isDefined() const;
 
-    /// @brief              Print numerical solver
+    /// @brief                  Print numerical solver
     ///
-    /// @param              [in] anOutputStream An output stream
-    /// @param              [in] (optional) displayDecorators If true, display decorators
+    /// @param                  [in] anOutputStream An output stream
+    /// @param                  [in] (optional) displayDecorators If true, display decorators
 
     void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
-    /// @brief              Get integration logging enum
+    /// @brief                  Get integration logging enum
     ///
     /// @code
-    ///                     numericalSolver.getLogType() ;
+    ///                         numericalSolver.getLogType() ;
     /// @endcode
     ///
-    /// @return             LogType
+    /// @return                 LogType
 
     NumericalSolver::LogType getLogType() const;
 
-    /// @brief              Get integration stepper enum
+    /// @brief                  Get integration stepper enum
     ///
     /// @code
-    ///                     numericalSolver.getStepperType() ;
+    ///                         numericalSolver.getStepperType() ;
     /// @endcode
     ///
-    /// @return             StepperType
+    /// @return                 StepperType
 
     NumericalSolver::StepperType getStepperType() const;
 
-    /// @brief              Get initial time step guess
+    /// @brief                  Get initial time step guess
     ///
     /// @code
-    ///                     numericalSolver.getTimeStep() ;
+    ///                         numericalSolver.getTimeStep() ;
     /// @endcode
     ///
-    /// @return             Real
+    /// @return                 Real
 
     Real getTimeStep() const;
 
-    /// @brief              Get relative integration tolerance
+    /// @brief                  Get relative integration tolerance
     ///
     /// @code
-    ///                     numericalSolver.getRelativeTolerance() ;
+    ///                         numericalSolver.getRelativeTolerance() ;
     /// @endcode
     ///
-    /// @return             Real
+    /// @return                 Real
 
     Real getRelativeTolerance() const;
 
-    /// @brief              Get absolute integration tolerance
+    /// @brief                  Get absolute integration tolerance
     ///
     /// @code
-    ///                     numericalSolver.getAbsoluteTolerance() ;
+    ///                         numericalSolver.getAbsoluteTolerance() ;
     /// @endcode
     ///
-    /// @return             Real
+    /// @return                 Real
 
     Real getAbsoluteTolerance() const;
 
-    /// @brief              Get root solver
+    /// @brief                  Get root solver
     ///
     /// @code
-    ///                     numericalSolver.getRootSolver() ;
+    ///                         numericalSolver.getRootSolver() ;
     /// @endcode
     ///
-    /// @return             RootSolver
+    /// @return                 RootSolver
 
     RootSolver getRootSolver() const;
 
-    /// @brief              Perform numerical integration from a start time to an array of times
+    /// @brief                  Perform numerical integration from a start time to an array of times
     ///
     /// @code
-    ///                     Array<Solution> solutions =
-    ///                     numericalSolver.integrateTime(stateVector, startTime, timeArray, systemOfEquations);
+    ///                         Array<Solution> solutions =
+    ///                         numericalSolver.integrateTime(stateVector, startTime, timeArray, systemOfEquations);
     /// @endcode
     ///
-    /// @param              [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
-    /// @param              [in] aStartTime A time to begin integrating from
-    /// @param              [in] aTimeArray A array of times to integrate to
-    /// @param              [in] aSystemOfEquations A std::function wrapper with a particular signature that
-    /// boost::odeint accepts to perform numerical integration
-    /// @return             Array<Solution>
+    /// @param                  [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
+    /// @param                  [in] aStartTime A time to begin integrating from
+    /// @param                  [in] aTimeArray A array of times to integrate to
+    /// @param                  [in] aSystemOfEquations A std::function wrapper with a particular signature that
+    ///                         boost::odeint accepts to perform numerical integration
+    /// @return                 Array<Solution>
 
     Array<Solution> integrateTime(
         const StateVector& anInitialStateVector,
@@ -210,18 +210,18 @@ class NumericalSolver
         const SystemOfEquationsWrapper& aSystemOfEquations
     );
 
-    /// @brief              Perform numerical integration from a start time to an end time
+    /// @brief                  Perform numerical integration from a start time to an end time
     ///
     /// @code
-    ///                     Solution solution = numericalSolver.integrateTime(stateVector, startTime, endTime,
-    ///                     systemOfEquations);
+    ///                         Solution solution = numericalSolver.integrateTime(stateVector, startTime, endTime,
+    ///                         systemOfEquations);
     /// @endcode
-    /// @param              [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
-    /// @param              [in] aStartTime A time to begin integrating from
-    /// @param              [in] anEndTime An time to integrate to
-    /// @param              [in] aSystemOfEquations A std::function wrapper with a particular signature that
-    /// boost::odeint accepts to perform numerical integration
-    /// @return             Solution
+    /// @param                  [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
+    /// @param                  [in] aStartTime A time to begin integrating from
+    /// @param                  [in] anEndTime An time to integrate to
+    /// @param                  [in] aSystemOfEquations A std::function wrapper with a particular signature that
+    ///                         boost::odeint accepts to perform numerical integration
+    /// @return                 Solution
 
     Solution integrateTime(
         const StateVector& anInitialStateVector,
@@ -230,21 +230,21 @@ class NumericalSolver
         const SystemOfEquationsWrapper& aSystemOfEquations
     );
 
-    /// @brief              Perform numerical integration from a start time until either a condition or the end time is
-    /// reached
+    /// @brief                  Perform numerical integration from a start time
+    ///                         until either a condition or the end time is reached
     ///
     ///
     /// @code
-    ///                     StateVector stateVector = numericalSolver.integrateTime(stateVector,
-    ///                     aStartTime, anEndTime, SystemOfEquations, anEventCondition) ;
+    ///                         StateVector stateVector = numericalSolver.integrateTime(stateVector,
+    ///                         aStartTime, anEndTime, SystemOfEquations, anEventCondition) ;
     /// @endcode
-    /// @param              [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
-    /// @param              [in] aStartTime A time to begin integrating from
-    /// @param              [in] anEndTime A maximum time to to integrate to
-    /// @param              [in] aSystemOfEquations An std::function wrapper with a particular signature that
-    ///                     boost::odeint accepts to perform numerical integration
-    /// @param              [in] anEventCondition An event condition
-    /// @return             Solution
+    /// @param                  [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
+    /// @param                  [in] aStartTime A time to begin integrating from
+    /// @param                  [in] anEndTime A maximum time to to integrate to
+    /// @param                  [in] aSystemOfEquations An std::function wrapper with a particular signature that
+    ///                         boost::odeint accepts to perform numerical integration
+    /// @param                  [in] anEventCondition An event condition
+    /// @return                 Solution
 
     ConditionSolution integrateTime(
         const StateVector& anInitialStateVector,
@@ -254,17 +254,17 @@ class NumericalSolver
         const EventCondition& anEventCondition
     );
 
-    /// @brief              Perform numerical integration for a specified duration
+    /// @brief                  Perform numerical integration for a specified duration
     ///
     /// @code
-    ///                     Solution solution = numericalsolver.integrateTime(stateVector, durationSeconds,
-    ///                     SystemofEquations) ;
+    ///                         Solution solution = numericalsolver.integrateTime(stateVector, durationSeconds,
+    ///                         SystemofEquations) ;
     /// @endcode
-    /// @param              [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
-    /// @param              [in] aDurationInSeconds A duration over which to integrate
-    /// @param              [in] aSystemOfEquations A std::function wrapper with a particular signature that
-    ///                              boost::odeint accepts to perform numerical integration
-    /// @return             Solution
+    /// @param                  [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
+    /// @param                  [in] aDurationInSeconds A duration over which to integrate
+    /// @param                  [in] aSystemOfEquations A std::function wrapper with a particular signature that
+    ///                         boost::odeint accepts to perform numerical integration
+    /// @return                 Solution
 
     Solution integrateDuration(
         const StateVector& anInitialStateVector,
@@ -272,17 +272,17 @@ class NumericalSolver
         const SystemOfEquationsWrapper& aSystemOfEquations
     );
 
-    /// @brief              Perform numerical integration for an array of durations
+    /// @brief                  Perform numerical integration for an array of durations
     ///
     /// @code
-    ///                     Array<Solution> solutions = numericalsolver.integrateTime(stateVector, durationArray,
-    ///                     SystemofEquations);
+    ///                         Array<Solution> solutions = numericalsolver.integrateTime(stateVector, durationArray,
+    ///                         systemOfEquations);
     /// @endcode
-    /// @param              [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
-    /// @param              [in] aDurationArray An array of durations over which to integrate
-    /// @param              [in] aSystemOfEquations A std::function wrapper with a particular signature that
-    ///                              boost::odeint accepts to perform numerical integration
-    /// @return             Array<Solution>
+    /// @param                  [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
+    /// @param                  [in] aDurationArray An array of durations over which to integrate
+    /// @param                  [in] aSystemOfEquations A std::function wrapper with a particular signature that
+    ///                         boost::odeint accepts to perform numerical integration
+    /// @return                 Array<Solution>
 
     Array<Solution> integrateDuration(
         const StateVector& anInitialStateVector,
@@ -290,19 +290,20 @@ class NumericalSolver
         const SystemOfEquationsWrapper& aSystemOfEquations
     );
 
-    /// @brief              Perform numerical integration from a start time until either a condition or duration is met
+    /// @brief                  Perform numerical integration from a start time
+    ///                         until either a condition or duration is met
     ///
     ///
     /// @code
-    ///                     StateVector stateVector = numericalSolver.integrateDuration(stateVector,
-    ///                     aStartTime, aDurationInSeconds, SystemOfEquations, anEventCondition) ;
+    ///                         StateVector stateVector = numericalSolver.integrateDuration(stateVector,
+    ///                         aStartTime, aDurationInSeconds, SystemOfEquations, anEventCondition) ;
     /// @endcode
-    /// @param              [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
-    /// @param              [in] aDurationInSeconds A duration to integrate for
-    /// @param              [in] aSystemOfEquations An std::function wrapper with a particular signature that
-    ///                     boost::odeint accepts to perform numerical integration
-    /// @param              [in] anEventCondition An event condition
-    /// @return             Solution
+    /// @param                  [in] anInitialStateVector An initial n-dimensional state vector to begin integrating at
+    /// @param                  [in] aDurationInSeconds A duration to integrate for
+    /// @param                  [in] aSystemOfEquations An std::function wrapper with a particular signature that
+    ///                         boost::odeint accepts to perform numerical integration
+    /// @param                  [in] anEventCondition An event condition
+    /// @return                 Solution
 
     ConditionSolution integrateDuration(
         const StateVector& anInitialStateVector,
@@ -311,35 +312,35 @@ class NumericalSolver
         const EventCondition& anEventCondition
     );
 
-    /// @brief              Get string from the integration stepper type
+    /// @brief                  Get string from the integration stepper type
     ///
     /// @code
-    ///                     NumericalSolver::StringFromStepperType(aStepperType) ;
+    ///                         NumericalSolver::StringFromStepperType(aStepperType) ;
     /// @endcode
-    /// @param              [in] aStepperType An integration stepper type enum
-    /// @return             StepperType
+    /// @param                  [in] aStepperType An integration stepper type enum
+    /// @return                 StepperType
 
     static String StringFromStepperType(const NumericalSolver::StepperType& aStepperType);
 
-    /// @brief              Get string from the integration log type
+    /// @brief                  Get string from the integration log type
     ///
     /// @code
-    ///                     NumericalSolver::StringFromLogType(aLogType) ;
+    ///                         NumericalSolver::StringFromLogType(aLogType) ;
     /// @endcode
-    /// @param              [in] aLogType An integration log type enum
-    /// @return             LogType
+    /// @param                  [in] aLogType An integration log type enum
+    /// @return                 LogType
 
     static String StringFromLogType(const NumericalSolver::LogType& aLogType);
 
-    /// @brief              Undefined
+    /// @brief                  Undefined
     ///
-    /// @return             An undefined numerical solver
+    /// @return                 An undefined numerical solver
 
     static NumericalSolver Undefined();
 
-    /// @brief              Default
+    /// @brief                  Default
     ///
-    /// @return             A default numerical solver
+    /// @return                 A default numerical solver
 
     static NumericalSolver Default();
 

--- a/include/OpenSpaceToolkit/Astrodynamics/RootSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/RootSolver.hpp
@@ -30,7 +30,7 @@ class RootSolver
     ///                         RootSolver rootSolver = {aMaximumIterationCount, aDigitCount};
     /// @endcode
     ///
-    /// @param                  [in] aMaximumIterationCount The maximum iterations count for the solver
+    /// @param                  [in] aMaximumIterationCount The maximum iteration count for the solver
     /// @param                  [in] aDigitCount The number of digits
 
     RootSolver(const Size& aMaximumIterationCount, const Size& aDigitCount);

--- a/include/OpenSpaceToolkit/Astrodynamics/RootSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/RootSolver.hpp
@@ -21,84 +21,84 @@ class RootSolver
     struct Solution
     {
         Real root;
-        Size numberOfIterations;
+        Size iterationCount;
     };
 
-    /// @brief              Constructor
+    /// @brief                  Constructor
     ///
     /// @code
-    ///                     RootSolver rootSolver = {aMaximumIterationsCount, aNumberOfDigits};
+    ///                         RootSolver rootSolver = {aMaximumIterationCount, aDigitCount};
     /// @endcode
     ///
-    /// @param              [in] aMaximumIterationsCount The maximum iterations count for the solver
-    /// @param              [in] aNumberOfDigits The number of digits
+    /// @param                  [in] aMaximumIterationCount The maximum iterations count for the solver
+    /// @param                  [in] aDigitCount The number of digits
 
-    RootSolver(const Size& aMaximumIterationsCount, const Size& aNumberOfDigits);
+    RootSolver(const Size& aMaximumIterationCount, const Size& aDigitCount);
 
-    /// @brief              Virtual destructor
+    /// @brief                  Virtual destructor
 
     virtual ~RootSolver();
 
-    /// @brief              Output stream operator
+    /// @brief                  Output stream operator
     ///
-    /// @param              [in] anOutputStream An output stream
-    /// @param              [in] aRootSolver A Root Solver
-    /// @return             An output stream
+    /// @param                  [in] anOutputStream An output stream
+    /// @param                  [in] aRootSolver A Root Solver
+    /// @return                 An output stream
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const RootSolver& aRootSolver);
 
-    /// @brief              Get maximum iterations count
+    /// @brief                  Get maximum iterations count
     ///
-    /// @return             Maximum iterations count
+    /// @return                 Maximum iterations count
 
-    Size getMaximumIterationsCount() const;
+    Size getMaximumIterationCount() const;
 
-    /// @brief              Get number of digits of precision
+    /// @brief                  Get number of digits of precision
     ///
-    /// @return             Number of digits of precision
+    /// @return                 Number of digits of precision
 
-    Size getNumberOfDigits() const;
+    Size getDigitCount() const;
 
-    /// @brief              Solve for root given a function, an initial guess and function direction
+    /// @brief                  Solve for root given a function, an initial guess and function direction
     ///
-    /// @param              [in] aFunction A function
-    /// @param              [in] anInitialGuess An initial guess
-    /// @param              [in] isRising A boolean indicating whether the function is rising
+    /// @param                  [in] aFunction A function
+    /// @param                  [in] anInitialGuess An initial guess
+    /// @param                  [in] isRising A boolean indicating whether the function is rising
     ///
-    /// @return             The solution
+    /// @return                 The solution
 
     Solution solve(
         const std::function<double(const double&)>& aFunction, const double& anInitialGuess, const bool& isRising
     ) const;
 
-    /// @brief              Solve for root given a function, and bounds
+    /// @brief                  Solve for root given a function, and bounds
     ///
-    /// @param              [in] aFunction A function
-    /// @param              [in] aLowerBound A lower bound
-    /// @param              [in] anUpperBound An upper bound
+    /// @param                  [in] aFunction A function
+    /// @param                  [in] aLowerBound A lower bound
+    /// @param                  [in] anUpperBound An upper bound
     ///
-    /// @return             The solution
+    /// @return                 The solution
 
     Solution solve(
         const std::function<double(const double&)>& aFunction, const double& aLowerBound, const double& anUpperBound
     ) const;
 
-    /// @brief              Print root solver
+    /// @brief                  Print root solver
     ///
-    /// @param              [in] anOutputStream An output stream
-    /// @param              [in] (optional) displayDecorators If true, display decorators
+    /// @param                  [in] anOutputStream An output stream
+    /// @param                  [in] (optional) displayDecorators If true, display decorators
 
     void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
-    /// @brief              Default root solver
+    /// @brief                  Default root solver
     ///
-    /// @return             Default root solver
+    /// @return                 Default root solver
 
     static RootSolver Default();
 
    private:
-    Size maximumIterationsCount_;
-    Size numberOfDigits_;
+    Size maximumIterationCount_;
+    Size digitCount_;
 
     static constexpr double factor_ = 2.0;
 };

--- a/src/OpenSpaceToolkit/Astrodynamics/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/NumericalSolver.cpp
@@ -512,7 +512,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateDuration(
     return {
         {solutionState, solutionTime},
         true,
-        solution.numberOfIterations,
+        solution.iterationCount,
     };
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/RootSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/RootSolver.cpp
@@ -12,9 +12,9 @@ namespace ostk
 namespace astro
 {
 
-RootSolver::RootSolver(const Size& aMaximumIterationsCount, const Size& aNumberOfDigits)
-    : maximumIterationsCount_(aMaximumIterationsCount),
-      numberOfDigits_(aNumberOfDigits)
+RootSolver::RootSolver(const Size& aMaximumIterationCount, const Size& aDigitCount)
+    : maximumIterationCount_(aMaximumIterationCount),
+      digitCount_(aDigitCount)
 {
 }
 
@@ -27,22 +27,22 @@ std::ostream& operator<<(std::ostream& anOutputStream, const RootSolver& aRootSo
     return anOutputStream;
 }
 
-Size RootSolver::getMaximumIterationsCount() const
+Size RootSolver::getMaximumIterationCount() const
 {
-    return maximumIterationsCount_;
+    return maximumIterationCount_;
 }
 
-Size RootSolver::getNumberOfDigits() const
+Size RootSolver::getDigitCount() const
 {
-    return numberOfDigits_;
+    return digitCount_;
 }
 
 RootSolver::Solution RootSolver::solve(
     const std::function<double(const double&)>& aFunction, const double& anInitialGuess, const bool& isRising
 ) const
 {
-    const boost::math::tools::eps_tolerance<double> tolerance(numberOfDigits_);
-    std::uintmax_t iteratorCount = maximumIterationsCount_;
+    const boost::math::tools::eps_tolerance<double> tolerance(digitCount_);
+    std::uintmax_t iteratorCount = maximumIterationCount_;
 
     std::pair<Real, Real> r = boost::math::tools::bracket_and_solve_root(
         aFunction, anInitialGuess, factor_, isRising, tolerance, iteratorCount
@@ -61,9 +61,8 @@ RootSolver::Solution RootSolver::solve(
     // account for the fact that the function may be decreasing
     const double lowerBound = std::min(aLowerBound, anUpperBound);
     const double upperBound = std::max(aLowerBound, anUpperBound);
-
-    std::uintmax_t iteratorCount = maximumIterationsCount_;
-    const boost::math::tools::eps_tolerance<double> tolerance(numberOfDigits_);
+    std::uintmax_t iteratorCount = maximumIterationCount_;
+    const boost::math::tools::eps_tolerance<double> tolerance(digitCount_);
 
     std::pair<Real, Real> r =
         boost::math::tools::toms748_solve(aFunction, lowerBound, upperBound, tolerance, iteratorCount);
@@ -78,8 +77,8 @@ void RootSolver::print(std::ostream& anOutputStream, bool displayDecorator) cons
 {
     displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Root Solver") : void();
 
-    ostk::core::utils::Print::Line(anOutputStream) << "Maximum Iterations Count:" << maximumIterationsCount_;
-    ostk::core::utils::Print::Line(anOutputStream) << "Number of Digits:" << numberOfDigits_;
+    ostk::core::utils::Print::Line(anOutputStream) << "Maximum Iterations Count:" << maximumIterationCount_;
+    ostk::core::utils::Print::Line(anOutputStream) << "Number of Digits:" << digitCount_;
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
@@ -644,7 +644,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateDuration_Conditi
 
                 EXPECT_DOUBLE_EQ(duration, solution.second);
                 EXPECT_FALSE(conditionSolution.conditionIsSatisfied);
-                EXPECT_EQ(conditionSolution.numberOfIterations, 0);
+                EXPECT_EQ(conditionSolution.iterationCount, 0);
             }
 
             const DurationCondition condition = DurationCondition(duration / 2.0, criteria);
@@ -733,7 +733,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateTime_Conditions)
 
                 EXPECT_DOUBLE_EQ(solution.second, endTime);
                 EXPECT_FALSE(conditionSolution.conditionIsSatisfied);
-                EXPECT_EQ(conditionSolution.numberOfIterations, 0);
+                EXPECT_EQ(conditionSolution.iterationCount, 0);
             }
 
             const DurationCondition condition = DurationCondition(duration / 2.0, criteria);

--- a/test/OpenSpaceToolkit/Astrodynamics/RootSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/RootSolver.test.cpp
@@ -34,12 +34,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_RootSolver, StreamOperator)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_RootSolver, GetMaximumNumberOfIterations)
 {
-    EXPECT_EQ(defaultMaxIterations_, defaultRootSolver_.getMaximumIterationsCount());
+    EXPECT_EQ(defaultMaxIterations_, defaultRootSolver_.getMaximumIterationCount());
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_RootSolver, GetNumberOfDigits)
+TEST_F(OpenSpaceToolkit_Astrodynamics_RootSolver, GetDigitCount)
 {
-    EXPECT_EQ(defaultNumDigits_, defaultRootSolver_.getNumberOfDigits());
+    EXPECT_EQ(defaultNumDigits_, defaultRootSolver_.getDigitCount());
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_RootSolver, Solve_WithFunctionAndInitialGuess)


### PR DESCRIPTION
This PR proposes a naming realignment (for consistency w/ rest of codebase):

- `numberOfSomething` -> `somethingCount`
- `someObjectsCount` -> `someObjectCount`

On top, it fixes some typos in the documentation.