### PR TITLE
feat: add simple PropulsionSystem class

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
@@ -162,7 +162,7 @@ class PropulsionSystem
         {0},
         Angle::Unit::Undefined,
         {0}
-    )); // TBI: Define in ostk physics as proper units
+    ));  // TBI: Define in ostk physics as proper units
 
     Scalar thrust_ = Scalar::Undefined();           /// Thrust [N]
     Scalar specificImpulse_ = Scalar::Undefined();  /// Specific impulse [s]

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
@@ -1,0 +1,187 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem__
+#define __OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem__
+
+#include <OpenSpaceToolkit/Core/Types/Real.hpp>
+
+#include <OpenSpaceToolkit/Physics/Data/Direction.hpp>
+#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
+#include <OpenSpaceToolkit/Physics/Unit.hpp>
+#include <OpenSpaceToolkit/Physics/Units/Derived.hpp>
+#include <OpenSpaceToolkit/Physics/Units/Time.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace flight
+{
+namespace system
+{
+
+using ostk::core::types::Real;
+
+using ostk::physics::data::Direction;
+using ostk::physics::data::Scalar;
+using ostk::physics::units::Length;
+using ostk::physics::units::Mass;
+using ostk::physics::units::Time;
+using ostk::physics::units::ElectricCurrent;
+using ostk::physics::units::Angle;
+using ostk::physics::units::Derived;
+using ostk::physics::Unit;
+
+/// @brief                      Define a propulsion system
+
+class PropulsionSystem
+{
+   public:
+    /// @brief              Constructor
+    ///
+    /// @code
+    ///                     PropulsionSystem propulsion = { ... };
+    /// @endcode
+    ///
+    /// @param              [in] aThruster Thruster (scalar)
+    /// @param              [in] aSpecificImpulse Specific impulse
+
+    PropulsionSystem(const Scalar& aThruster, const Scalar& aSpecificImpulse);
+
+    /// @brief              Constructor
+    ///
+    /// @code
+    ///                     PropulsionSystem propulsion = { ... };
+    /// @endcode
+    ///
+    /// @param              [in] aThruster Thruster (real)
+    /// @param              [in] aSpecificImpulse Specific impulse
+
+    PropulsionSystem(const Real& aThruster, const Real& aSpecificImpulse);
+
+    /// @brief              Equal to operator
+    ///
+    /// @param              [in] aPropulsionSystem A propulsion system
+    /// @return             True if propulsion systems are equal
+
+    bool operator==(const PropulsionSystem& aPropulsionSystem) const;
+
+    /// @brief              Not equal to operator
+    ///
+    /// @param              [in] aPropulsionSystem A propulsion system
+    /// @return             True if propulsion systems are not equal
+
+    bool operator!=(const PropulsionSystem& aPropulsionSystem) const;
+
+    /// @brief              Output stream operator
+    ///
+    /// @param              [in] anOutputStream An output stream
+    /// @param              [in] aPropulsionSystem A propulsion system
+    /// @return             A reference to output stream
+
+    friend std::ostream& operator<<(std::ostream& anOutputStream, const PropulsionSystem& aPropulsionSystem);
+
+    /// @brief              Check if propulsion system is defined
+    ///
+    /// @return             True if propulsion system is defined
+
+    bool isDefined() const;
+
+    /// @brief              Print propulsion system
+    ///
+    /// @param              [in] anOutputStream An output stream
+    /// @param              [in] (optional) displayDecorators If true, display decorators
+
+    void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
+
+    /// @brief              Get propulsion system's thrust
+    ///
+    /// @code
+    ///                     Scalar thrust = propulsionSystem.getThrust() ;
+    /// @endcode
+    ///
+    /// @return             Scalar
+
+    Scalar getThrust() const;
+
+    /// @brief              Get propulsion system's specific impulse
+    ///                     https://en.wikipedia.org/wiki/Specific_impulse
+    ///
+    /// @code
+    ///                     Scalar specificImpulse = propulsionSystem.getSpecificImpulse() ;
+    /// @endcode
+    ///
+    /// @return             Scalar
+
+    Scalar getSpecificImpulse() const;
+
+    /// @brief              Get propulsion system's mass flow rate
+    ///
+    /// @code
+    ///                     Scalar massFlowRate = propulsionSystem.getMassFlowRate() ;
+    /// @endcode
+    ///
+    /// @return             Scalar
+
+    Scalar getMassFlowRate() const;
+
+    /// @brief              Get propulsion system's acceleration
+    ///
+    /// @code
+    ///                     Real acceleration = propulsionSystem.getAcceleration() ;
+    /// @endcode
+    ///
+    /// @return             Real
+
+    Real getAcceleration(const Mass& aMass) const; // TBI: Should return acceleration unit
+
+    static PropulsionSystem Undefined();
+
+   private:
+    Unit thrustSIUnit_ = Unit::Derived(Derived::Unit(
+        Length::Unit::Meter,
+        {1},
+        Mass::Unit::Kilogram,
+        {1},
+        Time::Unit::Second,
+        {-2},
+        ElectricCurrent::Unit::Undefined,
+        {0},
+        Angle::Unit::Undefined,
+        {0}
+    ));
+    Unit specificImpulseSIUnit_ = Unit::Derived(Derived::Unit(
+        Length::Unit::Undefined,
+        {0},
+        Mass::Unit::Undefined,
+        {0},
+        Time::Unit::Second,
+        {1},
+        ElectricCurrent::Unit::Undefined,
+        {0},
+        Angle::Unit::Undefined,
+        {0}
+    ));
+    Unit massFlowRateSIUnit_ = Unit::Derived(Derived::Unit(
+        Length::Unit::Undefined,
+        {0},
+        Mass::Unit::Kilogram,
+        {1},
+        Time::Unit::Second,
+        {-1},
+        ElectricCurrent::Unit::Undefined,
+        {0},
+        Angle::Unit::Undefined,
+        {0}
+    ));
+
+    Scalar thrust_ = Scalar::Undefined();           /// Thruster [N]
+    Scalar specificImpulse_ = Scalar::Undefined();  /// Specific impulse [s]
+};
+
+}  // namespace system
+}  // namespace flight
+}  // namespace astro
+}  // namespace ostk
+
+#endif

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
@@ -37,6 +37,10 @@ using ostk::physics::Unit;
 class PropulsionSystem
 {
    public:
+    static Unit thrustSIUnit_;
+    static Unit specificImpulseSIUnit_;
+    static Unit massFlowRateSIUnit_;  // TBI: Define in ostk physics as proper units
+
     /// @brief              Constructor
     ///
     /// @code
@@ -127,43 +131,6 @@ class PropulsionSystem
     static PropulsionSystem Undefined();
 
    private:
-    Unit thrustSIUnit_ = Unit::Derived(Derived::Unit(
-        Length::Unit::Meter,
-        {1},
-        Mass::Unit::Kilogram,
-        {1},
-        Time::Unit::Second,
-        {-2},
-        ElectricCurrent::Unit::Undefined,
-        {0},
-        Angle::Unit::Undefined,
-        {0}
-    ));
-    Unit specificImpulseSIUnit_ = Unit::Derived(Derived::Unit(
-        Length::Unit::Undefined,
-        {0},
-        Mass::Unit::Undefined,
-        {0},
-        Time::Unit::Second,
-        {1},
-        ElectricCurrent::Unit::Undefined,
-        {0},
-        Angle::Unit::Undefined,
-        {0}
-    ));
-    Unit massFlowRateSIUnit_ = Unit::Derived(Derived::Unit(
-        Length::Unit::Undefined,
-        {0},
-        Mass::Unit::Kilogram,
-        {1},
-        Time::Unit::Second,
-        {-1},
-        ElectricCurrent::Unit::Undefined,
-        {0},
-        Angle::Unit::Undefined,
-        {0}
-    ));  // TBI: Define in ostk physics as proper units
-
     Scalar thrust_ = Scalar::Undefined();           /// Thrust [N]
     Scalar specificImpulse_ = Scalar::Undefined();  /// Specific impulse [s]
     Scalar massFlowRate_ = Scalar::Undefined();     /// Mass flow rate [kg/s]

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
@@ -37,9 +37,9 @@ using ostk::physics::Unit;
 class PropulsionSystem
 {
    public:
-    static Unit thrustSIUnit_;
-    static Unit specificImpulseSIUnit_;
-    static Unit massFlowRateSIUnit_;  // TBI: Define in ostk physics as proper units
+    static Unit thrustSIUnit;
+    static Unit specificImpulseSIUnit;
+    static Unit massFlowRateSIUnit;  // TBI: Define in ostk physics as proper units
 
     /// @brief              Constructor
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
@@ -32,7 +32,7 @@ using ostk::physics::units::Angle;
 using ostk::physics::units::Derived;
 using ostk::physics::Unit;
 
-/// @brief                      Define a propulsion system
+/// @brief                      Define a propulsion system (constant thrust, constant Isp for now)
 
 class PropulsionSystem
 {
@@ -43,21 +43,10 @@ class PropulsionSystem
     ///                     PropulsionSystem propulsion = { ... };
     /// @endcode
     ///
-    /// @param              [in] aThruster Thruster (scalar)
+    /// @param              [in] aThrust Thrust (scalar)
     /// @param              [in] aSpecificImpulse Specific impulse
 
-    PropulsionSystem(const Scalar& aThruster, const Scalar& aSpecificImpulse);
-
-    /// @brief              Constructor
-    ///
-    /// @code
-    ///                     PropulsionSystem propulsion = { ... };
-    /// @endcode
-    ///
-    /// @param              [in] aThruster Thruster (real)
-    /// @param              [in] aSpecificImpulse Specific impulse
-
-    PropulsionSystem(const Real& aThruster, const Real& aSpecificImpulse);
+    PropulsionSystem(const Scalar& aThrust, const Scalar& aSpecificImpulse);
 
     /// @brief              Equal to operator
     ///
@@ -128,12 +117,12 @@ class PropulsionSystem
     /// @brief              Get propulsion system's acceleration
     ///
     /// @code
-    ///                     Real acceleration = propulsionSystem.getAcceleration() ;
+    ///                     Scalar acceleration = propulsionSystem.getAcceleration() ;
     /// @endcode
     ///
-    /// @return             Real
+    /// @return             Scalar
 
-    Real getAcceleration(const Mass& aMass) const; // TBI: Should return acceleration unit
+    Scalar getAcceleration(const Mass& aMass) const;
 
     static PropulsionSystem Undefined();
 
@@ -173,10 +162,11 @@ class PropulsionSystem
         {0},
         Angle::Unit::Undefined,
         {0}
-    ));
+    )); // TBI: Define in ostk physics as proper units
 
