### PR TITLE
feat: add compute virtual method to Event Condition

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
@@ -2,11 +2,13 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
 
+#include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanEventCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/Conjunctive.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/Disjunctive.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/DurationCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalConnective.cpp>
+#include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealEventCondition.cpp>
 
 using namespace pybind11;
 
@@ -26,11 +28,6 @@ class PyEventCondition : public EventCondition
 
     // Trampoline (need one for each virtual function)
 
-    bool isSatisfied(const Real& currentValue, const Real& previousValue) const override
-    {
-        PYBIND11_OVERRIDE(bool, EventCondition, isSatisfied, currentValue, previousValue);
-    }
-
     bool isSatisfied(
         const VectorXd& currentStateVector,
         const Real& currentTime,
@@ -38,14 +35,16 @@ class PyEventCondition : public EventCondition
         const Real& previousTime
     ) const override
     {
-        PYBIND11_OVERRIDE(
-            bool, EventCondition, isSatisfied, currentStateVector, currentTime, previousStateVector, previousTime
+        PYBIND11_OVERRIDE_PURE_NAME(
+            bool,
+            EventCondition,
+            "is_satisfied",
+            isSatisfied,
+            currentStateVector,
+            currentTime,
+            previousStateVector,
+            previousTime
         );
-    }
-
-    Real compute(const VectorXd& aStateVector, const Real& aTime) const override
-    {
-        PYBIND11_OVERRIDE_PURE(Real, EventCondition, compute, aStateVector, aTime);
     }
 };
 
@@ -58,40 +57,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition(pybind11::module& aMo
 
         eventCondition_class
 
-            .def(
-                init<const String&, const EventCondition::Criteria&, const Real&>(),
-                arg("name"),
-                arg("criteria"),
-                arg("target")
-            )
+            .def(init<const String&, const EventCondition::Criteria&>(), arg("name"), arg("criteria"))
 
             .def("__str__", &(shiftToString<EventCondition>))
             .def("__repr__", &(shiftToString<EventCondition>))
 
             .def("get_name", &EventCondition::getName)
             .def("get_criteria", &EventCondition::getCriteria)
-            .def("get_target", &EventCondition::getTarget)
-
-            .def("evaluate", &EventCondition::evaluate, arg("state_vector"), arg("time"))
 
             .def(
                 "is_satisfied",
-                overload_cast<const Real&, const Real&>(&EventCondition::isSatisfied, const_),
-                arg("current_value"),
-                arg("previous_value")
-            )
-            .def(
-                "is_satisfied",
-                overload_cast<const VectorXd&, const Real&, const VectorXd&, const Real&>(
-                    &EventCondition::isSatisfied, const_
-                ),
+                &EventCondition::isSatisfied,
                 arg("current_state_vector"),
                 arg("current_time"),
                 arg("previous_state_vector"),
                 arg("previous_time")
             )
-
-            .def("compute", &EventCondition::compute, arg("state_vector"), arg("time"))
 
             .def_static("string_from_criteria", &EventCondition::StringFromCriteria, arg("criteria"))
 
@@ -115,6 +96,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition(pybind11::module& aMo
     // Add __path__ attribute for "event_condition" submodule
     event_condition.attr("__path__") = "ostk.astrodynamics.event_condition";
 
+    OpenSpaceToolkitAstrodynamicsPy_EventCondition_RealEventCondition(event_condition);
+    OpenSpaceToolkitAstrodynamicsPy_EventCondition_BooleanEventCondition(event_condition);
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_DurationCondition(event_condition);
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(event_condition);
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalConnective(event_condition);

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
@@ -43,9 +43,9 @@ class PyEventCondition : public EventCondition
         );
     }
 
-    Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override
+    Real compute(const VectorXd& aStateVector, const Real& aTime) const override
     {
-        PYBIND11_OVERRIDE_PURE(Real, EventCondition, evaluate, aStateVector, aTime);
+        PYBIND11_OVERRIDE_PURE(Real, EventCondition, compute, aStateVector, aTime);
     }
 };
 
@@ -58,10 +58,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition(pybind11::module& aMo
 
         eventCondition_class
 
-            .def(init<const String&, const EventCondition::Criteria&>(), arg("name"), arg("criteria"))
+            .def(
+                init<const String&, const EventCondition::Criteria&, const Real&>(),
+                arg("name"),
+                arg("criteria"),
+                arg("target")
+            )
 
             .def("__str__", &(shiftToString<EventCondition>))
             .def("__repr__", &(shiftToString<EventCondition>))
+
+            .def("get_name", &EventCondition::getName)
+            .def("get_criteria", &EventCondition::getCriteria)
+            .def("get_target", &EventCondition::getTarget)
+
+            .def("evaluate", &EventCondition::evaluate, arg("state_vector"), arg("time"))
 
             .def(
                 "is_satisfied",
@@ -80,10 +91,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition(pybind11::module& aMo
                 arg("previous_time")
             )
 
-            .def("get_name", &EventCondition::getName)
-            .def("get_criteria", &EventCondition::getCriteria)
-
-            .def("evaluate", &EventCondition::evaluate, arg("state_vector"), arg("time"))
+            .def("compute", &EventCondition::compute, arg("state_vector"), arg("time"))
 
             .def_static("string_from_criteria", &EventCondition::StringFromCriteria, arg("criteria"))
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanEventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanEventCondition.cpp
@@ -1,0 +1,51 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Types/Shared.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp>
+
+using namespace pybind11;
+
+using ostk::core::types::String;
+using ostk::core::types::Real;
+using ostk::core::types::Shared;
+
+using ostk::math::obj::VectorXd;
+
+using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::BooleanEventCondition;
+
+inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BooleanEventCondition(pybind11::module& aModule)
+{
+    class_<BooleanEventCondition, EventCondition, Shared<BooleanEventCondition>>(aModule, "BooleanEventCondition")
+
+        .def(
+            init<
+                const String&,
+                const EventCondition::Criteria&,
+                std::function<bool(const VectorXd&, const Real&)>,
+                const bool&>(),
+            arg("name"),
+            arg("criteria"),
+            arg("evaluator"),
+            arg("is_inverse")
+        )
+
+        .def("__str__", &(shiftToString<BooleanEventCondition>))
+        .def("__repr__", &(shiftToString<BooleanEventCondition>))
+
+        .def("is_inversed", &BooleanEventCondition::isInversed)
+
+        .def("evaluate", &BooleanEventCondition::evaluate, arg("state_vector"), arg("time"))
+
+        .def(
+            "is_satisfied",
+            &BooleanEventCondition::isSatisfied,
+            arg("current_state_vector"),
+            arg("current_time"),
+            arg("previous_state_vector"),
+            arg("previous_time")
+        )
+
+        ;
+}

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
@@ -9,23 +9,30 @@ using ostk::core::types::String;
 using ostk::core::types::Shared;
 
 using ostk::physics::units::Derived;
+using ostk::physics::coord::Frame;
 
-using ostk::astro::EventCondition;
 using ostk::astro::trajectory::orbit::models::kepler::COE;
+using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::eventcondition::COECondition;
 
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11::module& aModule)
 {
     {
-        class_<COECondition, EventCondition, Shared<COECondition>>(aModule, "COECondition")
+        class_<COECondition, RealEventCondition, Shared<COECondition>>(aModule, "COECondition")
 
             .def(
-                init<const String&, const EventCondition::Criteria&, const COE::Element&, const Real&, const Derived&>(
-                ),
+                init<
+                    const String&,
+                    const RealEventCondition::Criteria&,
+                    const COE::Element&,
+                    const Real&,
+                    const Shared<const Frame>&,
+                    const Derived&>(),
                 arg("name"),
                 arg("criteria"),
                 arg("element"),
                 arg("target"),
+                arg("frame"),
                 arg("gravitational_parameter")
             )
 
@@ -37,6 +44,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 &COECondition::SemiMajorAxis,
                 arg("criteria"),
                 arg("semi_major_axis"),
+                arg("frame"),
                 arg("gravitational_parameter")
             )
 
@@ -45,6 +53,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 &COECondition::Eccentricity,
                 arg("criteria"),
                 arg("eccentricity"),
+                arg("frame"),
                 arg("gravitational_parameter")
 
             )
@@ -54,16 +63,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 &COECondition::Inclination,
                 arg("criteria"),
                 arg("inclination"),
+                arg("frame"),
                 arg("gravitational_parameter")
             )
 
             .def_static(
-                "aop", &COECondition::Aop, arg("criteria"), arg("aop"), arg("gravitational_parameter")
+                "aop", &COECondition::Aop, arg("criteria"), arg("aop"), arg("frame"), arg("gravitational_parameter")
 
             )
 
             .def_static(
-                "raan", &COECondition::Raan, arg("criteria"), arg("raan"), arg("gravitational_parameter")
+                "raan", &COECondition::Raan, arg("criteria"), arg("raan"), arg("frame"), arg("gravitational_parameter")
 
             )
 
@@ -72,6 +82,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 &COECondition::TrueAnomaly,
                 arg("criteria"),
                 arg("true_anomaly"),
+                arg("frame"),
                 arg("gravitational_parameter")
             )
 
@@ -80,6 +91,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 &COECondition::MeanAnomaly,
                 arg("criteria"),
                 arg("mean_anomaly"),
+                arg("frame"),
                 arg("gravitational_parameter")
             )
 
@@ -88,6 +100,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 &COECondition::EccentricAnomaly,
                 arg("criteria"),
                 arg("eccentric_anomaly"),
+                arg("frame"),
                 arg("gravitational_parameter")
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
@@ -29,11 +29,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 arg("gravitational_parameter")
             )
 
-            .def("get_target", &COECondition::getTarget)
             .def("get_gravitational_parameter", &COECondition::getGravitationalParameter)
             .def("get_element", &COECondition::getElement)
-
-            .def_static("string_from_element", &COECondition::StringFromElement, arg("element"))
 
             .def_static(
                 "semi_major_axis",

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/DurationCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/DurationCondition.cpp
@@ -8,15 +8,15 @@ using ostk::core::types::Shared;
 
 using ostk::physics::time::Duration;
 
-using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::eventcondition::DurationCondition;
 
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_DurationCondition(pybind11::module& aModule)
 {
     {
-        class_<DurationCondition, EventCondition, Shared<DurationCondition>>(aModule, "DurationCondition")
+        class_<DurationCondition, RealEventCondition, Shared<DurationCondition>>(aModule, "DurationCondition")
 
-            .def(init<const EventCondition::Criteria&, const Duration&>(), arg("criteria"), arg("duration"))
+            .def(init<const RealEventCondition::Criteria&, const Duration&>(), arg("criteria"), arg("duration"))
 
             .def("get_duration", &DurationCondition::getDuration)
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalConnective.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalConnective.cpp
@@ -12,10 +12,40 @@ using ostk::core::types::String;
 using ostk::astro::EventCondition;
 using ostk::astro::eventcondition::LogicalConnective;
 
+// Trampoline class for virtual member functions
+class PyLogicalConnective : public LogicalConnective
+{
+   public:
+    using LogicalConnective::LogicalConnective;
+
+    // Trampoline (need one for each virtual function)
+
+    bool isSatisfied(
+        const VectorXd& currentStateVector,
+        const Real& currentTime,
+        const VectorXd& previousStateVector,
+        const Real& previousTime
+    ) const override
+    {
+        PYBIND11_OVERRIDE_PURE_NAME(
+            bool,
+            LogicalConnective,
+            "is_satisfied",
+            isSatisfied,
+            currentStateVector,
+            currentTime,
+            previousStateVector,
+            previousTime
+        );
+    }
+};
+
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalConnective(pybind11::module& aModule)
 {
     {
-        class_<LogicalConnective, EventCondition, Shared<LogicalConnective>>(aModule, "LogicalConnective")
+        class_<LogicalConnective, EventCondition, PyLogicalConnective, Shared<LogicalConnective>>(
+            aModule, "LogicalConnective"
+        )
 
             .def(init<const String&, const Array<Shared<EventCondition>>&>(), arg("name"), arg("event_conditions"))
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealEventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealEventCondition.cpp
@@ -1,0 +1,53 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Types/Shared.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
+
+using namespace pybind11;
+
+using ostk::core::types::String;
+using ostk::core::types::Real;
+using ostk::core::types::Shared;
+
+using ostk::math::obj::VectorXd;
+
+using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::RealEventCondition;
+
+inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_RealEventCondition(pybind11::module& aModule)
+{
+    {
+        class_<RealEventCondition, EventCondition, Shared<RealEventCondition>>(aModule, "RealEventCondition")
+
+            .def(
+                init<
+                    const String&,
+                    const EventCondition::Criteria&,
+                    std::function<Real(const VectorXd&, const Real&)>,
+                    const Real&>(),
+                arg("name"),
+                arg("criteria"),
+                arg("evaluator"),
+                arg("target") = 0.0
+            )
+
+            .def("__str__", &(shiftToString<RealEventCondition>))
+            .def("__repr__", &(shiftToString<RealEventCondition>))
+
+            .def("get_target", &RealEventCondition::getTarget)
+
+            .def("evaluate", &RealEventCondition::evaluate, arg("state_vector"), arg("time"))
+
+            .def(
+                "is_satisfied",
+                &RealEventCondition::isSatisfied,
+                arg("current_state_vector"),
+                arg("current_time"),
+                arg("previous_state_vector"),
+                arg("previous_time")
+            )
+
+            ;
+    }
+}

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -83,6 +83,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
             arg("tolerance")
         )
 
+        .def_static("string_from_element", &COE::StringFromElement, arg("element"))
+
         ;
 
     enum_<COE::Element>(coe, "Element")

--- a/bindings/python/test/event_condition/test_boolean_event_condition.py
+++ b/bindings/python/test/event_condition/test_boolean_event_condition.py
@@ -1,0 +1,44 @@
+# Apache License 2.0
+
+import pytest
+
+from ostk.astrodynamics.event_condition import BooleanEventCondition
+
+
+@pytest.fixture
+def evaluator():
+    return lambda state_vector, time: time > 0.0
+
+
+@pytest.fixture
+def is_inversed() -> bool:
+    return False
+
+
+@pytest.fixture
+def event_condition(evaluator, is_inversed: bool) -> BooleanEventCondition:
+    return BooleanEventCondition(
+        "My Condition",
+        BooleanEventCondition.Criteria.StrictlyPositive,
+        evaluator,
+        is_inversed,
+    )
+
+
+class TestBooleanEventCondition:
+    def test_is_inversed(self, event_condition: BooleanEventCondition, is_inversed: bool):
+        assert event_condition.is_inversed() == is_inversed
+
+    def test_evaluate(self, event_condition: BooleanEventCondition):
+        assert event_condition.evaluate(state_vector=[0.0], time=10.0) is not None
+
+    def test_is_satisfied(self, event_condition: BooleanEventCondition):
+        assert (
+            event_condition.is_satisfied(
+                previous_state_vector=[-1.0],
+                previous_time=-1.0,
+                current_state_vector=[1.0],
+                current_time=10.0,
+            )
+            == True
+        )

--- a/bindings/python/test/event_condition/test_coe_condition.py
+++ b/bindings/python/test/event_condition/test_coe_condition.py
@@ -4,9 +4,15 @@ import pytest
 
 from ostk.physics.environment.gravitational import Earth
 from ostk.physics.units import Derived, Length, Angle
+from ostk.physics.coordinate import Frame
 
 from ostk.astrodynamics.event_condition import COECondition
 from ostk.astrodynamics.trajectory.orbit.models.kepler import COE
+
+
+@pytest.fixture
+def frame() -> Frame:
+    return Frame.GCRF()
 
 
 @pytest.fixture
@@ -34,10 +40,11 @@ def condition(
     criteria: COECondition.Criteria,
     element: COE.Element,
     target: float,
+    frame: Frame,
     gravitational_parameter: Derived,
 ) -> COECondition:
     return COECondition(
-        "Test COECondition", criteria, element, target, gravitational_parameter
+        "Test COECondition", criteria, element, target, frame, gravitational_parameter
     )
 
 
@@ -54,13 +61,28 @@ def state_vector() -> list[float]:
 
 
 class TestCOECondition:
-    def test_constructor(self, criteria, element, target, gravitational_parameter):
+    def test_constructor(
+        self,
+        criteria: COECondition.Criteria,
+        element: COE.Element,
+        target: float,
+        frame: Frame,
+        gravitational_parameter: Derived,
+    ):
         name = "Test COECondition"
-        condition = COECondition(name, criteria, element, target, gravitational_parameter)
+        condition = COECondition(
+            name, criteria, element, target, frame, gravitational_parameter
+        )
 
         assert condition is not None
 
-    def test_getters(self, condition, element, target, gravitational_parameter):
+    def test_getters(
+        self,
+        condition: COECondition,
+        element: COE.Element,
+        target: float,
+        gravitational_parameter: Derived,
+    ):
         assert condition.get_element() == element
         assert condition.get_target() == target
         assert condition.get_gravitational_parameter() == gravitational_parameter
@@ -79,14 +101,22 @@ class TestCOECondition:
         ),
     )
     def test_static_constructors(
-        self, static_constructor, target, criteria, gravitational_parameter, state_vector
+        self,
+        static_constructor,
+        target: float,
+        criteria: COECondition.Criteria,
+        frame: Frame,
+        gravitational_parameter: Derived,
+        state_vector: list[float],
     ):
-        condition = static_constructor(criteria, target, gravitational_parameter)
+        condition = static_constructor(criteria, target, frame, gravitational_parameter)
         assert condition is not None
 
         assert condition.evaluate(state_vector, 0.0) is not None
 
-    def test_evaluate(self, condition, state_vector, target):
+    def test_evaluate(
+        self, condition: COECondition, state_vector: list[float], target: float
+    ):
         assert condition.evaluate(state_vector, 0.0) == pytest.approx(
             6904757.8910061345 - target, abs=1e-9
         )

--- a/bindings/python/test/event_condition/test_coe_condition.py
+++ b/bindings/python/test/event_condition/test_coe_condition.py
@@ -90,7 +90,3 @@ class TestCOECondition:
         assert condition.evaluate(state_vector, 0.0) == pytest.approx(
             6904757.8910061345 - target, abs=1e-9
         )
-
-    def test_string_from_element(self):
-        element_str = COECondition.string_from_element(COE.Element.SemiMajorAxis)
-        assert element_str == "Semi-major axis"

--- a/bindings/python/test/event_condition/test_conjunctive.py
+++ b/bindings/python/test/event_condition/test_conjunctive.py
@@ -2,42 +2,43 @@
 
 import pytest
 
-from ostk.astrodynamics import EventCondition
-from ostk.astrodynamics.event_condition import Conjunctive
+from ostk.astrodynamics.event_condition import Conjunctive, RealEventCondition
 
 
 @pytest.fixture
-def first_condition() -> EventCondition:
-    class FirstCondition(EventCondition):
-        def compute(self, state_vector, time):
-            return state_vector[0]
-
-    return FirstCondition("First Condition", EventCondition.Criteria.PositiveCrossing, 0.0)
+def first_condition() -> RealEventCondition:
+    return RealEventCondition(
+        "First Condition",
+        RealEventCondition.Criteria.PositiveCrossing,
+        lambda state_vector, time: state_vector[0],
+        0.0,
+    )
 
 
 @pytest.fixture
-def second_condition() -> EventCondition:
-    class SecondCondition(EventCondition):
-        def compute(self, state_vector, time):
-            return state_vector[1]
-
-    return SecondCondition("Second condition", EventCondition.Criteria.StrictlyNegative, 0.1)
+def second_condition() -> RealEventCondition:
+    return RealEventCondition(
+        "Second condition",
+        RealEventCondition.Criteria.StrictlyNegative,
+        lambda state_vector, time: state_vector[1],
+        0.1,
+    )
 
 
 @pytest.fixture
 def event_conditions(
-    first_condition: EventCondition, second_condition: EventCondition
-) -> list[EventCondition]:
+    first_condition: RealEventCondition, second_condition: RealEventCondition
+) -> list[RealEventCondition]:
     return [first_condition, second_condition]
 
 
 @pytest.fixture
-def conjunction_condition(event_conditions: list[EventCondition]) -> Conjunctive:
+def conjunction_condition(event_conditions: list[RealEventCondition]) -> Conjunctive:
     return Conjunctive(event_conditions)
 
 
 class TestConjunctiveCondition:
-    def test_constructor(self, event_conditions: list[EventCondition]):
+    def test_constructor(self, event_conditions: list[RealEventCondition]):
         assert Conjunctive(event_conditions) is not None
 
     def test_is_satisfied(self, conjunction_condition: Conjunctive):

--- a/bindings/python/test/event_condition/test_conjunctive.py
+++ b/bindings/python/test/event_condition/test_conjunctive.py
@@ -9,19 +9,19 @@ from ostk.astrodynamics.event_condition import Conjunctive
 @pytest.fixture
 def first_condition() -> EventCondition:
     class FirstCondition(EventCondition):
-        def evaluate(self, state_vector, time):
+        def compute(self, state_vector, time):
             return state_vector[0]
 
-    return FirstCondition("First Condition", EventCondition.Criteria.PositiveCrossing)
+    return FirstCondition("First Condition", EventCondition.Criteria.PositiveCrossing, 0.0)
 
 
 @pytest.fixture
 def second_condition() -> EventCondition:
     class SecondCondition(EventCondition):
-        def evaluate(self, state_vector, time):
-            return state_vector[1] - 0.1
+        def compute(self, state_vector, time):
+            return state_vector[1]
 
-    return SecondCondition("Second condition", EventCondition.Criteria.StrictlyNegative)
+    return SecondCondition("Second condition", EventCondition.Criteria.StrictlyNegative, 0.1)
 
 
 @pytest.fixture

--- a/bindings/python/test/event_condition/test_disjunctive.py
+++ b/bindings/python/test/event_condition/test_disjunctive.py
@@ -9,19 +9,19 @@ from ostk.astrodynamics.event_condition import Disjunctive
 @pytest.fixture
 def first_condition() -> EventCondition:
     class FirstCondition(EventCondition):
-        def evaluate(self, state_vector, time):
+        def compute(self, state_vector, time):
             return state_vector[0]
 
-    return FirstCondition("First Condition", EventCondition.Criteria.PositiveCrossing)
+    return FirstCondition("First Condition", EventCondition.Criteria.PositiveCrossing, 0.0)
 
 
 @pytest.fixture
 def second_condition() -> EventCondition:
     class SecondCondition(EventCondition):
-        def evaluate(self, state_vector, time):
-            return state_vector[1] - 0.1
+        def compute(self, state_vector, time):
+            return state_vector[1]
 
-    return SecondCondition("Second condition", EventCondition.Criteria.StrictlyNegative)
+    return SecondCondition("Second condition", EventCondition.Criteria.StrictlyNegative, 0.1)
 
 
 @pytest.fixture

--- a/bindings/python/test/event_condition/test_disjunctive.py
+++ b/bindings/python/test/event_condition/test_disjunctive.py
@@ -2,42 +2,43 @@
 
 import pytest
 
-from ostk.astrodynamics import EventCondition
-from ostk.astrodynamics.event_condition import Disjunctive
+from ostk.astrodynamics.event_condition import Disjunctive, RealEventCondition
 
 
 @pytest.fixture
-def first_condition() -> EventCondition:
-    class FirstCondition(EventCondition):
-        def compute(self, state_vector, time):
-            return state_vector[0]
-
-    return FirstCondition("First Condition", EventCondition.Criteria.PositiveCrossing, 0.0)
+def first_condition() -> RealEventCondition:
+    return RealEventCondition(
+        "First Condition",
+        RealEventCondition.Criteria.PositiveCrossing,
+        lambda state_vector, time: state_vector[0],
+        0.0,
+    )
 
 
 @pytest.fixture
-def second_condition() -> EventCondition:
-    class SecondCondition(EventCondition):
-        def compute(self, state_vector, time):
-            return state_vector[1]
-
-    return SecondCondition("Second condition", EventCondition.Criteria.StrictlyNegative, 0.1)
+def second_condition() -> RealEventCondition:
+    return RealEventCondition(
+        "Second condition",
+        RealEventCondition.Criteria.StrictlyNegative,
+        lambda state_vector, time: state_vector[1],
+        0.1,
+    )
 
 
 @pytest.fixture
 def event_conditions(
-    first_condition: EventCondition, second_condition: EventCondition
-) -> list[EventCondition]:
+    first_condition: RealEventCondition, second_condition: RealEventCondition
+) -> list[RealEventCondition]:
     return [first_condition, second_condition]
 
 
 @pytest.fixture
