### PR TITLE
feat: add Temporal Condition Solver

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy.cxx
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy.cxx
@@ -14,6 +14,7 @@
 #include <OpenSpaceToolkitAstrodynamicsPy/Flight.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/NumericalSolver.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp>
+#include <OpenSpaceToolkitAstrodynamicsPy/Solvers.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp>
 
 PYBIND11_MODULE(OpenSpaceToolkitAstrodynamicsPy, m)
@@ -40,6 +41,7 @@ PYBIND11_MODULE(OpenSpaceToolkitAstrodynamicsPy, m)
     OpenSpaceToolkitAstrodynamicsPy_Access(m);
     OpenSpaceToolkitAstrodynamicsPy_Conjunction(m);
     // [TBI] These modules will likely be moved to ostk-mathematics in a future version
+    OpenSpaceToolkitAstrodynamicsPy_Solvers(m);
     OpenSpaceToolkitAstrodynamicsPy_NumericalSolver(m);
     OpenSpaceToolkitAstrodynamicsPy_EventCondition(m);
     OpenSpaceToolkitAstrodynamicsPy_RootSolver(m);

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
@@ -42,7 +42,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
 
         .def("get_step", &Generator::getStep)
         .def("get_tolerance", &Generator::getTolerance)
+        .def("get_aer_filter", &Generator::getAerFilter)
+        .def("get_access_filter", &Generator::getAccessFilter)
+        .def("get_state_filter", &Generator::getStateFilter)
 
+        .def("get_condition_function", &Generator::getConditionFunction, arg("from_trajectory"), arg("to_trajectory"))
         .def(
             "compute_accesses",
             &Generator::computeAccesses,

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers.cpp
@@ -1,0 +1,15 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkitAstrodynamicsPy/Solvers/TemporalConditionSolver.cpp>
+
+inline void OpenSpaceToolkitAstrodynamicsPy_Solvers(pybind11::module& aModule)
+{
+    // Create "solvers" python submodule
+    auto solvers = aModule.def_submodule("solvers");
+
+    // Add __path__ attribute for "solvers" submodule
+    solvers.attr("__path__") = "ostk.astrodynamics.solvers";
+
+    // Add objects to "solvers" submodule
+    OpenSpaceToolkitAstrodynamicsPy_Solvers_TemporalConditionSolver(solvers);
+}

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/TemporalConditionSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/TemporalConditionSolver.cpp
@@ -1,0 +1,51 @@
+/// Apache License 2.0
+
+#include <pybind11/functional.h>  // To pass anonymous functions directly
+
+#include <OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.hpp>
+
+inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_TemporalConditionSolver(pybind11::module& aModule)
+{
+    using namespace pybind11;
+
+    using ostk::core::types::Size;
+    using ostk::core::ctnr::Array;
+
+    using ostk::physics::time::Duration;
+    using ostk::physics::time::Interval;
+
+    using ostk::astro::solvers::TemporalConditionSolver;
+
+    class_<TemporalConditionSolver>(aModule, "TemporalConditionSolver")
+
+        .def(
+            init<const Duration&, const Duration&, const Size&>(),
+            arg("time_step"),
+            arg("tolerance"),
+            arg("maximum_iteration_count") = DEFAULT_MAXIMUM_ITERATION_COUNT
+        )
+
+        .def("get_time_step", &TemporalConditionSolver::getTimeStep)
+        .def("get_tolerance", &TemporalConditionSolver::getTolerance)
+        .def("get_maximum_iteration_count", &TemporalConditionSolver::getMaximumIterationCount)
+
+        .def(
+            "solve",
+            overload_cast<const TemporalConditionSolver::Condition&, const Interval&>(
+                &TemporalConditionSolver::solve, const_
+            ),
+            arg("condition"),
+            arg("interval")
+        )
+
+        .def(
+            "solve",
+            overload_cast<const Array<TemporalConditionSolver::Condition>&, const Interval&>(
+                &TemporalConditionSolver::solve, const_
+            ),
+            arg("conditions"),
+            arg("interval")
+        )
+
+        ;
+}

--- a/bindings/python/test/solvers/__init__.py
+++ b/bindings/python/test/solvers/__init__.py
@@ -1,0 +1,1 @@
+# Apache License 2.0

--- a/bindings/python/test/solvers/test_temporal_condition_solver.py
+++ b/bindings/python/test/solvers/test_temporal_condition_solver.py
@@ -1,0 +1,153 @@
+# Apache License 2.0
+
+import pytest
+
+from ostk.physics.units import Length
+from ostk.physics.units import Angle
+from ostk.physics.time import Instant
+from ostk.physics.time import Duration
+from ostk.physics.time import Interval
+from ostk.physics.time import DateTime
+from ostk.physics.time import Scale
+from ostk.physics import Environment
+
+from ostk.astrodynamics.trajectory import Orbit
+from ostk.astrodynamics.trajectory.orbit.models import Kepler
+from ostk.astrodynamics.trajectory.orbit.models.kepler import COE
+from ostk.astrodynamics.access import Generator
+from ostk.astrodynamics.solvers import TemporalConditionSolver
+
+
+@pytest.fixture
+def temporal_condition_solver() -> TemporalConditionSolver:
+    return TemporalConditionSolver(
+        time_step=Duration.seconds(30.0),
+        tolerance=Duration.milliseconds(1.0),
+        maximum_iteration_count=1234,
+    )
+
+
+@pytest.fixture
+def interval() -> Interval:
+    return Interval.closed(
+        Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC),
+        Instant.date_time(DateTime(2018, 1, 1, 2, 0, 0), Scale.UTC),
+    )
+
+
+class TestTemporalConditionSolver:
+    def test_constructor_success(self):
+        temporal_condition_solver = TemporalConditionSolver(
+            time_step=Duration.seconds(30.0),
+            tolerance=Duration.milliseconds(1.0),
+            maximum_iteration_count=1234,
+        )
+
+        assert isinstance(temporal_condition_solver, TemporalConditionSolver)
+
+    def test_getters_success(
+        self,
+        temporal_condition_solver: TemporalConditionSolver,
+    ):
+        assert temporal_condition_solver.get_time_step() == Duration.seconds(30.0)
+        assert temporal_condition_solver.get_tolerance() == Duration.milliseconds(1.0)
+        assert temporal_condition_solver.get_maximum_iteration_count() == 1234
+
+    def test_solve_success_one_condition_always_true(
+        self,
+        temporal_condition_solver: TemporalConditionSolver,
+        interval: Interval,
+    ):
+        solution: list[Interval] = temporal_condition_solver.solve(
+            condition=lambda _: True,
+            interval=interval,
+        )
+
+        assert isinstance(solution, list)
+        assert solution == [interval]
+
+    def test_solve_success_one_condition_always_false(
+        self,
+        temporal_condition_solver: TemporalConditionSolver,
+        interval: Interval,
+    ):
+        solution: list[Interval] = temporal_condition_solver.solve(
+            condition=lambda _: False,
+            interval=interval,
+        )
+
+        assert isinstance(solution, list)
+        assert solution == []
+
+    def test_solve_success_multiple_conditions_always_true(
+        self,
+        temporal_condition_solver: TemporalConditionSolver,
+        interval: Interval,
+    ):
+        solution: list[Interval] = temporal_condition_solver.solve(
+            conditions=[
+                lambda _: True,
+                lambda _: True,
+            ],
+            interval=interval,
+        )
+
+        assert isinstance(solution, list)
+        assert solution == [interval]
+
+    def test_solve_success_multiple_conditions_one_always_false(
+        self,
+        temporal_condition_solver: TemporalConditionSolver,
+        interval: Interval,
+    ):
+        solution: list[Interval] = temporal_condition_solver.solve(
+            conditions=[
+                lambda _: True,
+                lambda _: False,
+            ],
+            interval=interval,
+        )
+
+        assert isinstance(solution, list)
+        assert solution == []
+
+    def test_solve_success_using_access_generator(
+        self,
+        temporal_condition_solver: TemporalConditionSolver,
+        interval: Interval,
+    ):
+        environment = Environment.default()
+
+        generator = Generator(
+            environment=environment,
+        )
+
+        earth = environment.access_celestial_object_with_name("Earth")
+
+        trajectory = Orbit(
+            model=Kepler(
+                coe=COE(
+                    semi_major_axis=Length.kilometers(7000.0),
+                    eccentricity=0.0,
+                    inclination=Angle.degrees(45.0),
+                    raan=Angle.degrees(0.0),
+                    aop=Angle.degrees(0.0),
+                    true_anomaly=Angle.degrees(0.0),
+                ),
+                epoch=Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC),
+                celestial_object=earth,
+                perturbation_type=Kepler.PerturbationType.No,
+            ),
+            celestial_object=earth,
+        )
+
+        solution: list[Interval] = temporal_condition_solver.solve(
+            condition=generator.get_condition_function(
+                from_trajectory=trajectory,
+                to_trajectory=trajectory,
+            ),
+            interval=interval,
+        )
+
+        assert isinstance(solution, list)
+        assert solution == [interval]

--- a/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
@@ -101,13 +101,13 @@ class Generator
 
     static Generator Undefined();
 
-    /// @brief              Constructs an access generator with defined AER ranges
+    /// @brief                  Constructs an access generator with defined AER ranges
     ///
-    /// @param              [in] anAzimuthRange An azimuth interval [deg]
-    /// @param              [in] anElevationRange An elevation interval [deg]
-    /// @param              [in] aRangeRange A range interval [m]
-    /// @param              [in] anEnvironment An environment
-    /// @return             An access generator
+    /// @param                  [in] anAzimuthRange An azimuth interval [deg]
+    /// @param                  [in] anElevationRange An elevation interval [deg]
+    /// @param                  [in] aRangeRange A range interval [m]
+    /// @param                  [in] anEnvironment An environment
+    /// @return                 An access generator
 
     static Generator AerRanges(
         const Interval<Real>& anAzimuthRange,
@@ -116,12 +116,12 @@ class Generator
         const Environment& anEnvironment
     );
 
-    /// @brief              Constructs an access generator with a defined AER mask
+    /// @brief                  Constructs an access generator with a defined AER mask
     ///
-    /// @param              [in] anAzimuthElevationMask An azimuth-elevation mask [deg]
-    /// @param              [in] aRangeRange A range interval [m]
-    /// @param              [in] anEnvironment An environment
-    /// @return             An access generator
+    /// @param                  [in] anAzimuthElevationMask An azimuth-elevation mask [deg]
+    /// @param                  [in] aRangeRange A range interval [m]
+    /// @param                  [in] anEnvironment An environment
+    /// @return                 An access generator
 
     static Generator AerMask(
         const Map<Real, Real>& anAzimuthElevationMask,

--- a/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp
@@ -292,7 +292,7 @@ class NumericalSolver
     );
 
     /// @brief                  Perform numerical integration from a start time
-    ///                         until either a condition or duration is met
+    ///                         until either a condition or duration is met.
     ///
     ///
     /// @code

--- a/include/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.hpp
@@ -1,0 +1,93 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkit_Astrodynamics_Solvers_TemporalConditionSolver__
+#define __OpenSpaceToolkit_Astrodynamics_Solvers_TemporalConditionSolver__
+
+#include <OpenSpaceToolkit/Core/Containers/Array.hpp>
+#include <OpenSpaceToolkit/Core/Types/Size.hpp>
+
+#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace solvers
+{
+
+using ostk::core::types::Size;
+using ostk::core::ctnr::Array;
+
+using ostk::physics::time::Instant;
+using ostk::physics::time::Duration;
+using ostk::physics::time::Interval;
+
+#define DEFAULT_MAXIUM_ITERATION_COUNT 500
+
+/// @brief                      Given a set of conditions and a time interval,
+///                             this solver computes all sub-intervals over which conditions are met.
+class TemporalConditionSolver
+{
+   public:
+    typedef std::function<bool(const Instant&)> Condition;
+
+    /// @brief                  Constructor
+    ///
+    /// @code
+    ///                         TemporalConditionSolver temporalConditionSolver = { Duration::Minutes(1.0),
+    ///                         Duration::Microseconds(1.0) };
+    /// @endcode
+    ///
+    /// @param                  [in] aTimeStep A time step used to generate the temporal grid.
+    /// @param                  [in] aTolerance A temporal tolerance used to determine the switching instant.
+    /// @param                  [in] aMaximumIterationCount The maximum iteration count for the solver.
+
+    TemporalConditionSolver(
+        const Duration& aTimeStep,
+        const Duration& aTolerance,
+        const Size& aMaximumIterationCount = DEFAULT_MAXIUM_ITERATION_COUNT
+    );
+
+    /// @brief                  Find the intervals over which the provided condition is true.
+    ///
+    /// @param                  [in] aCondition A temporal condition.
+    /// @param                  [in] anInterval A time interval within which to perform the search.
+    ///
+    /// @return                 An array of time intervals.
+
+    Array<Interval> solve(const TemporalConditionSolver::Condition& aCondition, const Interval& anInterval) const;
+
+    /// @brief                  Find the intervals over which all provided conditions are true.
+    ///
+    /// @param                  [in] aConditionArray An array of temporal conditions.
+    /// @param                  [in] anInterval A time interval within which to perform the search.
+    ///
+    /// @return                 An array of time intervals.
+
+    Array<Interval> solve(const Array<TemporalConditionSolver::Condition>& aConditionArray, const Interval& anInterval)
+        const;
+
+   private:
+    Duration timeStep_;
+    Duration tolerance_;
+    Size maximumIterationCount_;
+
+    Instant findSwitchingInstant(
+        const Instant& aPreviousInstant,
+        const Instant& aNextInstant,
+        const bool isConditionTrueAtPreviousInstant,
+        const Array<TemporalConditionSolver::Condition>& aConditionArray
+    ) const;
+
+    static bool EvaluateConditionAt(
+        const Instant& anInstant, const Array<TemporalConditionSolver::Condition>& aConditionArray
+    );
+};
+
+}  // namespace solvers
+}  // namespace astro
+}  // namespace ostk
+
+#endif