-    Scalar thrust_ = Scalar::Undefined();           /// Thruster [N]
+    Scalar thrust_ = Scalar::Undefined();           /// Thrust [N]
     Scalar specificImpulse_ = Scalar::Undefined();  /// Specific impulse [s]
+    Scalar massFlowRate_ = Scalar::Undefined();     /// Mass flow rate [kg/s]
 };
 
 }  // namespace system

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp
@@ -110,6 +110,16 @@ class SatelliteSystem : public System
 
     virtual bool isDefined() const override;
 
+    /// @brief              Access satellite system's propulsion model
+    ///
+    /// @code
+    ///                     PropulsionSystem propulsionModel = satelliteSystem.accessPropulsionSystem() ;
+    /// @endcode
+    ///
+    /// @return             PropulsionSystem
+
+    const PropulsionSystem& accessPropulsionSystem() const;
+
     /// @brief              Get satellite system's inertia tensor
     ///
     /// @code

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp
@@ -13,6 +13,7 @@
 #include <OpenSpaceToolkit/Physics/Units/Mass.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
 
 namespace ostk
 {
@@ -34,8 +35,9 @@ using ostk::math::obj::Vector3d;
 using ostk::physics::units::Mass;
 
 using ostk::astro::flight::System;
+using ostk::astro::flight::system::PropulsionSystem;
 
-/// @brief                      Defines the dynamics system who's motion is being studied, in particular this is a
+/// @brief                      Define the dynamics system who's motion is being studied, in particular this is a
 /// satellite system
 
 class SatelliteSystem : public System
@@ -49,8 +51,9 @@ class SatelliteSystem : public System
     ///                     Matrix3d intertiaTensor ( ... ) ;
     ///                     Real crossSectionalSurfaceArea = 0.8 ;
     ///                     Real dragCoefficient = 2.2 ;
+    ///                     PropulsionSystem propulsionSystem = { ... } ;
     ///                     System system = { mass, composite, intertiaTensor, crossSectionalSurfaceArea,
-    ///                     dragCoefficient } ;
+    ///                     dragCoefficient, propulsionSystem } ;
     /// @endcode
     ///
     /// @param              [in] aMass A mass
@@ -58,13 +61,15 @@ class SatelliteSystem : public System
     /// @param              [in] anInertiaTensor An inertia tensor
     /// @param              [in] aCrossSectionalSurfaceArea A cross sectional surface area
     /// @param              [in] aDragCoefficient A drag coefficient
+    /// @param              [in] aPropulsionSystem A propulsion system (optional)
 
     SatelliteSystem(
         const Mass& aMass,
         const Composite& aSatelliteGeometry,
         const Matrix3d& anInertiaTensor,
         const Real& aCrossSectionalSurfaceArea,
-        const Real& aDragCoefficient
+        const Real& aDragCoefficient,
+        const PropulsionSystem& aPropulsionSystem = PropulsionSystem::Undefined()
     );
 
     /// @brief              Destructor
@@ -105,13 +110,6 @@ class SatelliteSystem : public System
 
     virtual bool isDefined() const override;
 
-    /// @brief              Print satellite system
-    ///
-    /// @param              [in] anOutputStream An output stream
-    /// @param              [in] (optional) displayDecorators If true, display decorators
-
-    virtual void print(std::ostream& anOutputStream, bool displayDecorator = true) const override;
-
     /// @brief              Get satellite system's inertia tensor
     ///
     /// @code
@@ -142,9 +140,22 @@ class SatelliteSystem : public System
 
     Real getDragCoefficient() const;
 
-    /// @brief              Undefined satellite system
+    /// @brief              Get satellite system's propulsion model
     ///
-    /// @return             Undefined satellite system
+    /// @code
+    ///                     PropulsionSystem propulsionModel = satelliteSystem.getPropulsionSystem() ;
+    /// @endcode
+    ///
+    /// @return             PropulsionSystem
+
+    PropulsionSystem getPropulsionSystem() const;
+
+    /// @brief              Print satellite system
+    ///
+    /// @param              [in] anOutputStream An output stream
+    /// @param              [in] (optional) displayDecorators If true, display decorators
+
+    virtual void print(std::ostream& anOutputStream, bool displayDecorator = true) const override;
 
     static SatelliteSystem Undefined();
 
@@ -152,6 +163,7 @@ class SatelliteSystem : public System
     Matrix3d inertiaTensor_;
     Real crossSectionalSurfaceArea_;
     Real dragCoefficient_;
+    PropulsionSystem propulsionModel_;
 };
 
 }  // namespace system

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp
@@ -40,7 +40,8 @@ class CoordinatesSubset
    public:
     /// @brief              Constructor
     ///