-def disjunction_condition(event_conditions: list[EventCondition]) -> Disjunctive:
+def disjunction_condition(event_conditions: list[RealEventCondition]) -> Disjunctive:
     return Disjunctive(event_conditions)
 
 
 class TestDisjunctiveCondition:
-    def test_constructor(self, event_conditions: list[EventCondition]):
+    def test_constructor(self, event_conditions: list[RealEventCondition]):
         assert Disjunctive(event_conditions) is not None
 
     def test_is_satisfied(self, disjunction_condition: Disjunctive):

--- a/bindings/python/test/event_condition/test_logical_connective.py
+++ b/bindings/python/test/event_condition/test_logical_connective.py
@@ -12,7 +12,7 @@ def event_condition() -> EventCondition:
         def evaluate(self, state_vector, time):
             return time
 
-    return MyCondition("My Condition", EventCondition.Criteria.StrictlyNegative)
+    return MyCondition("My Condition", EventCondition.Criteria.StrictlyNegative, 0.0)
 
 
 @pytest.fixture

--- a/bindings/python/test/event_condition/test_logical_connective.py
+++ b/bindings/python/test/event_condition/test_logical_connective.py
@@ -9,10 +9,12 @@ from ostk.astrodynamics.event_condition import LogicalConnective
 @pytest.fixture
 def event_condition() -> EventCondition:
     class MyCondition(EventCondition):
-        def evaluate(self, state_vector, time):
-            return time
+        def is_satisfied(
+            self, current_state_vector, current_time, previous_state_vector, previous_time
+        ):
+            return True
 
-    return MyCondition("My Condition", EventCondition.Criteria.StrictlyNegative, 0.0)
+    return MyCondition("My Condition", EventCondition.Criteria.StrictlyNegative)
 
 
 @pytest.fixture

--- a/bindings/python/test/event_condition/test_real_event_condition.py
+++ b/bindings/python/test/event_condition/test_real_event_condition.py
@@ -1,0 +1,41 @@
+# Apache License 2.0
+
+import pytest
+
+from ostk.astrodynamics.event_condition import RealEventCondition
+
+
+@pytest.fixture
+def evaluator():
+    return lambda state_vector, time: time
+
+
+@pytest.fixture
+def target() -> float:
+    return 10.0
+
+
+@pytest.fixture
+def event_condition(evaluator, target: float) -> RealEventCondition:
+    return RealEventCondition(
+        "My Condition", RealEventCondition.Criteria.PositiveCrossing, evaluator, target
+    )
+
+
+class TestRealEventCondition:
+    def test_get_target(self, event_condition: RealEventCondition, target: float):
+        assert event_condition.get_target() == target
+
+    def test_evaluate(self, event_condition: RealEventCondition):
+        assert event_condition.evaluate(state_vector=[0.0], time=10.0) is not None
+
+    def test_is_satisfied(self, event_condition: RealEventCondition):
+        assert (
+            event_condition.is_satisfied(
+                previous_state_vector=[-1.0],
+                previous_time=5.0,
+                current_state_vector=[1.0],
+                current_time=15.0,
+            )
+            == True
+        )

--- a/bindings/python/test/test_event_condition.py
+++ b/bindings/python/test/test_event_condition.py
@@ -16,33 +16,14 @@ def criteria() -> EventCondition.Criteria:
 
 
 @pytest.fixture
-def target() -> float:
-    return 0.0
-
-
-@pytest.fixture
-def event_condition(
-    name: str, criteria: EventCondition.Criteria, target: float
-) -> EventCondition:
+def event_condition(name: str, criteria: EventCondition.Criteria) -> EventCondition:
     class MyEventCondition(EventCondition):
-        def compute(self, state_vector, time):
-            return state_vector[0]
+        def is_satisfied(
+            self, current_state_vector, current_time, previous_state_vector, previous_time
+        ):
+            return current_state_vector[0] > 0.0 and previous_state_vector[0] < 0.0
 
-    return MyEventCondition(name, criteria, target)
-
-
-@pytest.fixture
-def event_condition_overloaded(target: float) -> EventCondition:
-    class OverloadedEventCondition(EventCondition):
-        def is_satisfied(self, current_value, previous_value):
-            return (current_value > 0.0) and (previous_value < 0.0)
-
-        def compute(self, aStateVector, aTime):
-            return aStateVector[0]
-
-    return OverloadedEventCondition(
-        "OverloadedEventCondition", EventCondition.Criteria.Undefined, target
-    )
+    return MyEventCondition(name, criteria)
 
 
 class TestEventCondition:
@@ -57,14 +38,7 @@ class TestEventCondition:
     ):
         assert event_condition.get_criteria() == criteria
 
-    def test_get_target(self, event_condition: EventCondition, target: float):
-        assert event_condition.get_target() == target
-
     def test_is_satisfied(self, event_condition: EventCondition):
-        assert (
-            event_condition.is_satisfied(current_value=1.0, previous_value=-1.0) == True
-        )
-
         assert (
             event_condition.is_satisfied(
                 previous_state_vector=[-1.0],
@@ -73,17 +47,4 @@ class TestEventCondition:
                 current_time=1.0,
             )
             == True
-        )
-
-    def test_overloaded_is_satisfied(self, event_condition_overloaded: EventCondition):
-        assert event_condition_overloaded is not None
-        assert (
-            event_condition_overloaded.is_satisfied(
-                current_value=1.0, previous_value=-1.0
-            )
-            == True
-        )
-        assert (
-            event_condition_overloaded.is_satisfied(current_value=1.0, previous_value=1.0)
-            == False
         )

--- a/bindings/python/test/test_event_condition.py
+++ b/bindings/python/test/test_event_condition.py
@@ -14,27 +14,30 @@ def name() -> str:
 def criteria() -> EventCondition.Criteria:
     return EventCondition.Criteria.AnyCrossing
 
+@pytest.fixture
+def target() -> float:
+    return 0.0
 
 @pytest.fixture
-def event_condition(name: str, criteria: EventCondition.Criteria) -> EventCondition:
+def event_condition(name: str, criteria: EventCondition.Criteria, target: float) -> EventCondition:
     class MyEventCondition(EventCondition):
-        def evaluate(self, state_vector, time):
+        def compute(self, state_vector, time):
             return state_vector[0]
 
-    return MyEventCondition(name, criteria)
+    return MyEventCondition(name, criteria, target)
 
 
 @pytest.fixture
-def event_condition_overloaded() -> EventCondition:
+def event_condition_overloaded(target: float) -> EventCondition:
     class OverloadedEventCondition(EventCondition):
         def is_satisfied(self, current_value, previous_value):
             return (current_value > 0.0) and (previous_value < 0.0)
 
-        def evaluate(self, aStateVector, aTime):
+        def compute(self, aStateVector, aTime):
             return aStateVector[0]
 
     return OverloadedEventCondition(
-        "OverloadedEventCondition", EventCondition.Criteria.Undefined
+        "OverloadedEventCondition", EventCondition.Criteria.Undefined, target
     )
 
 
@@ -50,9 +53,18 @@ class TestEventCondition:
     ):
         assert event_condition.get_criteria() == criteria
 
+    def test_get_target(
+        self, event_condition: EventCondition, target: float
+    ):
+        assert event_condition.get_target() == target
+
     def test_is_satisfied(self, event_condition: EventCondition):
         assert (
             event_condition.is_satisfied(current_value=1.0, previous_value=-1.0) == True
+        )
+        
+        assert (
+            event_condition.is_satisfied(previous_state_vector=[-1.0], previous_time=0.0, current_state_vector=[1.0], current_time=1.0) == True
         )
 
     def test_overloaded_is_satisfied(self, event_condition_overloaded: EventCondition):

--- a/bindings/python/test/test_event_condition.py
+++ b/bindings/python/test/test_event_condition.py
@@ -14,12 +14,16 @@ def name() -> str:
 def criteria() -> EventCondition.Criteria:
     return EventCondition.Criteria.AnyCrossing
 
+
 @pytest.fixture
 def target() -> float:
     return 0.0
 
+
 @pytest.fixture
-def event_condition(name: str, criteria: EventCondition.Criteria, target: float) -> EventCondition:
+def event_condition(
+    name: str, criteria: EventCondition.Criteria, target: float
+) -> EventCondition:
     class MyEventCondition(EventCondition):
         def compute(self, state_vector, time):
             return state_vector[0]
@@ -53,18 +57,22 @@ class TestEventCondition:
     ):
         assert event_condition.get_criteria() == criteria
 
-    def test_get_target(
-        self, event_condition: EventCondition, target: float
-    ):
+    def test_get_target(self, event_condition: EventCondition, target: float):
         assert event_condition.get_target() == target
 
     def test_is_satisfied(self, event_condition: EventCondition):
         assert (
             event_condition.is_satisfied(current_value=1.0, previous_value=-1.0) == True
         )
-        
+
         assert (
-            event_condition.is_satisfied(previous_state_vector=[-1.0], previous_time=0.0, current_state_vector=[1.0], current_time=1.0) == True
+            event_condition.is_satisfied(
+                previous_state_vector=[-1.0],
+                previous_time=0.0,
+                current_state_vector=[1.0],
+                current_time=1.0,
+            )
+            == True
         )
 
     def test_overloaded_is_satisfied(self, event_condition_overloaded: EventCondition):

--- a/bindings/python/test/test_numerical_solver.py
+++ b/bindings/python/test/test_numerical_solver.py
@@ -26,14 +26,10 @@ def initial_state_vec() -> np.ndarray:
 @pytest.fixture
 def custom_condition() -> EventCondition:
     class CustomCondition(EventCondition):
-        def __init__(self, target: float, criteria: EventCondition.Criteria):
-            super().__init__("Custom", criteria)
-            self._target = target
+        def compute(self, state_vector, time: float) -> bool:
+            return time
 
-        def evaluate(self, state_vector, time: float) -> bool:
-            return time - self._target
-
-    return CustomCondition(5.0, EventCondition.Criteria.StrictlyPositive)
+    return CustomCondition("Custom", EventCondition.Criteria.StrictlyPositive, 5.0)
 
 
 @pytest.fixture
@@ -214,7 +210,7 @@ class TestNumericalSolver:
 
         state_vector, time = condition_solution.solution
 
-        assert abs(time - custom_condition._target) < 1e-6
+        assert abs(float(time - custom_condition.get_target())) < 1e-6
 
         assert 5e-9 >= abs(state_vector[0] - math.sin(time))
         assert 5e-9 >= abs(state_vector[1] - math.cos(time))
@@ -241,7 +237,7 @@ class TestNumericalSolver:
 
         state_vector, time = condition_solution.solution
 
-        assert abs(time - start_time - custom_condition._target) < 1e-6
+        assert abs(float(time - start_time - custom_condition.get_target())) < 1e-6
 
         assert 5e-9 >= abs(state_vector[0] - math.sin(time))
         assert 5e-9 >= abs(state_vector[1] - math.cos(time))

--- a/bindings/python/test/test_numerical_solver.py
+++ b/bindings/python/test/test_numerical_solver.py
@@ -5,7 +5,8 @@ import pytest
 import numpy as np
 import math
 
-from ostk.astrodynamics import NumericalSolver, EventCondition
+from ostk.astrodynamics import NumericalSolver
+from ostk.astrodynamics.event_condition import RealEventCondition
 
 
 def oscillator(x, dxdt, _):
@@ -24,12 +25,13 @@ def initial_state_vec() -> np.ndarray:
 
 
 @pytest.fixture
-def custom_condition() -> EventCondition:
-    class CustomCondition(EventCondition):
-        def compute(self, state_vector, time: float) -> bool:
-            return time
-
-    return CustomCondition("Custom", EventCondition.Criteria.StrictlyPositive, 5.0)
+def custom_condition() -> RealEventCondition:
+    return RealEventCondition(
+        "Custom",
+        RealEventCondition.Criteria.StrictlyPositive,
+        lambda state_vector, time: time,
+        5.0,
+    )
 
 
 @pytest.fixture
@@ -194,7 +196,7 @@ class TestNumericalSolver:
         self,
         numerical_solver_conditional: NumericalSolver,
         initial_state_vec: np.ndarray,
-        custom_condition: EventCondition,
+        custom_condition: RealEventCondition,
     ):
         integration_duration: float = 100.0
 
@@ -218,7 +220,7 @@ class TestNumericalSolver:
     def test_integrate_time_with_condition(
         self,
         numerical_solver_conditional: NumericalSolver,
-        custom_condition: EventCondition,
+        custom_condition: RealEventCondition,
     ):
         start_time: float = 500.0
         end_time: float = start_time + 100.0

--- a/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
+++ b/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
@@ -106,6 +106,7 @@ def test_trajectory_orbit_models_kepler_coe_static_methods():
         COE.eccentric_anomaly_from_mean_anomaly(Angle.degrees(0.0), 0.0, 0.0) is not None
     )
 
+
 def test_string_from_element():
     element_str = COE.string_from_element(COE.Element.SemiMajorAxis)
     assert element_str == "SemiMajorAxis"

--- a/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
+++ b/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
@@ -105,3 +105,7 @@ def test_trajectory_orbit_models_kepler_coe_static_methods():
     assert (
         COE.eccentric_anomaly_from_mean_anomaly(Angle.degrees(0.0), 0.0, 0.0) is not None
     )
+
+def test_string_from_element():
+    element_str = COE.string_from_element(COE.Element.SemiMajorAxis)
+    assert element_str == "SemiMajorAxis"

--- a/bindings/python/test/trajectory/test_propagator.py
+++ b/bindings/python/test/trajectory/test_propagator.py
@@ -13,6 +13,7 @@ from ostk.physics.units import Mass
 from ostk.physics.time import Instant
 from ostk.physics.time import DateTime
 from ostk.physics.time import Scale
+from ostk.physics.time import Duration
 from ostk.physics.coordinate import Position
 from ostk.physics.coordinate import Velocity
 from ostk.physics.coordinate import Frame
@@ -25,7 +26,7 @@ from ostk.astrodynamics.flight.system.dynamics import CentralBodyGravity
 from ostk.astrodynamics.flight.system.dynamics import PositionDerivative
 from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory import Propagator
-from ostk.astrodynamics import EventCondition
+from ostk.astrodynamics.event_condition import DurationCondition
 
 
 @pytest.fixture
@@ -104,12 +105,10 @@ def conditional_numerical_solver() -> NumericalSolver:
 
 
 @pytest.fixture
-def event_condition() -> EventCondition:
-    class MyEventCondition(EventCondition):
-        def compute(self, state_vector, time):
-            return time
-
-    return MyEventCondition("42 Seconds", EventCondition.Criteria.StrictlyPositive, 42.0)
+def event_condition() -> DurationCondition:
+    return DurationCondition(
+        DurationCondition.Criteria.StrictlyPositive, Duration.seconds(42.0)
+    )
 
 
 @pytest.fixture
@@ -191,7 +190,7 @@ class TestPropagator:
         conditional_numerical_solver: NumericalSolver,
         dynamics: list[Dynamics],
         state: State,