--- a/include/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.hpp
@@ -24,7 +24,7 @@ using ostk::physics::time::Instant;
 using ostk::physics::time::Duration;
 using ostk::physics::time::Interval;
 
-#define DEFAULT_MAXIUM_ITERATION_COUNT 500
+#define DEFAULT_MAXIMUM_ITERATION_COUNT 500
 
 /// @brief                      Given a set of conditions and a time interval,
 ///                             this solver computes all sub-intervals over which conditions are met.
@@ -47,7 +47,7 @@ class TemporalConditionSolver
     TemporalConditionSolver(
         const Duration& aTimeStep,
         const Duration& aTolerance,
-        const Size& aMaximumIterationCount = DEFAULT_MAXIUM_ITERATION_COUNT
+        const Size& aMaximumIterationCount = DEFAULT_MAXIMUM_ITERATION_COUNT
     );
 
     /// @brief                  Find the intervals over which the provided condition is true.

--- a/include/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.hpp
@@ -50,6 +50,24 @@ class TemporalConditionSolver
         const Size& aMaximumIterationCount = DEFAULT_MAXIMUM_ITERATION_COUNT
     );
 
+    /// @brief                  Get the time step.
+    ///
+    /// @return                 Time step.
+
+    Duration getTimeStep() const;
+
+    /// @brief                  Get the tolerance.
+    ///
+    /// @return                 Tolerance.
+
+    Duration getTolerance() const;
+
+    /// @brief                  Get the maximum iteration count.
+    ///
+    /// @return                 Maximum iteration count.
+
+    Size getMaximumIterationCount() const;
+
     /// @brief                  Find the intervals over which the provided condition is true.
     ///
     /// @param                  [in] aCondition A temporal condition.
@@ -77,7 +95,6 @@ class TemporalConditionSolver
     Instant findSwitchingInstant(
         const Instant& aPreviousInstant,
         const Instant& aNextInstant,
-        const bool isConditionTrueAtPreviousInstant,
         const Array<TemporalConditionSolver::Condition>& aConditionArray
     ) const;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -383,7 +383,8 @@ Instant Generator::FindTimeOfClosestApproach(
         {
             return GeneratorContext::GetStatesAt(anInstant, aFromTrajectory, aToTrajectory);
         },
-        GeneratorContext::GetPositionsFromStates};
+        GeneratorContext::GetPositionsFromStates
+    };
 
     nlopt::opt optimizer = {nlopt::LN_COBYLA, 1};
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Conjunction/Messages/CCSDS/CDM.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Conjunction/Messages/CCSDS/CDM.cpp
@@ -344,7 +344,8 @@ CDM CDM::Undefined()
          Real::Undefined(),
          String::Empty()},
         Array<CDM::Metadata>::Empty(),
-        Array<CDM::Data>::Empty()};
+        Array<CDM::Data>::Empty()
+    };
 }
 
 CDM CDM::Dictionary(const ctnr::Dictionary& aDictionary)
@@ -391,7 +392,8 @@ CDM CDM::Dictionary(const ctnr::Dictionary& aDictionary)
         ),
         aDictionary["ORIGINATOR"].getString(),
         aDictionary["MESSAGE_FOR"].getString(),
-        aDictionary["CDM_ID"].getString()};
+        aDictionary["CDM_ID"].getString()
+    };
 
     // Extract Conjunction Relative Metadata
 
@@ -411,7 +413,8 @@ CDM CDM::Dictionary(const ctnr::Dictionary& aDictionary)
         Instant::Undefined(),
         Instant::Undefined(),
         Real::Parse(aDictionary["COLLISION_PROBABILITY"].accessString()),
-        aDictionary["COLLISION_PROBABILITY_METHOD"].accessString()};
+        aDictionary["COLLISION_PROBABILITY_METHOD"].accessString()
+    };
 
     // Extract Conjunction Objects Metadata
 
@@ -439,7 +442,8 @@ CDM CDM::Dictionary(const ctnr::Dictionary& aDictionary)
         String::Empty(),
         false,
         false,
-        false};
+        false
+    };
 
     // Extract Object 2 Metadata
 
@@ -465,7 +469,8 @@ CDM CDM::Dictionary(const ctnr::Dictionary& aDictionary)
         String::Empty(),
         false,
         false,
-        false};
+        false
+    };
 
     Array<CDM::Metadata> metadataArray = {sat1ObjectMetadata, sat2ObjectMetadata};
 
@@ -543,7 +548,8 @@ CDM CDM::Dictionary(const ctnr::Dictionary& aDictionary)
                 sat1RefFramePtr
             )
         ),
-        object1CovarianceMatrix};
+        object1CovarianceMatrix
+    };
 
     // Extract Object 2 Data
 
@@ -617,7 +623,8 @@ CDM CDM::Dictionary(const ctnr::Dictionary& aDictionary)
                 sat2RefFramePtr
             )
         ),
-        object2CovarianceMatrix};
+        object2CovarianceMatrix
+    };
 
     Array<CDM::Data> dataArray = {sat1ObjectData, sat2ObjectData};
 
@@ -645,7 +652,8 @@ CDM::ObjectType CDM::ObjectTypeFromString(const String& aString)
         {"ROCKET BODY", CDM::ObjectType::RocketBody},
         {"DEBRIS", CDM::ObjectType::Debris},
         {"UNKNOWN", CDM::ObjectType::Unknown},
-        {"OTHER", CDM::ObjectType::Other}};
+        {"OTHER", CDM::ObjectType::Other}
+    };
 
     try
     {

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Models/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Models/Tabulated.cpp
@@ -97,17 +97,20 @@ State Tabulated::calculateStateAt(const Instant& anInstant) const
                     ratio * (nextState.accessPosition().accessCoordinates() -
                              previousState.accessPosition().accessCoordinates()),
                 previousState.accessPosition().getUnit(),
-                previousState.accessPosition().accessFrame()},
+                previousState.accessPosition().accessFrame()
+            },
             Velocity {
                 previousState.accessVelocity().accessCoordinates() +
                     ratio * (nextState.accessVelocity().accessCoordinates() -
                              previousState.accessVelocity().accessCoordinates()),
                 previousState.accessVelocity().getUnit(),
-                previousState.accessVelocity().accessFrame()},
+                previousState.accessVelocity().accessFrame()
+            },
             Quaternion::SLERP(previousState.accessAttitude(), nextState.accessAttitude(), ratio),
             previousState.accessAngularVelocity() +
                 ratio * (nextState.accessAngularVelocity() - previousState.accessAngularVelocity()),
-            previousState.getFrame()};
+            previousState.getFrame()
+        };
     }
     else if (stateRange.first != nullptr)
     {

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Models/Transform.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Models/Transform.cpp
@@ -64,7 +64,8 @@ State Transform::calculateStateAt(const Instant& anInstant) const
         Velocity::MetersPerSecond(v_REF_in_REF, this->frameSPtr_),
         q_B_REF,
         w_B_REF_in_B,
-        this->frameSPtr_};
+        this->frameSPtr_
+    };
 }
 
 Axes Transform::getAxesAt(const Instant& anInstant) const
@@ -105,7 +106,8 @@ Shared<const Frame> Transform::getBodyFrame(const String& aFrameName) const
         [this](const Instant& anInstant) -> Transform
         {
             return this->transformProvider_.getTransformAt(anInstant).getInverse();
-        }};
+        }
+    };
 
     return Frame::Construct(
         aFrameName, false, this->frameSPtr_, std::make_shared<const DynamicProvider>(dynamicTransformProvider)
@@ -149,7 +151,8 @@ Transform Transform::InertialPointing(const Trajectory& aTrajectory, const Quate
             const Vector3d v_GCRF = trajectoryState.getVelocity().getCoordinates();
 
             return Transform::Passive(anInstant, x_GCRF, v_GCRF, aQuaternion, {0.0, 0.0, 0.0});
-        }};
+        }
+    };
 
     return {dynamicTransformProvider, Frame::GCRF()};
 }
@@ -178,7 +181,8 @@ Transform Transform::NadirPointing(
             static const Shared<const Frame> gcrfSPtr = Frame::GCRF();
 
             return orbitalFrameSPtr->getTransformTo(gcrfSPtr, anInstant);
-        }};
+        }
+    };
 
     return {dynamicTransformProvider, Frame::GCRF()};
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/State.cpp
@@ -216,7 +216,8 @@ State State::Undefined()
         Velocity::Undefined(),
         Quaternion::Undefined(),
         Vector3d::Undefined(),
-        Frame::Undefined()};
+        Frame::Undefined()
+    };
 }
 
 }  // namespace profile

--- a/src/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.cpp
@@ -1,0 +1,192 @@
+/// Apache License 2.0
+
+#include <boost/math/tools/roots.hpp>
+
+#include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Utilities.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/RootSolver.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace solvers
+{
+
+TemporalConditionSolver::TemporalConditionSolver(
+    const Duration& aTimeStep, const Duration& aTolerance, const Size& aMaximumIterationCount
+)
+    : timeStep_(aTimeStep),
+      tolerance_(aTolerance),
+      maximumIterationCount_(aMaximumIterationCount)
+{
+}
+
+Array<Interval> TemporalConditionSolver::solve(
+    const TemporalConditionSolver::Condition& aCondition, const Interval& anInterval
+) const
+{
+    return this->solve(Array<TemporalConditionSolver::Condition>({aCondition}), anInterval);
+}
+
+Array<Interval> TemporalConditionSolver::solve(
+    const Array<TemporalConditionSolver::Condition>& aConditionArray, const Interval& anInterval
+) const
+{
+    if (!anInterval.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Interval");
+    }
+
+    Array<Interval> intervals = Array<Interval>::Empty();
+
+    using ostk::physics::time::Scale;
+
+    const Array<Instant> instants = anInterval.generateGrid(timeStep_);
+
+    bool inCondition = false;
+    Instant conditionStartCache = Instant::Undefined();
+    Instant previousInstantCache = Instant::Undefined();
+
+    for (const auto& instant : instants)
+    {
+        const bool conditionIsTrue = TemporalConditionSolver::EvaluateConditionAt(instant, aConditionArray);
+
+        // If this is the first iteration
+        if (!previousInstantCache.isDefined())
+        {
+            inCondition = conditionIsTrue;
+            if (conditionIsTrue)
+            {
+                conditionStartCache = instant;
+            }
+        }
+        else
+        {
+            const bool conditionIsSwitching = (conditionIsTrue != inCondition);
+
+            if (conditionIsSwitching)
+            {
+                const Instant switchingInstant =
+                    this->findSwitchingInstant(previousInstantCache, instant, !conditionIsTrue, aConditionArray);
+
+                if (conditionIsTrue)
+                {
+                    conditionStartCache = switchingInstant;
+                }
+                else
+                {
+                    intervals.add(Interval::Closed(conditionStartCache, switchingInstant));
+                    conditionStartCache = Instant::Undefined();
+                }
+
+                inCondition = conditionIsTrue;
+            }
+        }
+
+        previousInstantCache = instant;
+    }
+
+    // Add interval if condition is true on the last iteration
+    if (inCondition)
+    {
+        intervals.add(Interval::Closed(conditionStartCache, instants.accessLast()));
+    }
+
+    return intervals;
+}
+
+// Instant TemporalConditionSolver::findSwitchingInstant(
+//     const Instant& aPreviousInstant,
+//     const Instant& aNextInstant,
+//     const bool isConditionTrueAtPreviousInstant,
+//     const Array<TemporalConditionSolver::Condition>& aConditionArray
+// ) const
+// {
+//     const Duration step = Duration::Between(aPreviousInstant, aNextInstant);
+
+//     if (step <= this->tolerance_)
+//     {
+//         return aNextInstant;
+//     }
+
+//     const Instant midInstant = aPreviousInstant + (step / 2.0);
+
+//     const bool conditionIsTrueInMidInstant = TemporalConditionSolver::EvaluateConditionAt(midInstant,
+//     aConditionArray);
+
+//     if (isConditionTrueAtPreviousInstant != conditionIsTrueInMidInstant)
+//     {
+//         return this->findSwitchingInstant(
+//             aPreviousInstant, midInstant, isConditionTrueAtPreviousInstant, aConditionArray
+//         );
+//     }
+
+//     return this->findSwitchingInstant(midInstant, aNextInstant, isConditionTrueAtPreviousInstant, aConditionArray);
+// }
+
+// Instant TemporalConditionSolver::findSwitchingInstant(
+//     const Instant& aPreviousInstant,
+//     const Instant& aNextInstant,
+//     const bool isConditionTrueAtPreviousInstant,
+//     const Array<TemporalConditionSolver::Condition>& aConditionArray
+// ) const
+// {
+//     const RootSolver rootSolver = RootSolver(this->maximumIterationCount_, this->tolerance_.inSeconds());
+
+//     const auto result = rootSolver.bisection(
+//         [&aPreviousInstant, &aConditionArray](double aDurationInSeconds) -> double {
+//             return TemporalConditionSolver::EvaluateConditionAt(aPreviousInstant +
+//             Duration::Seconds(aDurationInSeconds), aConditionArray) ? +1.0 : -1.0;
+//         },
+//         0.0,
+//         Duration::Between(aPreviousInstant, aNextInstant).inSeconds()
+//     ) ;
+
+//     return aPreviousInstant + Duration::Seconds(result.root);
+// }
+
+Instant TemporalConditionSolver::findSwitchingInstant(
+    const Instant& aPreviousInstant,
+    const Instant& aNextInstant,
+    const bool isConditionTrueAtPreviousInstant,
+    const Array<TemporalConditionSolver::Condition>& aConditionArray
+) const
+{
+    const RootSolver rootSolver = RootSolver(this->maximumIterationCount_, this->tolerance_.inSeconds());
+
+    const auto result = rootSolver.solve(
+        [&aPreviousInstant, &aConditionArray](double aDurationInSeconds) -> double
+        {
+            return TemporalConditionSolver::EvaluateConditionAt(
+                       aPreviousInstant + Duration::Seconds(aDurationInSeconds), aConditionArray
+                   )
+                     ? +1.0
+                     : -1.0;
+        },
+        0.0,
+        Duration::Between(aPreviousInstant, aNextInstant).inSeconds()
+    );
+
+    return aPreviousInstant + Duration::Seconds(result.root);
+}
+
+bool TemporalConditionSolver::EvaluateConditionAt(
+    const Instant& anInstant, const Array<TemporalConditionSolver::Condition>& aConditionArray
+)
+{
+    return std::all_of(
+        aConditionArray.begin(),
+        aConditionArray.end(),
+        [&anInstant](const TemporalConditionSolver::Condition& aCondition)
+        {
+            return aCondition(anInstant);
+        }
+    );
+}
+
+}  // namespace solvers
+}  // namespace astro
+}  // namespace ostk

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -72,7 +72,8 @@ Orbit::~Orbit()
         Orbit::FrameType::LVLHGD,
         Orbit::FrameType::QSW,
         Orbit::FrameType::TNW,