-    ///                     The default CoordinatesSubset instance is frame-invariant and implements element-wise addition/substraction.
+    ///                     The default CoordinatesSubset instance is frame-invariant and implements element-wise
+    ///                     addition/substraction.
     /// @code
     ///                     CoordinateSubset coordinateSubset = {aName, aSize};
     /// @endcode

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
@@ -13,7 +13,7 @@ DurationCondition::DurationCondition(const Criteria& aCriteria, const Duration& 
     : RealEventCondition(
           "Duration Condition",
           aCriteria,
-          []([[maybe_unused]] const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
+          []([[maybe_unused]] const VectorXd& aStateVector, const Real& aTime) -> Real
           {
               return aTime;
           },

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/DurationCondition.cpp
@@ -13,7 +13,7 @@ DurationCondition::DurationCondition(const Criteria& aCriteria, const Duration& 
     : RealEventCondition(
           "Duration Condition",
           aCriteria,
-          [](const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
+          []([[maybe_unused]] const VectorXd& aStateVector, [[maybe_unused]] const Real& aTime) -> Real
           {
               return aTime;
           },

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -61,12 +61,18 @@ PropulsionSystem::PropulsionSystem(const Scalar& aThrust, const Scalar& aSpecifi
 {
     if (aThrust.getUnit() != thrustSIUnit_)
     {
-        throw ostk::core::error::RuntimeError("Thrust unit [{}], does not match SI unit [{}].", aThrust.getUnit().toString(), thrustSIUnit_.toString());
+        throw ostk::core::error::RuntimeError(
+            "Thrust unit [{}], does not match SI unit [{}].", aThrust.getUnit().toString(), thrustSIUnit_.toString()
+        );
     }
 
     if (aSpecificImpulse.getUnit() != specificImpulseSIUnit_)
     {
-        throw ostk::core::error::RuntimeError("Specific impulse unit [{}], does not match SI unit [{}].", aSpecificImpulse.getUnit().toString(), specificImpulseSIUnit_.toString());
+        throw ostk::core::error::RuntimeError(
+            "Specific impulse unit [{}], does not match SI unit [{}].",
+            aSpecificImpulse.getUnit().toString(),
+            specificImpulseSIUnit_.toString()
+        );
     }
 
     thrust_ = aThrust;
@@ -74,7 +80,9 @@ PropulsionSystem::PropulsionSystem(const Scalar& aThrust, const Scalar& aSpecifi
 
     if (aThrust.isDefined() && aSpecificImpulse.isDefined())
     {
-        massFlowRate_ = {aThrust.getValue() / (aSpecificImpulse.getValue() * Earth::gravityConstant), massFlowRateSIUnit_};
+        massFlowRate_ = {
+            aThrust.getValue() / (aSpecificImpulse.getValue() * Earth::gravityConstant), massFlowRateSIUnit_
+        };
     }
     else
     {
@@ -89,7 +97,8 @@ bool PropulsionSystem::operator==(const PropulsionSystem& aPropulsionSystem) con
         return false;
     }
 
-    return (thrust_ == aPropulsionSystem.thrust_) && (specificImpulse_ == aPropulsionSystem.specificImpulse_ && massFlowRate_ == aPropulsionSystem.massFlowRate_);
+    return (thrust_ == aPropulsionSystem.thrust_) &&
+           (specificImpulse_ == aPropulsionSystem.specificImpulse_ && massFlowRate_ == aPropulsionSystem.massFlowRate_);
 }
 
 bool PropulsionSystem::operator!=(const PropulsionSystem& aPropulsionSystem) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -1,0 +1,116 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Utilities.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace flight
+{
+namespace system
+{
+
+PropulsionSystem::PropulsionSystem(const Scalar& aThruster, const Scalar& aSpecificImpulse)
+    : thrust_(aThruster),
+      specificImpulse_(aSpecificImpulse)
+{
+}
+
+PropulsionSystem::PropulsionSystem(const Real& aThruster, const Real& aSpecificImpulse)
+    : thrust_({aThruster, thrustSIUnit_}),
+      specificImpulse_({aSpecificImpulse, specificImpulseSIUnit_})
+{
+}
+
+bool PropulsionSystem::operator==(const PropulsionSystem& aPropulsionSystem) const
+{
+    if ((!this->isDefined()) || (!aPropulsionSystem.isDefined()))
+    {
+        return false;
+    }
+
+    return (thrust_ == aPropulsionSystem.thrust_) && (specificImpulse_ == aPropulsionSystem.specificImpulse_);
+}
+
+bool PropulsionSystem::operator!=(const PropulsionSystem& aPropulsionSystem) const
+{
+    return !((*this) == aPropulsionSystem);
+}
+
+std::ostream& operator<<(std::ostream& anOutputStream, const PropulsionSystem& aPropulsionSystem)
+{
+    aPropulsionSystem.print(anOutputStream);
+
+    return anOutputStream;
+}
+
+bool PropulsionSystem::isDefined() const
+{
+    return thrust_.isDefined() && specificImpulse_.isDefined();
+}
+
+void PropulsionSystem::print(std::ostream& anOutputStream, bool displayDecorator) const
+{
+    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Propulsion") : void();
+
+    anOutputStream << "[Thruster = " << thrust_ << ", Specific Impulse = " << specificImpulse_
+                   << ", Mass Flow Rate = " << getMassFlowRate() << "]";
+
+    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+}
+
+Scalar PropulsionSystem::getThrust() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("PropulsionSystem");
+    }
+
+    return thrust_;
+}
+
+Scalar PropulsionSystem::getSpecificImpulse() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("PropulsionSystem");
+    }
+
+    return specificImpulse_;
+}
+
+Scalar PropulsionSystem::getMassFlowRate() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("PropulsionSystem");
+    }
+
+    return {
+        thrust_.getValue() / (specificImpulse_.getValue() * 9.80665),
+        massFlowRateSIUnit_};  // TBM: Replace with gravity constant
+}
+
+Real PropulsionSystem::getAcceleration(const Mass& aMass) const  // Should be using Scalar
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("PropulsionSystem");
+    }
+
+    return thrust_.getValue() / aMass.inKilograms();
+}
+
+PropulsionSystem PropulsionSystem::Undefined()
+{
+    return {Scalar::Undefined(), Scalar::Undefined()};
+}
+
+}  // namespace system
+}  // namespace flight
+}  // namespace astro
+}  // namespace ostk

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -61,7 +61,6 @@ PropulsionSystem::PropulsionSystem(const Scalar& aThrust, const Scalar& aSpecifi
 {
     if (aThrust.isDefined() && aSpecificImpulse.isDefined())
     {
-
         thrust_ = aThrust.inUnit(thrustSIUnit);
         specificImpulse_ = aSpecificImpulse.inUnit(specificImpulseSIUnit);
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -99,7 +99,10 @@ Scalar PropulsionSystem::getAcceleration(const Mass& aMass) const
         throw ostk::core::error::runtime::Undefined("PropulsionSystem");
     }
 
-    return {thrust_.getValue() / aMass.inKilograms(), Unit::Derived(Derived::Unit::Acceleration(Length::Unit::Meter, Time::Unit::Second))};
+    return {
+        thrust_.getValue() / aMass.inKilograms(),
+        Unit::Derived(Derived::Unit::Acceleration(Length::Unit::Meter, Time::Unit::Second))
+    };
 }
 
 PropulsionSystem PropulsionSystem::Undefined()

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -97,8 +97,8 @@ bool PropulsionSystem::operator==(const PropulsionSystem& aPropulsionSystem) con
         return false;
     }
 
-    return (thrust_ == aPropulsionSystem.thrust_) &&
-           (specificImpulse_ == aPropulsionSystem.specificImpulse_ && massFlowRate_ == aPropulsionSystem.massFlowRate_);
+    return (thrust_ == aPropulsionSystem.thrust_) && (specificImpulse_ == aPropulsionSystem.specificImpulse_) &&
+           (massFlowRate_ == aPropulsionSystem.massFlowRate_);
 }
 
 bool PropulsionSystem::operator!=(const PropulsionSystem& aPropulsionSystem) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -18,7 +18,7 @@ namespace system
 
 using ostk::physics::environment::gravitational::Earth;
 
