### PR TITLE
refactor: remove boost from headers in NumericalSolver

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
@@ -14,19 +14,6 @@
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/RootSolver.hpp>
 
-// TBI: Move this to eigen.hpp when we move this file to ostk mathematics
-// namespace boost::numeric::odeint
-// {
-
-// template <>
-// struct is_resizeable<ostk::math::obj::VectorXd>
-// {
-//     typedef boost::true_type type;
-//     static const bool value = type::value;
-// };
-
-// }  // namespace boost::numeric::odeint
-
 namespace ostk
 {
 namespace astro

--- a/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
@@ -50,11 +50,11 @@ class NumericalSolver
         LogAdaptive
     };
 
-    typedef VectorXd StateVector;                // Container used to hold the state vector
+    typedef VectorXd StateVector;  // Container used to hold the state vector
 
     typedef Pair<StateVector, double> Solution;  // Container used to hold the state vector and time
     typedef std::function<void(const StateVector&, StateVector&, const double)>
-        SystemOfEquationsWrapper;                // Function pointer type for returning dynamical equation's pointers
+        SystemOfEquationsWrapper;  // Function pointer type for returning dynamical equation's pointers
 
     struct ConditionSolution
     {

--- a/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
@@ -3,9 +3,6 @@
 #ifndef __OpenSpaceToolkit_Astrodynamics_NumericalSolver__
 #define __OpenSpaceToolkit_Astrodynamics_NumericalSolver__
 
-#include <boost/numeric/odeint.hpp>
-#include <boost/numeric/odeint/external/eigen/eigen_algebra.hpp>
-
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Containers/Pair.hpp>
 #include <OpenSpaceToolkit/Core/Types/Integer.hpp>
@@ -18,17 +15,17 @@
 #include <OpenSpaceToolkit/Astrodynamics/RootSolver.hpp>
 
 // TBI: Move this to eigen.hpp when we move this file to ostk mathematics
-namespace boost::numeric::odeint
-{
+// namespace boost::numeric::odeint
+// {
 
-template <>
-struct is_resizeable<ostk::math::obj::VectorXd>
-{
-    typedef boost::true_type type;
-    static const bool value = type::value;
-};
+// template <>
+// struct is_resizeable<ostk::math::obj::VectorXd>
+// {
+//     typedef boost::true_type type;
+//     static const bool value = type::value;
+// };
 
-}  // namespace boost::numeric::odeint
+// }  // namespace boost::numeric::odeint
 
 namespace ostk
 {
@@ -66,11 +63,11 @@ class NumericalSolver
         LogAdaptive
     };
 
-    typedef VectorXd StateVector;  // Container used to hold the state vector
+    typedef VectorXd StateVector;                // Container used to hold the state vector
 
     typedef Pair<StateVector, double> Solution;  // Container used to hold the state vector and time
     typedef std::function<void(const StateVector&, StateVector&, const double)>
-        SystemOfEquationsWrapper;  // Function pointer type for returning dynamical equation's pointers
+        SystemOfEquationsWrapper;                // Function pointer type for returning dynamical equation's pointers
 
     struct ConditionSolution
     {

--- a/src/OpenSpaceToolkit/Astrodynamics/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/NumericalSolver.cpp
@@ -1,5 +1,8 @@
 /// Apache License 2.0
 
+#include <boost/numeric/odeint.hpp>
+#include <boost/numeric/odeint/external/eigen/eigen.hpp>
+
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utilities.hpp>
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/AtmosphericDrag.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/AtmosphericDrag.test.cpp
@@ -1,6 +1,7 @@
 /// Apache License 2.0
 
 #include <boost/numeric/odeint.hpp>
+#include <boost/numeric/odeint/external/eigen/eigen.hpp>
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/CentralBodyGravity.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/CentralBodyGravity.test.cpp
@@ -1,6 +1,7 @@
 /// Apache License 2.0
 
 #include <boost/numeric/odeint.hpp>
+#include <boost/numeric/odeint/external/eigen/eigen.hpp>
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/ThirdBodyGravity.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/ThirdBodyGravity.test.cpp
@@ -1,6 +1,7 @@
 /// Apache License 2.0
 
 #include <boost/numeric/odeint.hpp>
+#include <boost/numeric/odeint/external/eigen/eigen.hpp>
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>


### PR DESCRIPTION
I found the boost header which has all the templates for VectorXd 👍 