-        event_condition: EventCondition,
+        event_condition: DurationCondition,
     ):
         propagator: Propagator = Propagator(conditional_numerical_solver, dynamics)
 

--- a/bindings/python/test/trajectory/test_propagator.py
+++ b/bindings/python/test/trajectory/test_propagator.py
@@ -106,10 +106,10 @@ def conditional_numerical_solver() -> NumericalSolver:
 @pytest.fixture
 def event_condition() -> EventCondition:
     class MyEventCondition(EventCondition):
-        def evaluate(self, state_vector, time):
-            return time - 42.0
+        def compute(self, state_vector, time):
+            return time
 
-    return MyEventCondition("42 Seconds", EventCondition.Criteria.StrictlyPositive)
+    return MyEventCondition("42 Seconds", EventCondition.Criteria.StrictlyPositive, 42.0)
 
 
 @pytest.fixture

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition.hpp
@@ -42,7 +42,7 @@ class EventCondition
     ///
     /// @param                  [in] aName A string representing the name of the Event Condition
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
-    ///
+    /// @param                  [in] aTarget A target value associated with the Event Condition
 
     EventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget);
 

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition.hpp
@@ -42,8 +42,9 @@ class EventCondition
     ///
     /// @param                  [in] aName A string representing the name of the Event Condition
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
+    ///
 
-    EventCondition(const String& aName, const Criteria& aCriteria);
+    EventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget);
 
     /// @brief                  Virtual destructor
 
@@ -61,7 +62,7 @@ class EventCondition
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const EventCondition& anEventCondition);
 
-    /// @brief                  Get name of the Event Condition
+    /// @brief                  Get the name of the Event Condition
     ///
     /// @return                 String representing the name of the Event Condition
 
@@ -72,6 +73,21 @@ class EventCondition
     /// @return                 Enum representing the criteria of the Event Condition
 
     Criteria getCriteria() const;
+
+    /// @brief                  Get the target of the Event Condition
+    ///
+    /// @return                 Real number representing the target of the Event Condition
+
+    Real getTarget() const;
+
+    /// @brief                  Evaluate the Event Condition
+    ///
+    /// @param                  [in] aStateVector The current state vector
+    /// @param                  [in] aTime The current time
+    ///
+    /// @return                 Real number representing the evaluation result of the Event Condition
+
+    Real evaluate(const VectorXd& aStateVector, const Real& aTime) const;
 
     /// @brief                  Print the Event Condition
     ///
@@ -109,14 +125,14 @@ class EventCondition
         const Real& previousTime
     ) const;
 
-    /// @brief                  Evaluate the Event Condition
+    /// @brief                  Compute the value of the Event Condition
     ///
-    /// @param                  [in] aStateVector The current state vector
-    /// @param                  [in] aTime The current time
+    /// @param                  [in] aStateVector The state vector
+    /// @param                  [in] aTime The time
     ///
-    /// @return                 Real number representing the evaluation result of the Event Condition
+    /// @return                 Real number representing the value of the Event Condition
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const = 0;
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const = 0;
 
     /// @brief                  Convert criteria to string
     ///
@@ -129,6 +145,7 @@ class EventCondition
    private:
     String name_;
     Criteria criteria_;
+    Real target_;
 
     std::function<bool(const Real&, const Real&)> comparator_;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition.hpp
@@ -41,10 +41,10 @@ class EventCondition
     /// @endcode
     ///
     /// @param                  [in] aName A string representing the name of the Event Condition
-    /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
-    /// @param                  [in] aTarget A target value associated with the Event Condition
+    /// @param                  [in] aCriteria An enum indicating the criteria used to determine if the Event Condition
+    /// is met
 
-    EventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget);
+    EventCondition(const String& aName, const Criteria& aCriteria);
 
     /// @brief                  Virtual destructor
 
@@ -74,20 +74,11 @@ class EventCondition
 
     Criteria getCriteria() const;
 
-    /// @brief                  Get the target of the Event Condition
+    /// @brief                  Get comparator
     ///
-    /// @return                 Real number representing the target of the Event Condition
+    /// @return                 Comparator
 
-    Real getTarget() const;
-
-    /// @brief                  Evaluate the Event Condition
-    ///
-    /// @param                  [in] aStateVector The current state vector
-    /// @param                  [in] aTime The current time
-    ///
-    /// @return                 Real number representing the evaluation result of the Event Condition
-
-    Real evaluate(const VectorXd& aStateVector, const Real& aTime) const;
+    std::function<bool(const Real&, const Real&)> getComparator() const;
 
     /// @brief                  Print the Event Condition
     ///
@@ -96,15 +87,6 @@ class EventCondition
     /// printing
 
     virtual void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
-
-    /// @brief                  Check if the Event Condition is satisfied based on current value and previous value
-    ///
-    /// @param                  [in] currentValue The current value
-    /// @param                  [in] previousValue The previous value
-    ///
-    /// @return                 Boolean value indicating if the Event Condition is met
-
-    virtual bool isSatisfied(const Real& currentValue, const Real& previousValue) const;
 
     /// @brief                  Check if the Event Condition is satisfied based on current state/time and previous
     /// state/time
@@ -123,16 +105,7 @@ class EventCondition
         const Real& currentTime,
         const VectorXd& previousStateVector,
         const Real& previousTime
-    ) const;
-
-    /// @brief                  Compute the value of the Event Condition
-    ///
-    /// @param                  [in] aStateVector The state vector
-    /// @param                  [in] aTime The time
-    ///
-    /// @return                 Real number representing the value of the Event Condition
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const = 0;
+    ) const = 0;
 
     /// @brief                  Convert criteria to string
     ///
@@ -145,8 +118,6 @@ class EventCondition
    private:
     String name_;
     Criteria criteria_;
-    Real target_;
-
     std::function<bool(const Real&, const Real&)> comparator_;
 
     static std::function<bool(const Real&, const Real&)> getComparator(const Criteria& aCriteria);

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp
@@ -1,0 +1,90 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkit_Astrodynamics_EventCondition_BooleanEventCondition__
+#define __OpenSpaceToolkit_Astrodynamics_EventCondition_BooleanEventCondition__
+
+#include <OpenSpaceToolkit/Core/Types/Real.hpp>
+#include <OpenSpaceToolkit/Core/Types/String.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace eventcondition
+{
+
+using ostk::core::types::Real;
+using ostk::core::types::String;
+
+using ostk::math::obj::VectorXd;
+
+using ostk::astro::EventCondition;
+
+/// @brief                      A Boolean Event Condition is a condition that is met when the computed value returns
+/// true
+
+class BooleanEventCondition : public EventCondition
+{
+   public:
+    /// @brief                  Constructor
+    ///
+    /// @code
+    ///                         BooleanEventCondition booleanEventCondition = {aName, aCriteria};
+    /// @endcode
+    ///
+    /// @param                  [in] aName A string representing the name of the Boolean Event Condition
+    /// @param                  [in] aCriteria An enum indicating the criteria used to determine if the Boolean Event
+    /// Condition is met
+    /// @param                  [in] anInverseFlag A flag indicating whether the condition is inverted
+
+    BooleanEventCondition(const String& aName, const Criteria& aCriteria, const bool& anInverseFlag = false);
+
+    /// @brief                  Virtual destructor
+
+    virtual ~BooleanEventCondition();
+
+    /// @brief                  Check if the condition is inversed
+    ///
+    /// @return                 Boolean value indicating whether the condition is inversed
+
+    Real isInversed() const;
+
+    /// @brief                  Check if the Event Condition is satisfied based on current state/time and previous
+    /// state/time
+    ///
+    /// @param                  [in] currentStateVector The current state vector
+    /// @param                  [in] currentTime The current time
+    /// @param                  [in] previousStateVector The previous state vector
+    /// @param                  [in] previousTime The previous time
+    ///
+    /// @return                 Boolean value indicating if the Real Event Condition is met
+
+    virtual bool isSatisfied(
+        const VectorXd& currentStateVector,
+        const Real& currentTime,
+        const VectorXd& previousStateVector,
+        const Real& previousTime
+    ) const override;
+
+    /// @brief                  Compute the value of the Boolean Event Condition
+    ///
+    /// @param                  [in] aStateVector The state vector
+    /// @param                  [in] aTime The time
+    ///
+    /// @return                 Boolean value representing the value of the Event Condition
+
+    virtual bool compute(const VectorXd& aStateVector, const Real& aTime) const = 0;
+
+   private:
+    bool inverse_;
+};
+
+}  // namespace eventcondition
+}  // namespace astro
+}  // namespace ostk
+
+#endif

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp
@@ -33,7 +33,8 @@ class BooleanEventCondition : public EventCondition
     /// @brief                  Constructor
     ///
     /// @code
-    ///                         BooleanEventCondition booleanEventCondition = {aName, aCriteria};
+    ///                         BooleanEventCondition booleanEventCondition = {aName, aCriteria, anEvaluator,
+    ///                         anInverseFlag};
     /// @endcode
     ///
     /// @param                  [in] aName A string representing the name of the Boolean Event Condition
@@ -43,10 +44,11 @@ class BooleanEventCondition : public EventCondition
     /// @param                  [in] anInverseFlag A flag indicating whether the condition is inverted
 
     BooleanEventCondition(
-        const String& aName, 
+        const String& aName,
         const Criteria& aCriteria,
         const std::function<bool(const VectorXd&, const Real&)> anEvaluator,
-        const bool& anInverseFlag = false);
+        const bool& anInverseFlag = false
+    );
 
     /// @brief                  Virtual destructor
 
@@ -57,6 +59,15 @@ class BooleanEventCondition : public EventCondition
     /// @return                 Boolean value indicating whether the condition is inversed
 
     bool isInversed() const;
+
+    /// @brief                  Evaluate the Event Condition
+    ///
+    /// @param                  [in] aStateVector The current state vector
+    /// @param                  [in] aTime The current time
+    ///
+    /// @return                 Boolean representing the evaluation result of the Event Condition
+
+    bool evaluate(const VectorXd& aStateVector, const Real& aTime) const;
 
     /// @brief                  Check if the Event Condition is satisfied based on current state/time and previous
     /// state/time
@@ -75,14 +86,14 @@ class BooleanEventCondition : public EventCondition
         const Real& previousTime
     ) const override;
 
-    /// @brief                  Evaluate the Event Condition
+    /// @brief                  Print the Boolean Event Condition
     ///
-    /// @param                  [in] aStateVector The current state vector
-    /// @param                  [in] aTime The current time
-    ///
-    /// @return                 boolean representing the evaluation result of the Event Condition
+    /// @param                  [in, out] anOutputStream The output stream where the Boolean Event Condition will be
+    /// printed
+    /// @param                  [in] displayDecorator A boolean indicating whether or not to display decorator during
+    /// printing
 
-    bool evaluate(const VectorXd& aStateVector, const Real& aTime) const;
+    virtual void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
    private:
     std::function<bool(const VectorXd&, const Real&)> evaluator_;

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp
@@ -39,9 +39,14 @@ class BooleanEventCondition : public EventCondition
     /// @param                  [in] aName A string representing the name of the Boolean Event Condition
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine if the Boolean Event
     /// Condition is met
+    /// @param                  [in] anEvaluator A function evaluating a state and a time
     /// @param                  [in] anInverseFlag A flag indicating whether the condition is inverted
 
-    BooleanEventCondition(const String& aName, const Criteria& aCriteria, const bool& anInverseFlag = false);
+    BooleanEventCondition(
+        const String& aName, 
+        const Criteria& aCriteria,
+        const std::function<bool(const VectorXd&, const Real&)> anEvaluator,
+        const bool& anInverseFlag = false);
 
     /// @brief                  Virtual destructor
 
@@ -51,7 +56,7 @@ class BooleanEventCondition : public EventCondition
     ///
     /// @return                 Boolean value indicating whether the condition is inversed
 
-    Real isInversed() const;
+    bool isInversed() const;
 
     /// @brief                  Check if the Event Condition is satisfied based on current state/time and previous
     /// state/time
@@ -70,16 +75,17 @@ class BooleanEventCondition : public EventCondition
         const Real& previousTime
     ) const override;
 
-    /// @brief                  Compute the value of the Boolean Event Condition
+    /// @brief                  Evaluate the Event Condition
     ///
-    /// @param                  [in] aStateVector The state vector
-    /// @param                  [in] aTime The time
+    /// @param                  [in] aStateVector The current state vector
+    /// @param                  [in] aTime The current time
     ///
-    /// @return                 Boolean value representing the value of the Event Condition
+    /// @return                 boolean representing the evaluation result of the Event Condition
 
-    virtual bool compute(const VectorXd& aStateVector, const Real& aTime) const = 0;
+    bool evaluate(const VectorXd& aStateVector, const Real& aTime) const;
 
    private:
+    std::function<bool(const VectorXd&, const Real&)> evaluator_;
     bool inverse_;
 };
 

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
@@ -63,12 +63,6 @@ class COECondition : public EventCondition
 
     virtual ~COECondition();
 
-    /// @brief                  Get target
-    ///
-    /// @return                 target
-
-    Real getTarget() const;
-
     /// @brief                  Get gravitational parameter
     ///
     /// @return                 gravitational parameter
@@ -81,22 +75,14 @@ class COECondition : public EventCondition
 
     COE::Element getElement() const;
 
-    /// @brief                  Evaluate the Event Condition
+    /// @brief                  Compute the Event Condition
     ///
     /// @param                  [in] aStateVector The current state vector
     /// @param                  [in] aTime The current time
     ///
     /// @return                 Real number representing the evaluation result of the Event Condition
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override;
-
-    /// @brief                  Convert element to string
-    ///
-    /// @param                  [in] anElement An element
-    ///
-    /// @return                 String representing the element
-
-    static String StringFromElement(const COE::Element& anElement);
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override;
 
     /// @brief                  Semi Major Axis based constructor
     ///
@@ -192,7 +178,6 @@ class COECondition : public EventCondition
 
    private:
     COE::Element element_;
-    Real target_;
     Derived gravitationalParameter_;
     std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> evaluator_;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
@@ -11,7 +11,7 @@
 #include <OpenSpaceToolkit/Physics/Units/Derived.hpp>
 #include <OpenSpaceToolkit/Physics/Units/Length.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.hpp>
 
 namespace ostk
@@ -31,12 +31,12 @@ using ostk::physics::units::Angle;
 using ostk::physics::units::Derived;
 using ostk::physics::units::Length;
 
-using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::trajectory::orbit::models::kepler::COE;
 
 /// @brief                      A Classical Orbital Element based event condition
 
-class COECondition : public EventCondition
+class COECondition : public RealEventCondition
 {
    public:
     /// @brief                  Constructor
@@ -179,7 +179,7 @@ class COECondition : public EventCondition
    private:
     COE::Element element_;
     Derived gravitationalParameter_;
-    std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> evaluator_;
+    std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> compute_;
 
     /// @brief                  Get evaluation function from element
     ///
@@ -187,7 +187,7 @@ class COECondition : public EventCondition
     ///
     /// @return                 Evaluation function
 
-    static std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> GetEvaluator(
+    static std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> GetComputeFunction(
         const COE::Element& anElement
     );
 };

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
@@ -80,7 +80,7 @@ class COECondition : public EventCondition
     /// @param                  [in] aStateVector The current state vector
     /// @param                  [in] aTime The current time
     ///
-    /// @return                 Real number representing the evaluation result of the Event Condition
+    /// @return                 Real number representing the computation result of the Event Condition
 
     virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
@@ -22,11 +22,13 @@ namespace eventcondition
 {
 
 using ostk::core::types::Real;
+using ostk::core::types::Shared;
 using ostk::core::types::String;
 
 using ostk::math::obj::VectorXd;
 using ostk::math::obj::Vector3d;
 
+using ostk::physics::coord::Frame;
 using ostk::physics::units::Angle;
 using ostk::physics::units::Derived;
 using ostk::physics::units::Length;
@@ -49,6 +51,7 @@ class COECondition : public RealEventCondition
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] anElement The Element related to the COECondition
     /// @param                  [in] aTarget A target value associated with the COECondition
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter The derived gravitational parameter
 
     COECondition(
@@ -56,6 +59,7 @@ class COECondition : public RealEventCondition
         const Criteria& aCriteria,
         const COE::Element& anElement,
         const Real& aTarget,
+        const Shared<const Frame>& aFrameSPTr,
         const Derived& aGravitationalParameter
     );
 
@@ -75,120 +79,131 @@ class COECondition : public RealEventCondition
 
     COE::Element getElement() const;
 
-    /// @brief                  Compute the Event Condition
-    ///
-    /// @param                  [in] aStateVector The current state vector
-    /// @param                  [in] aTime The current time
-    ///
-    /// @return                 Real number representing the computation result of the Event Condition
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override;
-
     /// @brief                  Semi Major Axis based constructor
     ///
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] aSemiMajorAxis A semi major axis
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter A gravitational parameter
     ///
     /// @return                 COECondition object
 
     static COECondition SemiMajorAxis(
-        const Criteria& aCriteria, const Length& aSemiMajorAxis, const Derived& aGravitationalParameter
+        const Criteria& aCriteria, const Length& aSemiMajorAxis,
+        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
     );
 
     /// @brief                  Eccentricity based constructor
     ///
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] anEccentricity An eccentricity
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter A gravitational parameter
     ///
     /// @return                 COECondition object
 
     static COECondition Eccentricity(
-        const Criteria& aCriteria, const Real& anEccentricity, const Derived& aGravitationalParameter
+        const Criteria& aCriteria, const Real& anEccentricity,
+        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
     );
 
     /// @brief                  Inclination based constructor
     ///
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] anInclination An inclination
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter A gravitational parameter
     ///
     /// @return                 COECondition object
 
     static COECondition Inclination(
-        const Criteria& aCriteria, const Angle& aSemiMajorAxis, const Derived& aGravitationalParameter
+        const Criteria& aCriteria, const Angle& aSemiMajorAxis,
+        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
     );
 
     /// @brief                  Argument of Periapsis based constructor
     ///
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] anAOP An argument of periapsis
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter A gravitational parameter
     ///
     /// @return                 COECondition object
 
-    static COECondition Aop(const Criteria& aCriteria, const Angle& anAOP, const Derived& aGravitationalParameter);
+    static COECondition Aop(const Criteria& aCriteria, const Angle& anAOP,
+    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter);
 
     /// @brief                  Right Ascension of Ascending Node based constructor
     ///
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] aRAAN A right angle of ascending node
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter A gravitational parameter
     ///
     /// @return                 COECondition object
 
-    static COECondition Raan(const Criteria& aCriteria, const Angle& aRAAN, const Derived& aGravitationalParameter);
+    static COECondition Raan(const Criteria& aCriteria, const Angle& aRAAN,
+    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter);
 
     /// @brief                  True Anomaly based constructor
     ///
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] aTrueAnomaly A true anomaly
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter A gravitational parameter
     ///
     /// @return                 COECondition object
 
     static COECondition TrueAnomaly(
-        const Criteria& aCriteria, const Angle& aTrueAnomaly, const Derived& aGravitationalParameter
+        const Criteria& aCriteria, const Angle& aTrueAnomaly,
+        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
     );
 
     /// @brief                  Mean Anomaly based constructor
     ///
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] aMeanAnomaly A mean anomaly
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter A gravitational parameter
     ///
     /// @return                 COECondition object
 
     static COECondition MeanAnomaly(
-        const Criteria& aCriteria, const Angle& aMeanAnomaly, const Derived& aGravitationalParameter
+        const Criteria& aCriteria, const Angle& aMeanAnomaly,
+        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
     );
 
     /// @brief                  Eccentric Anomaly based constructor
     ///
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine the Event Condition
     /// @param                  [in] anEccentricAnomaly An eccentric anomaly
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
     /// @param                  [in] aGravitationalParameter A gravitational parameter
     ///
     /// @return                 COECondition object
 
     static COECondition EccentricAnomaly(
-        const Criteria& aCriteria, const Angle& anEccentricAnomaly, const Derived& aGravitationalParameter
+        const Criteria& aCriteria, const Angle& anEccentricAnomaly,
+        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
     );
 
    private:
     COE::Element element_;