-ostk::physics::Unit PropulsionSystem::thrustSIUnit_ = Unit::Derived(Derived::Unit(
+ostk::physics::Unit PropulsionSystem::thrustSIUnit = Unit::Derived(Derived::Unit(
     Length::Unit::Meter,
     {1},
     Mass::Unit::Kilogram,
@@ -31,7 +31,7 @@ ostk::physics::Unit PropulsionSystem::thrustSIUnit_ = Unit::Derived(Derived::Uni
     {0}
 ));
 
-ostk::physics::Unit PropulsionSystem::specificImpulseSIUnit_ = Unit::Derived(Derived::Unit(
+ostk::physics::Unit PropulsionSystem::specificImpulseSIUnit = Unit::Derived(Derived::Unit(
     Length::Unit::Undefined,
     {0},
     Mass::Unit::Undefined,
@@ -44,7 +44,7 @@ ostk::physics::Unit PropulsionSystem::specificImpulseSIUnit_ = Unit::Derived(Der
     {0}
 ));
 
-ostk::physics::Unit PropulsionSystem::massFlowRateSIUnit_ = Unit::Derived(Derived::Unit(
+ostk::physics::Unit PropulsionSystem::massFlowRateSIUnit = Unit::Derived(Derived::Unit(
     Length::Unit::Undefined,
     {0},
     Mass::Unit::Kilogram,
@@ -59,34 +59,22 @@ ostk::physics::Unit PropulsionSystem::massFlowRateSIUnit_ = Unit::Derived(Derive
 
 PropulsionSystem::PropulsionSystem(const Scalar& aThrust, const Scalar& aSpecificImpulse)
 {
-    if (aThrust.getUnit() != thrustSIUnit_)
-    {
-        throw ostk::core::error::RuntimeError(
-            "Thrust unit [{}], does not match SI unit [{}].", aThrust.getUnit().toString(), thrustSIUnit_.toString()
-        );
-    }
-
-    if (aSpecificImpulse.getUnit() != specificImpulseSIUnit_)
-    {
-        throw ostk::core::error::RuntimeError(
-            "Specific impulse unit [{}], does not match SI unit [{}].",
-            aSpecificImpulse.getUnit().toString(),
-            specificImpulseSIUnit_.toString()
-        );
-    }
-
-    thrust_ = aThrust;
-    specificImpulse_ = aSpecificImpulse;
-
     if (aThrust.isDefined() && aSpecificImpulse.isDefined())
     {
+
+        thrust_ = aThrust.inUnit(thrustSIUnit);
+        specificImpulse_ = aSpecificImpulse.inUnit(specificImpulseSIUnit);
+
         massFlowRate_ = {
-            aThrust.getValue() / (aSpecificImpulse.getValue() * Earth::gravityConstant), massFlowRateSIUnit_
+            aThrust.getValue() / (aSpecificImpulse.getValue() * Earth::gravityConstant), massFlowRateSIUnit
         };
     }
+
     else
     {
-        massFlowRate_ = Scalar(Real::Undefined(), massFlowRateSIUnit_);
+        thrust_ = aThrust;
+        thrust_ = aSpecificImpulse;
+        massFlowRate_ = Scalar::Undefined();
     }
 }
 
@@ -174,8 +162,8 @@ Scalar PropulsionSystem::getAcceleration(const Mass& aMass) const
 PropulsionSystem PropulsionSystem::Undefined()
 {
     return {
-        Scalar(Real::Undefined(), thrustSIUnit_),
-        Scalar(Real::Undefined(), specificImpulseSIUnit_),
+        Scalar(Real::Undefined(), thrustSIUnit),
+        Scalar(Real::Undefined(), specificImpulseSIUnit),
     };
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.cpp
@@ -126,7 +126,14 @@ PropulsionSystem SatelliteSystem::getPropulsionSystem() const
 
 SatelliteSystem SatelliteSystem::Undefined()
 {
-    return {Mass::Undefined(), Composite::Undefined(), Matrix3d::Zero(), Real::Undefined(), Real::Undefined(), PropulsionSystem::Undefined()};
+    return {
+        Mass::Undefined(),
+        Composite::Undefined(),
+        Matrix3d::Zero(),
+        Real::Undefined(),
+        Real::Undefined(),
+        PropulsionSystem::Undefined()
+    };
 }
 
 }  // namespace system

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.cpp
@@ -14,21 +14,19 @@ namespace flight
 namespace system
 {
 
-using ostk::math::geom::d3::objects::Composite;
-
-using ostk::physics::units::Mass;
-
 SatelliteSystem::SatelliteSystem(
     const Mass& aMass,
     const Composite& aSatelliteGeometry,
     const Matrix3d& anInertiaTensor,
     const Real& aCrossSectionalSurfaceArea,
-    const Real& aDragCoefficient
+    const Real& aDragCoefficient,
+    const PropulsionSystem& aPropulsionSystem
 )
     : System(aMass, aSatelliteGeometry),
       inertiaTensor_(anInertiaTensor),
       crossSectionalSurfaceArea_(aCrossSectionalSurfaceArea),
-      dragCoefficient_(aDragCoefficient)
+      dragCoefficient_(aDragCoefficient),
+      propulsionModel_(aPropulsionSystem)
 {
 }
 
@@ -116,11 +114,19 @@ Real SatelliteSystem::getDragCoefficient() const
     return dragCoefficient_;
 }
 
+PropulsionSystem SatelliteSystem::getPropulsionSystem() const
+{
+    if (!propulsionModel_.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("PropulsionSystem");
+    }
+
+    return propulsionModel_;
+}
+
 SatelliteSystem SatelliteSystem::Undefined()
 {
-    return SatelliteSystem(
-        Mass::Undefined(), Composite::Undefined(), Matrix3d::Undefined(), Real::Undefined(), Real::Undefined()
-    );
+    return {Mass::Undefined(), Composite::Undefined(), Matrix3d::Zero(), Real::Undefined(), Real::Undefined(), PropulsionSystem::Undefined()};
 }
 
 }  // namespace system

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.cpp
@@ -84,6 +84,16 @@ void SatelliteSystem::print(std::ostream& anOutputStream, bool displayDecorator)
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 
+const PropulsionSystem& SatelliteSystem::accessPropulsionSystem() const
+{
+    if (!propulsionModel_.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("PropulsionSystem");
+    }
+
+    return this->propulsionModel_;
+}
+
 Matrix3d SatelliteSystem::getInertiaTensor() const
 {
     if (!this->isDefined())
@@ -116,12 +126,7 @@ Real SatelliteSystem::getDragCoefficient() const
 
 PropulsionSystem SatelliteSystem::getPropulsionSystem() const
 {
-    if (!propulsionModel_.isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("PropulsionSystem");
-    }
-
-    return propulsionModel_;
+    return this->accessPropulsionSystem();
 }
 
 SatelliteSystem SatelliteSystem::Undefined()
@@ -132,7 +137,7 @@ SatelliteSystem SatelliteSystem::Undefined()
         Matrix3d::Zero(),
         Real::Undefined(),
         Real::Undefined(),
-        PropulsionSystem::Undefined()
+        PropulsionSystem::Undefined(),
     };
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
@@ -32,8 +32,8 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem : public ::t
    protected:
     void SetUp() override
     {
-        thrust_ = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
-        specificImpulse_ = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
+        thrust_ = Scalar(0.01, PropulsionSystem::thrustSIUnit);
+        specificImpulse_ = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
 
         propulsionSystem_ = {thrust_, specificImpulse_};
     }
@@ -50,8 +50,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructo
     }
 
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
 
         EXPECT_NO_THROW(PropulsionSystem propulsionSystem(thrust, specificImpulse));
     }
@@ -60,8 +60,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructo
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOperator)
 {
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -69,8 +69,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOpe
     }
 
     {
-        const Scalar thrust = Scalar(0.02, PropulsionSystem::thrustSIUnit_);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
+        const Scalar thrust = Scalar(0.02, PropulsionSystem::thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -78,8 +78,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOpe
     }
 
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
-        const Scalar specificImpulse = Scalar(100.45, PropulsionSystem::specificImpulseSIUnit_);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.45, PropulsionSystem::specificImpulseSIUnit);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -94,8 +94,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOpe
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualToOperator)
 {
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -103,8 +103,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualTo
     }
 
     {
-        const Scalar thrust = Scalar(0.02, PropulsionSystem::thrustSIUnit_);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
+        const Scalar thrust = Scalar(0.02, PropulsionSystem::thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -112,8 +112,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualTo
     }
 
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
-        const Scalar specificImpulse = Scalar(100.45, PropulsionSystem::specificImpulseSIUnit_);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.45, PropulsionSystem::specificImpulseSIUnit);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -166,7 +166,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Getters)
         const Scalar massFlowRate = {
             propulsionSystem_.getThrust().getValue() /
                 (propulsionSystem_.getSpecificImpulse().getValue() * Earth::gravityConstant),
-            PropulsionSystem::massFlowRateSIUnit_
+            PropulsionSystem::massFlowRateSIUnit
         };
         EXPECT_TRUE(propulsionSystem_.getMassFlowRate() == massFlowRate);
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
@@ -87,7 +87,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOpe
     }
 
     {
-	    EXPECT_ANY_THROW(PropulsionSystem::Undefined() == propulsionSystem_);
+        EXPECT_ANY_THROW(PropulsionSystem::Undefined() == propulsionSystem_);
     }
 }
 
@@ -121,7 +121,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualTo
     }
 
     {
-	    EXPECT_ANY_THROW(PropulsionSystem::Undefined() != propulsionSystem_);
+        EXPECT_ANY_THROW(PropulsionSystem::Undefined() != propulsionSystem_);
     }
 }
 
@@ -177,11 +177,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Getters)
     }
 
     {
-	    EXPECT_ANY_THROW(PropulsionSystem::Undefined().getThrust());
+        EXPECT_ANY_THROW(PropulsionSystem::Undefined().getThrust());
         EXPECT_ANY_THROW(PropulsionSystem::Undefined().getSpecificImpulse());
         EXPECT_ANY_THROW(PropulsionSystem::Undefined().getMassFlowRate());
         EXPECT_ANY_THROW(PropulsionSystem::Undefined().getAcceleration(Mass(0.05, Mass::Unit::Kilogram)));
-	}
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Undefined)

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
@@ -32,15 +32,15 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem : public ::t
    protected:
     void SetUp() override
     {
-        thrust_ = Scalar(0.01, thrustSIUnit);
-        specificImpulse_ = Scalar(100.0, specificImpulseSIUnit);
+        thrust_ = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
+        specificImpulse_ = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
 
         propulsionSystem_ = {thrust_, specificImpulse_};
     }
 