-        Orbit::FrameType::VNC};
+        Orbit::FrameType::VNC
+    };
 
     for (const auto& frameType : frameTypes)
     {
@@ -311,7 +312,8 @@ Pass Orbit::getPassWithRevolutionNumber(const Integer& aRevolutionNumber) const
                     currentPass = {
                         Pass::Type::Complete,
                         currentRevolutionNumber + 1,
-                        Interval::Closed(currentPass.getInterval().accessEnd(), currentInstant)};
+                        Interval::Closed(currentPass.getInterval().accessEnd(), currentInstant)
+                    };
                 }
                 else
                 {
@@ -323,14 +325,16 @@ Pass Orbit::getPassWithRevolutionNumber(const Integer& aRevolutionNumber) const
                         currentPass = {
                             Pass::Type::Complete,
                             currentRevolutionNumber,
-                            Interval::Closed(this->modelPtr_->getEpoch(), currentInstant)};
+                            Interval::Closed(this->modelPtr_->getEpoch(), currentInstant)
+                        };
                     }
                     else
                     {
                         currentPass = {
                             Pass::Type::Partial,
                             currentRevolutionNumber,
-                            Interval::Closed(this->modelPtr_->getEpoch(), currentInstant)};
+                            Interval::Closed(this->modelPtr_->getEpoch(), currentInstant)
+                        };
                     }
                 }
 
@@ -425,7 +429,8 @@ Shared<const Frame> Orbit::getOrbitalFrame(const Orbit::FrameType& aFrameType) c
                     v_VVLH_GCRF_in_GCRF,
                     q_VVLH_GCRF,
                     w_VVLH_GCRF_in_VVLH,
-                    Transform::Type::Passive};
+                    Transform::Type::Passive
+                };
             }
         );
 
@@ -972,7 +977,8 @@ Orbit Orbit::SunSynchronous(
             aLocalTimeAtDescendingNode.getSecond(),
             aLocalTimeAtDescendingNode.getMillisecond(),
             aLocalTimeAtDescendingNode.getMicrosecond(),
-            aLocalTimeAtDescendingNode.getNanosecond()};
+            aLocalTimeAtDescendingNode.getNanosecond()
+        };
     };
 
     const Length semiMajorAxis = aCelestialObjectSPtr->getEquatorialRadius() + anAltitude;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
@@ -142,7 +142,8 @@ OPM OPM::Dictionary(const ctnr::Dictionary& aDictionary)
             Angle::Degrees(deploymentObject["mean_argument_of_perigee_deg"].accessReal()),
             Angle::Degrees(deploymentObject["mean_longitude_ascending_node_deg"].accessReal()),
             Angle::Degrees(deploymentObject["mean_mean_anomaly_deg"].accessReal()),
-            deploymentObject["ballistic_coef_kg_per_m2"].accessReal()};
+            deploymentObject["ballistic_coef_kg_per_m2"].accessReal()
+        };
 
         deployments.add(deployment);
     }
@@ -162,7 +163,8 @@ OPM OPM::Dictionary(const ctnr::Dictionary& aDictionary)
                 Scale::UTC
             ),
         },
-        deployments};
+        deployments
+    };
 }
 
 OPM OPM::Parse(const String& aString)

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler.cpp
@@ -393,7 +393,8 @@ State Kepler::CalculateNoneStateAt(
         Angle::Radians(inclination_rad),
         Angle::Radians(raan_rad),
         Angle::Radians(aop_rad),
-        Angle::Radians(trueAnomaly_rad)};
+        Angle::Radians(trueAnomaly_rad)
+    };
 
     static const Shared<const Frame> gcrfSPtr = Frame::GCRF();
 
@@ -498,7 +499,8 @@ State Kepler::CalculateJ2StateAt(
         Angle::Radians(inclination_rad),
         Angle::Radians(raan_rad),
         Angle::Radians(aop_rad),
-        Angle::Radians(trueAnomaly_rad)};
+        Angle::Radians(trueAnomaly_rad)
+    };
 
     static const Shared<const Frame> gcrfSPtr = Frame::GCRF();
 
@@ -771,7 +773,8 @@ State Kepler::CalculateJ4StateAt(
         Angle::Radians(inclination_rad),
         Angle::Radians(raan_rad),
         Angle::Radians(aop_rad),
-        Angle::Radians(trueAnomaly_rad)};
+        Angle::Radians(trueAnomaly_rad)
+    };
 
     static const Shared<const Frame> gcrfSPtr = Frame::GCRF();
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -240,10 +240,12 @@ COE::CartesianState COE::getCartesianState(
     const Vector3d R_pqw = {
         p_m * std::cos(nu_rad) / (1.0 + eccentricity_ * std::cos(nu_rad)),
         p_m * std::sin(nu_rad) / (1.0 + eccentricity_ * std::cos(nu_rad)),
-        0.0};
+        0.0
+    };
 
     const Vector3d V_pqw = {
-        -std::sqrt(mu_SI / p_m) * std::sin(nu_rad), +std::sqrt(mu_SI / p_m) * (eccentricity_ + std::cos(nu_rad)), 0.0};
+        -std::sqrt(mu_SI / p_m) * std::sin(nu_rad), +std::sqrt(mu_SI / p_m) * (eccentricity_ + std::cos(nu_rad)), 0.0
+    };
 
     try
     {
@@ -308,7 +310,8 @@ COE COE::Undefined()
         Angle::Undefined(),
         Angle::Undefined(),
         Angle::Undefined(),
-        Angle::Undefined()};
+        Angle::Undefined()
+    };
 }
 
 COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aGravitationalParameter)
@@ -511,7 +514,8 @@ COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aG
         Angle::Radians(i_rad),
         Angle::Radians(raan_rad),
         Angle::Radians(aop_rad),
-        Angle::Radians(nu_rad)};
+        Angle::Radians(nu_rad)
+    };
 }
 
 Angle COE::EccentricAnomalyFromTrueAnomaly(const Angle& aTrueAnomaly, const Real& anEccentricity)

--- a/test/OpenSpaceToolkit/Astrodynamics/Access.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access.test.cpp
@@ -89,9 +89,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, EqualToOperator)
         const Angle maxElevation = Angle::Degrees(54.3);
 
         const Access firstAccess = {
-            Access::Type::Complete, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+            Access::Type::Complete, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation
+        };
         const Access secondAccess = {
-            Access::Type::Partial, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+            Access::Type::Partial, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation
+        };
 
         EXPECT_FALSE(firstAccess == secondAccess);
     }
@@ -107,13 +109,15 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, EqualToOperator)
             Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
             timeOfClosestApproach,
             lossOfSignal,
-            maxElevation};
+            maxElevation
+        };
         const Access secondAccess = {
             type,
             Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
             timeOfClosestApproach,
             lossOfSignal,
-            maxElevation};
+            maxElevation
+        };
 
         EXPECT_FALSE(firstAccess == secondAccess);
     }
@@ -173,9 +177,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, NotEqualToOperator)
         const Angle maxElevation = Angle::Degrees(54.3);
 
         const Access firstAccess = {
-            Access::Type::Complete, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+            Access::Type::Complete, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation
+        };
         const Access secondAccess = {
-            Access::Type::Partial, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+            Access::Type::Partial, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation
+        };
 
         EXPECT_TRUE(firstAccess != secondAccess);
     }
@@ -191,13 +197,15 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, NotEqualToOperator)
             Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
             timeOfClosestApproach,
             lossOfSignal,
-            maxElevation};
+            maxElevation
+        };
         const Access secondAccess = {
             type,
             Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
             timeOfClosestApproach,
             lossOfSignal,
-            maxElevation};
+            maxElevation
+        };
 
         EXPECT_TRUE(firstAccess != secondAccess);
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -159,6 +159,26 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetTolerance)
     }
 }
 
+TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetAerFilter)
+{
+    FAIL();
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetAccessFilter)
+{
+    FAIL();
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetStateFilter)
+{
+    FAIL();
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
+{
+    FAIL();
+}
+
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_1)
 {
     const Environment environment = Environment::Default();

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -161,22 +161,117 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetTolerance)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetAerFilter)
 {
-    FAIL();
+    {
+        const Generator generator = {Environment::Default()};
+
+        EXPECT_EQ(nullptr, generator.getAerFilter());
+    }
+
+    {
+        EXPECT_ANY_THROW(Generator::Undefined().getAerFilter());
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetAccessFilter)
 {
-    FAIL();
+    {
+        const Generator generator = {Environment::Default()};
+
+        EXPECT_EQ(nullptr, generator.getAccessFilter());
+    }
+
+    {
+        EXPECT_ANY_THROW(Generator::Undefined().getAccessFilter());
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetStateFilter)
 {
-    FAIL();
+    {
+        const Generator generator = {Environment::Default()};
+
+        EXPECT_EQ(nullptr, generator.getStateFilter());
+    }
+
+    {
+        EXPECT_ANY_THROW(Generator::Undefined().getStateFilter());
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
 {
-    FAIL();
+    const Environment environment = Environment::Default();
+
+    const Instant startInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC);
+
+    const auto generateFirstOrbit = [&environment, &startInstant]() -> Orbit
+    {
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(+45.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
+
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+
+        const Instant epoch = startInstant;
+        const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
+        const Real J2 = Earth::EGM2008.J2_;
+        const Real J4 = Earth::EGM2008.J4_;
+
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
+
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        return orbit;
+    };
+
+    const auto generateSecondOrbit = [&environment, &startInstant]() -> Orbit
+    {
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(+45.0);
+        const Angle raan = Angle::Degrees(180.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(180.0);
+
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+
+        const Instant epoch = startInstant;
+        const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
+        const Real J2 = Earth::EGM2008.J2_;
+        const Real J4 = Earth::EGM2008.J4_;
+
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
+
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        return orbit;
+    };
+
+    const Orbit fromOrbit = generateFirstOrbit();
+    const Orbit toOrbit = generateSecondOrbit();
+
+    {
+        const Generator generator = {environment};
+
+        const auto conditionFunction = generator.getConditionFunction(fromOrbit, toOrbit);
+
+        EXPECT_NE(nullptr, conditionFunction);
+        EXPECT_TRUE(conditionFunction(startInstant));
+    }
+
+    {
+        EXPECT_ANY_THROW(Generator::Undefined().getConditionFunction(fromOrbit, toOrbit));
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_1)
@@ -208,7 +303,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_1)
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -233,7 +329,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_1)
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -327,7 +424,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_2)
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -407,7 +505,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_3)
     {
         const TLE tle = {
             "1 39419U 13066D   18248.44969859 -.00000394  00000-0 -31796-4 0  9997",
-            "2 39419  97.6313 314.6863 0012643 218.7350 141.2966 14.93878994260975"};
+            "2 39419  97.6313 314.6863 0012643 218.7350 141.2966 14.93878994260975"
+        };
 
         const SGP4 orbitalModel = {tle};
 
@@ -485,7 +584,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_4)
                         (aVelocity.getCoordinates() * (instant - interval.getStart()).inSeconds()),
                     Frame::GCRF()
                 ),
-                aVelocity};
+                aVelocity
+            };
 
             states.add(state);
         }
@@ -690,7 +790,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, AerRanges)
             const Real J4 = Earth::EGM2008.J4_;
 
             const Kepler keplerianModel = {
-                coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2};
+                coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
+            };
 
             const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -753,7 +854,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, AerMask)
         const Environment environment = Environment::Default();
 
         const ostk::core::ctnr::Map<Real, Real> azimuthElevationMask = {
-            {0.0, 30.0}, {90.0, 60.0}, {180.0, 60.0}, {270.0, 30.0}, {359.0, 30.0}};
+            {0.0, 30.0}, {90.0, 60.0}, {180.0, 60.0}, {270.0, 30.0}, {359.0, 30.0}
+        };
         const ostk::math::obj::Interval<Real> rangeRange = ostk::math::obj::Interval<Real>::Closed(0.0, 10000e3);
 
         const Generator generator = Generator::AerMask(azimuthElevationMask, rangeRange, environment);
@@ -793,7 +895,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, AerMask)
             const Real J4 = Earth::EGM2008.J4_;
 
             const Kepler keplerianModel = {
-                coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2};
+                coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
+            };
 
             const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -20,15 +20,42 @@
 
 #include <Global.test.hpp>
 