+    Shared<const Frame>& frameSPtr_;
     Derived gravitationalParameter_;
-    std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> compute_;
 
     /// @brief                  Get evaluation function from element
     ///
     /// @param                  [in] anElement The element
+    /// @param                  [in] aFrameSPtr The reference frame used to compute the element
+    /// @param                  [in] aGravitationalParameter The derived gravitational parameter
     ///
     /// @return                 Evaluation function
 
-    static std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> GetComputeFunction(
-        const COE::Element& anElement
+    static std::function<Real(const VectorXd&, const Real&)> GenerateEvaluator(
+        const COE::Element& anElement,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
     );
 };
 

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
@@ -59,7 +59,7 @@ class COECondition : public RealEventCondition
         const Criteria& aCriteria,
         const COE::Element& anElement,
         const Real& aTarget,
-        const Shared<const Frame>& aFrameSPTr,
+        const Shared<const Frame>& aFrameSPtr,
         const Derived& aGravitationalParameter
     );
 
@@ -89,8 +89,10 @@ class COECondition : public RealEventCondition
     /// @return                 COECondition object
 
     static COECondition SemiMajorAxis(
-        const Criteria& aCriteria, const Length& aSemiMajorAxis,
-        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+        const Criteria& aCriteria,
+        const Length& aSemiMajorAxis,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
     );
 
     /// @brief                  Eccentricity based constructor
@@ -103,8 +105,10 @@ class COECondition : public RealEventCondition
     /// @return                 COECondition object
 
     static COECondition Eccentricity(
-        const Criteria& aCriteria, const Real& anEccentricity,
-        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+        const Criteria& aCriteria,
+        const Real& anEccentricity,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
     );
 
     /// @brief                  Inclination based constructor
@@ -117,8 +121,10 @@ class COECondition : public RealEventCondition
     /// @return                 COECondition object
 
     static COECondition Inclination(
-        const Criteria& aCriteria, const Angle& aSemiMajorAxis,
-        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+        const Criteria& aCriteria,
+        const Angle& aSemiMajorAxis,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
     );
 
     /// @brief                  Argument of Periapsis based constructor
@@ -130,8 +136,12 @@ class COECondition : public RealEventCondition
     ///
     /// @return                 COECondition object
 
-    static COECondition Aop(const Criteria& aCriteria, const Angle& anAOP,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter);
+    static COECondition Aop(
+        const Criteria& aCriteria,
+        const Angle& anAOP,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
+    );
 
     /// @brief                  Right Ascension of Ascending Node based constructor
     ///
@@ -142,8 +152,12 @@ class COECondition : public RealEventCondition
     ///
     /// @return                 COECondition object
 
-    static COECondition Raan(const Criteria& aCriteria, const Angle& aRAAN,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter);
+    static COECondition Raan(
+        const Criteria& aCriteria,
+        const Angle& aRAAN,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
+    );
 
     /// @brief                  True Anomaly based constructor
     ///
@@ -155,8 +169,10 @@ class COECondition : public RealEventCondition
     /// @return                 COECondition object
 
     static COECondition TrueAnomaly(
-        const Criteria& aCriteria, const Angle& aTrueAnomaly,
-        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+        const Criteria& aCriteria,
+        const Angle& aTrueAnomaly,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
     );
 
     /// @brief                  Mean Anomaly based constructor
@@ -169,8 +185,10 @@ class COECondition : public RealEventCondition
     /// @return                 COECondition object
 
     static COECondition MeanAnomaly(
-        const Criteria& aCriteria, const Angle& aMeanAnomaly,
-        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+        const Criteria& aCriteria,
+        const Angle& aMeanAnomaly,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
     );
 
     /// @brief                  Eccentric Anomaly based constructor
@@ -183,13 +201,15 @@ class COECondition : public RealEventCondition
     /// @return                 COECondition object
 
     static COECondition EccentricAnomaly(
-        const Criteria& aCriteria, const Angle& anEccentricAnomaly,
-        const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+        const Criteria& aCriteria,
+        const Angle& anEccentricAnomaly,
+        const Shared<const Frame>& aFrameSPtr,
+        const Derived& aGravitationalParameter
     );
 
    private:
     COE::Element element_;
-    Shared<const Frame>& frameSPtr_;
+    Shared<const Frame> frameSPtr_;
     Derived gravitationalParameter_;
 
     /// @brief                  Get evaluation function from element
@@ -201,9 +221,7 @@ class COECondition : public RealEventCondition
     /// @return                 Evaluation function
 
     static std::function<Real(const VectorXd&, const Real&)> GenerateEvaluator(
-        const COE::Element& anElement,
-        const Shared<const Frame>& aFrameSPtr,
-        const Derived& aGravitationalParameter
+        const COE::Element& anElement, const Shared<const Frame>& aFrameSPtr, const Derived& aGravitationalParameter
     );
 };
 

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.hpp
@@ -10,7 +10,7 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
 
 namespace ostk
 {
@@ -26,11 +26,11 @@ using ostk::math::obj::VectorXd;
 
 using ostk::physics::time::Duration;
 
-using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::RealEventCondition;
 
 /// @brief                      A duration based event condition
 
-class DurationCondition : public EventCondition
+class DurationCondition : public RealEventCondition
 {
    public:
     /// @brief                  Constructor

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.hpp
@@ -54,17 +54,14 @@ class DurationCondition : public EventCondition
 
     Duration getDuration() const;
 
-    /// @brief                  Evaluate the Event Condition
+    /// @brief                  Compute the Event Condition
     ///
     /// @param                  [in] aStateVector The current state vector
     /// @param                  [in] aTime The current time
     ///
-    /// @return                 Real number representing the evaluation result of the Event Condition
+    /// @return                 Real number representing the computation result of the Event Condition
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override;
-
-   private:
-    Real durationInSeconds_;
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override;
 };
 
 }  // namespace eventcondition

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.hpp
@@ -53,15 +53,6 @@ class DurationCondition : public RealEventCondition
     /// @return                 Duration
 
     Duration getDuration() const;
-
-    /// @brief                  Compute the Event Condition
-    ///
-    /// @param                  [in] aStateVector The current state vector
-    /// @param                  [in] aTime The current time
-    ///
-    /// @return                 Real number representing the computation result of the Event Condition
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override;
 };
 
 }  // namespace eventcondition

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.hpp
@@ -39,7 +39,7 @@ class LogicalConnective : public EventCondition
     ///
     /// @param                  [in] aName A string representing the name of the Logical Connective Event Condition
     /// @param                  [in] eventConditions An Array of shared pointers to EventCondition instances,
-    ///                                         representing the individual event conditions to be evaluated.
+    /// representing the individual event conditions to be evaluated.
 
     LogicalConnective(const String& aName, const Array<Shared<EventCondition>>& eventConditions);
 
@@ -64,15 +64,15 @@ class LogicalConnective : public EventCondition
 
     virtual bool isSatisfied(const Real& currentValue, const Real& previousValue) const override;
 
-    /// @brief                  Throw an error as the condition cannot be evaluated based on the state vector and time
+    /// @brief                  Throw an error as the condition cannot be computed based on the state vector and time
     ///
     /// @param                  [in] aStateVector The current state vector
     /// @param                  [in] aTime The current time
     ///
-    /// @return                 Real number representing the evaluation result of the Logical Connective Event
+    /// @return                 Real number representing the computation result of the Logical Connective Event
     /// Condition.
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override;
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override;
 
    protected:
     Array<Shared<EventCondition>> eventConditions_;

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.hpp
@@ -54,26 +54,6 @@ class LogicalConnective : public EventCondition
 
     Array<Shared<EventCondition>> getEventConditions() const;
 
-    /// @brief                  Throw an error as the condition cannot be evaluated based on the current state vector
-    /// and time
-    ///
-    /// @param                  [in] currentValue The current value
-    /// @param                  [in] previousValue The previous value
-    ///
-    /// @return                 Boolean value indicating if the condition is met.
-
-    virtual bool isSatisfied(const Real& currentValue, const Real& previousValue) const override;
-
-    /// @brief                  Throw an error as the condition cannot be computed based on the state vector and time
-    ///
-    /// @param                  [in] aStateVector The current state vector
-    /// @param                  [in] aTime The current time
-    ///
-    /// @return                 Real number representing the computation result of the Logical Connective Event
-    /// Condition.
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override;
-
    protected:
     Array<Shared<EventCondition>> eventConditions_;
 };

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp
@@ -1,0 +1,99 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkit_Astrodynamics_EventCondition_RealEventCondition__
+#define __OpenSpaceToolkit_Astrodynamics_EventCondition_RealEventCondition__
+
+#include <OpenSpaceToolkit/Core/Types/Real.hpp>
+#include <OpenSpaceToolkit/Core/Types/String.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace eventcondition
+{
+
+using ostk::core::types::Real;
+using ostk::core::types::String;
+
+using ostk::math::obj::VectorXd;
+
+using ostk::astro::EventCondition;
+
+/// @brief                      A Real Event Condition is a condition that is met when computed value matches the
+/// criteria at a target value
+
+class RealEventCondition : public EventCondition
+{
+   public:
+    /// @brief                  Constructor
+    ///
+    /// @code
+    ///                         RealEventCondition realEventCondition = {aName, aCriteria};
+    /// @endcode
+    ///
+    /// @param                  [in] aName A string representing the name of the Real Event Condition
+    /// @param                  [in] aCriteria An enum indicating the criteria used to determine if the Real Event
+    /// Condition is met
+    /// @param                  [in] aTarget A target value associated with the Real Event Condition
+
+    RealEventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget);
+
+    /// @brief                  Virtual destructor
+
+    virtual ~RealEventCondition();
+
+    /// @brief                  Get the target of the Event Condition
+    ///
+    /// @return                 Real number representing the target of the Event Condition
+
+    Real getTarget() const;
+
+    /// @brief                  Check if the Real Event Condition is satisfied based on current state/time and previous
+    /// state/time
+    ///
+    /// @param                  [in] currentStateVector The current state vector
+    /// @param                  [in] currentTime The current time
+    /// @param                  [in] previousStateVector The previous state vector
+    /// @param                  [in] previousTime The previous time
+    ///
+    /// @return                 Boolean value indicating if the Real Event Condition is met
+
+    virtual bool isSatisfied(
+        const VectorXd& currentStateVector,
+        const Real& currentTime,
+        const VectorXd& previousStateVector,
+        const Real& previousTime
+    ) const override;
+
+    /// @brief                  Evaluate the Event Condition
+    ///
+    /// @param                  [in] aStateVector The current state vector
+    /// @param                  [in] aTime The current time
+    ///
+    /// @return                 Real number representing the evaluation result of the Event Condition
+
+    Real evaluate(const VectorXd& aStateVector, const Real& aTime) const;
+
+    /// @brief                  Compute the value of the Real Event Condition
+    ///
+    /// @param                  [in] aStateVector The state vector
+    /// @param                  [in] aTime The time
+    ///
+    /// @return                 Real number representing the value of the Event Condition
+
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const = 0;
+
+   private:
+    Real target_;
+};
+
+}  // namespace eventcondition
+}  // namespace astro
+}  // namespace ostk
+
+#endif

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp
@@ -44,9 +44,10 @@ class RealEventCondition : public EventCondition
 
     RealEventCondition(
         const String& aName,
-        const Criteria& aCriteria, 
+        const Criteria& aCriteria,
         const std::function<Real(const VectorXd&, const Real&)> anEvaluator,
-        const Real& aTarget = 0.0);
+        const Real& aTarget = 0.0
+    );
 
     /// @brief                  Virtual destructor
 
@@ -57,6 +58,15 @@ class RealEventCondition : public EventCondition
     /// @return                 Real number representing the target of the Event Condition
 
     Real getTarget() const;
+
+    /// @brief                  Evaluate the Event Condition
+    ///
+    /// @param                  [in] aStateVector The current state vector
+    /// @param                  [in] aTime The current time
+    ///
+    /// @return                 Real number representing the evaluation result of the Event Condition
+
+    Real evaluate(const VectorXd& aStateVector, const Real& aTime) const;
 
     /// @brief                  Check if the Real Event Condition is satisfied based on current state/time and previous
     /// state/time
@@ -75,14 +85,14 @@ class RealEventCondition : public EventCondition
         const Real& previousTime
     ) const override;
 
-    /// @brief                  Evaluate the Event Condition
+    /// @brief                  Print the Real Event Condition
     ///
-    /// @param                  [in] aStateVector The current state vector
-    /// @param                  [in] aTime The current time
-    ///
-    /// @return                 Real number representing the evaluation result of the Event Condition
+    /// @param                  [in, out] anOutputStream The output stream where the Real Event Condition will be
+    /// printed
+    /// @param                  [in] displayDecorator A boolean indicating whether or not to display decorator during
+    /// printing
 
-    Real evaluate(const VectorXd& aStateVector, const Real& aTime) const;
+    virtual void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
    private:
     std::function<Real(const VectorXd&, const Real&)> evaluator_;

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp
@@ -39,9 +39,14 @@ class RealEventCondition : public EventCondition
     /// @param                  [in] aName A string representing the name of the Real Event Condition
     /// @param                  [in] aCriteria An enum indicating the criteria used to determine if the Real Event
     /// Condition is met
+    /// @param                  [in] anEvaluator A function evaluating a state and a time
     /// @param                  [in] aTarget A target value associated with the Real Event Condition
 
-    RealEventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget);
+    RealEventCondition(
+        const String& aName,
+        const Criteria& aCriteria, 
+        const std::function<Real(const VectorXd&, const Real&)> anEvaluator,
+        const Real& aTarget = 0.0);
 
     /// @brief                  Virtual destructor
 
@@ -79,16 +84,8 @@ class RealEventCondition : public EventCondition
 
     Real evaluate(const VectorXd& aStateVector, const Real& aTime) const;
 
-    /// @brief                  Compute the value of the Real Event Condition
-    ///
-    /// @param                  [in] aStateVector The state vector
-    /// @param                  [in] aTime The time
-    ///
-    /// @return                 Real number representing the value of the Event Condition
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const = 0;
-
    private:
+    std::function<Real(const VectorXd&, const Real&)> evaluator_;
     Real target_;
 };
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.hpp
@@ -6,6 +6,7 @@
 #include <OpenSpaceToolkit/Core/Containers/Pair.hpp>
 #include <OpenSpaceToolkit/Core/Types/Real.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
+#include <OpenSpaceToolkit/Core/Types/String.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
@@ -31,6 +32,7 @@ namespace kepler
 using ostk::core::ctnr::Pair;
 using ostk::core::types::Real;
 using ostk::core::types::Shared;
+using ostk::core::types::String;
 
 using ostk::physics::coord::Frame;
 using ostk::physics::coord::Position;
@@ -115,6 +117,14 @@ class COE
     static Angle EccentricAnomalyFromMeanAnomaly(
         const Angle& aMeanAnomaly, const Real& anEccentricity, const Real& aTolerance
     );
+
+    /// @brief                  Convert element to string
+    ///
+    /// @param                  [in] anElement An element
+    ///
+    /// @return                 String representing the element
+
+    static String StringFromElement(const COE::Element& anElement);
 
    private:
     Length semiMajorAxis_;

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition.cpp
@@ -85,16 +85,14 @@ std::function<bool(const Real&, const Real&)> EventCondition::getComparator(cons
     switch (aCriteria)
     {
         case EventCondition::Criteria::StrictlyPositive:
-            return [](const Real& currentValue, const Real& previousValue) -> bool
+            return [](const Real& currentValue, [[maybe_unused]] const Real& previousValue) -> bool
             {
-                (void)previousValue;
                 return (currentValue > 0.0);
             };
 
         case EventCondition::Criteria::StrictlyNegative:
-            return [](const Real& currentValue, const Real& previousValue) -> bool
+            return [](const Real& currentValue, [[maybe_unused]] const Real& previousValue) -> bool
             {
-                (void)previousValue;
                 return (currentValue < 0.0);
             };
 
@@ -117,11 +115,8 @@ std::function<bool(const Real&, const Real&)> EventCondition::getComparator(cons
             };
 
         case EventCondition::Criteria::Undefined:
-            return [](const Real& currentValue, const Real& previousValue) -> bool
+            return []([[maybe_unused]] const Real& currentValue, [[maybe_unused]] const Real& previousValue) -> bool
             {
-                (void)currentValue;
-                (void)previousValue;
-
                 throw ostk::core::error::runtime::Undefined("Comparator");
 
                 return false;

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition.cpp
@@ -10,9 +10,10 @@ namespace ostk
 namespace astro
 {
 
-EventCondition::EventCondition(const String& aName, const Criteria& aCriteria)
+EventCondition::EventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget)
     : name_(aName),
       criteria_(aCriteria),
+      target_(aTarget),
       comparator_(getComparator(aCriteria))
 {
 }
@@ -36,12 +37,23 @@ EventCondition::Criteria EventCondition::getCriteria() const
     return criteria_;
 }
 
+Real EventCondition::getTarget() const
+{
+    return target_;
+}
+
+Real EventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+{
+    return compute(aStateVector, aTime) - target_;
+}
+
 void EventCondition::print(std::ostream& anOutputStream, bool displayDecorator) const
 {
     displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Event Condition") : void();
 
     ostk::core::utils::Print::Line(anOutputStream) << "Name:" << getName();
     ostk::core::utils::Print::Line(anOutputStream) << "Criteria:" << StringFromCriteria(getCriteria());
+    ostk::core::utils::Print::Line(anOutputStream) << "Target:" << getTarget();
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition.cpp
@@ -10,10 +10,9 @@ namespace ostk
 namespace astro
 {
 
-EventCondition::EventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget)
+EventCondition::EventCondition(const String& aName, const Criteria& aCriteria)
     : name_(aName),
       criteria_(aCriteria),
-      target_(aTarget),
       comparator_(getComparator(aCriteria))
 {
 }
@@ -37,14 +36,9 @@ EventCondition::Criteria EventCondition::getCriteria() const
     return criteria_;
 }
 
-Real EventCondition::getTarget() const
+std::function<bool(const Real&, const Real&)> EventCondition::getComparator() const
 {
-    return target_;
-}
-
-Real EventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
-{
-    return compute(aStateVector, aTime) - target_;
+    return comparator_;
 }
 
 void EventCondition::print(std::ostream& anOutputStream, bool displayDecorator) const
@@ -53,27 +47,8 @@ void EventCondition::print(std::ostream& anOutputStream, bool displayDecorator) 
 
     ostk::core::utils::Print::Line(anOutputStream) << "Name:" << getName();
     ostk::core::utils::Print::Line(anOutputStream) << "Criteria:" << StringFromCriteria(getCriteria());
-    ostk::core::utils::Print::Line(anOutputStream) << "Target:" << getTarget();
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
-}
-
-bool EventCondition::isSatisfied(const Real& currentValue, const Real& previousValue) const
-{
-    return comparator_(currentValue, previousValue);
-}
-
-bool EventCondition::isSatisfied(
-    const VectorXd& currentStateVector,
-    const Real& currentTime,
-    const VectorXd& previousStateVector,
-    const Real& previousTime
-) const
-{
-    const Real currentValue = evaluate(currentStateVector, currentTime);
-    const Real previousValue = evaluate(previousStateVector, previousTime);
-
-    return comparator_(currentValue, previousValue);
 }
 
 String EventCondition::StringFromCriteria(const Criteria& aCriteria)

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.cpp
@@ -1,0 +1,43 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Utilities.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace eventcondition
+{
+
+BooleanEventCondition::BooleanEventCondition(const String& aName, const Criteria& aCriteria, const bool& anInverseFlag)
+    : EventCondition(aName, aCriteria),
+      inverse_(anInverseFlag)
+{
+}
+
+BooleanEventCondition::~BooleanEventCondition() {}
+
+Real BooleanEventCondition::isInversed() const
+{
+    return inverse_;
+}
+
+bool BooleanEventCondition::isSatisfied(
+    const VectorXd& currentStateVector,
+    const Real& currentTime,
+    const VectorXd& previousStateVector,
+    const Real& previousTime
+) const
+{
+    const Real currentValue = compute(currentStateVector, currentTime) != inverse_ ? 1.0 : -1.0;
+    const Real previousValue = compute(previousStateVector, previousTime) != inverse_ ? 1.0 : -1.0;
+
+    return getComparator()(currentValue, previousValue);
+}
+
+}  // namespace eventcondition
+}  // namespace astro
+}  // namespace ostk

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.cpp
@@ -15,8 +15,9 @@ namespace eventcondition
 BooleanEventCondition::BooleanEventCondition(
     const String& aName,
     const Criteria& aCriteria,
-    const std::function<Real(const VectorXd&, const Real&)> anEvaluator,
-    const bool& anInverseFlag)
+    const std::function<bool(const VectorXd&, const Real&)> anEvaluator,
+    const bool& anInverseFlag
+)
     : EventCondition(aName, aCriteria),
       evaluator_(anEvaluator),
       inverse_(anInverseFlag)