-    const Scalar thrust_ = Scalar(0.01, thrustSIUnit);
-    const Scalar specificImpulse_ = Scalar(100.0, specificImpulseSIUnit);
-    const PropulsionSystem propulsionSystem_ = {thrust_, specificImpulse_};
+    Scalar thrust_ = Scalar::Undefined();
+    Scalar specificImpulse_ = Scalar::Undefined();
+    PropulsionSystem propulsionSystem_ = PropulsionSystem::Undefined();
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructor)
@@ -87,7 +87,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOpe
     }
 
     {
-        EXPECT_ANY_THROW(PropulsionSystem::Undefined() == propulsionSystem_);
+        EXPECT_NO_THROW(PropulsionSystem::Undefined() == propulsionSystem_);
     }
 }
 
@@ -121,7 +121,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualTo
     }
 
     {
-        EXPECT_ANY_THROW(PropulsionSystem::Undefined() != propulsionSystem_);
+        EXPECT_NO_THROW(PropulsionSystem::Undefined() != propulsionSystem_);
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
@@ -5,8 +5,8 @@
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
 
 #include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
-#include <OpenSpaceToolkit/Physics/Units/Mass.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
+#include <OpenSpaceToolkit/Physics/Units/Mass.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
 
@@ -72,15 +72,12 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem : public ::t
         thrust_ = Scalar(0.01, thrustSIUnit);
         specificImpulse_ = Scalar(100.0, specificImpulseSIUnit);
 
-        propulsionSystem_ = {
-            thrust_, specificImpulse_
-        };
+        propulsionSystem_ = {thrust_, specificImpulse_};
     }
 
     Scalar thrust_ = Scalar::Undefined();
     Scalar specificImpulse_ = Scalar::Undefined();
     PropulsionSystem propulsionSystem_ = PropulsionSystem::Undefined();
