### PR TITLE
feat: add CesiumPy Viewer to Python utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,6 +471,7 @@ test-unit-python-standalone: ## Run Python unit tests (standalone)
 		/bin/bash -c "cmake -DBUILD_PYTHON_BINDINGS=ON -DBUILD_UNIT_TESTS=OFF .. \
 		&& $(MAKE) -j 4 && python3.11 -m pip install --root-user-action=ignore bindings/python/dist/*311*.whl \
 		&& python3.11 -m pip install plotly pandas \
+		&& python3.11 -m pip install git+https://github.com/lucas-bremond/cesiumpy.git#egg=cesiumpy \
 		&& cd /usr/local/lib/python3.11/site-packages/ostk/$(project_name)/ \
 		&& python3.11 -m pytest -sv ."
 

--- a/bindings/python/docs/Demonstration/new-orbit-constructors.ipynb
+++ b/bindings/python/docs/Demonstration/new-orbit-constructors.ipynb
@@ -134,7 +134,10 @@
    "outputs": [],
    "source": [
     "orbit = Orbit.geo_synchronous(\n",
-    "    epoch, inclination, longitude, environment.access_celestial_object_with_name(\"Earth\")\n",
+    "    epoch,\n",
+    "    inclination,\n",
+    "    longitude,\n",
+    "    environment.access_celestial_object_with_name(\"Earth\"),\n",
     ")"
    ]
   },

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,3 +1,3 @@
 # Apache License 2.0
 
-open-space-toolkit-physics~=1.1.1
+open-space-toolkit-physics~=1.1

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,3 +1,3 @@
 # Apache License 2.0
 
-open-space-toolkit-physics~=1.1
+open-space-toolkit-physics~=1.1.1