@@ -28,6 +29,11 @@ BooleanEventCondition::~BooleanEventCondition() {}
 bool BooleanEventCondition::isInversed() const
 {
     return inverse_;
+}
+
+bool BooleanEventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+{
+    return inverse_ ? !this->evaluator_(aStateVector, aTime) : this->evaluator_(aStateVector, aTime);
 }
 
 bool BooleanEventCondition::isSatisfied(
@@ -43,9 +49,14 @@ bool BooleanEventCondition::isSatisfied(
     return getComparator()(currentValue, previousValue);
 }
 
-bool BooleanEventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+void BooleanEventCondition::print(std::ostream& anOutputStream, bool displayDecorator) const
 {
-    return inverse_? this->evaluator_(aStateVector, aTime) ? !this->evaluator_(aStateVector, aTime);
+    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Boolean Event Condition") : void();
+
+    EventCondition::print(anOutputStream, false);
+    ostk::core::utils::Print::Line(anOutputStream) << "isInversed:" << (isInversed() ? "True" : "False");
+
+    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 
 }  // namespace eventcondition

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
@@ -28,10 +28,10 @@ COECondition::COECondition(
     const Real& aTarget,
     const Derived& aGravitationalParameter
 )
-    : EventCondition(aName, aCriteria, aTarget),
+    : RealEventCondition(aName, aCriteria, aTarget),
       element_(anElement),
       gravitationalParameter_(aGravitationalParameter),
-      evaluator_(GetEvaluator(anElement))
+      compute_(GetComputeFunction(anElement))
 {
 }
 
@@ -54,7 +54,7 @@ Real COECondition::compute(const VectorXd& aStateVector, const Real& aTime) cons
     const Vector3d positionVector = aStateVector.segment(0, 3);
     const Vector3d velocityVector = aStateVector.segment(3, 3);
 
-    return evaluator_(positionVector, velocityVector, this->gravitationalParameter_);
+    return compute_(positionVector, velocityVector, this->gravitationalParameter_);
 }
 
 COECondition COECondition::SemiMajorAxis(
@@ -161,7 +161,7 @@ COECondition COECondition::EccentricAnomaly(
     };
 }
 
-std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> COECondition::GetEvaluator(
+std::function<Real(const Vector3d&, const Vector3d&, const Derived&)> COECondition::GetComputeFunction(
     const COE::Element& anElement
 )
 {

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
@@ -191,9 +191,10 @@ std::function<Real(const VectorXd&, const Real&)> COECondition::GenerateEvaluato
 )
 {
     // The parameters must be captured by value as the function is being initialized during construction
-    return [anElement, aFrameSPtr, aGravitationalParameter](const VectorXd& aStateVector, const Real& aTime) -> Real
+    return [anElement,
+            aFrameSPtr,
+            aGravitationalParameter](const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
     {
-        (void)aTime;
         // TBI: Get frame from Broker
         // TBI: Get pos,vel indexes from broker
         const Position position = Position::Meters(aStateVector.segment(0, 3), aFrameSPtr);

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
@@ -28,20 +28,14 @@ COECondition::COECondition(
     const Real& aTarget,
     const Derived& aGravitationalParameter
 )
-    : EventCondition(aName, aCriteria),
+    : EventCondition(aName, aCriteria, aTarget),
       element_(anElement),
-      target_(aTarget),
       gravitationalParameter_(aGravitationalParameter),
       evaluator_(GetEvaluator(anElement))
 {
 }
 
 COECondition::~COECondition() {}
-
-Real COECondition::getTarget() const
-{
-    return target_;
-}
 
 Derived COECondition::getGravitationalParameter() const
 {
@@ -53,39 +47,14 @@ COE::Element COECondition::getElement() const
     return element_;
 }
 
-Real COECondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+Real COECondition::compute(const VectorXd& aStateVector, const Real& aTime) const
 {
     (void)aTime;
 
     const Vector3d positionVector = aStateVector.segment(0, 3);
     const Vector3d velocityVector = aStateVector.segment(3, 3);
 
-    return evaluator_(positionVector, velocityVector, this->gravitationalParameter_) - target_;
-}
-
-String COECondition::StringFromElement(const COE::Element& anElement)
-{
-    switch (anElement)
-    {
-        case COE::Element::SemiMajorAxis:
-            return "Semi-major axis";
-        case COE::Element::Eccentricity:
-            return "Eccentricity";
-        case COE::Element::Inclination:
-            return "Inclination";
-        case COE::Element::Aop:
-            return "Argument of periapsis";
-        case COE::Element::Raan:
-            return "Right angle of ascending node";
-        case COE::Element::TrueAnomaly:
-            return "True anomaly";
-        case COE::Element::MeanAnomaly:
-            return "Mean anomaly";
-        case COE::Element::EccentricAnomaly:
-            return "Eccentric anomaly";
-    }
-
-    throw ostk::core::error::runtime::Wrong("Element");
+    return evaluator_(positionVector, velocityVector, this->gravitationalParameter_);
 }
 
 COECondition COECondition::SemiMajorAxis(

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+#include <iostream>
+
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.hpp>
 
@@ -26,12 +28,12 @@ COECondition::COECondition(
     const Criteria& aCriteria,
     const COE::Element& anElement,
     const Real& aTarget,
-    const Shared<const Frame>& aFrameSPTr,
+    const Shared<const Frame>& aFrameSPtr,
     const Derived& aGravitationalParameter
 )
-    : RealEventCondition(aName, aCriteria, GenerateEvaluator(anElement, aFrameSPTr, aGravitationalParameter), aTarget),
+    : RealEventCondition(aName, aCriteria, GenerateEvaluator(anElement, aFrameSPtr, aGravitationalParameter), aTarget),
       element_(anElement),
-      frameSPtr_(aFrameSPTr),
+      frameSPtr_(aFrameSPtr),
       gravitationalParameter_(aGravitationalParameter)
 {
 }
@@ -49,8 +51,10 @@ COE::Element COECondition::getElement() const
 }
 
 COECondition COECondition::SemiMajorAxis(
-    const Criteria& aCriteria, const Length& aSemiMajorAxis,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+    const Criteria& aCriteria,
+    const Length& aSemiMajorAxis,
+    const Shared<const Frame>& aFrameSPtr,
+    const Derived& aGravitationalParameter
 )
 {
     return {
@@ -58,14 +62,16 @@ COECondition COECondition::SemiMajorAxis(
         aCriteria,
         COE::Element::SemiMajorAxis,
         aSemiMajorAxis.inMeters(),
-        aFrameSPTr,
+        aFrameSPtr,
         aGravitationalParameter,
     };
 }
 
 COECondition COECondition::Eccentricity(
-    const Criteria& aCriteria, const Real& anEccentricity,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+    const Criteria& aCriteria,
+    const Real& anEccentricity,
+    const Shared<const Frame>& aFrameSPtr,
+    const Derived& aGravitationalParameter
 )
 {
     return {
@@ -73,14 +79,16 @@ COECondition COECondition::Eccentricity(
         aCriteria,
         COE::Element::Eccentricity,
         anEccentricity,
-        aFrameSPTr,
+        aFrameSPtr,
         aGravitationalParameter,
     };
 }
 
 COECondition COECondition::Inclination(
-    const Criteria& aCriteria, const Angle& anInclination,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+    const Criteria& aCriteria,
+    const Angle& anInclination,
+    const Shared<const Frame>& aFrameSPtr,
+    const Derived& aGravitationalParameter
 )
 {
     return {
@@ -88,14 +96,16 @@ COECondition COECondition::Inclination(
         aCriteria,
         COE::Element::Inclination,
         anInclination.inRadians(),
-        aFrameSPTr,
+        aFrameSPtr,
         aGravitationalParameter,
     };
 }
 
 COECondition COECondition::Aop(
-    const Criteria& aCriteria, const Angle& anArgumentOfPeriapsis,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+    const Criteria& aCriteria,
+    const Angle& anArgumentOfPeriapsis,
+    const Shared<const Frame>& aFrameSPtr,
+    const Derived& aGravitationalParameter
 )
 {
     return {
@@ -103,14 +113,16 @@ COECondition COECondition::Aop(
         aCriteria,
         COE::Element::Aop,
         anArgumentOfPeriapsis.inRadians(),
-        aFrameSPTr,
+        aFrameSPtr,
         aGravitationalParameter,
     };
 }
 
 COECondition COECondition::Raan(
-    const Criteria& aCriteria, const Angle& aRightAscensionOfAscendingNode,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+    const Criteria& aCriteria,
+    const Angle& aRightAscensionOfAscendingNode,
+    const Shared<const Frame>& aFrameSPtr,
+    const Derived& aGravitationalParameter
 )
 {
     return {
@@ -118,14 +130,16 @@ COECondition COECondition::Raan(
         aCriteria,
         COE::Element::Raan,
         aRightAscensionOfAscendingNode.inRadians(),
-        aFrameSPTr,
+        aFrameSPtr,
         aGravitationalParameter,
     };
 }
 
 COECondition COECondition::TrueAnomaly(
-    const Criteria& aCriteria, const Angle& aTrueAnomaly,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+    const Criteria& aCriteria,
+    const Angle& aTrueAnomaly,
+    const Shared<const Frame>& aFrameSPtr,
+    const Derived& aGravitationalParameter
 )
 {
     return {
@@ -133,14 +147,16 @@ COECondition COECondition::TrueAnomaly(
         aCriteria,
         COE::Element::TrueAnomaly,
         aTrueAnomaly.inRadians(),
-        aFrameSPTr,
+        aFrameSPtr,
         aGravitationalParameter,
     };
 }
 
 COECondition COECondition::MeanAnomaly(
-    const Criteria& aCriteria, const Angle& aMeanAnomaly,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+    const Criteria& aCriteria,
+    const Angle& aMeanAnomaly,
+    const Shared<const Frame>& aFrameSPtr,
+    const Derived& aGravitationalParameter
 )
 {
     return {
@@ -148,14 +164,16 @@ COECondition COECondition::MeanAnomaly(
         aCriteria,
         COE::Element::MeanAnomaly,
         aMeanAnomaly.inRadians(),
-        aFrameSPTr,
+        aFrameSPtr,
         aGravitationalParameter,
     };
 }
 
 COECondition COECondition::EccentricAnomaly(
-    const Criteria& aCriteria, const Angle& anEccentricAnomaly,
-    const Shared<const Frame>& aFrameSPTr, const Derived& aGravitationalParameter
+    const Criteria& aCriteria,
+    const Angle& anEccentricAnomaly,
+    const Shared<const Frame>& aFrameSPtr,
+    const Derived& aGravitationalParameter
 )
 {
     return {
@@ -163,20 +181,19 @@ COECondition COECondition::EccentricAnomaly(
         aCriteria,
         COE::Element::EccentricAnomaly,
         anEccentricAnomaly.inRadians(),
-        aFrameSPTr,
+        aFrameSPtr,
         aGravitationalParameter,
     };
 }
 
 std::function<Real(const VectorXd&, const Real&)> COECondition::GenerateEvaluator(
-    const COE::Element& anElement,
-    const Shared<const Frame>& aFrameSPtr,
-    const Derived& aGravitationalParameter
+    const COE::Element& anElement, const Shared<const Frame>& aFrameSPtr, const Derived& aGravitationalParameter
 )
 {
-    return [anElement](
-               const VectorXd& aStateVector, const Real& aTime) -> Real
+    // The parameters must be captured by value as the function is being initialized during construction
+    return [anElement, aFrameSPtr, aGravitationalParameter](const VectorXd& aStateVector, const Real& aTime) -> Real
     {
+        (void)aTime;
         // TBI: Get frame from Broker
         // TBI: Get pos,vel indexes from broker
         const Position position = Position::Meters(aStateVector.segment(0, 3), aFrameSPtr);

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
@@ -10,7 +10,16 @@ namespace eventcondition
 {
 
 DurationCondition::DurationCondition(const Criteria& aCriteria, const Duration& aDuration)
-    : RealEventCondition("Duration Condition", aCriteria, aDuration.inSeconds())
+    : RealEventCondition(
+          "Duration Condition",
+          aCriteria,
+          [](const VectorXd& aStateVector, const Real& aTime) -> Real
+          {
+              (void)aStateVector;
+              return aTime;
+          },
+          aDuration.inSeconds()
+      )
 {
 }
 
@@ -19,12 +28,6 @@ DurationCondition::~DurationCondition() {}
 Duration DurationCondition::getDuration() const
 {
     return Duration::Seconds(getTarget());
-}
-
-Real DurationCondition::compute(const VectorXd& aStateVector, const Real& aTime) const
-{
-    (void)aStateVector;
-    return aTime;
 }
 
 }  // namespace eventcondition

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
@@ -10,7 +10,7 @@ namespace eventcondition
 {
 
 DurationCondition::DurationCondition(const Criteria& aCriteria, const Duration& aDuration)
-    : EventCondition("Duration Condition", aCriteria, aDuration.inSeconds())
+    : RealEventCondition("Duration Condition", aCriteria, aDuration.inSeconds())
 {
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
@@ -13,9 +13,8 @@ DurationCondition::DurationCondition(const Criteria& aCriteria, const Duration& 
     : RealEventCondition(
           "Duration Condition",
           aCriteria,
-          [](const VectorXd& aStateVector, const Real& aTime) -> Real
+          [](const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
           {
-              (void)aStateVector;
               return aTime;
           },
           aDuration.inSeconds()

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
@@ -10,8 +10,7 @@ namespace eventcondition
 {
 
 DurationCondition::DurationCondition(const Criteria& aCriteria, const Duration& aDuration)
-    : EventCondition("Duration Condition", aCriteria),
-      durationInSeconds_(aDuration.inSeconds())
+    : EventCondition("Duration Condition", aCriteria, aDuration.inSeconds())
 {
 }
 
@@ -19,13 +18,13 @@ DurationCondition::~DurationCondition() {}
 
 Duration DurationCondition::getDuration() const
 {
-    return Duration::Seconds(durationInSeconds_);
+    return Duration::Seconds(getTarget());
 }
 
-Real DurationCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+Real DurationCondition::compute(const VectorXd& aStateVector, const Real& aTime) const
 {
     (void)aStateVector;
-    return aTime - durationInSeconds_;
+    return aTime;
 }
 
 }  // namespace eventcondition

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.cpp
@@ -9,7 +9,7 @@ namespace astro
 namespace eventcondition
 {
 LogicalConnective::LogicalConnective(const String& aName, const Array<Shared<EventCondition>>& eventConditions)
-    : EventCondition(aName, EventCondition::Criteria::Undefined),
+    : EventCondition(aName, EventCondition::Criteria::Undefined, Real::Undefined()),
       eventConditions_(eventConditions)
 {
 }
@@ -29,12 +29,12 @@ bool LogicalConnective::isSatisfied(const Real& currentValue, const Real& previo
     throw ostk::core::error::runtime::Undefined("LogicalConnective::isSatisfied");
 }
 
-Real LogicalConnective::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+Real LogicalConnective::compute(const VectorXd& aStateVector, const Real& aTime) const
 {
     (void)aStateVector;
     (void)aTime;
 
-    throw ostk::core::error::runtime::Undefined("LogicalConnective::evaluate");
+    throw ostk::core::error::runtime::Undefined("LogicalConnective::compute");
 }
 
 }  // namespace eventcondition

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.cpp
@@ -9,7 +9,7 @@ namespace astro
 namespace eventcondition
 {
 LogicalConnective::LogicalConnective(const String& aName, const Array<Shared<EventCondition>>& eventConditions)
-    : EventCondition(aName, EventCondition::Criteria::Undefined, Real::Undefined()),
+    : EventCondition(aName, EventCondition::Criteria::Undefined),
       eventConditions_(eventConditions)
 {
 }
@@ -19,22 +19,6 @@ LogicalConnective::~LogicalConnective() {}
 Array<Shared<EventCondition>> LogicalConnective::getEventConditions() const
 {
     return eventConditions_;
-}
-
-bool LogicalConnective::isSatisfied(const Real& currentValue, const Real& previousValue) const
-{
-    (void)currentValue;
-    (void)previousValue;
-
-    throw ostk::core::error::runtime::Undefined("LogicalConnective::isSatisfied");
-}
-
-Real LogicalConnective::compute(const VectorXd& aStateVector, const Real& aTime) const
-{
-    (void)aStateVector;
-    (void)aTime;
-
-    throw ostk::core::error::runtime::Undefined("LogicalConnective::compute");
 }
 
 }  // namespace eventcondition

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.cpp
@@ -1,0 +1,48 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Utilities.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace eventcondition
+{
+
+RealEventCondition::RealEventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget)
+    : EventCondition(aName, aCriteria),
+      target_(aTarget)
+{
+}
+
+RealEventCondition::~RealEventCondition() {}
+
+Real RealEventCondition::getTarget() const
+{
+    return target_;
+}
+
+Real RealEventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+{
+    return compute(aStateVector, aTime) - target_;
+}
+
+bool RealEventCondition::isSatisfied(
+    const VectorXd& currentStateVector,
+    const Real& currentTime,
+    const VectorXd& previousStateVector,
+    const Real& previousTime
+) const
+{
+    const Real currentValue = evaluate(currentStateVector, currentTime);
+    const Real previousValue = evaluate(previousStateVector, previousTime);
+
+    return getComparator()(currentValue, previousValue);
+}
+
+}  // namespace eventcondition
+}  // namespace astro
+}  // namespace ostk

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.cpp
@@ -16,7 +16,8 @@ RealEventCondition::RealEventCondition(
     const String& aName,
     const Criteria& aCriteria,
     const std::function<Real(const VectorXd&, const Real&)> anEvaluator,
-    const Real& aTarget)
+    const Real& aTarget
+)
     : EventCondition(aName, aCriteria),
       evaluator_(anEvaluator),
       target_(aTarget)
@@ -28,6 +29,11 @@ RealEventCondition::~RealEventCondition() {}
 Real RealEventCondition::getTarget() const
 {
     return target_;
+}
+
+Real RealEventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+{
+    return this->evaluator_(aStateVector, aTime) - target_;
 }
 
 bool RealEventCondition::isSatisfied(
@@ -43,9 +49,14 @@ bool RealEventCondition::isSatisfied(
     return getComparator()(currentValue, previousValue);
 }
 
-Real RealEventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+void RealEventCondition::print(std::ostream& anOutputStream, bool displayDecorator) const
 {
-    return this->evaluator_(aStateVector, aTime) - target_;
+    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Real Event Condition") : void();
+
+    EventCondition::print(anOutputStream, false);
+    ostk::core::utils::Print::Line(anOutputStream) << "Target:" << getTarget();
+
+    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 
 }  // namespace eventcondition

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.cpp
@@ -12,8 +12,13 @@ namespace astro
 namespace eventcondition
 {
 
-RealEventCondition::RealEventCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget)
+RealEventCondition::RealEventCondition(
+    const String& aName,
+    const Criteria& aCriteria,
+    const std::function<Real(const VectorXd&, const Real&)> anEvaluator,
+    const Real& aTarget)
     : EventCondition(aName, aCriteria),
+      evaluator_(anEvaluator),
       target_(aTarget)
 {
 }
@@ -23,11 +28,6 @@ RealEventCondition::~RealEventCondition() {}
 Real RealEventCondition::getTarget() const
 {
     return target_;
-}
-
-Real RealEventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
-{
-    return compute(aStateVector, aTime) - target_;
 }
 
 bool RealEventCondition::isSatisfied(
@@ -41,6 +41,11 @@ bool RealEventCondition::isSatisfied(
     const Real previousValue = evaluate(previousStateVector, previousTime);
 
     return getComparator()(currentValue, previousValue);
+}
+
+Real RealEventCondition::evaluate(const VectorXd& aStateVector, const Real& aTime) const
+{
+    return this->evaluator_(aStateVector, aTime) - target_;
 }
 
 }  // namespace eventcondition

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -240,12 +240,10 @@ COE::CartesianState COE::getCartesianState(
     const Vector3d R_pqw = {
         p_m * std::cos(nu_rad) / (1.0 + eccentricity_ * std::cos(nu_rad)),
         p_m * std::sin(nu_rad) / (1.0 + eccentricity_ * std::cos(nu_rad)),
-        0.0
-    };
+        0.0};
 
     const Vector3d V_pqw = {
-        -std::sqrt(mu_SI / p_m) * std::sin(nu_rad), +std::sqrt(mu_SI / p_m) * (eccentricity_ + std::cos(nu_rad)), 0.0
-    };
+        -std::sqrt(mu_SI / p_m) * std::sin(nu_rad), +std::sqrt(mu_SI / p_m) * (eccentricity_ + std::cos(nu_rad)), 0.0};
 
     try
     {
@@ -310,8 +308,7 @@ COE COE::Undefined()
         Angle::Undefined(),
         Angle::Undefined(),
         Angle::Undefined(),
-        Angle::Undefined()
-    };
+        Angle::Undefined()};
 }
 
 COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aGravitationalParameter)
@@ -514,8 +511,7 @@ COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aG
         Angle::Radians(i_rad),
         Angle::Radians(raan_rad),
         Angle::Radians(aop_rad),
-        Angle::Radians(nu_rad)
-    };
+        Angle::Radians(nu_rad)};
 }
 
 Angle COE::EccentricAnomalyFromTrueAnomaly(const Angle& aTrueAnomaly, const Real& anEccentricity)
@@ -722,6 +718,31 @@ Angle COE::EccentricAnomalyFromMeanAnomaly(
     }
 
     return Angle::Radians(E);
+}
+
+String COE::StringFromElement(const COE::Element& anElement)
+{
+    switch (anElement)
+    {
+        case COE::Element::SemiMajorAxis:
+            return "SemiMajorAxis";
+        case COE::Element::Eccentricity:
+            return "Eccentricity";
+        case COE::Element::Inclination:
+            return "Inclination";
+        case COE::Element::Aop:
+            return "Aop";
+        case COE::Element::Raan:
+            return "Raan";
+        case COE::Element::TrueAnomaly:
+            return "TrueAnomaly";
+        case COE::Element::MeanAnomaly:
+            return "MeanAnomaly";
+        case COE::Element::EccentricAnomaly:
+            return "EccentricAnomaly";
+    }
+
+    throw ostk::core::error::runtime::Wrong("Element");
 }
 
 }  // namespace kepler

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -240,10 +240,14 @@ COE::CartesianState COE::getCartesianState(
     const Vector3d R_pqw = {
         p_m * std::cos(nu_rad) / (1.0 + eccentricity_ * std::cos(nu_rad)),
         p_m * std::sin(nu_rad) / (1.0 + eccentricity_ * std::cos(nu_rad)),
-        0.0};
+        0.0,
+    };
 
     const Vector3d V_pqw = {
-        -std::sqrt(mu_SI / p_m) * std::sin(nu_rad), +std::sqrt(mu_SI / p_m) * (eccentricity_ + std::cos(nu_rad)), 0.0};
+        -std::sqrt(mu_SI / p_m) * std::sin(nu_rad),
+        +std::sqrt(mu_SI / p_m) * (eccentricity_ + std::cos(nu_rad)),
+        0.0,
+    };
 
     try
     {
@@ -254,10 +258,13 @@ COE::CartesianState COE::getCartesianState(
                                RotationMatrix::RX(Angle::Radians(-inclination_rad)) *
                                RotationMatrix::RZ(Angle::Radians(-aop_rad)) * V_pqw;
 
-        const Position position = {x_ECI, Position::Unit::Meter, aFrameSPtr};
-        const Velocity velocity = {v_ECI, Velocity::Unit::MeterPerSecond, aFrameSPtr};
+        const Position position = Position::Metrs(x_ECI, aFrameSPtr);
+        const Velocity velocity = Velocity::MetersPerSecond(v_ECI, aFrameSPtr);
 
-        return {position, velocity};
+        return {
+            position,
+            velocity,
+        };
     }
     catch (const ostk::core::error::Exception& anException)
     {
@@ -308,7 +315,8 @@ COE COE::Undefined()
         Angle::Undefined(),
         Angle::Undefined(),
         Angle::Undefined(),
-        Angle::Undefined()};
+        Angle::Undefined(),
+    };
 }
 
 COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aGravitationalParameter)
@@ -511,7 +519,8 @@ COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aG
         Angle::Radians(i_rad),
         Angle::Radians(raan_rad),
         Angle::Radians(aop_rad),
-        Angle::Radians(nu_rad)};
+        Angle::Radians(nu_rad),
+    };
 }
 
 Angle COE::EccentricAnomalyFromTrueAnomaly(const Angle& aTrueAnomaly, const Real& anEccentricity)

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -258,7 +258,7 @@ COE::CartesianState COE::getCartesianState(
                                RotationMatrix::RX(Angle::Radians(-inclination_rad)) *
                                RotationMatrix::RZ(Angle::Radians(-aop_rad)) * V_pqw;
 
-        const Position position = Position::Metrs(x_ECI, aFrameSPtr);
+        const Position position = Position::Meters(x_ECI, aFrameSPtr);
         const Velocity velocity = Velocity::MetersPerSecond(v_ECI, aFrameSPtr);
 
         return {

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition.test.cpp
@@ -130,7 +130,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, isSatisfied)
         };
 
         EXPECT_TRUE(testCondition.isSatisfied(-5.0, 4.0));
-        EXPECT_TRUE(testCondition.isSatisfied(-5.0, 4.0));
+        EXPECT_TRUE(testCondition.isSatisfied(5.0, -4.0));
         EXPECT_FALSE(testCondition.isSatisfied(3.0, 5.0));
         EXPECT_FALSE(testCondition.isSatisfied(5.0, 3.0));
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition.test.cpp
@@ -19,12 +19,12 @@ using ostk::astro::EventCondition;
 class TestCondition : public EventCondition
 {
    public:
-    TestCondition(const String& aName, const Criteria& aCriteria)
-        : EventCondition(aName, aCriteria)
+    TestCondition(const String& aName, const Criteria& aCriteria, const Real& aTarget)
+        : EventCondition(aName, aCriteria, aTarget)
     {
     }
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
     {
         (void)aStateVector;
         (void)aTime;
@@ -37,23 +37,23 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition : public ::testing::Test
    protected:
     const EventCondition::Criteria defaultCriteria_ = EventCondition::Criteria::PositiveCrossing;
     const String defaultName_ = "Test";
+    const Real defaultTarget_ = 5.0;
+    const TestCondition defaultCondition_ = {defaultName_, defaultCriteria_, defaultTarget_};
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, Constructor)
 {
     {
-        EXPECT_NO_THROW(TestCondition testCondition(defaultName_, defaultCriteria_));
+        EXPECT_NO_THROW(TestCondition testCondition(defaultName_, defaultCriteria_, defaultTarget_));
     }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, StreamOperator)
 {
     {
-        TestCondition testCondition(defaultName_, defaultCriteria_);
-
         testing::internal::CaptureStdout();
 
-        EXPECT_NO_THROW(std::cout << testCondition << std::endl);
+        EXPECT_NO_THROW(std::cout << defaultCondition_ << std::endl);
 
         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
     }
@@ -62,12 +62,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, StreamOperator)
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, Print)
 {
     {
-        TestCondition testCondition(defaultName_, defaultCriteria_);
-
         testing::internal::CaptureStdout();
 
-        EXPECT_NO_THROW(testCondition.print(std::cout, true));
-        EXPECT_NO_THROW(testCondition.print(std::cout, false));
+        EXPECT_NO_THROW(defaultCondition_.print(std::cout, true));
+        EXPECT_NO_THROW(defaultCondition_.print(std::cout, false));
         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
     }
 }
@@ -75,18 +73,21 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, Print)
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, getName)
 {
     {
-        TestCondition testCondition(defaultName_, defaultCriteria_);
-
-        EXPECT_TRUE(testCondition.getName() == defaultName_);
+        EXPECT_TRUE(defaultCondition_.getName() == defaultName_);
     }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, getCriteria)
 {
     {
-        TestCondition testCondition(defaultName_, defaultCriteria_);
+        EXPECT_TRUE(defaultCondition_.getCriteria() == defaultCriteria_);
+    }
+}
 