-
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructor)
@@ -201,7 +198,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetSpecifi
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetMassFlowRate)
 {
     {
-        const Scalar massFlowRate = {propulsionSystem_.getThrust().getValue() / (propulsionSystem_.getSpecificImpulse().getValue() * Earth::gravityConstant), massFlowRateSIUnit};
+        const Scalar massFlowRate = {
+            propulsionSystem_.getThrust().getValue() /
+                (propulsionSystem_.getSpecificImpulse().getValue() * Earth::gravityConstant),
+            massFlowRateSIUnit
+        };
         EXPECT_TRUE(propulsionSystem_.getMassFlowRate() == massFlowRate);
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
@@ -27,43 +27,6 @@ using ostk::physics::environment::gravitational::Earth;
 
 using ostk::astro::flight::system::PropulsionSystem;
 
-Unit thrustSIUnit = Unit::Derived(Derived::Unit(
-    Length::Unit::Meter,
-    {1},
-    Mass::Unit::Kilogram,
-    {1},
-    Time::Unit::Second,
-    {-2},
-    ElectricCurrent::Unit::Undefined,
-    {0},
-    Angle::Unit::Undefined,
-    {0}
-));
-Unit specificImpulseSIUnit = Unit::Derived(Derived::Unit(
-    Length::Unit::Undefined,
-    {0},
-    Mass::Unit::Undefined,
-    {0},
-    Time::Unit::Second,
-    {1},
-    ElectricCurrent::Unit::Undefined,
-    {0},
-    Angle::Unit::Undefined,
-    {0}
-));
-Unit massFlowRateSIUnit = Unit::Derived(Derived::Unit(
-    Length::Unit::Undefined,
-    {0},
-    Mass::Unit::Kilogram,
-    {1},
-    Time::Unit::Second,
-    {-1},
-    ElectricCurrent::Unit::Undefined,
-    {0},
-    Angle::Unit::Undefined,
-    {0}
-));
-
 class OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem : public ::testing::Test
 {
    protected:
@@ -75,9 +38,9 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem : public ::t
         propulsionSystem_ = {thrust_, specificImpulse_};
     }
 
-    Scalar thrust_ = Scalar::Undefined();
-    Scalar specificImpulse_ = Scalar::Undefined();
-    PropulsionSystem propulsionSystem_ = PropulsionSystem::Undefined();
+    const Scalar thrust_ = Scalar(0.01, thrustSIUnit);
+    const Scalar specificImpulse_ = Scalar(100.0, specificImpulseSIUnit);
+    const PropulsionSystem propulsionSystem_ = {thrust_, specificImpulse_};
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructor)
@@ -87,8 +50,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructo
     }
 
     {
-        const Scalar thrust = Scalar(0.01, thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
 
         EXPECT_NO_THROW(PropulsionSystem propulsionSystem(thrust, specificImpulse));
     }
@@ -97,8 +60,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructo
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOperator)
 {
     {
-        const Scalar thrust = Scalar(0.01, thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -106,8 +69,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOpe
     }
 
     {
-        const Scalar thrust = Scalar(0.02, thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+        const Scalar thrust = Scalar(0.02, PropulsionSystem::thrustSIUnit_);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -115,20 +78,24 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOpe
     }
 
     {
-        const Scalar thrust = Scalar(0.01, thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.45, specificImpulseSIUnit);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
+        const Scalar specificImpulse = Scalar(100.45, PropulsionSystem::specificImpulseSIUnit_);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
         EXPECT_FALSE(propulsionSystem == propulsionSystem_);
+    }
+
+    {
+	    EXPECT_ANY_THROW(PropulsionSystem::Undefined() == propulsionSystem_);
     }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualToOperator)
 {
     {
-        const Scalar thrust = Scalar(0.01, thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -136,8 +103,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualTo
     }
 
     {
-        const Scalar thrust = Scalar(0.02, thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+        const Scalar thrust = Scalar(0.02, PropulsionSystem::thrustSIUnit_);
+        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
@@ -145,12 +112,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualTo
     }
 
     {
-        const Scalar thrust = Scalar(0.01, thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.45, specificImpulseSIUnit);
+        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
+        const Scalar specificImpulse = Scalar(100.45, PropulsionSystem::specificImpulseSIUnit_);
 
         const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
 
         EXPECT_TRUE(propulsionSystem != propulsionSystem_);
+    }
+
+    {
+	    EXPECT_ANY_THROW(PropulsionSystem::Undefined() != propulsionSystem_);
     }
 }
 
@@ -181,38 +152,36 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Print)
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetThrust)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Getters)
 {
     {
         EXPECT_TRUE(propulsionSystem_.getThrust() == thrust_);
     }
-}
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetSpecificImpulse)
-{
     {
         EXPECT_TRUE(propulsionSystem_.getSpecificImpulse() == specificImpulse_);
     }
-}
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetMassFlowRate)
-{
     {
         const Scalar massFlowRate = {
             propulsionSystem_.getThrust().getValue() /
                 (propulsionSystem_.getSpecificImpulse().getValue() * Earth::gravityConstant),
-            massFlowRateSIUnit
+            PropulsionSystem::massFlowRateSIUnit_
         };
         EXPECT_TRUE(propulsionSystem_.getMassFlowRate() == massFlowRate);
     }
-}
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetAcceleration)
-{
     {
         const Mass mass = Mass(0.05, Mass::Unit::Kilogram);
         EXPECT_NO_THROW(propulsionSystem_.getAcceleration(mass));
     }
+
+    {
+	    EXPECT_ANY_THROW(PropulsionSystem::Undefined().getThrust());
+        EXPECT_ANY_THROW(PropulsionSystem::Undefined().getSpecificImpulse());
+        EXPECT_ANY_THROW(PropulsionSystem::Undefined().getMassFlowRate());
+        EXPECT_ANY_THROW(PropulsionSystem::Undefined().getAcceleration(Mass(0.05, Mass::Unit::Kilogram)));
+	}
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Undefined)

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
@@ -1,0 +1,222 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Types/Integer.hpp>
+#include <OpenSpaceToolkit/Core/Types/Real.hpp>
+#include <OpenSpaceToolkit/Core/Types/String.hpp>
+
+#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
+#include <OpenSpaceToolkit/Physics/Units/Mass.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::types::Real;
+
+using ostk::physics::data::Scalar;
+using ostk::physics::units::Length;
+using ostk::physics::units::Mass;
+using ostk::physics::units::Time;
+using ostk::physics::units::ElectricCurrent;
+using ostk::physics::units::Angle;
+using ostk::physics::units::Derived;
+using ostk::physics::Unit;
+
+using ostk::physics::environment::gravitational::Earth;
+
+using ostk::astro::flight::system::PropulsionSystem;
+
+Unit thrustSIUnit = Unit::Derived(Derived::Unit(
+    Length::Unit::Meter,
+    {1},
+    Mass::Unit::Kilogram,
+    {1},
+    Time::Unit::Second,
+    {-2},
+    ElectricCurrent::Unit::Undefined,
+    {0},
+    Angle::Unit::Undefined,
+    {0}
+));
+Unit specificImpulseSIUnit = Unit::Derived(Derived::Unit(
+    Length::Unit::Undefined,
+    {0},
+    Mass::Unit::Undefined,
+    {0},
+    Time::Unit::Second,
+    {1},
+    ElectricCurrent::Unit::Undefined,
+    {0},
+    Angle::Unit::Undefined,
+    {0}
+));
+Unit massFlowRateSIUnit = Unit::Derived(Derived::Unit(
+    Length::Unit::Undefined,
+    {0},
+    Mass::Unit::Kilogram,
+    {1},
+    Time::Unit::Second,
+    {-1},
+    ElectricCurrent::Unit::Undefined,
+    {0},
+    Angle::Unit::Undefined,
+    {0}
+));
+
+class OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem : public ::testing::Test
+{
+   protected:
+    void SetUp() override
+    {
+        thrust_ = Scalar(0.01, thrustSIUnit);
+        specificImpulse_ = Scalar(100.0, specificImpulseSIUnit);
+
+        propulsionSystem_ = {
+            thrust_, specificImpulse_
+        };
+    }
+
+    Scalar thrust_ = Scalar::Undefined();
+    Scalar specificImpulse_ = Scalar::Undefined();
+    PropulsionSystem propulsionSystem_ = PropulsionSystem::Undefined();
+
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructor)
+{
+    {
+        EXPECT_NO_THROW(PropulsionSystem propulsionSystem(thrust_, specificImpulse_));
+    }
+
+    {
+        const Scalar thrust = Scalar(0.01, thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+
+        EXPECT_NO_THROW(PropulsionSystem propulsionSystem(thrust, specificImpulse));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOperator)
+{
+    {
+        const Scalar thrust = Scalar(0.01, thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+
+        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
+
+        EXPECT_TRUE(propulsionSystem == propulsionSystem_);
+    }
+
+    {
+        const Scalar thrust = Scalar(0.02, thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+
+        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
+
+        EXPECT_FALSE(propulsionSystem == propulsionSystem_);
+    }
+
+    {
+        const Scalar thrust = Scalar(0.01, thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.45, specificImpulseSIUnit);
+
+        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
+
+        EXPECT_FALSE(propulsionSystem == propulsionSystem_);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualToOperator)
+{
+    {
+        const Scalar thrust = Scalar(0.01, thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+
+        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
+
+        EXPECT_FALSE(propulsionSystem != propulsionSystem_);
+    }
+
+    {
+        const Scalar thrust = Scalar(0.02, thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.0, specificImpulseSIUnit);
+
+        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
+
+        EXPECT_TRUE(propulsionSystem != propulsionSystem_);
+    }
+
+    {
+        const Scalar thrust = Scalar(0.01, thrustSIUnit);
+        const Scalar specificImpulse = Scalar(100.45, specificImpulseSIUnit);
+
+        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
+
+        EXPECT_TRUE(propulsionSystem != propulsionSystem_);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, IsDefined)
+{
+    EXPECT_TRUE(propulsionSystem_.isDefined());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, StreamOperator)
+{
+    {
+        testing::internal::CaptureStdout();
+
+        EXPECT_NO_THROW(std::cout << propulsionSystem_ << std::endl);
+
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Print)
+{
+    {
+        testing::internal::CaptureStdout();
+
+        EXPECT_NO_THROW(propulsionSystem_.print(std::cout, true));
+        EXPECT_NO_THROW(propulsionSystem_.print(std::cout, false));
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetThrust)
+{
+    {
+        EXPECT_TRUE(propulsionSystem_.getThrust() == thrust_);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetSpecificImpulse)
+{
+    {
+        EXPECT_TRUE(propulsionSystem_.getSpecificImpulse() == specificImpulse_);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetMassFlowRate)
+{
+    {
+        const Scalar massFlowRate = {propulsionSystem_.getThrust().getValue() / (propulsionSystem_.getSpecificImpulse().getValue() * Earth::gravityConstant), massFlowRateSIUnit};
+        EXPECT_TRUE(propulsionSystem_.getMassFlowRate() == massFlowRate);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, GetAcceleration)
+{
+    {
+        const Mass mass = Mass(0.05, Mass::Unit::Kilogram);
+        EXPECT_NO_THROW(propulsionSystem_.getAcceleration(mass));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Undefined)
+{
+    {
+        EXPECT_NO_THROW(PropulsionSystem::Undefined());
+    }
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
@@ -37,7 +37,6 @@ using ostk::physics::Unit;
 using ostk::astro::flight::system::SatelliteSystem;
 using ostk::astro::flight::system::PropulsionSystem;
 
-
 class OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem : public ::testing::Test
 {
    protected:

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
@@ -65,8 +65,8 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem : public ::te
         dragCoefficient_ = 1.2;
 
         // Define propulsion system
-        const Scalar thrust_ = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
-        const Scalar specificImpulse_ = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
+        const Scalar thrust_ = Scalar(0.01, PropulsionSystem::thrustSIUnit);
+        const Scalar specificImpulse_ = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
 
         propulsionSystem_ = {
             thrust_,
@@ -341,6 +341,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, GetPropulsi
 {
     {
         EXPECT_EQ(satelliteSystem_.getPropulsionSystem(), propulsionSystem_);
+    }
+    
+    {
+        EXPECT_ANY_THROW(SatelliteSystem::Undefined().getPropulsionSystem());
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
@@ -15,22 +15,109 @@
 
 #include <Global.test.hpp>
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Constructor)
+using ostk::core::types::Integer;
+using ostk::core::types::Real;
+using ostk::core::types::String;
+
+using ostk::math::geom::d3::objects::Composite;
+using ostk::math::geom::d3::objects::Cuboid;
+using ostk::math::geom::d3::objects::Point;
+using ostk::math::obj::Matrix3d;
+using ostk::math::obj::Vector3d;
+
+using ostk::physics::data::Scalar;
+using ostk::physics::units::Length;
+using ostk::physics::units::Mass;
+using ostk::physics::units::Time;
+using ostk::physics::units::ElectricCurrent;
+using ostk::physics::units::Angle;
+using ostk::physics::units::Derived;
+using ostk::physics::Unit;
+
+using ostk::astro::flight::system::SatelliteSystem;
+using ostk::astro::flight::system::PropulsionSystem;
+
+Unit thrustSIUnit_ = Unit::Derived(Derived::Unit(
+    Length::Unit::Meter,
+    {1},
+    Mass::Unit::Kilogram,
+    {1},
+    Time::Unit::Second,
+    {-2},
+    ElectricCurrent::Unit::Undefined,
+    {0},
+    Angle::Unit::Undefined,
+    {0}
+));
+Unit specificImpulseSIUnit_ = Unit::Derived(Derived::Unit(
+    Length::Unit::Undefined,
+    {0},
+    Mass::Unit::Undefined,
+    {0},
+    Time::Unit::Second,
+    {1},
+    ElectricCurrent::Unit::Undefined,
+    {0},
+    Angle::Unit::Undefined,
+    {0}
+));
+
+class OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem : public ::testing::Test
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
+   protected:
+    void SetUp() override
+    {
+        // Define satellite mass
+        mass_ = {100.0, Mass::Unit::Kilogram};
 
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
+        // Define satellite intertia tensor
+        satelliteInertiaTensor_ = Matrix3d::Identity();
 
-    using ostk::physics::units::Mass;
+        // Define satellite geometry
+        const Point center = {0.0, 0.0, 0.0};
+        const std::array<Vector3d, 3> axes = {
+            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
+        };
+        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
 
-    using ostk::astro::flight::system::SatelliteSystem;
+        const Cuboid satelliteCuboid = {center, axes, extent};
+        const Composite satelliteGeometry_(satelliteCuboid);
 
+        // Define satellite cross sectional surface area
+        crossSectionalSurfaceArea_ = 0.8;
+
+        // Define satellite coefficient of drag
+        dragCoefficient_ = 1.2;
+
+        // Define propulsion system
+        const Scalar thrust_ = Scalar(0.01, thrustSIUnit_);
+        const Scalar specificImpulse_ = Scalar(100.0, specificImpulseSIUnit_);
+
+        propulsionSystem_ = {
+            thrust_,
+            specificImpulse_,
+        };
+
+        satelliteSystem_ = {
+            mass_,
+            satelliteGeometry_,
+            satelliteInertiaTensor_,
+            crossSectionalSurfaceArea_,
+            dragCoefficient_,
+            propulsionSystem_,
+        };
+    }
+
+    Mass mass_ = Mass::Undefined();
+    Matrix3d satelliteInertiaTensor_ = Matrix3d::Identity();
+    Real crossSectionalSurfaceArea_ = Real::Undefined();
+    Real dragCoefficient_ = Real::Undefined();
+    PropulsionSystem propulsionSystem_ = PropulsionSystem::Undefined();
+    SatelliteSystem satelliteSystem_ = SatelliteSystem::Undefined();
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Constructor)
+{
     // Normal constructor
     {
         // Define satellite mass
@@ -56,77 +143,21 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Constructor)
         const Real dragCoefficient = 1.2;
 
         // Construct SatelliteSystem object
-        EXPECT_NO_THROW(SatelliteSystem satellitesystem(
+        EXPECT_NO_THROW(SatelliteSystem satelliteSystem(
             satelliteMass, satelliteGeometry, satelliteInertiaTensor, crossSectionalSurfaceArea, dragCoefficient
         ));
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, CopyConstructor)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, CopyConstructor)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
-    // Copy constructor
     {
-        // Define satellite mass
-        const Mass satelliteMass = {100.0, Mass::Unit::Kilogram};
-
-        // Define satellite intertia tensor
-        const Matrix3d satelliteInertiaTensor = Matrix3d::Identity();
-
-        // Define satellite geometry
-        const Point center = {0.0, 0.0, 0.0};
-        const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
-        };
-        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
-
-        const Cuboid satelliteCuboid = {center, axes, extent};
-        const Composite satelliteGeometry(satelliteCuboid);
-
-        // Define satellite cross sectional surface area
-        const Real crossSectionalSurfaceArea = 0.8;
-
-        // Define satellite coefficient of drag
-        const Real dragCoefficient = 1.2;
-
-        // Construct SatelliteSystem object
-        const SatelliteSystem satellitesystem = {
-            satelliteMass, satelliteGeometry, satelliteInertiaTensor, crossSectionalSurfaceArea, dragCoefficient
-        };
-
-        EXPECT_NO_THROW(SatelliteSystem satellitesystemCopy(satellitesystem));
+        EXPECT_NO_THROW(SatelliteSystem satelliteSystemCopy(satelliteSystem_));
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, EqualToOperator)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, EqualToOperator)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
         // Test for all same parameters
         // Define satellite mass
@@ -186,22 +217,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, EqualToOperat
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, NotEqualToOperator)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, NotEqualToOperator)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
         // Test for all same parameters
         // Define satellite mass
@@ -262,190 +279,44 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, NotEqualToOpe
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, IsDefined)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, IsDefined)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
-        // Define satellite mass
-        const Mass satelliteMass(90.0, Mass::Unit::Kilogram);
-
-        // Define satellite intertia tensor
-        const Matrix3d satelliteInertiaTensor = Matrix3d::Identity();
-
-        // Define satellite geometry
-        const Point center = {0.0, 0.0, 0.0};
-        const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
-        };
-        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
-
-        const Cuboid satelliteCuboid = {center, axes, extent};
-        const Composite satelliteGeometry(satelliteCuboid);
-
-        // Construct SatelliteSystem object
-        const SatelliteSystem satelliteSystem = {satelliteMass, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2};
-
-        EXPECT_TRUE(satelliteSystem.isDefined());
+        EXPECT_TRUE(satelliteSystem_.isDefined());
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, StreamOperator)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, StreamOperator)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
-        // Define satellite mass
-        const Mass satelliteMass(90.0, Mass::Unit::Kilogram);
-
-        // Define satellite intertia tensor
-        const Matrix3d satelliteInertiaTensor = Matrix3d::Identity();
-
-        // Define satellite geometry
-        const Point center = {0.0, 0.0, 0.0};
-        const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
-        };
-        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
-
-        const Cuboid satelliteCuboid = {center, axes, extent};
-        const Composite satelliteGeometry(satelliteCuboid);
-
-        // Construct SatelliteSystem object
-        const SatelliteSystem satelliteSystem = {satelliteMass, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2};
-
         testing::internal::CaptureStdout();
 
-        EXPECT_NO_THROW(std::cout << satelliteSystem << std::endl);
+        EXPECT_NO_THROW(std::cout << satelliteSystem_ << std::endl);
 
         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Print)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Print)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
-        // Define satellite mass
-        const Mass satelliteMass(90.0, Mass::Unit::Kilogram);
-
-        // Define satellite intertia tensor
-        const Matrix3d satelliteInertiaTensor = Matrix3d::Identity();
-
-        // Define satellite geometry
-        const Point center = {0.0, 0.0, 0.0};
-        const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
-        };
-        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
-
-        const Cuboid satelliteCuboid = {center, axes, extent};
-        const Composite satelliteGeometry(satelliteCuboid);
-
-        // Construct SatelliteSystem object
-        const SatelliteSystem satelliteSystem = {satelliteMass, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2};
-
         testing::internal::CaptureStdout();
 
-        EXPECT_NO_THROW(satelliteSystem.print(std::cout, true));
-        EXPECT_NO_THROW(satelliteSystem.print(std::cout, false));
+        EXPECT_NO_THROW(satelliteSystem_.print(std::cout, true));
+        EXPECT_NO_THROW(satelliteSystem_.print(std::cout, false));
         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getMass)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, GetMass)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
-        // Define satellite mass
-        const Mass satelliteMass(90.0, Mass::Unit::Kilogram);
-
-        // Define satellite intertia tensor
-        const Matrix3d satelliteInertiaTensor = Matrix3d::Identity();
-
-        // Define satellite geometry
-        const Point center = {0.0, 0.0, 0.0};
-        const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
-        };
-        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
-
-        const Cuboid satelliteCuboid = {center, axes, extent};
-        const Composite satelliteGeometry(satelliteCuboid);
-
-        // Construct SatelliteSystem object
-        const SatelliteSystem satelliteSystem = {satelliteMass, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2};
-
-        EXPECT_EQ(satelliteSystem.getMass(), satelliteMass);
+        EXPECT_EQ(satelliteSystem_.getMass(), mass_);
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getGeometry)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, GetGeometry)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
         // Define satellite mass
         const Mass satelliteMass(90.0, Mass::Unit::Kilogram);