+using ostk::core::ctnr::Array;
+using ostk::core::ctnr::Table;
+using ostk::core::ctnr::Tuple;
+using ostk::core::fs::File;
+using ostk::core::fs::Path;
+using ostk::core::types::Real;
+using ostk::core::types::String;
+
+using ostk::physics::Environment;
+using ostk::physics::coord::Frame;
+using ostk::physics::coord::Position;
+using ostk::physics::coord::Velocity;
+using ostk::physics::coord::spherical::LLA;
+using ostk::physics::coord::spherical::AER;
+using ostk::physics::environment::gravitational::Earth;
+using ostk::physics::time::DateTime;
+using ostk::physics::time::Duration;
+using ostk::physics::time::Instant;
+using ostk::physics::time::Interval;
+using ostk::physics::time::Scale;
+using ostk::physics::units::Angle;
+using ostk::physics::units::Derived;
+using ostk::physics::units::Length;
+
+using ostk::astro::Access;
+using ostk::astro::Trajectory;
+using ostk::astro::access::Generator;
+using ostk::astro::trajectory::Orbit;
+using ostk::astro::trajectory::State;
+using ostk::astro::trajectory::orbit::models::Kepler;
+using ostk::astro::trajectory::orbit::models::SGP4;
+using ostk::astro::trajectory::orbit::models::kepler::COE;
+using ostk::astro::trajectory::orbit::models::sgp4::TLE;
+
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, Constructor)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::coord::spherical::AER;
-
-    using ostk::astro::Access;
-    using ostk::astro::access::Generator;
-    using ostk::astro::trajectory::State;
-
     {
         const Environment environment = Environment::Default();
 
@@ -75,12 +102,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, Constructor)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, IsDefined)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::coord::spherical::AER;
-
-    using ostk::astro::Access;
-    using ostk::astro::access::Generator;
-
     {
         const Environment environment = Environment::Default();
 
@@ -114,11 +135,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, IsDefined)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetStep)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::time::Duration;
-
-    using ostk::astro::access::Generator;
-
     {
         const Generator generator = {Environment::Default()};
 
@@ -132,11 +148,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetStep)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetTolerance)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::time::Duration;
-
-    using ostk::astro::access::Generator;
-
     {
         const Generator generator = {Environment::Default()};
 
@@ -148,425 +159,378 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetTolerance)
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses)
+TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_1)
 {
-    using ostk::core::ctnr::Array;
-    using ostk::core::ctnr::Table;
-    using ostk::core::ctnr::Tuple;
-    using ostk::core::fs::File;
-    using ostk::core::fs::Path;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
+    const Environment environment = Environment::Default();
 
-    using ostk::physics::Environment;
-    using ostk::physics::coord::Frame;
-    using ostk::physics::coord::Position;
-    using ostk::physics::coord::Velocity;
-    using ostk::physics::coord::spherical::LLA;
-    using ostk::physics::environment::gravitational::Earth;
-    using ostk::physics::time::DateTime;
-    using ostk::physics::time::Duration;
-    using ostk::physics::time::Instant;
-    using ostk::physics::time::Interval;
-    using ostk::physics::time::Scale;
-    using ostk::physics::units::Angle;
-    using ostk::physics::units::Derived;
-    using ostk::physics::units::Length;
+    const Generator generator = {environment};
 
-    using ostk::astro::Access;
-    using ostk::astro::Trajectory;
-    using ostk::astro::access::Generator;
-    using ostk::astro::trajectory::Orbit;
-    using ostk::astro::trajectory::State;
-    using ostk::astro::trajectory::orbit::models::Kepler;
-    using ostk::astro::trajectory::orbit::models::SGP4;
-    using ostk::astro::trajectory::orbit::models::kepler::COE;
-    using ostk::astro::trajectory::orbit::models::sgp4::TLE;
+    const Instant startInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC);
 