-        EXPECT_TRUE(testCondition.getCriteria() == defaultCriteria_);
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, getTarget)
+{
+    {
+        EXPECT_TRUE(defaultCondition_.getCriteria() == defaultCriteria_);
     }
 }
 
@@ -94,7 +95,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, isSatisfied)
 {
     // Positive Crossing
     {
-        TestCondition testCondition(defaultName_, EventCondition::Criteria::PositiveCrossing);
+        TestCondition testCondition = {
+            defaultName_,
+            EventCondition::Criteria::PositiveCrossing,
+            defaultTarget_,
+        };
 
         EXPECT_TRUE(testCondition.isSatisfied(5.0, -4.0));
         EXPECT_FALSE(testCondition.isSatisfied(-4.0, 5.0));
@@ -104,7 +109,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, isSatisfied)
 
     // Negative Crossing
     {
-        TestCondition testCondition(defaultName_, EventCondition::Criteria::NegativeCrossing);
+        TestCondition testCondition = {
+            defaultName_,
+            EventCondition::Criteria::NegativeCrossing,
+            defaultTarget_,
+        };
 
         EXPECT_TRUE(testCondition.isSatisfied(-4.0, 5.0));
         EXPECT_FALSE(testCondition.isSatisfied(5.0, -4.0));
@@ -114,7 +123,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, isSatisfied)
 
     // Any Crossing
     {
-        TestCondition testCondition(defaultName_, EventCondition::Criteria::AnyCrossing);
+        TestCondition testCondition = {
+            defaultName_,
+            EventCondition::Criteria::AnyCrossing,
+            defaultTarget_,
+        };
 
         EXPECT_TRUE(testCondition.isSatisfied(-5.0, 4.0));
         EXPECT_TRUE(testCondition.isSatisfied(-5.0, 4.0));
@@ -124,7 +137,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, isSatisfied)
 
     // Strictly Positive (previous value doesn't matter)
     {
-        TestCondition testCondition(defaultName_, EventCondition::Criteria::StrictlyPositive);
+        TestCondition testCondition = {
+            defaultName_,
+            EventCondition::Criteria::StrictlyPositive,
+            defaultTarget_,
+        };
 
         EXPECT_TRUE(testCondition.isSatisfied(5.0, 4.0));
         EXPECT_TRUE(testCondition.isSatisfied(4.0, 5.0));
@@ -133,7 +150,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition, isSatisfied)
 
     // Strictly Negative (previous value doesn't matter)
     {
-        TestCondition testCondition(defaultName_, EventCondition::Criteria::StrictlyNegative);
+        TestCondition testCondition = {
+            defaultName_,
+            EventCondition::Criteria::StrictlyNegative,
+            defaultTarget_,
+        };
 
         EXPECT_TRUE(testCondition.isSatisfied(-5.0, 4.0));
         EXPECT_TRUE(testCondition.isSatisfied(-4.0, 5.0));

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.test.cpp
@@ -28,9 +28,9 @@ class OpenSpaceToolkit_Astrodynamics_BooleanEventCondition : public ::testing::T
 
    protected:
     const BooleanEventCondition::Criteria defaultCriteria_ = BooleanEventCondition::Criteria::PositiveCrossing;
-    const std::function<bool(VectorXd, Real)> evaluator_ = [](const VectorXd& aStateVector, const Real& aTime) -> Real
+    const std::function<bool(VectorXd, Real)> evaluator_ = [](const VectorXd& aStateVector,
+                                                              [[maybe_unused]] const Real& aTime) -> Real
     {
-        (void)aTime;
         return aStateVector[0] > 0.0 && aStateVector[0] < 1.0;
     };
     const bool isInverse_ = false;

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.test.cpp
@@ -1,0 +1,108 @@
+/// Apache License 2.0
+
+#include <gmock/gmock.h>
+
+#include <OpenSpaceToolkit/Core/Types/Real.hpp>
+#include <OpenSpaceToolkit/Core/Types/String.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanEventCondition.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::types::Real;
+using ostk::core::types::String;
+
+using ostk::math::obj::VectorXd;
+
+using ostk::astro::eventcondition::BooleanEventCondition;
+
+class OpenSpaceToolkit_Astrodynamics_BooleanEventCondition : public ::testing::Test
+{
+    void SetUp() override
+    {
+        defaultStateVector_.resize(1);
+        defaultStateVector_ << 0.5;
+    }
+
+   protected:
+    const BooleanEventCondition::Criteria defaultCriteria_ = BooleanEventCondition::Criteria::PositiveCrossing;
+    const std::function<bool(VectorXd, Real)> evaluator_ = [](const VectorXd& aStateVector, const Real& aTime) -> Real
+    {
+        (void)aTime;
+        return aStateVector[0] > 0.0 && aStateVector[0] < 1.0;
+    };
+    const bool isInverse_ = false;
+    const BooleanEventCondition defaultCondition_ = {
+        "test",
+        defaultCriteria_,
+        evaluator_,
+        isInverse_,
+    };
+    VectorXd defaultStateVector_;
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_BooleanEventCondition, Constructor)
+{
+    {
+        EXPECT_NO_THROW(BooleanEventCondition condition("name", defaultCriteria_, evaluator_, isInverse_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_BooleanEventCondition, Print)
+{
+    {
+        testing::internal::CaptureStdout();
+
+        EXPECT_NO_THROW(defaultCondition_.print(std::cout, true));
+        EXPECT_NO_THROW(defaultCondition_.print(std::cout, false));
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_BooleanEventCondition, isInversed)
+{
+    {
+        EXPECT_TRUE(defaultCondition_.isInversed() == isInverse_);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_BooleanEventCondition, Evaluate)
+{
+    {
+        EXPECT_TRUE(defaultCondition_.evaluate(defaultStateVector_, 0.0));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_BooleanEventCondition, IsSatisfied)
+{
+    VectorXd currentState(1);
+    currentState << 0.5;
+    VectorXd previousState(1);
+    previousState << -0.5;
+
+    {
+        const BooleanEventCondition condition = {
+            "test",
+            defaultCriteria_,
+            evaluator_,
+            false,
+        };
+
+        EXPECT_TRUE(condition.isSatisfied(currentState, 0.0, previousState, 0.0));
+        EXPECT_FALSE(condition.isSatisfied(previousState, 0.0, currentState, 0.0));
+    }
+
+    {
+        const BooleanEventCondition condition = {
+            "test",
+            defaultCriteria_,
+            evaluator_,
+            true,
+        };
+
+        EXPECT_FALSE(condition.isSatisfied(currentState, 0.0, previousState, 0.0));
+        EXPECT_TRUE(condition.isSatisfied(previousState, 0.0, currentState, 0.0));
+    }
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
@@ -6,6 +6,7 @@
 
 #include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
 
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Units/Derived.hpp>
 #include <OpenSpaceToolkit/Physics/Units/Derived/Angle.hpp>
@@ -26,6 +27,7 @@ using ostk::math::obj::VectorXd;
 using ostk::physics::units::Angle;
 using ostk::physics::units::Length;
 using ostk::physics::units::Derived;
+using ostk::physics::coord::Frame;
 using ostk::physics::environment::gravitational::Earth;
 
 using ostk::astro::EventCondition;
@@ -47,9 +49,11 @@ class OpenSpaceToolkit_Astrodynamics_COECondition
     const COE::Element defaultElement_ = COE::Element::SemiMajorAxis;
     const Real defaultTarget_ = 7000000.0;
     const Derived gravitationalParameter_ = Earth::Spherical.gravitationalParameter_;
+    const Shared<const Frame> defaultFrameSPtr_ = Frame::GCRF();
 
-    const COECondition defaultCondition_ =
-        COECondition("COE Condition", defaultCriteria_, defaultElement_, defaultTarget_, gravitationalParameter_);
+    const COECondition defaultCondition_ = COECondition(
+        "COE Condition", defaultCriteria_, defaultElement_, defaultTarget_, defaultFrameSPtr_, gravitationalParameter_
+    );
 
     VectorXd defaultStateVector_;
 };
@@ -74,7 +78,12 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_COECondition, Constructor)
     auto parameters = GetParam();
     {
         EXPECT_NO_THROW(COECondition(
-            "COE condition", defaultCriteria_, std::get<0>(parameters), std::get<1>(parameters), gravitationalParameter_
+            "COE condition",
+            defaultCriteria_,
+            std::get<0>(parameters),
+            std::get<1>(parameters),
+            defaultFrameSPtr_,
+            gravitationalParameter_
         ));
     }
 }
@@ -108,7 +117,14 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_COECondition, evaluate)
     const Real target = std::get<1>(parameters);
     const Real expectedValue = std::get<2>(parameters);
 
-    const COECondition condition = {"COE condition", defaultCriteria_, element, target, gravitationalParameter_};
+    const COECondition condition = {
+        "COE condition",
+        defaultCriteria_,
+        element,
+        target,
+        defaultFrameSPtr_,
+        gravitationalParameter_,
+    };
 
     {
         EXPECT_DOUBLE_EQ(condition.evaluate(defaultStateVector_, 0.0), expectedValue - target);
@@ -117,50 +133,58 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_COECondition, evaluate)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, SemiMajorAxis)
 {
-    COECondition condition =
-        COECondition::SemiMajorAxis(defaultCriteria_, Length::Meters(7000000.0), gravitationalParameter_);
+    COECondition condition = COECondition::SemiMajorAxis(
+        defaultCriteria_, Length::Meters(7000000.0), defaultFrameSPtr_, gravitationalParameter_
+    );
     EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, Eccentricity)
 {
-    COECondition condition = COECondition::Eccentricity(defaultCriteria_, 0.0, gravitationalParameter_);
+    COECondition condition =
+        COECondition::Eccentricity(defaultCriteria_, 0.0, defaultFrameSPtr_, gravitationalParameter_);
     EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, Inclination)
 {
-    COECondition condition = COECondition::Inclination(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    COECondition condition =
+        COECondition::Inclination(defaultCriteria_, Angle::Degrees(0.0), defaultFrameSPtr_, gravitationalParameter_);
     EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, Aop)
 {
-    COECondition condition = COECondition::Aop(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    COECondition condition =
+        COECondition::Aop(defaultCriteria_, Angle::Degrees(0.0), defaultFrameSPtr_, gravitationalParameter_);
     EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, Raan)
 {
-    COECondition condition = COECondition::Raan(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    COECondition condition =
+        COECondition::Raan(defaultCriteria_, Angle::Degrees(0.0), defaultFrameSPtr_, gravitationalParameter_);
     EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, TrueAnomaly)
 {
-    COECondition condition = COECondition::TrueAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    COECondition condition =
+        COECondition::TrueAnomaly(defaultCriteria_, Angle::Degrees(0.0), defaultFrameSPtr_, gravitationalParameter_);
     EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, MeanAnomaly)
 {
-    COECondition condition = COECondition::MeanAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    COECondition condition =
+        COECondition::MeanAnomaly(defaultCriteria_, Angle::Degrees(0.0), defaultFrameSPtr_, gravitationalParameter_);
     EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, EccentricAnomaly)
 {
-    COECondition condition =
-        COECondition::EccentricAnomaly(defaultCriteria_, Angle::Degrees(0.0), gravitationalParameter_);
+    COECondition condition = COECondition::EccentricAnomaly(
+        defaultCriteria_, Angle::Degrees(0.0), defaultFrameSPtr_, gravitationalParameter_
+    );
     EXPECT_NO_THROW(condition.evaluate(defaultStateVector_, 0.0));
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
@@ -115,18 +115,6 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_COECondition, evaluate)
     }
 }
 
-TEST_P(OpenSpaceToolkit_Astrodynamics_COECondition, StringFromElement)
-{
-    auto parameters = GetParam();
-
-    const COE::Element element = std::get<0>(parameters);
-    const String expectedString = std::get<3>(parameters);
-
-    {
-        EXPECT_EQ(COECondition::StringFromElement(element), expectedString);
-    }
-}
-
 TEST_F(OpenSpaceToolkit_Astrodynamics_COECondition, SemiMajorAxis)
 {
     COECondition condition =

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.test.cpp
@@ -22,11 +22,11 @@ class FirstCondition : public EventCondition
 {
    public:
     FirstCondition()
-        : EventCondition("First", EventCondition::Criteria::PositiveCrossing)
+        : EventCondition("First", EventCondition::Criteria::PositiveCrossing, 0.0)
     {
     }
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
     {
         (void)aTime;
         return aStateVector[0];
@@ -37,11 +37,11 @@ class SecondCondition : public EventCondition
 {
    public:
     SecondCondition()
-        : EventCondition("Second", EventCondition::Criteria::StrictlyNegative)
+        : EventCondition("Second", EventCondition::Criteria::StrictlyNegative, 0.0)
     {
     }
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
     {
         (void)aTime;
         return aStateVector[1] - 0.1;

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.test.cpp
@@ -19,58 +19,41 @@ using ostk::math::obj::VectorXd;
 using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::eventcondition::Conjunctive;
 
-class FirstCondition : public RealEventCondition
-{
-   public:
-    FirstCondition()
-        : RealEventCondition("First", RealEventCondition::Criteria::PositiveCrossing, 0.0)
-    {
-    }
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
-    {
-        (void)aTime;
-        return aStateVector[0];
-    }
-};
-
-class SecondCondition : public RealEventCondition
-{
-   public:
-    SecondCondition()
-        : RealEventCondition("Second", RealEventCondition::Criteria::StrictlyNegative, 0.0)
-    {
-    }
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
-    {
-        (void)aTime;
-        return aStateVector[1] - 0.1;
-    }
-};
-
 class OpenSpaceToolkit_Astrodynamics_EventCondition_Conjunctive : public ::testing::Test
 {
-    void SetUp() override
-    {
-        conjuntionCondition_ = {{
-            std::make_shared<FirstCondition>(firstCondition_),
-            std::make_shared<SecondCondition>(secondCondition_),
-        }};
-    }
-
    protected:
-    const FirstCondition firstCondition_;
-    const SecondCondition secondCondition_;
-    Conjunctive conjuntionCondition_ = {{}};
+    const RealEventCondition firstCondition_ = {
+        "First",
+        RealEventCondition::Criteria::PositiveCrossing,
+        [](const VectorXd& aStateVector, const Real& aTime) -> Real
+        {
+            (void)aTime;
+            return aStateVector[0];
+        },
+        0.0,
+    };
+    const RealEventCondition secondCondition_ = {
+        "Second",
+        RealEventCondition::Criteria::StrictlyNegative,
+        [](const VectorXd& aStateVector, const Real& aTime) -> Real
+        {
+            (void)aTime;
+            return aStateVector[1];
+        },
+        0.1,
+    };
+    Conjunctive conjuntionCondition_ = {{
+        std::make_shared<RealEventCondition>(firstCondition_),
+        std::make_shared<RealEventCondition>(secondCondition_),
+    }};
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_Conjunctive, Constructor)
 {
     {
         EXPECT_NO_THROW(Conjunctive conjunction({
-            std::make_shared<FirstCondition>(firstCondition_),
-            std::make_shared<SecondCondition>(secondCondition_),
+            std::make_shared<RealEventCondition>(firstCondition_),
+            std::make_shared<RealEventCondition>(secondCondition_),
         }));
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.test.cpp
@@ -7,6 +7,7 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
 
 #include <Global.test.hpp>
 
@@ -15,14 +16,14 @@ using ostk::core::types::String;
 
 using ostk::math::obj::VectorXd;
 
-using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::eventcondition::Conjunctive;
 
-class FirstCondition : public EventCondition
+class FirstCondition : public RealEventCondition
 {
    public:
     FirstCondition()
-        : EventCondition("First", EventCondition::Criteria::PositiveCrossing, 0.0)
+        : RealEventCondition("First", RealEventCondition::Criteria::PositiveCrossing, 0.0)
     {
     }
 
@@ -33,11 +34,11 @@ class FirstCondition : public EventCondition
     }
 };
 
-class SecondCondition : public EventCondition
+class SecondCondition : public RealEventCondition
 {
    public:
     SecondCondition()
-        : EventCondition("Second", EventCondition::Criteria::StrictlyNegative, 0.0)
+        : RealEventCondition("Second", RealEventCondition::Criteria::StrictlyNegative, 0.0)
     {
     }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.test.cpp
@@ -25,9 +25,8 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_Conjunctive : public ::testi
     const RealEventCondition firstCondition_ = {
         "First",
         RealEventCondition::Criteria::PositiveCrossing,
-        [](const VectorXd& aStateVector, const Real& aTime) -> Real
+        [](const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
         {
-            (void)aTime;
             return aStateVector[0];
         },
         0.0,
@@ -35,9 +34,8 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_Conjunctive : public ::testi
     const RealEventCondition secondCondition_ = {
         "Second",
         RealEventCondition::Criteria::StrictlyNegative,
-        [](const VectorXd& aStateVector, const Real& aTime) -> Real
+        [](const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
         {
-            (void)aTime;
             return aStateVector[1];
         },
         0.1,

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.test.cpp
@@ -22,11 +22,11 @@ class FirstCondition : public EventCondition
 {
    public:
     FirstCondition()
-        : EventCondition("First", EventCondition::Criteria::PositiveCrossing)
+        : EventCondition("First", EventCondition::Criteria::PositiveCrossing, 0.0)
     {
     }
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
     {
         (void)aTime;
         return aStateVector[0];
@@ -37,11 +37,11 @@ class SecondCondition : public EventCondition
 {
    public:
     SecondCondition()
-        : EventCondition("Second", EventCondition::Criteria::StrictlyNegative)
+        : EventCondition("Second", EventCondition::Criteria::StrictlyNegative, 0.0)
     {
     }
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
     {
         (void)aTime;
         return aStateVector[1] - 0.1;

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.test.cpp
@@ -7,6 +7,7 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
 
 #include <Global.test.hpp>
 
@@ -15,14 +16,14 @@ using ostk::core::types::String;
 
 using ostk::math::obj::VectorXd;
 
-using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::eventcondition::Disjunctive;
 
-class FirstCondition : public EventCondition
+class FirstCondition : public RealEventCondition
 {
    public:
     FirstCondition()
-        : EventCondition("First", EventCondition::Criteria::PositiveCrossing, 0.0)
+        : RealEventCondition("First", RealEventCondition::Criteria::PositiveCrossing, 0.0)
     {
     }
 
@@ -33,11 +34,11 @@ class FirstCondition : public EventCondition
     }
 };
 
-class SecondCondition : public EventCondition
+class SecondCondition : public RealEventCondition
 {
    public:
     SecondCondition()
-        : EventCondition("Second", EventCondition::Criteria::StrictlyNegative, 0.0)
+        : RealEventCondition("Second", RealEventCondition::Criteria::StrictlyNegative, 0.0)
     {
     }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.test.cpp
@@ -25,9 +25,8 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_Disjunctive : public ::testi
     const RealEventCondition firstCondition_ = {
         "First",
         RealEventCondition::Criteria::PositiveCrossing,
-        [](const VectorXd& aStateVector, const Real& aTime) -> Real
+        [](const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
         {
-            (void)aTime;
             return aStateVector[0];
         },
         0.0,
@@ -35,9 +34,8 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_Disjunctive : public ::testi
     const RealEventCondition secondCondition_ = {
         "Second",
         RealEventCondition::Criteria::StrictlyNegative,
-        [](const VectorXd& aStateVector, const Real& aTime) -> Real
+        [](const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
         {
-            (void)aTime;
             return aStateVector[1];
         },
         0.1,

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.test.cpp
@@ -19,58 +19,41 @@ using ostk::math::obj::VectorXd;
 using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::eventcondition::Disjunctive;
 
-class FirstCondition : public RealEventCondition
-{
-   public:
-    FirstCondition()
-        : RealEventCondition("First", RealEventCondition::Criteria::PositiveCrossing, 0.0)
-    {
-    }
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
-    {
-        (void)aTime;
-        return aStateVector[0];
-    }
-};
-
-class SecondCondition : public RealEventCondition
-{
-   public:
-    SecondCondition()
-        : RealEventCondition("Second", RealEventCondition::Criteria::StrictlyNegative, 0.0)
-    {
-    }
-
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
-    {
-        (void)aTime;
-        return aStateVector[1] - 0.1;
-    }
-};
-
 class OpenSpaceToolkit_Astrodynamics_EventCondition_Disjunctive : public ::testing::Test
 {
-    void SetUp() override
-    {
-        disjunctionCondition_ = {{
-            std::make_shared<FirstCondition>(firstCondition_),
-            std::make_shared<SecondCondition>(secondCondition_),
-        }};
-    }
-
    protected:
-    const FirstCondition firstCondition_;
-    const SecondCondition secondCondition_;
-    Disjunctive disjunctionCondition_ = {{}};
+    const RealEventCondition firstCondition_ = {
+        "First",
+        RealEventCondition::Criteria::PositiveCrossing,
+        [](const VectorXd& aStateVector, const Real& aTime) -> Real
+        {
+            (void)aTime;
+            return aStateVector[0];
+        },
+        0.0,
+    };
+    const RealEventCondition secondCondition_ = {
+        "Second",
+        RealEventCondition::Criteria::StrictlyNegative,
+        [](const VectorXd& aStateVector, const Real& aTime) -> Real
+        {
+            (void)aTime;
+            return aStateVector[1];
+        },
+        0.1,
+    };
+    Disjunctive disjunctionCondition_ = {{
+        std::make_shared<RealEventCondition>(firstCondition_),
+        std::make_shared<RealEventCondition>(secondCondition_),
+    }};
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_Disjunctive, Constructor)
 {
     {
         EXPECT_NO_THROW(Disjunctive Disjunctive({
-            std::make_shared<FirstCondition>(firstCondition_),
-            std::make_shared<SecondCondition>(secondCondition_),
+            std::make_shared<RealEventCondition>(firstCondition_),
+            std::make_shared<RealEventCondition>(secondCondition_),
         }));
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.test.cpp
@@ -2,18 +2,23 @@
 
 #include <gmock/gmock.h>
 
+#include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/Real.hpp>
+#include <OpenSpaceToolkit/Core/Types/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
 
 #include <Global.test.hpp>
 
+using ostk::core::ctnr::Array;
 using ostk::core::types::Real;
 using ostk::core::types::String;
+using ostk::core::types::Shared;
 
 using ostk::math::obj::VectorXd;
 
@@ -23,59 +28,60 @@ using ostk::astro::eventcondition::LogicalConnective;
 class TestCondition : public EventCondition
 {
    public:
-    TestCondition(const String& aName)
-        : EventCondition(aName, EventCondition::Criteria::PositiveCrossing, 0.0)
+    TestCondition()
+        : EventCondition("name", EventCondition::Criteria::PositiveCrossing)
     {
     }
 
-    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
+    MOCK_METHOD(
+        bool,
+        isSatisfied,
+        (const VectorXd& currentStateVector,
+         const Real& currentTime,
+         const VectorXd& previousStateVector,
+         const Real& previousTime),
+        (const, override)
+    );
+};
+
+class LogicalConnectiveMock : public LogicalConnective
+{
+   public:
+    LogicalConnectiveMock(const std::vector<std::shared_ptr<EventCondition>>& aEventConditions)
+        : LogicalConnective("name", aEventConditions)
     {
-        (void)aStateVector;
-        return aTime;
     }
+
+    MOCK_METHOD(
+        bool,
+        isSatisfied,
+        (const VectorXd& currentStateVector,
+         const Real& currentTime,
+         const VectorXd& previousStateVector,
+         const Real& previousTime),
+        (const, override)
+    );
 };
 
 class OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective : public ::testing::Test
 {
    protected:
-    const String defaultName_ = "test";
-    const TestCondition testCondition_ = {defaultName_};
-    const LogicalConnective logicalConnectiveCondition_ = {
-        "Logical Connective Condition",
-        {std::make_shared<TestCondition>(testCondition_)},
+    const Array<Shared<EventCondition>> defaultEventConditions_ = {
+        std::make_shared<TestCondition>(),
     };
+    const LogicalConnectiveMock logicalConnectiveCondition_ = {defaultEventConditions_};
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, Constructor)
 {
     {
-        EXPECT_NO_THROW(LogicalConnective logicalConnective(
-            "Logical Connective Condition",
-            {
-                std::make_shared<TestCondition>(testCondition_),
-            }
-        ));
+        EXPECT_NO_THROW(LogicalConnectiveMock logicalConnective(defaultEventConditions_));
     }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, GetEventConditions)
 {
     {
-        EXPECT_EQ(logicalConnectiveCondition_.getEventConditions().getSize(), 1);
-        EXPECT_EQ(logicalConnectiveCondition_.getEventConditions()[0]->getName(), defaultName_);
-    }
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, IsSatisfied)
-{
-    {
-        EXPECT_ANY_THROW(logicalConnectiveCondition_.isSatisfied(0.0, 0.0));
-    }
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, Compute)
-{
-    {
-        EXPECT_ANY_THROW(logicalConnectiveCondition_.compute(VectorXd::Zero(2), 0.0));
+        EXPECT_EQ(logicalConnectiveCondition_.getEventConditions().getSize(), defaultEventConditions_.getSize());
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.test.cpp
@@ -24,11 +24,11 @@ class TestCondition : public EventCondition
 {
    public:
     TestCondition(const String& aName)
-        : EventCondition(aName, EventCondition::Criteria::PositiveCrossing)
+        : EventCondition(aName, EventCondition::Criteria::PositiveCrossing, 0.0)
     {
     }
 
-    virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override
+    virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
     {
         (void)aStateVector;
         return aTime;
@@ -48,9 +48,9 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective : public :
     }
 
    protected:
-    LogicalConnective logicalConnectiveCondition_ = {"Logical Connective Condition", {}};
     const String defaultName_ = "test";
     const TestCondition testCondition_ = {defaultName_};
+    LogicalConnective logicalConnectiveCondition_ = {"Logical Connective Condition", {}};
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, Constructor)
@@ -80,9 +80,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, IsSatisf
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, Evaluate)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, Compute)
 {
     {
-        EXPECT_ANY_THROW(logicalConnectiveCondition_.evaluate(VectorXd::Zero(2), 0.0));
+        EXPECT_ANY_THROW(logicalConnectiveCondition_.compute(VectorXd::Zero(2), 0.0));
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/LogicalConnective.test.cpp
@@ -37,20 +37,13 @@ class TestCondition : public EventCondition
 
 class OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective : public ::testing::Test
 {
-    void SetUp() override
-    {
-        logicalConnectiveCondition_ = {
-            "Logical Connective Condition",
-            {
-                std::make_shared<TestCondition>(testCondition_),
-            },
-        };
-    }
-
    protected:
     const String defaultName_ = "test";
     const TestCondition testCondition_ = {defaultName_};
-    LogicalConnective logicalConnectiveCondition_ = {"Logical Connective Condition", {}};
+    const LogicalConnective logicalConnectiveCondition_ = {
+        "Logical Connective Condition",
+        {std::make_shared<TestCondition>(testCondition_)},
+    };
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_LogicalConnective, Constructor)

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.test.cpp
@@ -1,0 +1,151 @@
+/// Apache License 2.0
+
+#include <gmock/gmock.h>
+
+#include <OpenSpaceToolkit/Core/Types/Real.hpp>
+#include <OpenSpaceToolkit/Core/Types/String.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::types::Real;
+using ostk::core::types::String;
+
+using ostk::math::obj::VectorXd;
+
+using ostk::astro::eventcondition::RealEventCondition;
+
+class OpenSpaceToolkit_Astrodynamics_RealEventCondition : public ::testing::Test
+{
+    void SetUp() override
+    {
+        defaultStateVector_.resize(1);
+        defaultStateVector_ << 1.0;
+    }
+
+   protected:
+    const RealEventCondition::Criteria defaultCriteria_ = RealEventCondition::Criteria::PositiveCrossing;
+    const Real defaultTarget_ = 1.0;
+    const std::function<Real(VectorXd, Real)> evaluator_ = [](const VectorXd& aStateVector, const Real& aTime) -> Real
+    {
+        (void)aStateVector;
+        return aTime;
+    };
+    const RealEventCondition defaultCondition_ = {
+        "test",
+        defaultCriteria_,
+        evaluator_,
+        defaultTarget_,
+    };
+    VectorXd defaultStateVector_;
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_RealEventCondition, Constructor)
+{
+    {
+        EXPECT_NO_THROW(RealEventCondition condition("name", defaultCriteria_, evaluator_, defaultTarget_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_RealEventCondition, Print)
+{
+    {
+        testing::internal::CaptureStdout();
+
+        EXPECT_NO_THROW(defaultCondition_.print(std::cout, true));
+        EXPECT_NO_THROW(defaultCondition_.print(std::cout, false));
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_RealEventCondition, getTarget)
+{
+    {
+        EXPECT_TRUE(defaultCondition_.getTarget() == defaultTarget_);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_RealEventCondition, Evaluate)
+{
+    {
+        const Real time = 5.0;
+        EXPECT_TRUE(defaultCondition_.evaluate(defaultStateVector_, time) == (time - defaultTarget_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_RealEventCondition, IsSatisfied)
+{
+    // Positive Crossing
+    {
+        RealEventCondition condition = {
+            "name",
+            RealEventCondition::Criteria::PositiveCrossing,
+            evaluator_,
+            defaultTarget_,
+        };
+
+        EXPECT_TRUE(condition.isSatisfied(defaultStateVector_, 2.0, defaultStateVector_, 0.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 0.0, defaultStateVector_, 2.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 0.0, defaultStateVector_, -1.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 3.0, defaultStateVector_, 2.0));
+    }
+
+    // Negative Crossing
+    {
+        RealEventCondition condition = {
+            "name",
+            RealEventCondition::Criteria::NegativeCrossing,
+            evaluator_,
+            defaultTarget_,
+        };
+
+        EXPECT_TRUE(condition.isSatisfied(defaultStateVector_, 0.0, defaultStateVector_, 2.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 2.0, defaultStateVector_, 0.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 0.0, defaultStateVector_, -1.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 3.0, defaultStateVector_, 2.0));
+    }
+
+    // Any Crossing
+    {
+        RealEventCondition condition = {
+            "name",
+            RealEventCondition::Criteria::AnyCrossing,
+            evaluator_,
+            defaultTarget_,
+        };
+
+        EXPECT_TRUE(condition.isSatisfied(defaultStateVector_, 0.0, defaultStateVector_, 2.0));
+        EXPECT_TRUE(condition.isSatisfied(defaultStateVector_, 2.0, defaultStateVector_, 0.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 0.0, defaultStateVector_, -1.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 3.0, defaultStateVector_, 2.0));
+    }
+
+    // Strictly Positive (previous value doesn't matter)
+    {
+        RealEventCondition condition = {
+            "name",
+            RealEventCondition::Criteria::StrictlyPositive,
+            evaluator_,
+            defaultTarget_,
+        };
+
+        EXPECT_TRUE(condition.isSatisfied(defaultStateVector_, 2.0, defaultStateVector_, 0.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 0.0, defaultStateVector_, 0.0));
+    }
+
+    // Strictly Negative (previous value doesn't matter)
+    {
+        RealEventCondition condition = {
+            "name",
+            RealEventCondition::Criteria::StrictlyNegative,
+            evaluator_,
+            defaultTarget_,
+        };
+
+        EXPECT_TRUE(condition.isSatisfied(defaultStateVector_, 0.0, defaultStateVector_, 1.0));
+        EXPECT_FALSE(condition.isSatisfied(defaultStateVector_, 2.0, defaultStateVector_, 1.0));
+    }
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.test.cpp
@@ -29,9 +29,9 @@ class OpenSpaceToolkit_Astrodynamics_RealEventCondition : public ::testing::Test
    protected:
     const RealEventCondition::Criteria defaultCriteria_ = RealEventCondition::Criteria::PositiveCrossing;
     const Real defaultTarget_ = 1.0;
-    const std::function<Real(VectorXd, Real)> evaluator_ = [](const VectorXd& aStateVector, const Real& aTime) -> Real
+    const std::function<Real(VectorXd, Real)> evaluator_ = []([[maybe_unused]] const VectorXd& aStateVector,
+                                                              const Real& aTime) -> Real
     {
-        (void)aStateVector;
         return aTime;
     };
     const RealEventCondition defaultCondition_ = {

--- a/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
@@ -12,6 +12,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/Conjunctive.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/Disjunctive.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/NumericalSolver.hpp>
 
 #include <Global.test.hpp>
@@ -25,17 +26,17 @@ using ostk::core::types::Shared;
 
 using ostk::math::obj::VectorXd;
 
-using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::eventcondition::Conjunctive;
 using ostk::astro::eventcondition::Disjunctive;
 using ostk::astro::NumericalSolver;
 
 // Simple duration based condition
 
-struct DurationCondition : public EventCondition
+struct DurationCondition : public RealEventCondition
 {
-    DurationCondition(const Real &aTarget, const EventCondition::Criteria &aCriteria)
-        : EventCondition("test", aCriteria, aTarget)
+    DurationCondition(const Real &aTarget, const RealEventCondition::Criteria &aCriteria)
+        : RealEventCondition("test", aCriteria, aTarget)
     {
     }
 
@@ -48,10 +49,10 @@ struct DurationCondition : public EventCondition
 
 // Simple value based struct
 
-struct XCrossingCondition : public EventCondition
+struct XCrossingCondition : public RealEventCondition
 {
     XCrossingCondition(const Real &aTarget)
-        : EventCondition("test", XCrossingCondition::Criteria::AnyCrossing, aTarget)
+        : RealEventCondition("test", RealEventCondition::Criteria::AnyCrossing, aTarget)
     {
     }
 
@@ -610,7 +611,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateDuration_Conditi
                         defaultStateVector_,
                         defaultDuration_,
                         systemOfEquations_,
-                        DurationCondition(0.0, EventCondition::Criteria::StrictlyPositive)
+                        DurationCondition(0.0, RealEventCondition::Criteria::StrictlyPositive)
                     );
                 }
                 catch (const ostk::core::error::runtime::ToBeImplemented &e)
@@ -632,7 +633,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateDuration_Conditi
             defaultStateVector_,
             0.0,
             systemOfEquations_,
-            DurationCondition(0.0, EventCondition::Criteria::StrictlyPositive)
+            DurationCondition(0.0, RealEventCondition::Criteria::StrictlyPositive)
         );
         const NumericalSolver::Solution solution = conditionSolution.solution;
 
@@ -648,7 +649,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateDuration_Conditi
             defaultStateVector_,
             5.0,
             systemOfEquations_,
-            DurationCondition(-1.0, EventCondition::Criteria::StrictlyPositive)
+            DurationCondition(-1.0, RealEventCondition::Criteria::StrictlyPositive)
         );
         const NumericalSolver::Solution solution = conditionSolution.solution;
 
@@ -660,15 +661,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateDuration_Conditi
     }
 
     {
-        const Array<Tuple<Real, EventCondition::Criteria>> testCases = {
-            {defaultDuration_, EventCondition::Criteria::StrictlyPositive},
-            {-defaultDuration_, EventCondition::Criteria::StrictlyNegative},
+        const Array<Tuple<Real, RealEventCondition::Criteria>> testCases = {
+            {defaultDuration_, RealEventCondition::Criteria::StrictlyPositive},
+            {-defaultDuration_, RealEventCondition::Criteria::StrictlyNegative},
         };
 
         for (const auto &testCase : testCases)
         {
             const Real duration = std::get<0>(testCase);
-            const EventCondition::Criteria criteria = std::get<1>(testCase);
+            const RealEventCondition::Criteria criteria = std::get<1>(testCase);
             // Ensure that integration terminates at maximum duration if condition is not met
 
             {
@@ -749,15 +750,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateTime_Conditions)
     const NumericalSolver::StateVector stateVector = getStateVector(startTime);
 
     {
-        const Array<Tuple<Real, EventCondition::Criteria>> testCases = {
-            {defaultDuration_, EventCondition::Criteria::AnyCrossing},
-            {-defaultDuration_, EventCondition::Criteria::AnyCrossing},
+        const Array<Tuple<Real, RealEventCondition::Criteria>> testCases = {
+            {defaultDuration_, RealEventCondition::Criteria::AnyCrossing},
+            {-defaultDuration_, RealEventCondition::Criteria::AnyCrossing},
         };
 
         for (const auto &testCase : testCases)
         {
             const Real duration = std::get<0>(testCase);
-            const EventCondition::Criteria criteria = std::get<1>(testCase);
+            const RealEventCondition::Criteria criteria = std::get<1>(testCase);
 
             const Real endTime = startTime + duration;
 
@@ -835,15 +836,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateTime_Conditions)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateTime_Conjunctive)
 {
-    const Array<Tuple<Real, EventCondition::Criteria>> testCases = {
-        {defaultDuration_, EventCondition::Criteria::StrictlyPositive},
-        {-defaultDuration_, EventCondition::Criteria::StrictlyNegative},
+    const Array<Tuple<Real, RealEventCondition::Criteria>> testCases = {
+        {defaultDuration_, RealEventCondition::Criteria::StrictlyPositive},
+        {-defaultDuration_, RealEventCondition::Criteria::StrictlyNegative},
     };
 
     for (const auto testCase : testCases)
     {
         const Real duration = std::get<0>(testCase);
-        const EventCondition::Criteria criteria = std::get<1>(testCase);
+        const RealEventCondition::Criteria criteria = std::get<1>(testCase);
 
         const Real endTime = defaultStartTime_ + duration;
 
@@ -875,15 +876,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateTime_Conjunctive
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateTime_Disjunctive)
 {
-    const Array<Tuple<Real, EventCondition::Criteria>> testCases = {
-        {defaultDuration_, EventCondition::Criteria::StrictlyPositive},
-        {-defaultDuration_, EventCondition::Criteria::StrictlyNegative},
+    const Array<Tuple<Real, RealEventCondition::Criteria>> testCases = {
+        {defaultDuration_, RealEventCondition::Criteria::StrictlyPositive},
+        {-defaultDuration_, RealEventCondition::Criteria::StrictlyNegative},
     };
 
     for (const auto testCase : testCases)
     {
         const Real duration = std::get<0>(testCase);
-        const EventCondition::Criteria criteria = std::get<1>(testCase);
+        const RealEventCondition::Criteria criteria = std::get<1>(testCase);
 
         const Real endTime = defaultStartTime_ + duration;
 

--- a/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
@@ -36,30 +36,36 @@ using ostk::astro::NumericalSolver;
 struct DurationCondition : public RealEventCondition
 {
     DurationCondition(const Real &aTarget, const RealEventCondition::Criteria &aCriteria)
-        : RealEventCondition("test", aCriteria, aTarget)
+        : RealEventCondition(
+              "test",
+              aCriteria,
+              [](const VectorXd &aStateVector, const Real &aTime) -> Real
+              {
+                  (void)aStateVector;
+                  return aTime;
+              },
+              aTarget
+          )
     {
-    }
-
-    Real compute(const VectorXd &stateVector, const Real &aTime) const override
-    {
-        (void)stateVector;
-        return aTime;
     }
 };
 
-// Simple value based struct
+// Simple state based condition
 
 struct XCrossingCondition : public RealEventCondition
 {
     XCrossingCondition(const Real &aTarget)
-        : RealEventCondition("test", RealEventCondition::Criteria::AnyCrossing, aTarget)
+        : RealEventCondition(
+              "test",
+              RealEventCondition::Criteria::AnyCrossing,
+              [](const VectorXd &aStateVector, const double &aTime) -> Real
+              {
+                  (void)aTime;
+                  return aStateVector[0];
+              },
+              aTarget
+          )
     {
-    }
-
-    Real compute(const VectorXd &aStateVector, const Real &aTime) const
-    {
-        (void)aTime;
-        return aStateVector[0];
     }
 };
 

--- a/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
@@ -39,9 +39,8 @@ struct DurationCondition : public RealEventCondition
         : RealEventCondition(
               "test",
               aCriteria,
-              [](const VectorXd &aStateVector, const Real &aTime) -> Real
+              []([[maybe_unused]] const VectorXd &aStateVector, const Real &aTime) -> Real
               {
-                  (void)aStateVector;
                   return aTime;
               },
               aTarget
@@ -58,9 +57,8 @@ struct XCrossingCondition : public RealEventCondition
         : RealEventCondition(
               "test",
               RealEventCondition::Criteria::AnyCrossing,
-              [](const VectorXd &aStateVector, const double &aTime) -> Real
+              [](const VectorXd &aStateVector, [[maybe_unused]] const double &aTime) -> Real
               {
-                  (void)aTime;
                   return aStateVector[0];
               },
               aTarget

--- a/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/NumericalSolver.test.cpp
@@ -35,18 +35,15 @@ using ostk::astro::NumericalSolver;
 struct DurationCondition : public EventCondition
 {
     DurationCondition(const Real &aTarget, const EventCondition::Criteria &aCriteria)
-        : EventCondition("test", aCriteria),
-          target_(aTarget)
+        : EventCondition("test", aCriteria, aTarget)
     {
     }
 
-    Real evaluate(const VectorXd &stateVector, const Real &aTime) const override
+    Real compute(const VectorXd &stateVector, const Real &aTime) const override
     {
         (void)stateVector;
-        return aTime - target_;
+        return aTime;
     }
-
-    Real target_;
 };
 
 // Simple value based struct
@@ -54,18 +51,15 @@ struct DurationCondition : public EventCondition
 struct XCrossingCondition : public EventCondition
 {
     XCrossingCondition(const Real &aTarget)
-        : EventCondition("test", XCrossingCondition::Criteria::AnyCrossing),
-          target_(aTarget)
+        : EventCondition("test", XCrossingCondition::Criteria::AnyCrossing, aTarget)
     {
     }
 
-    Real evaluate(const VectorXd &aStateVector, const Real &aTime) const
+    Real compute(const VectorXd &aStateVector, const Real &aTime) const
     {
         (void)aTime;
-        return aStateVector[0] - target_;
+        return aStateVector[0];
     }
-
-    Real target_;
 };
 
 class OpenSpaceToolkit_Astrodynamics_NumericalSolver : public ::testing::Test
@@ -702,7 +696,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateDuration_Conditi
 
             // Ensure that integration terminates at condition if condition is met
 
-            EXPECT_NEAR(propagatedTime, condition.target_, 1e-6);
+            EXPECT_NEAR(propagatedTime, condition.getTarget(), 1e-6);
             EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
             EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
 
@@ -736,7 +730,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateDuration_Conditi
             // Ensure that integration terminates at condition if condition is met
 
             EXPECT_TRUE(std::abs(propagatedTime) < std::abs(duration));
-            EXPECT_NEAR(propagatedTime, std::asin(condition.target_), 1e-6);
+            EXPECT_NEAR(propagatedTime, std::asin(condition.getTarget()), 1e-6);
             EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
             EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
 
@@ -793,7 +787,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_NumericalSolver, IntegrateTime_Conditions)
 
             // Ensure that integration terminates at condition if condition is met
 
-            EXPECT_NEAR(propagatedTime, startTime + condition.target_, 1e-6);
+            EXPECT_NEAR(propagatedTime, startTime + condition.getTarget(), 1e-6);
             EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
             EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.test.cpp
@@ -17,6 +17,8 @@
 
 using ostk::core::types::Real;
 using ostk::core::types::String;
+using ostk::core::ctnr::Array;
+using ostk::core::ctnr::Tuple;
 
 using ostk::math::obj::Vector3d;
 
@@ -628,5 +630,27 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler_COE, Eccentri
         EXPECT_ANY_THROW(COE::EccentricAnomalyFromMeanAnomaly(Angle::Undefined(), eccentricity, tolerance));
         EXPECT_ANY_THROW(COE::EccentricAnomalyFromMeanAnomaly(meanAnomaly, Real::Undefined(), tolerance));
         EXPECT_ANY_THROW(COE::EccentricAnomalyFromMeanAnomaly(meanAnomaly, eccentricity, Real::Undefined()));
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Kepler_COE, StringFromElement)
+{
+    const Array<Tuple<COE::Element, String>> testCases = {
+        {COE::Element::SemiMajorAxis, "SemiMajorAxis"},
+        {COE::Element::Eccentricity, "Eccentricity"},
+        {COE::Element::Inclination, "Inclination"},
+        {COE::Element::Aop, "Aop"},
+        {COE::Element::Raan, "Raan"},
+        {COE::Element::TrueAnomaly, "TrueAnomaly"},
+        {COE::Element::MeanAnomaly, "MeanAnomaly"},
+        {COE::Element::EccentricAnomaly, "EccentricAnomaly"},
+    };
+
+    for (const auto& testCase : testCases)
+    {
+        const COE::Element element = std::get<0>(testCase);
+        const String& expectedString = std::get<1>(testCase);
+
+        EXPECT_EQ(COE::StringFromElement(element), expectedString);
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -35,7 +35,7 @@
 #include <OpenSpaceToolkit/Physics/Units/Length.hpp>
 #include <OpenSpaceToolkit/Physics/Units/Mass.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/AtmosphericDrag.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/CentralBodyGravity.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/PositionDerivative.hpp>
@@ -91,7 +91,7 @@ using EarthMagneticModel = ostk::physics::environment::magnetic::Earth;
 using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 
 using ostk::astro::NumericalSolver;
-using ostk::astro::eventcondition::RealEventCondition;
+using ostk::astro::eventcondition::DurationCondition;
 using ostk::astro::trajectory::State;
 using ostk::astro::trajectory::Propagator;
 using ostk::astro::trajectory::state::coordinatessubsets::CartesianPosition;
@@ -374,37 +374,26 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, Calcul
         // Setup instants
         const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 2, 1, 0, 0), Scale::UTC);
 
-        class TestCondition : public RealEventCondition
-        {
-           public:
-            TestCondition(const Real& aTarget)
-                : RealEventCondition("test", RealEventCondition::Criteria::StrictlyPositive, aTarget)
-            {
-            }
-
-            virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
-            {
-                (void)aStateVector;
-                return aTime;
-            }
-        };
-
         const Real target = 60.0;
 
-        const TestCondition condition(target);
+        const DurationCondition condition = {
+            DurationCondition::Criteria::StrictlyPositive,
+            Duration::Seconds(60.0),
+        };
 
         const Propagator propagator = {defaultRKD5_, defaultDynamics_};
 
         const State endState = propagator.calculateStateAt(state, endInstant, condition);
 
         EXPECT_TRUE(endState.getInstant() < endInstant);
-        EXPECT_NEAR(
-            endState.getInstant().getJulianDate(Scale::UTC),
-            (state.getInstant() + Duration::Seconds(target)).getJulianDate(Scale::UTC),
-            1e-12
-        );
+        EXPECT_LT(endState.getInstant() - (state.getInstant() + Duration::Seconds(target)), 1e-12);
 
-        EXPECT_ANY_THROW(propagator.calculateStateAt(state, endInstant, TestCondition(7000.0)));
+        const DurationCondition failureCondition = {
+            DurationCondition::Criteria::StrictlyPositive,
+            Duration::Seconds(7000.0),
+        };
+
+        EXPECT_ANY_THROW(propagator.calculateStateAt(state, endInstant, failureCondition));
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -35,7 +35,7 @@
 #include <OpenSpaceToolkit/Physics/Units/Length.hpp>
 #include <OpenSpaceToolkit/Physics/Units/Mass.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealEventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/AtmosphericDrag.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/CentralBodyGravity.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/Dynamics/PositionDerivative.hpp>
@@ -91,7 +91,7 @@ using EarthMagneticModel = ostk::physics::environment::magnetic::Earth;
 using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 
 using ostk::astro::NumericalSolver;
-using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::RealEventCondition;
 using ostk::astro::trajectory::State;
 using ostk::astro::trajectory::Propagator;
 using ostk::astro::trajectory::state::coordinatessubsets::CartesianPosition;
@@ -374,11 +374,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, Calcul
         // Setup instants
         const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 2, 1, 0, 0), Scale::UTC);
 
-        class TestCondition : public EventCondition
+        class TestCondition : public RealEventCondition
         {
            public:
             TestCondition(const Real& aTarget)
-                : EventCondition("test", EventCondition::Criteria::StrictlyPositive, aTarget)
+                : RealEventCondition("test", RealEventCondition::Criteria::StrictlyPositive, aTarget)
             {
             }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -378,19 +378,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, Calcul
         {
            public:
             TestCondition(const Real& aTarget)
-                : EventCondition("test", EventCondition::Criteria::StrictlyPositive),
-                  target_(aTarget)
+                : EventCondition("test", EventCondition::Criteria::StrictlyPositive, aTarget)
             {
             }
 
-            virtual Real evaluate(const VectorXd& aStateVector, const Real& aTime) const override
+            virtual Real compute(const VectorXd& aStateVector, const Real& aTime) const override
             {
                 (void)aStateVector;
-                return aTime - target_;
+                return aTime;
             }
-
-           private:
-            Real target_ = Real::Undefined();
         };
 
         const Real target = 60.0;


### PR DESCRIPTION
- Add a compute method that returns the computed value
- Add a "target" member variable to EventCondition
- evaluate is now a non-virtual parent method in EventCondition that calls compute and subtracts the target