@@ -470,132 +341,37 @@ TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getGeometry)
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getInertiaTensor)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, GetInertiaTensor)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
-        // Define satellite mass
-        const Mass satelliteMass(90.0, Mass::Unit::Kilogram);
-
-        // Define satellite intertia tensor
-        const Matrix3d satelliteInertiaTensor = Matrix3d::Identity();
-
-        // Define satellite geometry
-        const Point center = {0.0, 0.0, 0.0};
-        const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
-        };
-        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
-
-        const Cuboid satelliteCuboid = {center, axes, extent};
-        const Composite satelliteGeometry(satelliteCuboid);
-
-        // Construct SatelliteSystem object
-        const SatelliteSystem satelliteSystem = {satelliteMass, satelliteGeometry, satelliteInertiaTensor, 0.8, 2.2};
-
-        EXPECT_EQ(satelliteSystem.getInertiaTensor(), satelliteInertiaTensor);
+        EXPECT_EQ(satelliteSystem_.getInertiaTensor(), satelliteInertiaTensor_);
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getCrossSectionalSurfaceArea)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, GetCrossSectionalSurfaceArea)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
-        // Define satellite mass
-        const Mass satelliteMass(90.0, Mass::Unit::Kilogram);
-
-        // Define satellite intertia tensor
-        const Matrix3d satelliteInertiaTensor = Matrix3d::Identity();
-
-        // Define satellite geometry
-        const Point center = {0.0, 0.0, 0.0};
-        const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
-        };
-        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
-
-        const Cuboid satelliteCuboid = {center, axes, extent};
-        const Composite satelliteGeometry(satelliteCuboid);
-
-        // Define satellite coefficient of drag
-        const Real surfaceArea = 0.8;
-
-        // Construct SatelliteSystem object
-        const SatelliteSystem satelliteSystem = {
-            satelliteMass, satelliteGeometry, satelliteInertiaTensor, surfaceArea, 2.2
-        };
-
-        EXPECT_EQ(satelliteSystem.getCrossSectionalSurfaceArea(), surfaceArea);
+        EXPECT_EQ(satelliteSystem_.getCrossSectionalSurfaceArea(), crossSectionalSurfaceArea_);
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, getDragCoefficient)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, GetDragCoefficient)
 {
-    using ostk::core::types::Integer;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
-
-    using ostk::math::geom::d3::objects::Composite;
-    using ostk::math::geom::d3::objects::Cuboid;
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::obj::Matrix3d;
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::units::Mass;
-
-    using ostk::astro::flight::system::SatelliteSystem;
-
     {
-        // Define satellite mass
-        const Mass satelliteMass(90.0, Mass::Unit::Kilogram);
+        EXPECT_EQ(satelliteSystem_.getDragCoefficient(), dragCoefficient_);
+    }
+}
 