+    const Interval interval = Interval::Closed(startInstant, endInstant);
+
+    const auto generateFirstOrbit = [&environment, &startInstant]() -> Orbit
     {
-        // Access computation
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(+45.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
 
-        const Environment environment = Environment::Default();
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        const Generator generator = {environment};
+        const Instant epoch = startInstant;
+        const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
+        const Real J2 = Earth::EGM2008.J2_;
+        const Real J4 = Earth::EGM2008.J4_;
 
-        const Instant startInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC);
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
 
-        const Interval interval = Interval::Closed(startInstant, endInstant);
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-        const auto generateFirstOrbit = [&environment, &startInstant]() -> Orbit
-        {
-            const Length semiMajorAxis = Length::Kilometers(7000.0);
-            const Real eccentricity = 0.0;
-            const Angle inclination = Angle::Degrees(+45.0);
-            const Angle raan = Angle::Degrees(0.0);
-            const Angle aop = Angle::Degrees(0.0);
-            const Angle trueAnomaly = Angle::Degrees(0.0);
+        return orbit;
+    };
 
-            const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+    const auto generateSecondOrbit = [&environment, &startInstant]() -> Orbit
+    {
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(+45.0);
+        const Angle raan = Angle::Degrees(180.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(180.0);
 
-            const Instant epoch = startInstant;
-            const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
-            const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
-            const Real J2 = Earth::EGM2008.J2_;
-            const Real J4 = Earth::EGM2008.J4_;
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-            const Kepler keplerianModel = {
-                coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+        const Instant epoch = startInstant;
+        const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
+        const Real J2 = Earth::EGM2008.J2_;
+        const Real J4 = Earth::EGM2008.J4_;
 
-            const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
 
-            return orbit;
-        };
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-        const auto generateSecondOrbit = [&environment, &startInstant]() -> Orbit
-        {
-            const Length semiMajorAxis = Length::Kilometers(7000.0);
-            const Real eccentricity = 0.0;
-            const Angle inclination = Angle::Degrees(+45.0);
-            const Angle raan = Angle::Degrees(180.0);
-            const Angle aop = Angle::Degrees(0.0);
-            const Angle trueAnomaly = Angle::Degrees(180.0);
+        return orbit;
+    };
 
-            const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+    const Orbit fromOrbit = generateFirstOrbit();
+    const Orbit toOrbit = generateSecondOrbit();
 
-            const Instant epoch = startInstant;
-            const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
-            const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
-            const Real J2 = Earth::EGM2008.J2_;
-            const Real J4 = Earth::EGM2008.J4_;
+    const Array<Access> accesses = generator.computeAccesses(interval, fromOrbit, toOrbit);
 
-            const Kepler keplerianModel = {
-                coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+    // Reference data setup
 
-            const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+    const File referenceDataFile = File::Path(
+        Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Access/Generator/ComputeAccesses/Scenario 1.csv")
+    );
 
-            return orbit;
-        };
+    const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
 
-        const Orbit fromOrbit = generateFirstOrbit();
-        const Orbit toOrbit = generateSecondOrbit();
+    const Duration toleranceDuration = Duration::Seconds(0.1);
 
-        const Array<Access> accesses = generator.computeAccesses(interval, fromOrbit, toOrbit);
+    // Test
 
-        // Reference data setup
+    ASSERT_EQ(referenceData.getRowCount(), accesses.getSize());
 
-        const File referenceDataFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Access/Generator/ComputeAccesses/Scenario 1.csv")
+    for (const auto accessTuple : ostk::core::ctnr::iterators::Zip(referenceData, accesses))
+    {
+        const auto& referenceRow = std::get<0>(accessTuple);
+        const Access& access = std::get<1>(accessTuple);
+
+        const Instant reference_acquisitionOfSignal =
+            Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
+        const Instant reference_timeOfClosestApproach =
+            Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+        const Instant reference_lossOfSignal =
+            Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+        const Duration reference_duration = Duration::Seconds(referenceRow[3].accessReal());
+
+        ASSERT_TRUE(access.getAcquisitionOfSignal().isNear(reference_acquisitionOfSignal, toleranceDuration))
+            << String::Format(
+                   "{} ~ {}", reference_acquisitionOfSignal.toString(), access.getAcquisitionOfSignal().toString()
+               );
+        ASSERT_TRUE(access.getTimeOfClosestApproach().isNear(reference_timeOfClosestApproach, toleranceDuration))
+            << String::Format(
+                   "{} ~ {}", reference_timeOfClosestApproach.toString(), access.getTimeOfClosestApproach().toString()
+               );
+        ASSERT_TRUE(access.getLossOfSignal().isNear(reference_lossOfSignal, toleranceDuration))
+            << String::Format("{} ~ {}", reference_lossOfSignal.toString(), access.getLossOfSignal().toString());
+        ASSERT_TRUE(access.getDuration().isNear(reference_duration, toleranceDuration))
+            << String::Format("{} ~ {}", reference_duration.toString(), access.getDuration().toString());
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_2)
+{
+    const Environment environment = Environment::Default();
+
+    const Generator generator = {environment};
+
+    const Instant startInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC);
+
+    const Interval interval = Interval::Closed(startInstant, endInstant);
+
+    const auto generateGroundStationTrajectory = []() -> Trajectory
+    {
+        const LLA groundStationLla = {Angle::Degrees(0.0), Angle::Degrees(0.0), Length::Meters(20.0)};
+
+        const Position groundStationPosition = Position::Meters(
+            groundStationLla.toCartesian(Earth::EGM2008.equatorialRadius_, Earth::EGM2008.flattening_), Frame::ITRF()
         );
 
-        const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
+        return Trajectory::Position(groundStationPosition);
+    };
 
-        const Duration toleranceDuration = Duration::Seconds(0.1);
+    const auto generateSatelliteOrbit = [&environment, &startInstant]() -> Orbit
+    {
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(+45.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
 
-        // Test
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        ASSERT_EQ(referenceData.getRowCount(), accesses.getSize());
+        const Instant epoch = startInstant;
+        const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
+        const Real J2 = Earth::EGM2008.J2_;
+        const Real J4 = Earth::EGM2008.J4_;
 
-        for (const auto accessTuple : ostk::core::ctnr::iterators::Zip(referenceData, accesses))
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        return orbit;
+    };
+
+    const Trajectory groundStationTrajectory = generateGroundStationTrajectory();
+    const Orbit satelliteOrbit = generateSatelliteOrbit();
+
+    const Array<Access> accesses = generator.computeAccesses(interval, groundStationTrajectory, satelliteOrbit);
+
+    // Reference data setup
+
+    const File referenceDataFile = File::Path(
+        Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Access/Generator/ComputeAccesses/Scenario 2.csv")
+    );
+
+    const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
+
+    const Duration toleranceDuration = Duration::Seconds(0.1);
+
+    // Test
+
+    ASSERT_EQ(referenceData.getRowCount(), accesses.getSize());
+
+    for (const auto accessTuple : ostk::core::ctnr::iterators::Zip(referenceData, accesses))
+    {
+        const auto& referenceRow = std::get<0>(accessTuple);
+        const Access& access = std::get<1>(accessTuple);
+
+        const Instant reference_acquisitionOfSignal =
+            Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
+        const Instant reference_timeOfClosestApproach =
+            Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+        const Instant reference_lossOfSignal =
+            Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+        const Duration reference_duration = Duration::Seconds(referenceRow[3].accessReal());
+
+        EXPECT_TRUE(access.getAcquisitionOfSignal().isNear(reference_acquisitionOfSignal, toleranceDuration))
+            << String::Format(
+                   "{} ~ {}", reference_acquisitionOfSignal.toString(), access.getAcquisitionOfSignal().toString()
+               );
+        EXPECT_TRUE(access.getTimeOfClosestApproach().isNear(reference_timeOfClosestApproach, toleranceDuration))
+            << String::Format(
+                   "{} ~ {}", reference_timeOfClosestApproach.toString(), access.getTimeOfClosestApproach().toString()
+               );
+        EXPECT_TRUE(access.getLossOfSignal().isNear(reference_lossOfSignal, toleranceDuration))
+            << String::Format("{} ~ {}", reference_lossOfSignal.toString(), access.getLossOfSignal().toString());
+        EXPECT_TRUE(access.getDuration().isNear(reference_duration, toleranceDuration))
+            << String::Format("{} ~ {}", reference_duration.toString(), access.getDuration().toString());
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_3)
+{
+    const Environment environment = Environment::Default();
+
+    const Generator generator = {environment};
+
+    const Instant startInstant = Instant::DateTime(DateTime(2018, 9, 6, 0, 0, 0), Scale::UTC);
+    const Instant endInstant = Instant::DateTime(DateTime(2018, 9, 7, 0, 0, 0), Scale::UTC);
+
+    const Interval interval = Interval::Closed(startInstant, endInstant);
+
+    const auto generateGroundStationTrajectory = []() -> Trajectory
+    {
+        const LLA groundStationLla = {Angle::Degrees(-45.0), Angle::Degrees(-170.0), Length::Meters(5.0)};
+
+        const Position groundStationPosition = Position::Meters(
+            groundStationLla.toCartesian(Earth::EGM2008.equatorialRadius_, Earth::EGM2008.flattening_), Frame::ITRF()
+        );
+
+        return Trajectory::Position(groundStationPosition);
+    };
+
+    const auto generateSatelliteOrbit = [&environment, &startInstant]() -> Orbit
+    {
+        const TLE tle = {
+            "1 39419U 13066D   18248.44969859 -.00000394  00000-0 -31796-4 0  9997",
+            "2 39419  97.6313 314.6863 0012643 218.7350 141.2966 14.93878994260975"};
+
+        const SGP4 orbitalModel = {tle};
+
+        const Orbit orbit = {orbitalModel, environment.accessCelestialObjectWithName("Earth")};
+
+        return orbit;
+    };
+
+    const Trajectory groundStationTrajectory = generateGroundStationTrajectory();
+    const Orbit satelliteOrbit = generateSatelliteOrbit();
+
+    const Array<Access> accesses = generator.computeAccesses(interval, groundStationTrajectory, satelliteOrbit);
+
+    // Reference data setup
+
+    const File referenceDataFile = File::Path(
+        Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Access/Generator/ComputeAccesses/Scenario 3.csv")
+    );
+
+    const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
+
+    const Duration toleranceDuration = Duration::Seconds(0.1);
+
+    // Test
+
+    ASSERT_EQ(referenceData.getRowCount(), accesses.getSize());
+
+    for (const auto accessTuple : ostk::core::ctnr::iterators::Zip(referenceData, accesses))
+    {
+        const auto& referenceRow = std::get<0>(accessTuple);
+        const Access& access = std::get<1>(accessTuple);
+
+        const Instant reference_acquisitionOfSignal =
+            Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
+        const Instant reference_timeOfClosestApproach =
+            Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+        const Instant reference_lossOfSignal =
+            Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+        const Duration reference_duration = Duration::Seconds(referenceRow[3].accessReal());
+
+        EXPECT_TRUE(access.getAcquisitionOfSignal().isNear(reference_acquisitionOfSignal, toleranceDuration))
+            << String::Format(
+                   "{} ~ {}", reference_acquisitionOfSignal.toString(), access.getAcquisitionOfSignal().toString()
+               );
+        EXPECT_TRUE(access.getTimeOfClosestApproach().isNear(reference_timeOfClosestApproach, toleranceDuration))
+            << String::Format(
+                   "{} ~ {}", reference_timeOfClosestApproach.toString(), access.getTimeOfClosestApproach().toString()
+               );
+        EXPECT_TRUE(access.getLossOfSignal().isNear(reference_lossOfSignal, toleranceDuration))
+            << String::Format("{} ~ {}", reference_lossOfSignal.toString(), access.getLossOfSignal().toString());
+        EXPECT_TRUE(access.getDuration().isNear(reference_duration, toleranceDuration))
+            << String::Format("{} ~ {}", reference_duration.toString(), access.getDuration().toString());
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_4)
+{
+    const Instant startInstant = Instant::DateTime(DateTime(2020, 1, 1, 0, 0, 0), Scale::UTC);
+    const Instant endInstant = Instant::DateTime(DateTime(2020, 1, 1, 0, 10, 0), Scale::UTC);
+
+    const Interval interval = Interval::Closed(startInstant, endInstant);
+    const Duration step = Duration::Minutes(1.0);
+
+    const auto generateTrajectory = [&interval,
+                                     &step](const Position& aStartPosition, const Velocity& aVelocity) -> Trajectory
+    {
+        Array<State> states = Array<State>::Empty();
+
+        for (const auto& instant : interval.generateGrid(step))
         {
-            const auto& referenceRow = std::get<0>(accessTuple);
-            const Access& access = std::get<1>(accessTuple);
+            const State state = {
+                instant,
+                Position::Meters(
+                    aStartPosition.getCoordinates() +
+                        (aVelocity.getCoordinates() * (instant - interval.getStart()).inSeconds()),
+                    Frame::GCRF()
+                ),
+                aVelocity};
 
-            const Instant reference_acquisitionOfSignal =
-                Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
-            const Instant reference_timeOfClosestApproach =
-                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-            const Instant reference_lossOfSignal =
-                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
-            const Duration reference_duration = Duration::Seconds(referenceRow[3].accessReal());
-
-            EXPECT_TRUE(access.getAcquisitionOfSignal().isNear(reference_acquisitionOfSignal, toleranceDuration))
-                << String::Format(
-                       "{} ~ {}", reference_acquisitionOfSignal.toString(), access.getAcquisitionOfSignal().toString()
-                   );
-            EXPECT_TRUE(access.getTimeOfClosestApproach().isNear(reference_timeOfClosestApproach, toleranceDuration))
-                << String::Format(
-                       "{} ~ {}",
-                       reference_timeOfClosestApproach.toString(),
-                       access.getTimeOfClosestApproach().toString()
-                   );
-            EXPECT_TRUE(access.getLossOfSignal().isNear(reference_lossOfSignal, toleranceDuration))
-                << String::Format("{} ~ {}", reference_lossOfSignal.toString(), access.getLossOfSignal().toString());
-            EXPECT_TRUE(access.getDuration().isNear(reference_duration, toleranceDuration))
-                << String::Format("{} ~ {}", reference_duration.toString(), access.getDuration().toString());
+            states.add(state);
         }
+
+        return Trajectory(states);
+    };
+
+    const Trajectory firstTrajectory = generateTrajectory(
+        Position::Meters({0.0, 0.0, 0.0}, Frame::GCRF()), Velocity::MetersPerSecond({1.0, 0.0, 0.0}, Frame::GCRF())
+    );
+
+    const Trajectory secondTrajectory = generateTrajectory(
+        Position::Meters({0.0, 0.0, 0.0}, Frame::GCRF()), Velocity::MetersPerSecond({0.0, 0.0, 1.0}, Frame::GCRF())
+    );
+
+    {
+        const auto stateFilter = [](const State& aFirstState, const State& aSecondState) -> bool
+        {
+            (void)aFirstState;
+            (void)aSecondState;
+            return true;
+        };
+
+        const Generator generator = {Environment::Default(), {}, {}, stateFilter};
+
+        const Array<Access> accesses = generator.computeAccesses(interval, firstTrajectory, secondTrajectory);
+
+        EXPECT_EQ(1, accesses.getSize());
+
+        const Duration toleranceDuration = Duration::Microseconds(1.0);
+
+        EXPECT_TRUE(accesses.at(0).getAcquisitionOfSignal().isNear(startInstant, toleranceDuration));
+        EXPECT_TRUE(accesses.at(0).getLossOfSignal().isNear(endInstant, toleranceDuration));
     }
 
     {
-        const Environment environment = Environment::Default();
-
-        const Generator generator = {environment};
-
-        const Instant startInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC);
-
-        const Interval interval = Interval::Closed(startInstant, endInstant);
-
-        const auto generateGroundStationTrajectory = []() -> Trajectory
+        const auto stateFilter = [](const State& aFirstState, const State& aSecondState) -> bool
         {
-            const LLA groundStationLla = {Angle::Degrees(0.0), Angle::Degrees(0.0), Length::Meters(20.0)};
-
-            const Position groundStationPosition = Position::Meters(
-                groundStationLla.toCartesian(Earth::EGM2008.equatorialRadius_, Earth::EGM2008.flattening_),
-                Frame::ITRF()
-            );
-
-            return Trajectory::Position(groundStationPosition);
+            (void)aSecondState;
+            return (aFirstState.getInstant() - Instant::DateTime(DateTime(2020, 1, 1, 0, 5, 0), Scale::UTC))
+                       .getAbsolute() >= Duration::Minutes(2.0);
         };
 
-        const auto generateSatelliteOrbit = [&environment, &startInstant]() -> Orbit
-        {
-            const Length semiMajorAxis = Length::Kilometers(7000.0);
-            const Real eccentricity = 0.0;
-            const Angle inclination = Angle::Degrees(+45.0);
-            const Angle raan = Angle::Degrees(0.0);
-            const Angle aop = Angle::Degrees(0.0);
-            const Angle trueAnomaly = Angle::Degrees(0.0);
+        const Generator generator = {Environment::Default(), {}, {}, stateFilter};
 
-            const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+        const Array<Access> accesses = generator.computeAccesses(interval, firstTrajectory, secondTrajectory);
 
-            const Instant epoch = startInstant;
-            const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
-            const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
-            const Real J2 = Earth::EGM2008.J2_;
-            const Real J4 = Earth::EGM2008.J4_;
+        EXPECT_EQ(2, accesses.getSize());
 
-            const Kepler keplerianModel = {
-                coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+        const Duration toleranceDuration = Duration::Microseconds(1.0);
 
-            const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+        EXPECT_TRUE(accesses.at(0).getAcquisitionOfSignal().isNear(startInstant, toleranceDuration));
+        EXPECT_TRUE(accesses.at(0).getLossOfSignal().isNear(
+            Instant::DateTime(DateTime(2020, 1, 1, 0, 3, 0), Scale::UTC), toleranceDuration
+        ));
 
-            return orbit;
-        };
-
-        const Trajectory groundStationTrajectory = generateGroundStationTrajectory();
-        const Orbit satelliteOrbit = generateSatelliteOrbit();
-
-        const Array<Access> accesses = generator.computeAccesses(interval, groundStationTrajectory, satelliteOrbit);
-
-        // Reference data setup
-
-        const File referenceDataFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Access/Generator/ComputeAccesses/Scenario 2.csv")
-        );
-
-        const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
-
-        const Duration toleranceDuration = Duration::Seconds(0.1);
-
-        // Test
-
-        ASSERT_EQ(referenceData.getRowCount(), accesses.getSize());
-
-        for (const auto accessTuple : ostk::core::ctnr::iterators::Zip(referenceData, accesses))
-        {
-            const auto& referenceRow = std::get<0>(accessTuple);
-            const Access& access = std::get<1>(accessTuple);
-
-            const Instant reference_acquisitionOfSignal =
-                Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
-            const Instant reference_timeOfClosestApproach =
-                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-            const Instant reference_lossOfSignal =
-                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
-            const Duration reference_duration = Duration::Seconds(referenceRow[3].accessReal());
-
-            EXPECT_TRUE(access.getAcquisitionOfSignal().isNear(reference_acquisitionOfSignal, toleranceDuration))
-                << String::Format(
-                       "{} ~ {}", reference_acquisitionOfSignal.toString(), access.getAcquisitionOfSignal().toString()
-                   );
-            EXPECT_TRUE(access.getTimeOfClosestApproach().isNear(reference_timeOfClosestApproach, toleranceDuration))
-                << String::Format(
-                       "{} ~ {}",
-                       reference_timeOfClosestApproach.toString(),
-                       access.getTimeOfClosestApproach().toString()
-                   );
-            EXPECT_TRUE(access.getLossOfSignal().isNear(reference_lossOfSignal, toleranceDuration))
-                << String::Format("{} ~ {}", reference_lossOfSignal.toString(), access.getLossOfSignal().toString());
-            EXPECT_TRUE(access.getDuration().isNear(reference_duration, toleranceDuration))
-                << String::Format("{} ~ {}", reference_duration.toString(), access.getDuration().toString());
-        }
-    }
-
-    {
-        const Environment environment = Environment::Default();
-
-        const Generator generator = {environment};
-
-        const Instant startInstant = Instant::DateTime(DateTime(2018, 9, 6, 0, 0, 0), Scale::UTC);
-        const Instant endInstant = Instant::DateTime(DateTime(2018, 9, 7, 0, 0, 0), Scale::UTC);
-
-        const Interval interval = Interval::Closed(startInstant, endInstant);
-
-        const auto generateGroundStationTrajectory = []() -> Trajectory
-        {
-            const LLA groundStationLla = {Angle::Degrees(-45.0), Angle::Degrees(-170.0), Length::Meters(5.0)};
-
-            const Position groundStationPosition = Position::Meters(
-                groundStationLla.toCartesian(Earth::EGM2008.equatorialRadius_, Earth::EGM2008.flattening_),
-                Frame::ITRF()
-            );
-
-            return Trajectory::Position(groundStationPosition);
-        };
-
-        const auto generateSatelliteOrbit = [&environment, &startInstant]() -> Orbit
-        {
-            const TLE tle = {
-                "1 39419U 13066D   18248.44969859 -.00000394  00000-0 -31796-4 0  9997",
-                "2 39419  97.6313 314.6863 0012643 218.7350 141.2966 14.93878994260975"};
-
-            const SGP4 orbitalModel = {tle};
-
-            const Orbit orbit = {orbitalModel, environment.accessCelestialObjectWithName("Earth")};
-
-            return orbit;
-        };
-
-        const Trajectory groundStationTrajectory = generateGroundStationTrajectory();
-        const Orbit satelliteOrbit = generateSatelliteOrbit();
-
-        const Array<Access> accesses = generator.computeAccesses(interval, groundStationTrajectory, satelliteOrbit);
-
-        // Reference data setup
-
-        const File referenceDataFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Access/Generator/ComputeAccesses/Scenario 3.csv")
-        );
-
-        const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
-
-        const Duration toleranceDuration = Duration::Seconds(0.1);
-
-        // Test
-
-        ASSERT_EQ(referenceData.getRowCount(), accesses.getSize());
-
-        for (const auto accessTuple : ostk::core::ctnr::iterators::Zip(referenceData, accesses))
-        {
-            const auto& referenceRow = std::get<0>(accessTuple);
-            const Access& access = std::get<1>(accessTuple);
-
-            const Instant reference_acquisitionOfSignal =
-                Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
-            const Instant reference_timeOfClosestApproach =
-                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-            const Instant reference_lossOfSignal =
-                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
-            const Duration reference_duration = Duration::Seconds(referenceRow[3].accessReal());
-
-            EXPECT_TRUE(access.getAcquisitionOfSignal().isNear(reference_acquisitionOfSignal, toleranceDuration))
-                << String::Format(
-                       "{} ~ {}", reference_acquisitionOfSignal.toString(), access.getAcquisitionOfSignal().toString()
-                   );
-            EXPECT_TRUE(access.getTimeOfClosestApproach().isNear(reference_timeOfClosestApproach, toleranceDuration))
-                << String::Format(
-                       "{} ~ {}",
-                       reference_timeOfClosestApproach.toString(),
-                       access.getTimeOfClosestApproach().toString()
-                   );
-            EXPECT_TRUE(access.getLossOfSignal().isNear(reference_lossOfSignal, toleranceDuration))
-                << String::Format("{} ~ {}", reference_lossOfSignal.toString(), access.getLossOfSignal().toString());
-            EXPECT_TRUE(access.getDuration().isNear(reference_duration, toleranceDuration))
-                << String::Format("{} ~ {}", reference_duration.toString(), access.getDuration().toString());
-        }
-    }
-
-    {
-        const Instant startInstant = Instant::DateTime(DateTime(2020, 1, 1, 0, 0, 0), Scale::UTC);
-        const Instant endInstant = Instant::DateTime(DateTime(2020, 1, 1, 0, 10, 0), Scale::UTC);
-
-        const Interval interval = Interval::Closed(startInstant, endInstant);
-        const Duration step = Duration::Minutes(1.0);
-
-        const auto generateTrajectory = [&interval,
-                                         &step](const Position& aStartPosition, const Velocity& aVelocity) -> Trajectory
-        {
-            Array<State> states = Array<State>::Empty();
-
-            for (const auto& instant : interval.generateGrid(step))
-            {
-                const State state = {
-                    instant,
-                    Position::Meters(
-                        aStartPosition.getCoordinates() +
-                            (aVelocity.getCoordinates() * (instant - interval.getStart()).inSeconds()),
-                        Frame::GCRF()
-                    ),
-                    aVelocity};
-
-                states.add(state);
-            }
-
-            return Trajectory(states);
-        };
-
-        const Trajectory firstTrajectory = generateTrajectory(
-            Position::Meters({0.0, 0.0, 0.0}, Frame::GCRF()), Velocity::MetersPerSecond({1.0, 0.0, 0.0}, Frame::GCRF())
-        );
-
-        const Trajectory secondTrajectory = generateTrajectory(
-            Position::Meters({0.0, 0.0, 0.0}, Frame::GCRF()), Velocity::MetersPerSecond({0.0, 0.0, 1.0}, Frame::GCRF())
-        );
-
-        {
-            const auto stateFilter = [](const State& aFirstState, const State& aSecondState) -> bool
-            {
-                (void)aFirstState;
-                (void)aSecondState;
-                return true;
-            };
-
-            const Generator generator = {Environment::Default(), {}, {}, stateFilter};
-
-            const Array<Access> accesses = generator.computeAccesses(interval, firstTrajectory, secondTrajectory);
-
-            EXPECT_EQ(1, accesses.getSize());
-
-            const Duration toleranceDuration = Duration::Microseconds(1.0);
-
-            EXPECT_TRUE(accesses.at(0).getAcquisitionOfSignal().isNear(startInstant, toleranceDuration));
-            EXPECT_TRUE(accesses.at(0).getLossOfSignal().isNear(endInstant, toleranceDuration));
-        }
-
-        {
-            const auto stateFilter = [](const State& aFirstState, const State& aSecondState) -> bool
-            {
-                (void)aSecondState;
-                return (aFirstState.getInstant() - Instant::DateTime(DateTime(2020, 1, 1, 0, 5, 0), Scale::UTC))
-                           .getAbsolute() >= Duration::Minutes(2.0);
-            };
-
-            const Generator generator = {Environment::Default(), {}, {}, stateFilter};
-
-            const Array<Access> accesses = generator.computeAccesses(interval, firstTrajectory, secondTrajectory);
-
-            EXPECT_EQ(2, accesses.getSize());
-
-            const Duration toleranceDuration = Duration::Microseconds(1.0);
-
-            EXPECT_TRUE(accesses.at(0).getAcquisitionOfSignal().isNear(startInstant, toleranceDuration));
-            EXPECT_TRUE(accesses.at(0).getLossOfSignal().isNear(
-                Instant::DateTime(DateTime(2020, 1, 1, 0, 3, 0), Scale::UTC), toleranceDuration
-            ));
-
-            EXPECT_TRUE(accesses.at(1).getAcquisitionOfSignal().isNear(
-                Instant::DateTime(DateTime(2020, 1, 1, 0, 7, 0), Scale::UTC), toleranceDuration
-            ));
-            EXPECT_TRUE(accesses.at(1).getLossOfSignal().isNear(endInstant, toleranceDuration));
-        }
+        EXPECT_TRUE(accesses.at(1).getAcquisitionOfSignal().isNear(
+            Instant::DateTime(DateTime(2020, 1, 1, 0, 7, 0), Scale::UTC), toleranceDuration
+        ));
+        EXPECT_TRUE(accesses.at(1).getLossOfSignal().isNear(endInstant, toleranceDuration));
     }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetStep)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::time::Duration;
-
-    using ostk::astro::access::Generator;
-
     {
         const Environment environment = Environment::Default();
 
@@ -582,11 +546,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetStep)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetTolerance)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::time::Duration;
-
-    using ostk::astro::access::Generator;
-
     {
         const Environment environment = Environment::Default();
 
@@ -602,11 +561,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetTolerance)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetAerFilter)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::coord::spherical::AER;
-
-    using ostk::astro::access::Generator;
-
     {
         const Environment environment = Environment::Default();
 
@@ -625,12 +579,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetAerFilter)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetAccessFilter)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::coord::spherical::AER;
-
-    using ostk::astro::Access;
-    using ostk::astro::access::Generator;
-
     {
         const Environment environment = Environment::Default();
 
@@ -649,13 +597,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetAccessFilter)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetStateFilter)
 {
-    using ostk::physics::Environment;
-    using ostk::physics::coord::spherical::AER;
-
-    using ostk::astro::Access;
-    using ostk::astro::access::Generator;
-    using ostk::astro::trajectory::State;
-
     {
         const Environment environment = Environment::Default();
 
@@ -674,8 +615,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, SetStateFilter)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, Undefined)
 {
-    using ostk::astro::access::Generator;
-
     {
         EXPECT_NO_THROW(Generator::Undefined());
 
@@ -685,34 +624,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, Undefined)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, AerRanges)
 {
-    using ostk::core::ctnr::Array;
-    using ostk::core::ctnr::Table;
-    using ostk::core::fs::File;
-    using ostk::core::fs::Path;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::physics::Environment;
-    using ostk::physics::coord::Frame;
-    using ostk::physics::coord::Position;
-    using ostk::physics::coord::spherical::LLA;
-    using ostk::physics::environment::gravitational::Earth;
-    using ostk::physics::time::DateTime;
-    using ostk::physics::time::Duration;
-    using ostk::physics::time::Instant;
-    using ostk::physics::time::Interval;
-    using ostk::physics::time::Scale;
-    using ostk::physics::units::Angle;
-    using ostk::physics::units::Derived;
-    using ostk::physics::units::Length;
-
-    using ostk::astro::Access;
-    using ostk::astro::Trajectory;
-    using ostk::astro::access::Generator;
-    using ostk::astro::trajectory::Orbit;
-    using ostk::astro::trajectory::orbit::models::Kepler;
-    using ostk::astro::trajectory::orbit::models::kepler::COE;
-
     {
         // Access computation
 
@@ -816,34 +727,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, AerRanges)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, AerMask)
 {
-    using ostk::core::ctnr::Array;
-    using ostk::core::ctnr::Table;
-    using ostk::core::fs::File;
-    using ostk::core::fs::Path;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::physics::Environment;
-    using ostk::physics::coord::Frame;
-    using ostk::physics::coord::Position;
-    using ostk::physics::coord::spherical::LLA;
-    using ostk::physics::environment::gravitational::Earth;
-    using ostk::physics::time::DateTime;
-    using ostk::physics::time::Duration;
-    using ostk::physics::time::Instant;
-    using ostk::physics::time::Interval;
-    using ostk::physics::time::Scale;
-    using ostk::physics::units::Angle;
-    using ostk::physics::units::Derived;
-    using ostk::physics::units::Length;
-
-    using ostk::astro::Access;
-    using ostk::astro::Trajectory;
-    using ostk::astro::access::Generator;
-    using ostk::astro::trajectory::Orbit;
-    using ostk::astro::trajectory::orbit::models::Kepler;
-    using ostk::astro::trajectory::orbit::models::kepler::COE;
-
     {
         // Access computation
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Conjunction/Messages/CCSDS/CDM.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Conjunction/Messages/CCSDS/CDM.test.cpp
@@ -38,7 +38,8 @@ class OpenSpaceToolkit_Astrodynamics_Conjunction_Messages_CCSDS_CDM : public ::t
                 Instant::DateTime(DateTime(2010, 3, 12, 22, 31, 12), Scale::UTC),
                 "JSPOC",
                 "SATELLITE A",
-                "201113719185"},
+                "201113719185"
+            },
             CDM::RelativeMetadata {
                 String::Empty(),
                 Instant::DateTime(DateTime(2010, 3, 13, 22, 37, 52, 618), Scale::UTC),
@@ -79,7 +80,8 @@ class OpenSpaceToolkit_Astrodynamics_Conjunction_Messages_CCSDS_CDM : public ::t
                  "MOON, SUN",
                  false,
                  false,
-                 false},
+                 false
+             },
              CDM::Metadata {
                  String::Empty(),
                  "OBJECT2",
@@ -102,7 +104,8 @@ class OpenSpaceToolkit_Astrodynamics_Conjunction_Messages_CCSDS_CDM : public ::t
                  "MOON, SUN",
                  true,
                  false,
-                 false}},
+                 false
+             }},
             {CDM::Data {
                  Instant::DateTime(DateTime(2010, 3, 12, 2, 14, 12, 746), Scale::UTC),
                  Instant::DateTime(DateTime(2010, 3, 12, 2, 14, 12, 746), Scale::UTC),
@@ -123,7 +126,8 @@ class OpenSpaceToolkit_Astrodynamics_Conjunction_Messages_CCSDS_CDM : public ::t
                  0.0,
                  0.000045457,
                  State::Undefined(),
-                 MatrixXd(9, 9)},
+                 MatrixXd(9, 9)
+             },
              CDM::Data {
                  Instant::DateTime(DateTime(2010, 3, 12, 1, 14, 12, 746), Scale::UTC),
                  Instant::DateTime(DateTime(2010, 3, 12, 3, 14, 12, 746), Scale::UTC),
@@ -144,7 +148,9 @@ class OpenSpaceToolkit_Astrodynamics_Conjunction_Messages_CCSDS_CDM : public ::t
                  Real::Undefined(),
                  Real::Undefined(),
                  State::Undefined(),
-                 MatrixXd(9, 9)}}};
+                 MatrixXd(9, 9)
+             }}
+        };
     }
 
     CDM cdm_ = CDM::Undefined();

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -70,7 +70,8 @@ class OpenSpaceToolkit_Astrodynamics_Flight_Profile : public ::testing::Test
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         this->orbit_ = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -207,7 +208,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, GetStatesAt)
              Velocity::MetersPerSecond({-8.134701312198, 7546.048902632449, 0.000000000000}, Frame::GCRF()),
              Quaternion::XYZS(-0.499730425479, -0.500269429259, 0.500269429259, 0.499730425479),
              {0.000000000000, -0.001078007612, 0.000000000000},