--- a/bindings/python/test/access/test_generator.py
+++ b/bindings/python/test/access/test_generator.py
@@ -101,7 +101,8 @@ class TestGenerator:
         assert isinstance(generator, Generator)
 
     def test_constructor_success_environment_access_filter(
-        self, environment: Environment
+        self,
+        environment: Environment,
     ):
         generator = Generator(
             environment=environment,
@@ -111,7 +112,10 @@ class TestGenerator:
         assert generator is not None
         assert isinstance(generator, Generator)
 
-    def test_constructor_success_environment_state_filter(self, environment: Environment):
+    def test_constructor_success_environment_state_filter(
+        self,
+        environment: Environment,
+    ):
         generator = Generator(
             environment=environment,
             state_filter=lambda state_1, state_2: True,
@@ -121,7 +125,8 @@ class TestGenerator:
         assert isinstance(generator, Generator)
 
     def test_constructor_success_environment_step_tolerance(
-        self, environment: Environment
+        self,
+        environment: Environment,
     ):
         generator = Generator(
             environment=environment,

--- a/bindings/python/test/conjunction/messages/ccsds/test_cdm.py
+++ b/bindings/python/test/conjunction/messages/ccsds/test_cdm.py
@@ -25,7 +25,9 @@ def cdm() -> CDM:
     return CDM(
         header=CDM.Header(
             ccsds_cdm_version="1.0",
-            creation_date=Instant.date_time(datetime(2010, 3, 12, 22, 31, 12), Scale.UTC),
+            creation_date=Instant.date_time(
+                datetime(2010, 3, 12, 22, 31, 12), Scale.UTC
+            ),
             originator="JSPOC",
             message_for="SATELLITE A",
             message_id="201113719185",

--- a/bindings/python/test/event_condition/test_coe_condition.py
+++ b/bindings/python/test/event_condition/test_coe_condition.py
@@ -56,7 +56,9 @@ def state_vector() -> list[float]:
 class TestCOECondition:
     def test_constructor(self, criteria, element, target, gravitational_parameter):
         name = "Test COECondition"
-        condition = COECondition(name, criteria, element, target, gravitational_parameter)
+        condition = COECondition(
+            name, criteria, element, target, gravitational_parameter
+        )
 
         assert condition is not None
 

--- a/bindings/python/test/flight/profile/test_state.py
+++ b/bindings/python/test/flight/profile/test_state.py
@@ -78,7 +78,8 @@ class TestState:
         angular_velocity = [0.01, 0.01, 0.0]
 
         assert isinstance(
-            State(instant, position, velocity, quaternion, angular_velocity, frame), State
+            State(instant, position, velocity, quaternion, angular_velocity, frame),
+            State,
         )
 
     def test_constructors_tuples(
@@ -89,7 +90,8 @@ class TestState:
         angular_velocity = (0.01, 0.01, 0.0)
 
         assert isinstance(
-            State(instant, position, velocity, quaternion, angular_velocity, frame), State
+            State(instant, position, velocity, quaternion, angular_velocity, frame),
+            State,
         )
 
     def test_constructors_array(
@@ -100,7 +102,8 @@ class TestState:
         angular_velocity = np.array((0.01, 0.01, 0.0))
 
         assert isinstance(
-            State(instant, position, velocity, quaternion, angular_velocity, frame), State
+            State(instant, position, velocity, quaternion, angular_velocity, frame),
+            State,
         )
 
     def test_comparators(self, state: State):

--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -1,41 +1,35 @@
 # Apache License 2.0
 
-import pytest
-
 from datetime import datetime
 
-import numpy as np
+import pytest
 
-import ostk.mathematics as mathematics
+from ostk.mathematics.geometry.d3.transformations.rotations import Quaternion
 
-import ostk.physics as physics
+from ostk.physics import Environment
+from ostk.physics.time import DateTime
+from ostk.physics.time import Time
+from ostk.physics.time import Scale
+from ostk.physics.time import Instant
+from ostk.physics.units import Length
+from ostk.physics.coordinate import Transform
+from ostk.physics.coordinate import Position
+from ostk.physics.coordinate import Velocity
+from ostk.physics.coordinate import Frame
+from ostk.physics.coordinate import Axes
+from ostk.physics.coordinate.frame.providers import Dynamic as DynamicProvider
 
-import ostk.astrodynamics as astrodynamics
-
-Quaternion = mathematics.geometry.d3.transformations.rotations.Quaternion
-Environment = physics.Environment
-DateTime = physics.time.DateTime
-Time = physics.time.Time
-Scale = physics.time.Scale
-Instant = physics.time.Instant
-Length = physics.units.Length
-Transform = physics.coordinate.Transform
-Position = physics.coordinate.Position
-Velocity = physics.coordinate.Velocity
-Frame = physics.coordinate.Frame
-Axes = physics.coordinate.Axes
-DynamicProvider = physics.coordinate.frame.providers.Dynamic
-Trajectory = astrodynamics.Trajectory
-Orbit = astrodynamics.trajectory.Orbit
-Profile = astrodynamics.flight.Profile
-State = astrodynamics.flight.profile.State
-TransformModel = astrodynamics.flight.profile.models.Transform
-TabulatedModel = astrodynamics.flight.profile.models.Tabulated
+from ostk.astrodynamics import Trajectory
+from ostk.astrodynamics.trajectory import Orbit
+from ostk.astrodynamics.flight import Profile
+from ostk.astrodynamics.flight.profile import State
+from ostk.astrodynamics.flight.profile.models import Transform as TransformModel
+from ostk.astrodynamics.flight.profile.models import Tabulated as TabulatedModel
 
 
 @pytest.fixture
 def instant() -> Instant:
-    return Instant.date_time(DateTime(2020, 1, 3, 0, 0, 0), Scale.UTC)
+    return Instant.date_time(DateTime(2020, 1, 3), Scale.UTC)
 
 
 @pytest.fixture
@@ -44,7 +38,10 @@ def profile() -> Profile:
         return Transform.identity(instant)
 
     return Profile(
-        model=TransformModel(DynamicProvider(dynamic_provider_generator), Frame.GCRF())
+        model=TransformModel(
+            dynamic_provider=DynamicProvider(dynamic_provider_generator),
+            frame=Frame.GCRF(),
+        ),
     )
 
 
@@ -116,29 +113,27 @@ class TestProfile:
         assert profile.is_defined()
 
     def test_tabulated(self):
-        tabulated_model = TabulatedModel(
-            states=[
-                State(
-                    instant=Instant.date_time(datetime(2020, 1, 1, 0, 0, 0), Scale.UTC),
-                    position=Position.meters((0.0, 0.0, 0.0), Frame.GCRF()),
-                    velocity=Velocity.meters_per_second((0.0, 0.0, 0.0), Frame.GCRF()),
-                    attitude=Quaternion.unit(),
-                    angular_velocity=(0.0, 0.0, 0.0),
-                    reference_frame=Frame.GCRF(),
-                ),
-                State(
-                    instant=Instant.date_time(datetime(2020, 1, 1, 0, 1, 0), Scale.UTC),
-                    position=Position.meters((0.0, 0.0, 0.0), Frame.GCRF()),
-                    velocity=Velocity.meters_per_second((0.0, 0.0, 0.0), Frame.GCRF()),
-                    attitude=Quaternion.unit(),
-                    angular_velocity=(0.0, 0.0, 0.0),
-                    reference_frame=Frame.GCRF(),
-                ),
-            ],
-        )
-
         profile = Profile(
-            model=tabulated_model,
+            model=TabulatedModel(
+                states=[
+                    State(
+                        instant=Instant.date_time(datetime(2020, 1, 1, 0, 0, 0), Scale.UTC),
+                        position=Position.meters((0.0, 0.0, 0.0), Frame.GCRF()),
+                        velocity=Velocity.meters_per_second((0.0, 0.0, 0.0), Frame.GCRF()),
+                        attitude=Quaternion.unit(),
+                        angular_velocity=(0.0, 0.0, 0.0),
+                        reference_frame=Frame.GCRF(),
+                    ),
+                    State(
+                        instant=Instant.date_time(datetime(2020, 1, 1, 0, 1, 0), Scale.UTC),
+                        position=Position.meters((0.0, 0.0, 0.0), Frame.GCRF()),
+                        velocity=Velocity.meters_per_second((0.0, 0.0, 0.0), Frame.GCRF()),
+                        attitude=Quaternion.unit(),
+                        angular_velocity=(0.0, 0.0, 0.0),
+                        reference_frame=Frame.GCRF(),
+                    ),
+                ],
+            ),
         )
 
         assert isinstance(profile, Profile)

--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -44,7 +44,7 @@ def profile() -> Profile:
         return Transform.identity(instant)
 
     return Profile(
-        TransformModel(DynamicProvider(dynamic_provider_generator), Frame.GCRF())
+        model=TransformModel(DynamicProvider(dynamic_provider_generator), Frame.GCRF())
     )
 
 

--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -85,7 +85,9 @@ class TestProfile:
         assert profile.is_defined() is False
 
     def test_inertial_pointing(self):
-        quaternion: Quaternion = Quaternion([0.0, 0.0, 0.0, 1.0], Quaternion.Format.XYZS)
+        quaternion: Quaternion = Quaternion(
+            [0.0, 0.0, 0.0, 1.0], Quaternion.Format.XYZS
+        )
 
         trajectory: Trajectory = Trajectory.position(
             Position.meters((0.0, 0.0, 0.0), Frame.GCRF())

--- a/bindings/python/test/test_access.py
+++ b/bindings/python/test/test_access.py
@@ -38,7 +38,9 @@ Access = astrodynamics.Access
 
 def test_access_constructors():
     acquisition_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
-    time_at_closest_approach = Instant.date_time(DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC)
+    time_at_closest_approach = Instant.date_time(
+        DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC
+    )
     loss_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 2, 0), Scale.UTC)
     max_elevation = Angle.degrees(54.3)
 
@@ -64,7 +66,9 @@ def test_access_undefined():
 
 def test_access_getters():
     acquisition_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
-    time_at_closest_approach = Instant.date_time(DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC)
+    time_at_closest_approach = Instant.date_time(
+        DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC
+    )
     loss_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 2, 0), Scale.UTC)
     max_elevation = Angle.degrees(54.3)
 

--- a/bindings/python/test/test_converters.py
+++ b/bindings/python/test/test_converters.py
@@ -1,0 +1,180 @@
+# Apache License 2.0
+
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+
+from ostk.mathematics.geometry.d3.transformations.rotations import Quaternion
+
+from ostk.physics.time import Instant
+from ostk.physics.time import Interval
+from ostk.physics.time import Duration
+from ostk.physics.time import DateTime
+from ostk.physics.time import Scale
+from ostk.physics.coordinate import Position
+from ostk.physics.coordinate import Velocity
+from ostk.physics.coordinate import Frame
+
+from ostk.astrodynamics.converters import coerce_to_datetime
+from ostk.astrodynamics.converters import coerce_to_instant
+from ostk.astrodynamics.converters import coerce_to_interval
+from ostk.astrodynamics.converters import coerce_to_duration
+from ostk.astrodynamics.converters import coerce_to_position
+from ostk.astrodynamics.converters import coerce_to_velocity
+from ostk.astrodynamics.converters import coerce_to_quaternion
+
+
+def test_coerce_to_datetime_success_instant():
+    value = Instant.date_time(DateTime(2020, 1, 1), Scale.UTC)
+    assert coerce_to_datetime(value) == datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+def test_coerce_to_datetime_success_datetime():
+    value = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    assert coerce_to_datetime(value) == value
+
+
+def test_coerce_to_instant_success_datetime():
+    value = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    assert coerce_to_instant(value) == Instant.date_time(
+        DateTime(2020, 1, 1), Scale.UTC
+    )
+
+
+def test_coerce_to_instant_success_instant():
+    value = Instant.date_time(DateTime(2020, 1, 1), Scale.UTC)
+    assert coerce_to_instant(value) == value
+
+
+def test_coerce_to_interval_success_interval():
+    value = Interval.closed(
+        Instant.date_time(DateTime(2020, 1, 1), Scale.UTC),
+        Instant.date_time(DateTime(2020, 1, 2), Scale.UTC),
+    )
+    assert coerce_to_interval(value) == value
+
+
+def test_coerce_to_interval_success_tuple_instant():
+    value = (
+        Instant.date_time(DateTime(2020, 1, 1), Scale.UTC),
+        Instant.date_time(DateTime(2020, 1, 2), Scale.UTC),
+    )
+    assert coerce_to_interval(value) == Interval.closed(
+        Instant.date_time(DateTime(2020, 1, 1), Scale.UTC),
+        Instant.date_time(DateTime(2020, 1, 2), Scale.UTC),
+    )
+
+
+def test_coerce_to_interval_success_list_instant():
+    value = [
+        Instant.date_time(DateTime(2020, 1, 1), Scale.UTC),
+        Instant.date_time(DateTime(2020, 1, 2), Scale.UTC),
+    ]
+    assert coerce_to_interval(value) == Interval.closed(
+        Instant.date_time(DateTime(2020, 1, 1), Scale.UTC),
+        Instant.date_time(DateTime(2020, 1, 2), Scale.UTC),
+    )
+
+
+def test_coerce_to_interval_success_tuple_datetime():
+    value = (
+        datetime(2020, 1, 1, tzinfo=timezone.utc),
+        datetime(2020, 1, 2, tzinfo=timezone.utc),
+    )
+    assert coerce_to_interval(value) == Interval.closed(
+        Instant.date_time(DateTime(2020, 1, 1), Scale.UTC),
+        Instant.date_time(DateTime(2020, 1, 2), Scale.UTC),
+    )
+
+
+def test_coerce_to_interval_success_list_datetime():
+    value = [
+        datetime(2020, 1, 1, tzinfo=timezone.utc),
+        datetime(2020, 1, 2, tzinfo=timezone.utc),
+    ]
+    assert coerce_to_interval(value) == Interval.closed(
+        Instant.date_time(DateTime(2020, 1, 1), Scale.UTC),
+        Instant.date_time(DateTime(2020, 1, 2), Scale.UTC),
+    )
+
+
+def test_coerce_to_duration_success_duration():
+    value = Duration.seconds(1.0)
+    assert coerce_to_duration(value) == value
+
+
+def test_coerce_to_duration_success_timedelta():
+    value = timedelta(seconds=1.0)
+    assert coerce_to_duration(value) == Duration.seconds(1.0)
+
+
+def test_coerce_to_position_success_position():
+    value = Position.meters((1.0, 2.0, 3.0), Frame.GCRF())
+    assert coerce_to_position(value, Frame.GCRF()) == value
+
+
+def test_coerce_to_position_success_tuple_float():
+    value = (1.0, 2.0, 3.0)
+    assert coerce_to_position(value, Frame.GCRF()) == Position.meters(
+        (1.0, 2.0, 3.0), Frame.GCRF()
+    )
+
+
+def test_coerce_to_position_success_list_float():
+    value = [1.0, 2.0, 3.0]
+    assert coerce_to_position(value, Frame.GCRF()) == Position.meters(
+        (1.0, 2.0, 3.0), Frame.GCRF()
+    )
+
+
+def test_coerce_to_position_success_np_array():
+    value = np.array((1.0, 2.0, 3.0))
+    assert coerce_to_position(value, Frame.GCRF()) == Position.meters(
+        (1.0, 2.0, 3.0), Frame.GCRF()
+    )
+
+
+def test_coerce_to_velocity_success_velocity():
+    value = Velocity.meters_per_second((1.0, 2.0, 3.0), Frame.GCRF())
+    assert coerce_to_velocity(value, Frame.GCRF()) == value
+
+
+def test_coerce_to_velocity_success_tuple_float():
+    value = (1.0, 2.0, 3.0)
+    assert coerce_to_velocity(value, Frame.GCRF()) == Velocity.meters_per_second(
+        (1.0, 2.0, 3.0), Frame.GCRF()
+    )
+
+
+def test_coerce_to_velocity_success_list_float():
+    value = [1.0, 2.0, 3.0]
+    assert coerce_to_velocity(value, Frame.GCRF()) == Velocity.meters_per_second(
+        (1.0, 2.0, 3.0), Frame.GCRF()
+    )
+
+
+def test_coerce_to_velocity_success_np_array():
+    value = np.array((1.0, 2.0, 3.0))
+    assert coerce_to_velocity(value, Frame.GCRF()) == Velocity.meters_per_second(
+        (1.0, 2.0, 3.0), Frame.GCRF()
+    )
+
+
+def test_coerce_to_quaternion_success_quaternion():
+    value = Quaternion.xyzs(1.0, 2.0, 3.0, 4.0)
+    assert coerce_to_quaternion(value) == value
+
+
+def test_coerce_to_quaternion_success_list_float():
+    value = [1.0, 2.0, 3.0, 4.0]
+    assert coerce_to_quaternion(value) == Quaternion.xyzs(1.0, 2.0, 3.0, 4.0)
+
+
+def test_coerce_to_quaternion_success_np_array():
+    value = np.array((1.0, 2.0, 3.0, 4.0))
+    assert coerce_to_quaternion(value) == Quaternion.xyzs(1.0, 2.0, 3.0, 4.0)
+
+
+def test_coerce_to_quaternion_success_tuple_float():
+    value = (1.0, 2.0, 3.0, 4.0)
+    assert coerce_to_quaternion(value) == Quaternion.xyzs(1.0, 2.0, 3.0, 4.0)

--- a/bindings/python/test/test_display.py
+++ b/bindings/python/test/test_display.py
@@ -1,7 +1,5 @@
 # Apache License 2.0
 
-import pytest
-
 from ostk.mathematics.objects import RealInterval
 
 from ostk.physics import Environment

--- a/bindings/python/test/test_event_condition.py
+++ b/bindings/python/test/test_event_condition.py
@@ -64,6 +64,8 @@ class TestEventCondition:
             == True
         )
         assert (
-            event_condition_overloaded.is_satisfied(current_value=1.0, previous_value=1.0)
+            event_condition_overloaded.is_satisfied(
+                current_value=1.0, previous_value=1.0
+            )
             == False
         )

--- a/bindings/python/test/test_numerical_solver.py
+++ b/bindings/python/test/test_numerical_solver.py
@@ -129,7 +129,8 @@ class TestNumericalSolver:
             == "RungeKuttaFehlberg78"
         )
         assert (
-            NumericalSolver.string_from_log_type(NumericalSolver.LogType.NoLog) == "NoLog"
+            NumericalSolver.string_from_log_type(NumericalSolver.LogType.NoLog)
+            == "NoLog"
         )
         assert (
             NumericalSolver.string_from_log_type(NumericalSolver.LogType.LogConstant)

--- a/bindings/python/test/test_utilities.py
+++ b/bindings/python/test/test_utilities.py
@@ -35,7 +35,12 @@ class TestUtilities:
         assert lla[0] >= -180.0 and lla[0] <= 180.0
         assert isinstance(lla[2], float)
 
-    def test_lla_from_position(self, instant: Instant, position: Position, state: State):
+    def test_lla_from_position(
+        self,
+        instant: Instant,
+        position: Position,
+        state: State,
+    ):
         lla: LLA = utilities.lla_from_position(position, instant)
 
         assert lla is not None

--- a/bindings/python/test/test_viewer.py
+++ b/bindings/python/test/test_viewer.py
@@ -1,0 +1,129 @@
+# Apache License 2.0
+
+import pytest
+
+from ostk.physics import Environment
+from ostk.physics.units import Length
+from ostk.physics.units import Angle
+from ostk.physics.time import Instant
+from ostk.physics.time import Interval
+from ostk.physics.time import Duration
+from ostk.physics.time import DateTime
+from ostk.physics.time import Time
+from ostk.physics.time import Scale
+from ostk.physics.units import Length
+from ostk.physics.coordinate import Position
+from ostk.physics.coordinate import Frame
+
+from ostk.astrodynamics.trajectory import Orbit
+from ostk.astrodynamics.flight import Profile
+from ostk.astrodynamics.viewer import Viewer
+from ostk.astrodynamics.viewer import ConicSensor
+
+
+@pytest.fixture
+def environment() -> Environment:
+    return Environment.default()
+
+
+@pytest.fixture
+def orbit(environment: Environment) -> Orbit:
+    return Orbit.sun_synchronous(
+        epoch=Instant.date_time(DateTime(2020, 1, 1, 0, 0, 0), Scale.UTC),
+        altitude=Length.kilometers(500.0),
+        local_time_at_descending_node=Time(14, 0, 0),
+        celestial_object=environment.access_celestial_object_with_name("Earth"),
+    )
+
+
+@pytest.fixture
+def profile(orbit: Orbit) -> Profile:
+    return Profile.nadir_pointing(
+        orbit=orbit,
+        orbital_frame_type=Orbit.FrameType.VVLH,
+    )
+
+
+@pytest.fixture
+def interval() -> Interval:
+    return Interval.closed(
+        start_instant=Instant.date_time(DateTime(2020, 1, 1, 0, 0, 0), Scale.UTC),
+        end_instant=Instant.date_time(DateTime(2020, 1, 1, 0, 10, 0), Scale.UTC),
+    )
+
+
+@pytest.fixture
+def viewer(interval: Interval) -> Viewer:
+    return Viewer(
+        interval=interval,
+    )
+
+
+class TestViewer:
+    def test_constructor_success(self, interval: Interval):
+        viewer = Viewer(
+            interval=interval,
+        )
+
+        assert viewer is not None
+        assert viewer.interval == interval
+
+        rendered_html: str = viewer.render()
+
+        assert rendered_html.startswith('<meta charset="utf-8">')
+        assert "var widget = new Cesium.Viewer" in rendered_html
+        assert rendered_html.endswith("</script>")
+
+    def test_add_profile_success(
+        self,
+        viewer: Viewer,
+        profile: Profile,
+    ):
+        viewer.add_profile(
+            profile=profile,
+            step=Duration.seconds(30.0),
+            show_orbital_track=True,
+            cesium_asset_id=123,
+            sensors=[
+                ConicSensor(
+                    name="star_tracker",
+                    direction=(1.0, 0.0, 0.0),
+                    half_angle=Angle.degrees(8.0),
+                    length=Length.meters(0.1),
+                    color="red",
+                ),
+            ],
+        )
+
+        rendered_html: str = viewer.render()
+
+        assert rendered_html.startswith('<meta charset="utf-8">')
+        assert "var widget = new Cesium.Viewer" in rendered_html
+        assert " widget.entities.add({position: widget" in rendered_html
+        assert "Cesium.IonResource.fromAssetId(123)" in rendered_html
+        assert "widget.entities.add({polyline:" in rendered_html
+        assert (
+            "widget.entities.add({position: widget.star_tracker_position"
+            in rendered_html
+        )
+        assert rendered_html.endswith("</script>")
+
+    def test_add_target_success(
+        self,
+        viewer: Viewer,
+    ):
+        viewer.add_target(
+            position=Position.meters([1.0, 2.0, 3.0], Frame.ITRF()),
+            size=123,
+            color="red",
+        )
+
+        rendered_html: str = viewer.render()
+
+        assert rendered_html.startswith('<meta charset="utf-8">')
+        assert "var widget = new Cesium.Viewer" in rendered_html
+        assert (
+            "widget.entities.add({position: Cesium.Cartesian3.fromDegrees(63.43494882292201, 18.22447811510915, -6376045.535225509), point: {pixelSize: 123.0, color: Cesium.Color.RED}});"
+            in rendered_html
+        )
+        assert rendered_html.endswith("</script>")

--- a/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
+++ b/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
@@ -103,5 +103,6 @@ def test_trajectory_orbit_models_kepler_coe_static_methods():
     assert COE.true_anomaly_from_eccentric_anomaly(Angle.degrees(0.0), 0.0) is not None
     assert COE.mean_anomaly_from_eccentric_anomaly(Angle.degrees(0.0), 0.0) is not None
     assert (
-        COE.eccentric_anomaly_from_mean_anomaly(Angle.degrees(0.0), 0.0, 0.0) is not None
+        COE.eccentric_anomaly_from_mean_anomaly(Angle.degrees(0.0), 0.0, 0.0)
+        is not None
     )

--- a/bindings/python/test/trajectory/orbit/models/sgp4/test_tle.py
+++ b/bindings/python/test/trajectory/orbit/models/sgp4/test_tle.py
@@ -318,7 +318,8 @@ class TestTLE:
             TLE.generate_checksum(tle.get_first_line()) == tle.get_first_line_checksum()
         )
         assert (
-            TLE.generate_checksum(tle.get_second_line()) == tle.get_second_line_checksum()
+            TLE.generate_checksum(tle.get_second_line())
+            == tle.get_second_line_checksum()
         )
 
         assert (

--- a/bindings/python/test/trajectory/orbit/models/test_propagated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_propagated.py
@@ -63,7 +63,9 @@ def numerical_solver() -> NumericalSolver:
 
 
 @pytest.fixture
-def propagator(numerical_solver: NumericalSolver, dynamics: list[Dynamics]) -> Propagator:
+def propagator(
+    numerical_solver: NumericalSolver, dynamics: list[Dynamics]
+) -> Propagator:
     return Propagator(numerical_solver, dynamics)
 
 

--- a/bindings/python/test/trajectory/orbit/models/test_tabulated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_tabulated.py
@@ -271,7 +271,8 @@ class TestTabulated:
         )
 
         assert (
-            tabulated.get_interpolation_type() == Tabulated.InterpolationType.CubicSpline
+            tabulated.get_interpolation_type()
+            == Tabulated.InterpolationType.CubicSpline
         )
 
     @pytest.mark.parametrize(
@@ -306,7 +307,8 @@ class TestTabulated:
             )
             assert np.all(
                 np.abs(
-                    calculated_state.get_coordinates() - reference_state.get_coordinates()
+                    calculated_state.get_coordinates()
+                    - reference_state.get_coordinates()
                 )
                 < error_tolerance
             )
@@ -347,7 +349,8 @@ class TestTabulated:
         ):
             assert np.all(
                 np.abs(
-                    calculated_state.get_coordinates() - reference_state.get_coordinates()
+                    calculated_state.get_coordinates()
+                    - reference_state.get_coordinates()
                 )
                 < error_tolerance
             )

--- a/bindings/python/test/trajectory/test_propagator.py
+++ b/bindings/python/test/trajectory/test_propagator.py
@@ -113,7 +113,9 @@ def event_condition() -> EventCondition:
 
 
 @pytest.fixture
-def propagator(numerical_solver: NumericalSolver, dynamics: list[Dynamics]) -> Propagator:
+def propagator(
+    numerical_solver: NumericalSolver, dynamics: list[Dynamics]
+) -> Propagator:
     return Propagator(numerical_solver, dynamics)
 
 
@@ -192,7 +194,9 @@ class TestPropagator:
 
         instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 10, 0), Scale.UTC)
 