-        // Define satellite intertia tensor
-        const Matrix3d satelliteInertiaTensor = Matrix3d::Identity();
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, GetPropulsionSystem)
+{
+    {
+        EXPECT_EQ(satelliteSystem_.getPropulsionSystem(), propulsionSystem_);
+    }
+}
 
-        // Define satellite geometry
-        const Point center = {0.0, 0.0, 0.0};
-        const std::array<Vector3d, 3> axes = {
-            Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}
-        };
-        const std::array<Real, 3> extent = {1.0, 2.0, 3.0};
-
-        const Cuboid satelliteCuboid = {center, axes, extent};
-        const Composite satelliteGeometry(satelliteCuboid);
-
-        // Define satellite coefficient of drag
-        const Real dragCoefficient = 2.2;
-
-        // Construct SatelliteSystem object
-        const SatelliteSystem satelliteSystem = {
-            satelliteMass, satelliteGeometry, satelliteInertiaTensor, 0.8, dragCoefficient
-        };
-
-        EXPECT_EQ(satelliteSystem.getDragCoefficient(), dragCoefficient);
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Undefined)
+{
+    {
+        EXPECT_NO_THROW(SatelliteSystem::Undefined());
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
@@ -342,7 +342,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, GetPropulsi
     {
         EXPECT_EQ(satelliteSystem_.getPropulsionSystem(), propulsionSystem_);
     }
-    
+
     {
         EXPECT_ANY_THROW(SatelliteSystem::Undefined().getPropulsionSystem());
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
@@ -37,30 +37,6 @@ using ostk::physics::Unit;
 using ostk::astro::flight::system::SatelliteSystem;
 using ostk::astro::flight::system::PropulsionSystem;
 
-Unit thrustSIUnit_ = Unit::Derived(Derived::Unit(
-    Length::Unit::Meter,
-    {1},
-    Mass::Unit::Kilogram,
-    {1},
-    Time::Unit::Second,
-    {-2},
-    ElectricCurrent::Unit::Undefined,
-    {0},
-    Angle::Unit::Undefined,
-    {0}
-));
-Unit specificImpulseSIUnit_ = Unit::Derived(Derived::Unit(
-    Length::Unit::Undefined,
-    {0},
-    Mass::Unit::Undefined,
-    {0},
-    Time::Unit::Second,
-    {1},
-    ElectricCurrent::Unit::Undefined,
-    {0},
-    Angle::Unit::Undefined,
-    {0}
-));
 
 class OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem : public ::testing::Test
 {
@@ -90,8 +66,8 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem : public ::te
         dragCoefficient_ = 1.2;
 
         // Define propulsion system
-        const Scalar thrust_ = Scalar(0.01, thrustSIUnit_);
-        const Scalar specificImpulse_ = Scalar(100.0, specificImpulseSIUnit_);
+        const Scalar thrust_ = Scalar(0.01, PropulsionSystem::thrustSIUnit_);
+        const Scalar specificImpulse_ = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit_);
 
         propulsionSystem_ = {
             thrust_,


### PR DESCRIPTION
- Adds a simple propulsionSystem (constant thrust, constant Isp) class to hold information about thrusting system. 
- No python bindings in this PR for now on purpose. 