### PR TITLE
build: fix format-python in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,8 +371,7 @@ format-python: build-development-image ## Run the black format tool against pyth
 
 	docker run \
 		--rm \
-		--user="$(shell id -u):$(shell id -g)" \
-		--volume="$(CURDIR):/app:delegated" \
+		--volume="$(CURDIR):/app" \
 		--workdir=/app \
 		$(docker_development_image_repository):$(docker_image_version) \
 		ostk-format-python

--- a/bindings/python/test/conjunction/messages/ccsds/test_cdm.py
+++ b/bindings/python/test/conjunction/messages/ccsds/test_cdm.py
@@ -25,9 +25,7 @@ def cdm() -> CDM:
     return CDM(
         header=CDM.Header(
             ccsds_cdm_version="1.0",
-            creation_date=Instant.date_time(
-                datetime(2010, 3, 12, 22, 31, 12), Scale.UTC
-            ),
+            creation_date=Instant.date_time(datetime(2010, 3, 12, 22, 31, 12), Scale.UTC),
             originator="JSPOC",
             message_for="SATELLITE A",
             message_id="201113719185",

--- a/bindings/python/test/event_condition/test_coe_condition.py
+++ b/bindings/python/test/event_condition/test_coe_condition.py
@@ -56,9 +56,7 @@ def state_vector() -> list[float]:
 class TestCOECondition:
     def test_constructor(self, criteria, element, target, gravitational_parameter):
         name = "Test COECondition"
-        condition = COECondition(
-            name, criteria, element, target, gravitational_parameter
-        )
+        condition = COECondition(name, criteria, element, target, gravitational_parameter)
 
         assert condition is not None
 

--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -82,9 +82,7 @@ class TestProfile:
         assert profile.is_defined() is False
 
     def test_inertial_pointing(self):
-        quaternion: Quaternion = Quaternion(
-            [0.0, 0.0, 0.0, 1.0], Quaternion.Format.XYZS
-        )
+        quaternion: Quaternion = Quaternion([0.0, 0.0, 0.0, 1.0], Quaternion.Format.XYZS)
 
         trajectory: Trajectory = Trajectory.position(
             Position.meters((0.0, 0.0, 0.0), Frame.GCRF())
@@ -117,17 +115,25 @@ class TestProfile:
             model=TabulatedModel(
                 states=[
                     State(
-                        instant=Instant.date_time(datetime(2020, 1, 1, 0, 0, 0), Scale.UTC),
+                        instant=Instant.date_time(
+                            datetime(2020, 1, 1, 0, 0, 0), Scale.UTC
+                        ),
                         position=Position.meters((0.0, 0.0, 0.0), Frame.GCRF()),
-                        velocity=Velocity.meters_per_second((0.0, 0.0, 0.0), Frame.GCRF()),
+                        velocity=Velocity.meters_per_second(
+                            (0.0, 0.0, 0.0), Frame.GCRF()
+                        ),
                         attitude=Quaternion.unit(),
                         angular_velocity=(0.0, 0.0, 0.0),
                         reference_frame=Frame.GCRF(),
                     ),
                     State(
-                        instant=Instant.date_time(datetime(2020, 1, 1, 0, 1, 0), Scale.UTC),
+                        instant=Instant.date_time(
+                            datetime(2020, 1, 1, 0, 1, 0), Scale.UTC
+                        ),
                         position=Position.meters((0.0, 0.0, 0.0), Frame.GCRF()),
-                        velocity=Velocity.meters_per_second((0.0, 0.0, 0.0), Frame.GCRF()),
+                        velocity=Velocity.meters_per_second(
+                            (0.0, 0.0, 0.0), Frame.GCRF()
+                        ),
                         attitude=Quaternion.unit(),
                         angular_velocity=(0.0, 0.0, 0.0),
                         reference_frame=Frame.GCRF(),

--- a/bindings/python/test/test_access.py
+++ b/bindings/python/test/test_access.py
@@ -38,9 +38,7 @@ Access = astrodynamics.Access
 
 def test_access_constructors():
     acquisition_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
-    time_at_closest_approach = Instant.date_time(
-        DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC
-    )
+    time_at_closest_approach = Instant.date_time(DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC)
     loss_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 2, 0), Scale.UTC)
     max_elevation = Angle.degrees(54.3)
 
@@ -66,9 +64,7 @@ def test_access_undefined():
 
 def test_access_getters():
     acquisition_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
-    time_at_closest_approach = Instant.date_time(
-        DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC
-    )
+    time_at_closest_approach = Instant.date_time(DateTime(2018, 1, 1, 0, 1, 0), Scale.UTC)
     loss_of_signal = Instant.date_time(DateTime(2018, 1, 1, 0, 2, 0), Scale.UTC)
     max_elevation = Angle.degrees(54.3)
 

--- a/bindings/python/test/test_converters.py
+++ b/bindings/python/test/test_converters.py
@@ -36,9 +36,7 @@ def test_coerce_to_datetime_success_datetime():
 
 def test_coerce_to_instant_success_datetime():
     value = datetime(2020, 1, 1, tzinfo=timezone.utc)
-    assert coerce_to_instant(value) == Instant.date_time(
-        DateTime(2020, 1, 1), Scale.UTC
-    )
+    assert coerce_to_instant(value) == Instant.date_time(DateTime(2020, 1, 1), Scale.UTC)
 
 
 def test_coerce_to_instant_success_instant():

--- a/bindings/python/test/test_event_condition.py
+++ b/bindings/python/test/test_event_condition.py
@@ -64,8 +64,6 @@ class TestEventCondition:
             == True
         )
         assert (
-            event_condition_overloaded.is_satisfied(
-                current_value=1.0, previous_value=1.0
-            )
+            event_condition_overloaded.is_satisfied(current_value=1.0, previous_value=1.0)
             == False
         )

--- a/bindings/python/test/test_numerical_solver.py
+++ b/bindings/python/test/test_numerical_solver.py
@@ -129,8 +129,7 @@ class TestNumericalSolver:
             == "RungeKuttaFehlberg78"
         )
         assert (
-            NumericalSolver.string_from_log_type(NumericalSolver.LogType.NoLog)
-            == "NoLog"
+            NumericalSolver.string_from_log_type(NumericalSolver.LogType.NoLog) == "NoLog"
         )
         assert (
             NumericalSolver.string_from_log_type(NumericalSolver.LogType.LogConstant)

--- a/bindings/python/test/test_viewer.py
+++ b/bindings/python/test/test_viewer.py
@@ -103,8 +103,7 @@ class TestViewer:
         assert "Cesium.IonResource.fromAssetId(123)" in rendered_html
         assert "widget.entities.add({polyline:" in rendered_html
         assert (
-            "widget.entities.add({position: widget.star_tracker_position"
-            in rendered_html
+            "widget.entities.add({position: widget.star_tracker_position" in rendered_html
         )
         assert rendered_html.endswith("</script>")
 

--- a/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
+++ b/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
@@ -103,6 +103,5 @@ def test_trajectory_orbit_models_kepler_coe_static_methods():
     assert COE.true_anomaly_from_eccentric_anomaly(Angle.degrees(0.0), 0.0) is not None
     assert COE.mean_anomaly_from_eccentric_anomaly(Angle.degrees(0.0), 0.0) is not None
     assert (
-        COE.eccentric_anomaly_from_mean_anomaly(Angle.degrees(0.0), 0.0, 0.0)
-        is not None
+        COE.eccentric_anomaly_from_mean_anomaly(Angle.degrees(0.0), 0.0, 0.0) is not None
     )

--- a/bindings/python/test/trajectory/orbit/models/sgp4/test_tle.py
+++ b/bindings/python/test/trajectory/orbit/models/sgp4/test_tle.py
@@ -318,8 +318,7 @@ class TestTLE:
             TLE.generate_checksum(tle.get_first_line()) == tle.get_first_line_checksum()
         )
         assert (
-            TLE.generate_checksum(tle.get_second_line())
-            == tle.get_second_line_checksum()
+            TLE.generate_checksum(tle.get_second_line()) == tle.get_second_line_checksum()
         )
 
         assert (

--- a/bindings/python/test/trajectory/orbit/models/test_propagated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_propagated.py
@@ -63,9 +63,7 @@ def numerical_solver() -> NumericalSolver:
 
 
 @pytest.fixture
-def propagator(
-    numerical_solver: NumericalSolver, dynamics: list[Dynamics]
-) -> Propagator:
+def propagator(numerical_solver: NumericalSolver, dynamics: list[Dynamics]) -> Propagator:
     return Propagator(numerical_solver, dynamics)
 
 

--- a/bindings/python/test/trajectory/orbit/models/test_tabulated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_tabulated.py
@@ -271,8 +271,7 @@ class TestTabulated:
         )
 
         assert (
-            tabulated.get_interpolation_type()
-            == Tabulated.InterpolationType.CubicSpline
+            tabulated.get_interpolation_type() == Tabulated.InterpolationType.CubicSpline
         )
 
     @pytest.mark.parametrize(
@@ -307,8 +306,7 @@ class TestTabulated:
             )
             assert np.all(
                 np.abs(
-                    calculated_state.get_coordinates()
-                    - reference_state.get_coordinates()
+                    calculated_state.get_coordinates() - reference_state.get_coordinates()
                 )
                 < error_tolerance
             )
@@ -349,8 +347,7 @@ class TestTabulated:
         ):
             assert np.all(
                 np.abs(
-                    calculated_state.get_coordinates()
-                    - reference_state.get_coordinates()
+                    calculated_state.get_coordinates() - reference_state.get_coordinates()
                 )
                 < error_tolerance
             )

--- a/bindings/python/test/trajectory/test_propagator.py
+++ b/bindings/python/test/trajectory/test_propagator.py
@@ -113,9 +113,7 @@ def event_condition() -> EventCondition:
 
 
 @pytest.fixture
-def propagator(
-    numerical_solver: NumericalSolver, dynamics: list[Dynamics]
-) -> Propagator:
+def propagator(numerical_solver: NumericalSolver, dynamics: list[Dynamics]) -> Propagator:
     return Propagator(numerical_solver, dynamics)
 
 
@@ -194,9 +192,7 @@ class TestPropagator:
 
         instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 10, 0), Scale.UTC)
 
-        propagator_state = propagator.calculate_state_at(
-            state, instant, event_condition
-        )
+        propagator_state = propagator.calculate_state_at(state, instant, event_condition)
 
         assert pytest.approx(42.0, abs=1e-3) == float(
             (propagator_state.get_instant() - state.get_instant()).in_seconds()


### PR DESCRIPTION
This fixes the issue @kyle-cochran found with running `make format-python` locally.
I checked the /etc/group in the docker container and it doesn't contain our groups.

If you exec into the container it complains about this:
groups: cannot find name for group ID 1050