### PR TITLE
fix: COECondition static construction

### DIFF
--- a/bindings/python/test/event_condition/test_coe_condition.py
+++ b/bindings/python/test/event_condition/test_coe_condition.py
@@ -79,9 +79,12 @@ class TestCOECondition:
         ),
     )
     def test_static_constructors(
-        self, static_constructor, target, criteria, gravitational_parameter
+        self, static_constructor, target, criteria, gravitational_parameter, state_vector
     ):
-        assert static_constructor(criteria, target, gravitational_parameter) is not None
+        condition = static_constructor(criteria, target, gravitational_parameter)
+        assert condition is not None
+        
+        condition.evaluate(state_vector, 0.0) is not None
 
     def test_evaluate(self, condition, state_vector, target):
         assert condition.evaluate(state_vector, 0.0) == pytest.approx(

--- a/bindings/python/test/event_condition/test_coe_condition.py
+++ b/bindings/python/test/event_condition/test_coe_condition.py
@@ -84,7 +84,7 @@ class TestCOECondition:
         condition = static_constructor(criteria, target, gravitational_parameter)
         assert condition is not None
         
-        condition.evaluate(state_vector, 0.0) is not None
+        assert condition.evaluate(state_vector, 0.0) is not None
 
     def test_evaluate(self, condition, state_vector, target):
         assert condition.evaluate(state_vector, 0.0) == pytest.approx(

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
@@ -194,7 +194,7 @@ class COECondition : public EventCondition
     COE::Element element_;
     Real target_;
     Derived gravitationalParameter_;
-    std::function<Real(const Vector3d&, const Vector3d&)> evaluator_;
+    std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> evaluator_;
 
     /// @brief                  Get evaluation function from element
     ///
@@ -202,7 +202,9 @@ class COECondition : public EventCondition
     ///
     /// @return                 Evaluation function
 
-    std::function<Real(const Vector3d&, const Vector3d&)> getEvaluator(const COE::Element& anElement) const;
+    static std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> GetEvaluator(
+        const COE::Element& anElement
+    );
 };
 
 }  // namespace eventcondition

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
@@ -32,7 +32,7 @@ COECondition::COECondition(
       element_(anElement),
       target_(aTarget),
       gravitationalParameter_(aGravitationalParameter),
-      evaluator_(getEvaluator(anElement))
+      evaluator_(GetEvaluator(anElement))
 {
 }
 
@@ -60,7 +60,7 @@ Real COECondition::evaluate(const VectorXd& aStateVector, const Real& aTime) con
     const Vector3d positionVector = aStateVector.segment(0, 3);
     const Vector3d velocityVector = aStateVector.segment(3, 3);
 
-    return evaluator_(positionVector, velocityVector) - target_;
+    return evaluator_(positionVector, velocityVector, this->gravitationalParameter_) - target_;
 }
 
 String COECondition::StringFromElement(const COE::Element& anElement)
@@ -192,15 +192,19 @@ COECondition COECondition::EccentricAnomaly(
     };
 }
 
-std::function<Real(const Vector3d&, const Vector3d&)> COECondition::getEvaluator(const COE::Element& anElement) const
+std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> COECondition::GetEvaluator(
+    const COE::Element& anElement
+)
 {
-    return [anElement, this](const Vector3d& aPositionVector, const Vector3d& aVelocityVector) -> Real
+    return [anElement](
+               const Vector3d& aPositionVector, const Vector3d& aVelocityVector, const Derived& aGravitationalParameter
+           ) -> Real
     {
         // TBI: Get frame from Broker
         const Position position = Position::Meters(aPositionVector, Frame::GCRF());
         const Velocity velocity = Velocity::MetersPerSecond(aVelocityVector, Frame::GCRF());
 
-        const COE coe = COE::Cartesian({position, velocity}, this->gravitationalParameter_);
+        const COE coe = COE::Cartesian({position, velocity}, aGravitationalParameter);
 
         switch (anElement)
         {

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
@@ -129,40 +129,50 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_COECondition, StringFromElement)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, SemiMajorAxis)
 {
-    EXPECT_NO_THROW(COECondition::SemiMajorAxis(defaultCriteria_, Length::Meters(7000000.0), gravitationalParameter_));
+    COECondition condition =
+        COECondition::SemiMajorAxis(defaultCriteria_, Length::Meters(7000000.0), gravitationalParameter_);
+    EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, Eccentricity)
 {
-    EXPECT_NO_THROW(COECondition::Eccentricity(defaultCriteria_, 0.0, gravitationalParameter_));
+    COECondition condition = COECondition::Eccentricity(defaultCriteria_, 0.0, gravitationalParameter_);
+    EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, Inclination)
 {
-    EXPECT_NO_THROW(COECondition::Inclination(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_));
+    COECondition condition = COECondition::Inclination(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, Aop)
 {
-    EXPECT_NO_THROW(COECondition::Aop(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_));
+    COECondition condition = COECondition::Aop(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, Raan)
 {
-    EXPECT_NO_THROW(COECondition::Raan(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_));
+    COECondition condition = COECondition::Raan(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, TrueAnomaly)
 {
-    EXPECT_NO_THROW(COECondition::TrueAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_));
+    COECondition condition = COECondition::TrueAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, MeanAnomaly)
 {
-    EXPECT_NO_THROW(COECondition::MeanAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_));
+    COECondition condition = COECondition::MeanAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, EccentricAnomaly)
 {
-    EXPECT_NO_THROW(COECondition::EccentricAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_));
+    COECondition condition =
+        COECondition::EccentricAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }


### PR DESCRIPTION
Because of how the member variables were getting initialized, this would produce a segfault as it was getting captured in the lambda before initialization.