-             Frame::GCRF()}};
+             Frame::GCRF()}
+        };
 
         const Array<State> states = profile_.getStatesAt(referenceInstants);
 
@@ -297,7 +299,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, InertialPointing)
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -324,11 +327,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, InertialPointing)
             const Vector3d x_BODY_GCRF_ref = {
                 referenceRow["x (m)"].accessReal(),
                 referenceRow["y (m)"].accessReal(),
-                referenceRow["z (m)"].accessReal()};
+                referenceRow["z (m)"].accessReal()
+            };
             const Vector3d v_BODY_GCRF_in_GCRF_ref = {
                 referenceRow["vx (m/sec)"].accessReal(),
                 referenceRow["vy (m/sec)"].accessReal(),
-                referenceRow["vz (m/sec)"].accessReal()};
+                referenceRow["vz (m/sec)"].accessReal()
+            };
             const Quaternion q_BODY_GCRF_ref = Quaternion::XYZS(
                                                    referenceRow["q1"].accessReal(),
                                                    referenceRow["q2"].accessReal(),
@@ -339,7 +344,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, InertialPointing)
             const Vector3d w_BODY_GCRF_in_BODY_ref = {
                 referenceRow["wx (rad/sec)"].accessReal(),
                 referenceRow["wy (rad/sec)"].accessReal(),
-                referenceRow["wz (rad/sec)"].accessReal()};
+                referenceRow["wz (rad/sec)"].accessReal()
+            };
 
             const State state = profile.getStateAt(instant_ref);
 
@@ -435,7 +441,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -462,11 +469,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
             const Vector3d x_BODY_GCRF_ref = {
                 referenceRow["x (m)"].accessReal(),
                 referenceRow["y (m)"].accessReal(),
-                referenceRow["z (m)"].accessReal()};
+                referenceRow["z (m)"].accessReal()
+            };
             const Vector3d v_BODY_GCRF_in_GCRF_ref = {
                 referenceRow["vx (m/sec)"].accessReal(),
                 referenceRow["vy (m/sec)"].accessReal(),
-                referenceRow["vz (m/sec)"].accessReal()};
+                referenceRow["vz (m/sec)"].accessReal()
+            };
             const Quaternion q_BODY_GCRF_ref = Quaternion::XYZS(
                                                    referenceRow["q1"].accessReal(),
                                                    referenceRow["q2"].accessReal(),
@@ -477,7 +486,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
             const Vector3d w_BODY_GCRF_in_BODY_ref = {
                 referenceRow["wx (rad/sec)"].accessReal(),
                 referenceRow["wy (rad/sec)"].accessReal(),
-                referenceRow["wz (rad/sec)"].accessReal()};
+                referenceRow["wz (rad/sec)"].accessReal()
+            };
 
             const State state = profile.getStateAt(instant_ref);
 
@@ -541,7 +551,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -568,11 +579,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
             const Vector3d x_BODY_GCRF_ref = {
                 referenceRow["x (m)"].accessReal(),
                 referenceRow["y (m)"].accessReal(),
-                referenceRow["z (m)"].accessReal()};
+                referenceRow["z (m)"].accessReal()
+            };
             const Vector3d v_BODY_GCRF_in_GCRF_ref = {
                 referenceRow["vx (m/sec)"].accessReal(),
                 referenceRow["vy (m/sec)"].accessReal(),
-                referenceRow["vz (m/sec)"].accessReal()};
+                referenceRow["vz (m/sec)"].accessReal()
+            };
             const Quaternion q_BODY_GCRF_ref = Quaternion::XYZS(
                                                    referenceRow["q1"].accessReal(),
                                                    referenceRow["q2"].accessReal(),
@@ -583,7 +596,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
             const Vector3d w_BODY_GCRF_in_BODY_ref = {
                 referenceRow["wx (rad/sec)"].accessReal(),
                 referenceRow["wy (rad/sec)"].accessReal(),
-                referenceRow["wz (rad/sec)"].accessReal()};
+                referenceRow["wz (rad/sec)"].accessReal()
+            };
 
             const State state = profile.getStateAt(instant_ref);
 
@@ -647,7 +661,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -674,11 +689,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
             const Vector3d x_BODY_GCRF_ref = {
                 referenceRow["x (m)"].accessReal(),
                 referenceRow["y (m)"].accessReal(),
-                referenceRow["z (m)"].accessReal()};
+                referenceRow["z (m)"].accessReal()
+            };
             const Vector3d v_BODY_GCRF_in_GCRF_ref = {
                 referenceRow["vx (m/sec)"].accessReal(),
                 referenceRow["vy (m/sec)"].accessReal(),
-                referenceRow["vz (m/sec)"].accessReal()};
+                referenceRow["vz (m/sec)"].accessReal()
+            };
             const Quaternion q_BODY_GCRF_ref = Quaternion::XYZS(
                                                    referenceRow["q1"].accessReal(),
                                                    referenceRow["q2"].accessReal(),
@@ -689,7 +706,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
             const Vector3d w_BODY_GCRF_in_BODY_ref = {
                 referenceRow["wx (rad/sec)"].accessReal(),
                 referenceRow["wy (rad/sec)"].accessReal(),
-                referenceRow["wz (rad/sec)"].accessReal()};
+                referenceRow["wz (rad/sec)"].accessReal()
+            };
 
             const State state = profile.getStateAt(instant_ref);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System.test.cpp