-        propagator_state = propagator.calculate_state_at(state, instant, event_condition)
+        propagator_state = propagator.calculate_state_at(
+            state, instant, event_condition
+        )
 
         assert pytest.approx(42.0, abs=1e-3) == float(
             (propagator_state.get_instant() - state.get_instant()).in_seconds()

--- a/bindings/python/tools/python/ostk/astrodynamics/converters.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/converters.py
@@ -1,0 +1,13 @@
+# Apache License 2.0
+
+from datetime import datetime
+
+from ostk.physics.time import Scale
+from ostk.physics.time import Instant
+
+
+def coerce_to_datetime(instant: Instant | datetime) -> datetime:
+    if isinstance(instant, datetime):
+        return instant
+
+    return instant.get_date_time(Scale.UTC)

--- a/bindings/python/tools/python/ostk/astrodynamics/converters.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/converters.py
@@ -1,13 +1,149 @@
 # Apache License 2.0
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
-from ostk.physics.time import Scale
+import numpy as np
+
+from ostk.mathematics.geometry.d3.transformations.rotations import Quaternion
+
 from ostk.physics.time import Instant
+from ostk.physics.time import Interval
+from ostk.physics.time import Duration
+from ostk.physics.time import Scale
+from ostk.physics.coordinate import Position
+from ostk.physics.coordinate import Velocity
+from ostk.physics.coordinate import Frame
 
 
-def coerce_to_datetime(instant: Instant | datetime) -> datetime:
-    if isinstance(instant, datetime):
-        return instant
+def coerce_to_datetime(value: Instant | datetime) -> datetime:
+    """
+    Return datetime from value.
 
-    return instant.get_date_time(Scale.UTC)
+    Args:
+        value (Instant | datetime): A value to coerce.
+
+    Returns:
+        datetime: The coerced datetime.
+    """
+
+    if isinstance(value, datetime):
+        return value
+
+    return value.get_date_time(Scale.UTC).replace(tzinfo=timezone.utc)
+
+
+def coerce_to_instant(value: Instant | datetime) -> Instant:
+    """
+    Return Instant from value.
+
+    Args:
+        value (Instant | datetime): A value to coerce.
+
+    Returns:
+        Instant: The coerced Instant.
+    """
+
+    if isinstance(value, Instant):
+        return value
+
+    return Instant.date_time(value, Scale.UTC)
+
+
+def coerce_to_interval(
+    value: Interval | tuple[Instant, Instant] | tuple[datetime, datetime],
+) -> Interval:
+    """
+    Return Interval from value.
+
+    Args:
+        value (Interval | tuple[Instant, Instant] | tuple[datetime, datetime]): A value to coerce.
+
+    Returns:
+        Interval: The coerced Interval.
+    """
+
+    if isinstance(value, Interval):
+        return value
+
+    return Interval.closed(
+        start_instant=coerce_to_instant(value[0]),
+        end_instant=coerce_to_instant(value[1]),
+    )
+
+
+def coerce_to_duration(value: Duration | timedelta) -> Duration:
+    """
+    Return Duration from value.
+
+    Args:
+        value (Duration | datetime): A value to coerce.
+
+    Returns:
+        Duration: The coerced Duration.
+    """
+
+    if isinstance(value, Duration):
+        return value
+
+    return Duration.seconds(value.total_seconds())
+
+
+def coerce_to_position(
+    value: Position | tuple[float, float, float] | list[float] | np.ndarray,
+    frame: Frame,
+) -> Position:
+    """
+    Return Position from value.
+
+    Args:
+        value (Position | tuple[float, float, float] | list[float] | np.ndarray): A value to coerce.
+        frame (Frame): A reference frame.
+
+    Returns:
+        Position: The coerced Position.
+    """
+
+    if isinstance(value, Position):
+        return value
+
+    return Position.meters(value, frame)
+
+
+def coerce_to_velocity(
+    value: Velocity | tuple[float, float, float] | list[float] | np.ndarray,
+    frame: Frame,
+) -> Velocity:
+    """
+    Return Velocity from value.
+
+    Args:
+        value (Velocity | tuple[float, float, float] | list[float] | np.ndarray): A value to coerce.
+        frame (Frame): A reference frame.
+
+    Returns:
+        Velocity: The coerced Velocity.
+    """
+
+    if isinstance(value, Velocity):
+        return value
+
+    return Velocity.meters_per_second(value, frame)
+
+
+def coerce_to_quaternion(
+    value: Quaternion | tuple[float, float, float, float] | list[float] | np.ndarray
+) -> Quaternion:
+    """
+    Return quaternion from value.
+
+    Args:
+        value (Quaternion | tuple[float, float, float, float] | list[float] | np.ndarray): A value to coerce.
+
+    Returns:
+        Quaternion: The coerced Quaternion.
+    """
+
+    if isinstance(value, Quaternion):
+        return value
+
+    return Quaternion(vector=value, format=Quaternion.Format.XYZS)

--- a/bindings/python/tools/python/ostk/astrodynamics/utilities.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/utilities.py
@@ -29,13 +29,23 @@ def lla_from_state(state: trajectory.State) -> list:
     ]
 
 