@@ -37,7 +37,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, Constructor)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};
@@ -55,7 +56,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, Constructor)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};
@@ -92,7 +94,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, EqualToOperator)
         // Define system geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};
@@ -142,7 +145,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, NotEqualToOperator)
         // Define system geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};
@@ -191,7 +195,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, IsDefined)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};
@@ -227,7 +232,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, StreamOperator)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};
@@ -267,7 +273,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, Print)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};
@@ -307,7 +314,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, getMass)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};
@@ -343,7 +351,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System, getGeometry)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid systemCuboid = {center, axes, extent};

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/AtmosphericDrag.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/AtmosphericDrag.test.cpp
@@ -241,7 +241,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_AtmosphericDrag, On
 {
     // Setup dynamics
     const Array<Shared<Dynamics>> dynamics = {
-        std::make_shared<AtmosphericDrag>(AtmosphericDrag(earthSPtr_, satelliteSystem_))};
+        std::make_shared<AtmosphericDrag>(AtmosphericDrag(earthSPtr_, satelliteSystem_))
+    };
 
     // Perform 1.0s integration step
     runge_kutta4<NumericalSolver::StateVector> stepper;
@@ -272,9 +273,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_Dynamics_AtmosphericDrag, On
     const Shared<Celestial> earthSPtr = std::make_shared<Celestial>(earth);
 
     const Composite satelliteGeometry(Cuboid {
-        {0.0, 0.0, 0.0},
-        {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}},
-        {1.0, 2.0, 3.0}});
+        {0.0, 0.0, 0.0}, {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}}, {1.0, 2.0, 3.0}
+    });
 
     const SatelliteSystem satelliteSystem = {
         Mass::Kilograms(100.0),

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
@@ -42,7 +42,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Constructor)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -88,7 +89,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, CopyConstruct
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -102,7 +104,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, CopyConstruct
 
         // Construct SatelliteSystem object
         const SatelliteSystem satellitesystem = {
-            satelliteMass, satelliteGeometry, satelliteInertiaTensor, crossSectionalSurfaceArea, dragCoefficient};
+            satelliteMass, satelliteGeometry, satelliteInertiaTensor, crossSectionalSurfaceArea, dragCoefficient
+        };
 
         EXPECT_NO_THROW(SatelliteSystem satellitesystemCopy(satellitesystem));
     }
@@ -135,7 +138,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, EqualToOperat
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
         const Cuboid satelliteCuboid = {center, axes, extent};
         const Composite satelliteGeometry(satelliteCuboid);
@@ -149,7 +153,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, EqualToOperat
         // Test for different mass
         const Mass satelliteMass_1(100.0, Mass::Unit::Kilogram);
         const SatelliteSystem satelliteSystem_1 = {
-            satelliteMass_1, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2};
+            satelliteMass_1, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2
+        };
 
         EXPECT_FALSE(satelliteSystem == satelliteSystem_1);
 
@@ -157,7 +162,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, EqualToOperat
         const Point center_0 = {1.0, 0.0, 0.0};
         const Composite satelliteGeometry_0(Cuboid(center_0, axes, extent));
         const SatelliteSystem satelliteSystem_3 = {
-            satelliteMass, satelliteGeometry_0, satelliteInertiaTensor, 0.8, 2.2};
+            satelliteMass, satelliteGeometry_0, satelliteInertiaTensor, 0.8, 2.2
+        };
 
         EXPECT_FALSE(satelliteSystem == satelliteSystem_3);
 
@@ -165,7 +171,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, EqualToOperat
         Matrix3d satelliteInertiaTensor_0 = satelliteInertiaTensor;
         satelliteInertiaTensor_0(0, 0) = 2.0;
         const SatelliteSystem satelliteSystem_2 = {
-            satelliteMass, satelliteGeometry, satelliteInertiaTensor_0, 0.8, 2.2};
+            satelliteMass, satelliteGeometry, satelliteInertiaTensor_0, 0.8, 2.2
+        };
 
         EXPECT_FALSE(satelliteSystem == satelliteSystem_2);
 
@@ -207,7 +214,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, NotEqualToOpe
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
         const Cuboid satelliteCuboid = {center, axes, extent};
         const Composite satelliteGeometry(satelliteCuboid);
@@ -221,7 +229,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, NotEqualToOpe
         // Test for different mass
         const Mass satelliteMass_1(100.0, Mass::Unit::Kilogram);
         const SatelliteSystem satelliteSystem_1 = {
-            satelliteMass_1, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2};
+            satelliteMass_1, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2
+        };
 
         EXPECT_TRUE(satelliteSystem != satelliteSystem_1);
 
@@ -229,7 +238,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, NotEqualToOpe
         const Point center_0 = {1.0, 0.0, 0.0};
         const Composite satelliteGeometry_0(Cuboid(center_0, axes, extent));
         const SatelliteSystem satelliteSystem_3 = {
-            satelliteMass, satelliteGeometry_0, satelliteInertiaTensor, 0.8, 2.2};
+            satelliteMass, satelliteGeometry_0, satelliteInertiaTensor, 0.8, 2.2
+        };
 
         EXPECT_TRUE(satelliteSystem != satelliteSystem_3);
 
@@ -237,7 +247,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, NotEqualToOpe
         Matrix3d satelliteInertiaTensor_0 = satelliteInertiaTensor;
         satelliteInertiaTensor_0(0, 0) = 2.0;
         const SatelliteSystem satelliteSystem_2 = {
-            satelliteMass, satelliteGeometry, satelliteInertiaTensor_0, 0.8, 2.2};
+            satelliteMass, satelliteGeometry, satelliteInertiaTensor_0, 0.8, 2.2
+        };
 
         EXPECT_TRUE(satelliteSystem != satelliteSystem_2);
 
@@ -277,7 +288,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, IsDefined)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -316,7 +328,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, StreamOperato
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -359,7 +372,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Print)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -402,7 +416,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getMass)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -441,7 +456,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getGeometry)
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -480,7 +496,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getInertiaTen
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -519,7 +536,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getCrossSecti
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -530,7 +548,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getCrossSecti
 
         // Construct SatelliteSystem object
         const SatelliteSystem satelliteSystem = {
-            satelliteMass, satelliteGeometry, satelliteInertiaTensor, surfaceArea, 2.2};
+            satelliteMass, satelliteGeometry, satelliteInertiaTensor, surfaceArea, 2.2
+        };
 
         EXPECT_EQ(satelliteSystem.getCrossSectionalSurfaceArea(), surfaceArea);
     }
@@ -562,7 +581,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getDragCoeffi
         // Define satellite geometry
         const Point center = {0.0, 0.0, 0.0};
         const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}};
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
         const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
         const Cuboid satelliteCuboid = {center, axes, extent};
@@ -573,7 +593,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getDragCoeffi
 
         // Construct SatelliteSystem object
         const SatelliteSystem satelliteSystem = {
-            satelliteMass, satelliteGeometry, satelliteInertiaTensor, 0.8, dragCoefficient};
+            satelliteMass, satelliteGeometry, satelliteInertiaTensor, 0.8, dragCoefficient
+        };
 
         EXPECT_EQ(satelliteSystem.getDragCoefficient(), dragCoefficient);
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -32,7 +32,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, Constructor)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 
@@ -50,7 +51,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, Constructor)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Trajectory trajectory = {states};
 
@@ -83,7 +85,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, EqualToOperator)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 
@@ -101,7 +104,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, EqualToOperator)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model_A = {states_A};
 
@@ -113,7 +117,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, EqualToOperator)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({0.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({0.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model_B = {states_B};
 
@@ -155,7 +160,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, NotEqualToOperator)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 
@@ -173,7 +179,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, NotEqualToOperator)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model_A = {states_A};
 
@@ -185,7 +192,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, NotEqualToOperator)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({0.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({0.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model_B = {states_B};
 
@@ -227,7 +235,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, StreamOperator)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 
@@ -266,7 +275,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, IsDefined)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 
@@ -305,7 +315,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, AccessModel)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 
@@ -344,7 +355,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GetStateAt)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 
@@ -414,7 +426,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GetStatesAt)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 
@@ -424,7 +437,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GetStatesAt)
             const Array<Instant> referenceInstants = {
                 states.at(0).accessInstant(),
                 Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0, 500), Scale::UTC),
-                states.at(1).accessInstant()};
+                states.at(1).accessInstant()
+            };
 
             const Array<State> referenceStates = {
                 {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
@@ -435,7 +449,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GetStatesAt)
                  Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
                 {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
                  Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-                 Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+                 Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+            };
 
             EXPECT_EQ(referenceStates, trajectory.getStatesAt(referenceInstants));
         }
@@ -445,7 +460,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GetStatesAt)
                 Instant::DateTime(DateTime(2017, 12, 31, 23, 59, 59), Scale::UTC),
                 states.at(0).accessInstant(),
                 states.at(1).accessInstant(),
-                Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 2), Scale::UTC)};
+                Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 2), Scale::UTC)
+            };
 
             EXPECT_ANY_THROW(trajectory.getStatesAt(referenceInstants));
         }
@@ -489,7 +505,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GetStatesAt)
                  Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
                 {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1, 500), Scale::UTC),
                  Position::Meters({1.5, 0.0, 0.0}, gcrfSPtr),
-                 Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+                 Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+            };
 
             EXPECT_EQ(referenceStates, trajectory.getStatesAt(desiredInstants));
         }
@@ -528,7 +545,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, Print)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Tabulated model = {states};
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -80,7 +80,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Constructor)
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -98,7 +99,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Constructor)
              Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)},
             {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC),
              Position::Meters({1.0, 0.0, 0.0}, gcrfSPtr),
-             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}};
+             Velocity::MetersPerSecond({1.0, 0.0, 0.0}, gcrfSPtr)}
+        };
 
         const Integer initialRevolutionNumber = 123;
 
@@ -129,7 +131,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, EqualToOperator)
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -165,7 +168,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, NotEqualToOperator)
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -201,7 +205,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, IsDefined)
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -238,7 +243,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetRevolutionNumberAt)
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -295,7 +301,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassAt)
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -362,7 +369,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -426,7 +434,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -490,7 +499,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -567,7 +577,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetOrbitalFrame)
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Shared<const Earth> earthSPtr =
             std::dynamic_pointer_cast<const Earth>(environment.accessObjectWithName("Earth"));
@@ -581,9 +592,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetOrbitalFrame)
             const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
             const Vector3d x_NED_ITRF_ref = {
-                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+            };
             const Vector3d v_NED_ITRF_in_ITRF_ref = {
-                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+            };
 
             const Quaternion q_NED_ITRF_ref = Quaternion::XYZS(
                                                   referenceRow[7].accessReal(),
@@ -593,7 +606,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetOrbitalFrame)
             )
                                                   .normalize();
             const Vector3d w_NED_ITRF_in_NED_ref = {
-                referenceRow[11].accessReal(), referenceRow[12].accessReal(), referenceRow[13].accessReal()};
+                referenceRow[11].accessReal(), referenceRow[12].accessReal(), referenceRow[13].accessReal()
+            };
 
             const Quaternion q_ITRF_NED_ref = q_NED_ITRF_ref.toConjugate();
             const Vector3d w_ITRF_NED_in_ITRF_ref = -(q_ITRF_NED_ref * w_NED_ITRF_in_NED_ref);
@@ -762,7 +776,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Print)
         const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
@@ -899,7 +914,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              1e-3,
              1e-6,
              1e-1,
-             1e-4}};
+             1e-4}
+        };
 
         for (const auto& scenario : scenarios)
         {
@@ -1035,7 +1051,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Equatorial)
              1e-3,
              1e-6,
              1e-0,
-             1e-3}};
+             1e-3}
+        };
 
         for (const auto& scenario : scenarios)
         {
@@ -1092,7 +1109,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, CircularEquatorial)
              1e-3,
              1e-6,
              1e-1,
-             1e-4}};
+             1e-4}
+        };
 
         for (const auto& scenario : scenarios)
         {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Messages/SpaceX/OPM.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Messages/SpaceX/OPM.test.cpp
@@ -48,7 +48,8 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Messages_SpaceX_OPM : publ
                  Angle::Degrees(2.0),
                  Angle::Degrees(3.0),
                  Angle::Degrees(4.0),
-                 123.456},
+                 123.456
+             },
              OPM::Deployment {
                  "B",
                  456,
@@ -62,7 +63,9 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Messages_SpaceX_OPM : publ
                  Angle::Degrees(6.0),
                  Angle::Degrees(7.0),
                  Angle::Degrees(8.0),
-                 456.123}}};
+                 456.123
+             }}
+        };
     }
 
     OPM opm_ = OPM::Undefined();
@@ -88,7 +91,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Messages_SpaceX_OPM, Cons
             Angle::Degrees(2.0),
             Angle::Degrees(3.0),
             Angle::Degrees(4.0),
-            123.456}}};
+            123.456
+        }}
+    };
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Messages_SpaceX_OPM, IsDefined)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler.test.cpp
@@ -171,7 +171,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_1)
         const Real J4 = Earth::EGM2008.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
         // Orbit setup
 
@@ -194,14 +195,18 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_1)
             const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
             const Vector3d referencePosition_GCRF = {
-                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+            };
             const Vector3d referenceVelocity_GCRF = {
-                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+            };
 
             const Vector3d referencePosition_ITRF = {
-                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()};
+                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()
+            };
             const Vector3d referenceVelocity_ITRF = {
-                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()};
+                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()
+            };
 
             const Real referenceRevolutionNumber = referenceRow[13].accessReal();
 
@@ -277,7 +282,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_2)
         const Real J4 = Earth::EGM96.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
+        };
 
         // Orbit setup
 
@@ -300,14 +306,18 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_2)
             const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
             const Vector3d referencePosition_GCRF = {
-                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+            };
             const Vector3d referenceVelocity_GCRF = {
-                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+            };
 
             const Vector3d referencePosition_ITRF = {
-                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()};
+                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()
+            };
             const Vector3d referenceVelocity_ITRF = {
-                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()};
+                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()
+            };
 
             const Real referenceRevolutionNumber = referenceRow[13].accessReal();
 
@@ -390,7 +400,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_3)
         const Real J4 = Earth::EGM96.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
+        };
 
         // Orbit setup
 
@@ -413,14 +424,18 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_3)
             const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
             const Vector3d referencePosition_GCRF = {
-                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+            };
             const Vector3d referenceVelocity_GCRF = {
-                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+            };
 
             const Vector3d referencePosition_ITRF = {
-                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()};
+                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()
+            };
             const Vector3d referenceVelocity_ITRF = {
-                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()};
+                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()
+            };
 
             const State state_GCRF = orbit.getStateAt(instant);
 
@@ -492,7 +507,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_4)
         const Real J4 = Earth::EGM96.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4
+        };
 
         // Orbit setup
 
@@ -515,14 +531,18 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_4)
             const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
             const Vector3d referencePosition_GCRF = {
-                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+            };
             const Vector3d referenceVelocity_GCRF = {
-                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+            };
 
             const Vector3d referencePosition_ITRF = {
-                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()};
+                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()
+            };
             const Vector3d referenceVelocity_ITRF = {
-                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()};
+                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()
+            };
 
             const State state_GCRF = orbit.getStateAt(instant);
 
@@ -594,7 +614,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_5)
         const Real J4 = Earth::EGM96.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4
+        };
 
         // Orbit setup
 
@@ -617,14 +638,18 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_5)
             const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
             const Vector3d referencePosition_GCRF = {
-                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+            };
             const Vector3d referenceVelocity_GCRF = {
-                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+            };
 
             const Vector3d referencePosition_ITRF = {
-                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()};
+                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()
+            };
             const Vector3d referenceVelocity_ITRF = {
-                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()};
+                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()
+            };
 
             const State state_GCRF = orbit.getStateAt(instant);
 
@@ -696,7 +721,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_6)
         const Real J4 = Earth::EGM96.J4_;
 
         const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4};
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4
+        };
 
         // Orbit setup
 
@@ -719,14 +745,18 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler, Test_6)
             const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
             const Vector3d referencePosition_GCRF = {
-                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+            };
             const Vector3d referenceVelocity_GCRF = {
-                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+            };
 
             const Vector3d referencePosition_ITRF = {
-                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()};
+                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()
+            };
             const Vector3d referenceVelocity_ITRF = {
-                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()};
+                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()
+            };
 
             const State state_GCRF = orbit.getStateAt(instant);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Propagated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Propagated.test.cpp
@@ -91,7 +91,8 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagated : public
 
     const Shared<const Frame> gcrfSPtr_ = Frame::GCRF();
     const NumericalSolver defaultNumericalSolver_ = {
-        NumericalSolver::LogType::NoLog, NumericalSolver::StepperType::RungeKuttaFehlberg78, 5.0, 1.0e-15, 1.0e-15};
+        NumericalSolver::LogType::NoLog, NumericalSolver::StepperType::RungeKuttaFehlberg78, 5.0, 1.0e-15, 1.0e-15
+    };
 
     const Instant defaultInstant_ = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC);
 
@@ -168,7 +169,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagated, EqualT
             NumericalSolver::StepperType::RungeKuttaFehlberg78,
             5.0,
             1.0e-15,
-            1.0e-15};
+            1.0e-15
+        };
         const Propagated propagatedModel_1 = {{numericalSolver_1, defaultDynamics_}, defaultState_};
         EXPECT_FALSE(propagatedModel == propagatedModel_1);
 
@@ -204,7 +206,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagated, NotEqu
             NumericalSolver::StepperType::RungeKuttaFehlberg78,
             5.0,
             1.0e-15,
-            1.0e-15};
+            1.0e-15
+        };
         const Propagated propagatedModel_1 = {{numericalSolver_1, defaultDynamics_}, defaultState_};
         EXPECT_TRUE(propagatedModel != propagatedModel_1);
 
@@ -546,12 +549,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagated, Access
         // Current state and instant setup
         Array<State> stateArray = Array<State>::Empty();
         const State state_1 = {
-            Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_};
+            Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_
+        };
         stateArray.add(state_1);
         const State state_2 = {defaultInstant_, defaultPosition_, defaultVelocity_};
         stateArray.add(state_2);
         const State state_3 = {
-            Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_};
+            Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_
+        };
         stateArray.add(state_3);
 
         // Setup Propagated model
@@ -571,10 +576,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagated, Access
         // Current state and instant setup
         Array<State> stateArray = Array<State>::Empty();
         const State state_3 = {
-            Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_};
+            Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_
+        };
         stateArray.add(state_3);
         const State state_1 = {
-            Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_};
+            Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_
+        };
         stateArray.add(state_1);
         const State state_2 = {defaultInstant_, defaultPosition_, defaultVelocity_};
         stateArray.add(state_2);
@@ -607,12 +614,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagated, SetCac
         // Current state and instant setup
         Array<State> stateArray = Array<State>::Empty();
         const State state_1 = {
-            Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_};
+            Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_
+        };
         stateArray.add(state_1);
         const State state_2 = {defaultInstant_, defaultPosition_, defaultVelocity_};
         stateArray.add(state_2);
         const State state_3 = {
-            Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_};
+            Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_
+        };
         stateArray.add(state_3);
 
         // Manually set cachedStateArray
@@ -636,10 +645,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagated, SetCac
         // Current state and instant setup
         Array<State> stateArray = Array<State>::Empty();
         const State state_3 = {
-            Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_};
+            Instant::DateTime(DateTime(2018, 1, 3, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_
+        };
         stateArray.add(state_3);
         const State state_1 = {
-            Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_};
+            Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC), defaultPosition_, defaultVelocity_
+        };
         stateArray.add(state_1);
         const State state_2 = {defaultInstant_, defaultPosition_, defaultVelocity_};
         stateArray.add(state_2);
@@ -698,7 +709,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagated, Propag
                 Instant::DateTime(DateTime::Parse("2023-01-30T18:40:00.184", DateTime::Format::ISO8601), Scale::UTC),
                 Position::Meters({-2965004.866673604585, 1695085.379882899811, 5976267.045515080914}, gcrfSPtr_),
                 Velocity::MetersPerSecond({6539.557709872774, -1396.675776577052, 3637.641862957897}, gcrfSPtr_),
-            }};
+            }
+        };
 
         Propagated propagatedModel(propagator_, states);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/SGP4.test.cpp
@@ -92,19 +92,25 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_SGP4, Test_1)
             const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
             const Vector3d referencePosition_TEME = {
-                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+            };
             const Vector3d referenceVelocity_TEME = {
-                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+            };
 
             const Vector3d referencePosition_GCRF = {
-                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()};
+                referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()
+            };
             const Vector3d referenceVelocity_GCRF = {
-                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()};
+                referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()
+            };
 
             const Vector3d referencePosition_ITRF = {
-                referenceRow[13].accessReal(), referenceRow[14].accessReal(), referenceRow[15].accessReal()};
+                referenceRow[13].accessReal(), referenceRow[14].accessReal(), referenceRow[15].accessReal()
+            };
             const Vector3d referenceVelocity_ITRF = {
-                referenceRow[16].accessReal(), referenceRow[17].accessReal(), referenceRow[18].accessReal()};
+                referenceRow[16].accessReal(), referenceRow[17].accessReal(), referenceRow[18].accessReal()
+            };
 
             // const Real referenceRevolutionNumber = referenceRow[19].accessReal() ;
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Utilities.test.hpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Utilities.test.hpp
@@ -75,14 +75,18 @@ void testOrbit(
         const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::UTC);
 
         const Vector3d referencePosition_GCRF = {
-            referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+            referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()
+        };
         const Vector3d referenceVelocity_GCRF = {
-            referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+            referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()
+        };
 
         const Vector3d referencePosition_ITRF = {
-            referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()};
+            referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal()
+        };
         const Vector3d referenceVelocity_ITRF = {
-            referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()};
+            referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal()
+        };
 
         const Real referenceRevolutionNumber = referenceRow[13].accessReal();
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -177,7 +177,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, EqualT
             NumericalSolver::StepperType::RungeKuttaFehlberg78,
             5.0,
             1.0e-15,
-            1.0e-15};
+            1.0e-15
+        };
         const Propagator propagator_1 = {numericalSolver_1, defaultDynamics_};
         EXPECT_FALSE(defaultPropagator_ == propagator_1);
     }
@@ -194,7 +195,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, NotEqu
             NumericalSolver::StepperType::RungeKuttaFehlberg78,
             5.0,
             1.0e-15,
-            1.0e-15};
+            1.0e-15
+        };
         const Propagator propagator1 = {numericalSolver1, defaultDynamics_};
         EXPECT_TRUE(defaultPropagator_ != propagator1);
     }
@@ -2026,7 +2028,8 @@ TEST_F(
 
         // Construct default numerical solver
         const NumericalSolver numericalSolver54 = {
-            NumericalSolver::LogType::NoLog, NumericalSolver::StepperType::RungeKuttaCashKarp54, 5.0, 1.0e-15, 1.0e-15};
+            NumericalSolver::LogType::NoLog, NumericalSolver::StepperType::RungeKuttaCashKarp54, 5.0, 1.0e-15, 1.0e-15
+        };
 
         // Setup initial conditions
         const State state = {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.test.cpp
@@ -25,7 +25,8 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinatesSubsets_Cartesi
     const String defaultName_ = "NAME";
     const CartesianPosition defaultCartesianPosition_ = CartesianPosition(defaultName_);
     const Array<Shared<const CoordinatesSubset>> defaultCoordinateSubsets_ = {
-        std::make_shared<CartesianPosition>(defaultCartesianPosition_)};
+        std::make_shared<CartesianPosition>(defaultCartesianPosition_)
+    };
     const Shared<const CoordinatesBroker> defaultCoordinatesBroker_ =
         std::make_shared<CoordinatesBroker>(defaultCoordinateSubsets_);
 };

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.test.cpp
@@ -29,7 +29,8 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinatesSubsets_Cartesi
     const CartesianVelocity defaultCartesianVelocity_ = CartesianVelocity(defaultCartesianPositionSPtr_, defaultName_);
 
     const Array<Shared<const CoordinatesSubset>> defaultCoordinateSubsets_ = {
-        std::make_shared<CartesianVelocity>(defaultCartesianVelocity_)};
+        std::make_shared<CartesianVelocity>(defaultCartesianVelocity_)
+    };
     const Shared<const CoordinatesBroker> defaultCoordinatesBroker_ =
         std::make_shared<CoordinatesBroker>(defaultCoordinateSubsets_);
 };
@@ -93,7 +94,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinatesSubsets_Cartes
         VectorXd fullCoordinatesVector(6);
         fullCoordinatesVector << 1.0e6, 2.0e6, 3.0e5, 4.0e3, -5.0e3, 6.0e3;
         const Array<Shared<const CoordinatesSubset>> coordinateSubsets = {
-            defaultCartesianPositionSPtr_, std::make_shared<CartesianVelocity>(defaultCartesianVelocity_)};
+            defaultCartesianPositionSPtr_, std::make_shared<CartesianVelocity>(defaultCartesianVelocity_)
+        };
         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(coordinateSubsets);
 
         Vector3d expected = Velocity::MetersPerSecond({4.0e3, -5.0e3, 6.0e3}, fromFrame)

--- a/tutorials/cpp/sensor-modeling/SensorModeling.cxx
+++ b/tutorials/cpp/sensor-modeling/SensorModeling.cxx
@@ -86,7 +86,8 @@ int main()
     const Instant epoch = Instant::DateTime(DateTime(2018, 9, 5, 0, 0, 0), Scale::UTC);
 
     const Kepler orbitalModel = {
-        coe, epoch, *earthSPtr, Kepler::PerturbationType::None, true};  // True = COE expressed in ITRF frame
+        coe, epoch, *earthSPtr, Kepler::PerturbationType::None, true
+    };  // True = COE expressed in ITRF frame
 
     const Orbit orbit = {orbitalModel, earthSPtr};
 
@@ -157,7 +158,8 @@ int main()
         Polygon2d({{-1.0, -1.0}, {+1.0, -1.0}, {+1.0, +1.0}, {-1.0, +1.0}}),
         apex_B + Vector3d(0.0, 0.0, 5.0),
         Vector3d(1.0, 0.0, 0.0),
-        Vector3d(0.0, 1.0, 0.0)};
+        Vector3d(0.0, 1.0, 0.0)
+    };
 
     const Pyramid pyramid_B = {base_B, apex_B};
 


### PR DESCRIPTION
This PR adds a Temporal Condition Solver class, providing a generic algorithm to find the set of sub-intervals over which a set of conditions are met.

The Access Generator being a special case, it has been refactored to rely on this new solver under the hood.

In addition, this solver can be used to handle more complex cases, for example by returning time intervals over a certain zone while not being in eclipse, etc.

Here's an example of how this translates into Python (assuming `in_access` and `in_eclipse` are provided functions):

```py
temporal_condition_solver = TemporalConditionSolver(
    time_step=Duration.seconds(30.0),
    tolerance=Duration.milliseconds(1.0),
    maximum_iteration_count=500,
)

intervals: list[Interval] = temporal_condition_solver.solve(
    conditions=[
        lambda instant: in_access(instant),
        lambda instant: not in_eclipse(instant),
    ],
    interval=interval,
)
```

Note that an `in_access` function can now be obtained from the Access Generator class:

```py
access_generator = Generator(
    environment=Environment.default(),
)

in_access = access_generator.get_condition_function(
    from_trajectory=trajectory,
    to_trajectory=trajectory,
)
```