-def lla_from_position(position: Position, instant: Instant) -> LLA:
+def lla_from_position(
+    position: Position,
+    instant: Instant | None = None,
+) -> LLA:
     """
     Return LLA from position and instant.
     """
 
+    if position.access_frame() != Frame.ITRF():
+        if instant is None:
+            raise ValueError(
+                "Instant must be provided if position is not expressed in ECEF."
+            )
+        position = position.in_frame(Frame.ITRF(), instant)
+
     return LLA.cartesian(
-        position.in_frame(Frame.ITRF(), instant).get_coordinates(),
+        position.get_coordinates(),
         EarthGravitationalModel.EGM2008.equatorial_radius,
         EarthGravitationalModel.EGM2008.flattening,
     )

--- a/bindings/python/tools/python/ostk/astrodynamics/utilities.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/utilities.py
@@ -93,7 +93,9 @@ def compute_aer(
 
 
 def compute_time_lla_aer_state(
-    state: trajectory.State, from_position: Position, environment: Environment
+    state: trajectory.State,
+    from_position: Position,
+    environment: Environment,
 ) -> list:
     """
     Return [instant, latitude, longitude, altitude, azimuth, elevation, range] from State and observer Position.

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -20,6 +20,7 @@ from ostk.physics.units import Length
 from ostk.physics.units import Angle
 from ostk.physics.time import Instant, Interval, Duration
 from ostk.physics.coordinate import Position
+from ostk.physics.coordinate import Frame
 from ostk.physics.coordinate.spherical import LLA
 
 from ostk.astrodynamics.flight import Profile
@@ -230,7 +231,7 @@ def _generate_sampled_orientation(states: list[State]) -> cesiumpy.SampledProper
         samples=[
             (
                 coerce_to_datetime(state.get_instant()),
-                _cesium_from_ostk_quaternion(state.get_attitude()),
+                _cesium_from_ostk_quaternion(state.in_frame(Frame.ITRF()).get_attitude()),
                 None,
             )
             for state in states

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -178,6 +178,9 @@ class Viewer:
 
         return self._viewer.to_html()
 
+    def _repr_html_(self) -> str:
+        return self.render()
+
 
 def _generate_llas(states: list[State]) -> list[LLA]:
     return [

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -1,12 +1,18 @@
 # Apache License 2.0
 
+from __future__ import annotations
+
 import functools
 import operator
 from dataclasses import dataclass
 
 import numpy as np
 
-import cesiumpy
+try:
+    import cesiumpy
+
+except ImportError:
+    ...
 
 from ostk.mathematics.geometry.d3.transformations.rotations import Quaternion
 

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -1,0 +1,299 @@
+# Apache License 2.0
+
+import functools
+import operator
+from dataclasses import dataclass
+
+import numpy as np
+
+import cesiumpy
+
+from ostk.mathematics.geometry.d3.transformations.rotations import Quaternion
+
+from ostk.physics.units import Length
+from ostk.physics.units import Angle
+from ostk.physics.time import Instant, Interval, Duration
+from ostk.physics.coordinate import Position
+from ostk.physics.coordinate.spherical import LLA
+
+from ostk.astrodynamics.flight import Profile
+from ostk.astrodynamics.flight.profile import State
+
+from .converters import coerce_to_datetime
+from .utilities import lla_from_position
+
+
+@dataclass
+class Sensor:
+    name: str
+    direction: tuple[float, float, float] | np.ndarray
+    color: str
+
+
+@dataclass
+class ConicSensor(Sensor):
+    half_angle: Angle
+    length: Length
+
+
+class Viewer:
+    def __init__(
+        self,
+        interval: Interval,
+        cesium_token: str | None = None,
+        width: str = "1500px",
+        height: str = "800px",
+    ) -> None:
+        self._interval: Interval = interval
+
+        self._viewer: cesiumpy.Viewer = cesiumpy.Viewer(
+            width=width,
+            height=height,
+            clock_view_model=cesiumpy.ClockViewModel(
+                clock=cesiumpy.Clock(
+                    start_time=coerce_to_datetime(interval.get_start()),
+                    stop_time=coerce_to_datetime(interval.get_end()),
+                    clock_range=cesiumpy.Clock.Range.CLAMPED,
+                    can_animate=True,
+                    should_animate=False,
+                )
+            ),
+            fullscreen_button=False,
+            home_button=False,
+            info_box=False,
+            timeline=True,
+            navigation_help_button=False,
+            navigation_instructions_initially_visible=False,
+            scene_mode_picker=False,
+            selection_indicator=False,
+            scene3d_only=True,
+            zoom_to_entity=True,
+            track_entity=True,
+            default_access_token=cesium_token,
+        )
+
+    @property
+    def interval(self) -> Interval:
+        return self._interval
+
+    def add_profile(
+        self,
+        profile: Profile,
+        step: Duration,
+        show_orbital_track: bool = False,
+        cesium_asset_id: int | None = None,
+        sensors: list[Sensor] | None = None,
+    ) -> None:
+        """
+        Add Profile to Viewer.
+
+        Args:
+            profile (Profile): Profile to be added.
+            step (Duration): Step between two consecutive states.
+            show_orbital_track (bool, optional): Whether to show the orbital track. Defaults to False.
+            cesium_asset_id (int, optional): The Cesium asset ID. Defaults to None.
+            sensors (list[Sensor], optional): Sensors to be added to the asset. Defaults to None.
+        """
+
+        instants: list[Instant] = self._interval.generate_grid(step)
+        states: list[State] = profile.get_states_at(instants)
+        llas: list[LLA] = _generate_llas(states)
+
+        satellite = cesiumpy.Satellite(
+            position=_generate_sampled_position(instants, llas),
+            orientation=_generate_sampled_orientation(states),
+            availability=cesiumpy.TimeIntervalCollection(
+                intervals=[
+                    cesiumpy.TimeInterval(
+                        start=coerce_to_datetime(self._interval.get_start()),
+                        stop=coerce_to_datetime(self._interval.get_end()),
+                    ),
+                ],
+            ),
+            model=cesiumpy.IonResource(
+                asset_id=cesium_asset_id or 0
+            ),  # TBM: Should be made more robust
+            sensors=[_cesium_from_ostk_sensor(sensor) for sensor in sensors or []],
+        )
+
+        satellite.render(self._viewer)
+
+        if show_orbital_track:
+            self._viewer.entities.add(
+                cesiumpy.Polyline(
+                    positions=cesiumpy.entities.cartesian.Cartesian3Array(
+                        functools.reduce(
+                            operator.iconcat,
+                            [
+                                [
+                                    float(lla.get_longitude().in_degrees()),
+                                    float(lla.get_latitude().in_degrees()),
+                                    float(lla.get_altitude().in_meters()),
+                                ]
+                                for lla in _generate_llas(states)
+                            ],
+                            [],
+                        )
+                    ),
+                    width=1,
+                )
+            )
+
+    def add_target(
+        self,
+        position: Position,
+        size: int | None = None,
+        color: str | None = None,
+    ) -> None:
+        """
+        Add target to Viewer.
+
+        Args:
+            position (Position): Target position.
+            size (int, optional): Target size. Defaults to None.
+            color (str, optional): Target color. Defaults to None.
+        """
+
+        self._viewer.entities.add(
+            cesiumpy.Point(
+                position=_cesium_from_ostk_position(position),
+                pixel_size=size or 10,
+                color=color or cesiumpy.color.YELLOW,
+            )
+        )
+
+    def render(self) -> str:
+        """
+        Render Viewer as HTML string.
+
+        Returns:
+            str: Rendered HTML string.
+        """
+
+        return self._viewer.to_html()
+
+
+def _generate_llas(states: list[State]) -> list[LLA]:
+    return [
+        lla_from_position(state.get_position(), state.get_instant()) for state in states
+    ]
+
+
+def _generate_sampled_position(
+    instants: list[Instant],
+    llas: list[LLA],
+) -> cesiumpy.SampledPositionProperty:
+    """
+    Generate a sampled position property from a list of OSTk LLAs.
+
+    Args:
+        states (list[LLA]): A list of OSTk LLAs.
+
+    Returns:
+        cesiumpy.SampledPositionProperty: Sampled position property.
+    """
+
+    return cesiumpy.SampledPositionProperty(
+        samples=[
+            (
+                coerce_to_datetime(instant),
+                _cesium_from_ostk_lla(lla),
+                None,
+            )
+            for instant, lla in zip(instants, llas)
+        ],
+    )
+
+
+def _generate_sampled_orientation(states: list[State]) -> cesiumpy.SampledProperty:
+    """
+    Generate a sampled orientation property from a list of OSTk States.
+
+    Args:
+        states (list[State]): A list of OSTk States.
+
+    Returns:
+        cesiumpy.SampledProperty: Sampled orientation property.
+    """
+
+    return cesiumpy.SampledProperty(
+        type=cesiumpy.Quaternion,
+        samples=[
+            (
+                coerce_to_datetime(state.get_instant()),
+                _cesium_from_ostk_quaternion(state.get_attitude()),
+                None,
+            )
+            for state in states
+        ],
+    )
+
+
+def _cesium_from_ostk_position(
+    position: Position,
+    instant: Instant | None = None,
+) -> cesiumpy.Cartesian3:
+    """
+    Convert OSTk Position into Cesium Cartesian3.
+
+    Args:
+        position (Position): Position to convert.
+        instant (Instant, optional): Instant at which the position is valid (required if position is not expressed in ECEF).
+
+    Returns:
+        cesiumpy.Cartesian3: Converted position.
+    """
+
+    return _cesium_from_ostk_lla(lla_from_position(position, instant))
+
+
+def _cesium_from_ostk_lla(
+    lla: LLA,
+) -> cesiumpy.Cartesian3:
+    """
+    Convert OSTk LLA into Cesium Cartesian3.
+
+    Args:
+        lla (LLA): LLA to convert.
+
+    Returns:
+        cesiumpy.Cartesian3: Converted LLA.
+    """
+
+    return cesiumpy.Cartesian3.fromDegrees(
+        float(lla.get_longitude().in_degrees()),
+        float(lla.get_latitude().in_degrees()),
+        float(lla.get_altitude().in_meters()),
+    )
+
+
+def _cesium_from_ostk_quaternion(quaternion: Quaternion) -> cesiumpy.Quaternion:
+    """
+    Convert OSTk Quaternion into Cesium Quaternion.
+
+    Args:
+        quaternion (Quaternion): Quaternion to convert.
+
+    Returns:
+        cesiumpy.Quaternion: Converted quaternion.
+    """
+
+    return cesiumpy.Quaternion(
+        float(quaternion.x()),
+        float(quaternion.y()),
+        float(quaternion.z()),
+        float(quaternion.s()),
+    )
+
+
+def _cesium_from_ostk_sensor(sensor: Sensor) -> cesiumpy.ConicSensor:
+    if not isinstance(sensor, ConicSensor):
+        raise NotImplementedError("Only Conic Sensor is supported at the moment.")
+
+    return cesiumpy.ConicSensor(
+        name=sensor.name,
+        direction=cesiumpy.Cartesian3(*sensor.direction),
+        half_angle=cesiumpy.math.to_radians(float(sensor.half_angle.in_radians())),
+        length=float(sensor.length.in_meters()),
+        material=sensor.color or cesiumpy.color.RED,
+    )

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -265,7 +265,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
         const auto conditionFunction = generator.getConditionFunction(fromOrbit, toOrbit);
 
         EXPECT_NE(nullptr, conditionFunction);
-        EXPECT_TRUE(conditionFunction(startInstant));
+        EXPECT_TRUE(conditionFunction(epoch));
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -215,7 +215,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
 
         const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        const Instant epoch = epoch;
         const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
         const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
         const Real J2 = Earth::EGM2008.J2_;
@@ -241,7 +240,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
 
         const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        const Instant epoch = epoch;
         const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
         const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
         const Real J2 = Earth::EGM2008.J2_;

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -202,10 +202,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
 {
     const Environment environment = Environment::Default();
 
-    const Instant startInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-    const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC);
+    const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
 
-    const auto generateFirstOrbit = [&environment, &startInstant]() -> Orbit
+    const auto generateFirstOrbit = [&environment, &epoch]() -> Orbit
     {
         const Length semiMajorAxis = Length::Kilometers(7000.0);
         const Real eccentricity = 0.0;
@@ -216,7 +215,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
 
         const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        const Instant epoch = startInstant;
+        const Instant epoch = epoch;
         const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
         const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
         const Real J2 = Earth::EGM2008.J2_;
@@ -231,7 +230,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
         return orbit;
     };
 
-    const auto generateSecondOrbit = [&environment, &startInstant]() -> Orbit
+    const auto generateSecondOrbit = [&environment, &epoch]() -> Orbit
     {
         const Length semiMajorAxis = Length::Kilometers(7000.0);
         const Real eccentricity = 0.0;
@@ -242,7 +241,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, GetConditionFunction)
 
         const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        const Instant epoch = startInstant;
+        const Instant epoch = epoch;
         const Derived gravitationalParameter = Earth::EGM2008.gravitationalParameter_;
         const Length equatorialRadius = Earth::EGM2008.equatorialRadius_;
         const Real J2 = Earth::EGM2008.J2_;


### PR DESCRIPTION
This PR adds a 3D viewer based on [CesiumPy](https://github.com/lucas-bremond/cesiumpy) to the Python utilities, to simplify displaying Profiles in Python.

<img width="1728" alt="image" src="https://github.com/open-space-collective/open-space-toolkit-astrodynamics/assets/4208560/8295c210-a921-4775-bcaa-8b0c0a384616">