### PR TITLE
feat: add getCoordinatesSubsets method to States

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -49,6 +49,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
         .def("get_frame", &State::getFrame)
 
         .def("extract_coordinates", &State::extractCoordinates, arg("coordinates_subset"))
+        .def("get_coordinates_subsets", &State::getCoordinatesSubsets)
 
         .def("in_frame", &State::inFrame, arg("frame"))
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -46,10 +46,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
         .def("get_position", &State::getPosition)
         .def("get_velocity", &State::getVelocity)
         .def("get_coordinates", &State::getCoordinates)
+        .def("get_coordinates_subsets", &State::getCoordinatesSubsets)
         .def("get_frame", &State::getFrame)
 
         .def("extract_coordinates", &State::extractCoordinates, arg("coordinates_subset"))
-        .def("get_coordinates_subsets", &State::getCoordinatesSubsets)
 
         .def("in_frame", &State::inFrame, arg("frame"))
 

--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -102,6 +102,7 @@ class TestState:
         position: Position,
         velocity: Velocity,
         frame: Frame,
+        coordinates_broker: CoordinatesBroker,
     ):
         assert state.get_instant() == instant
         assert state.get_position() == position
@@ -111,6 +112,7 @@ class TestState:
             state.get_coordinates()
             == np.append(position.get_coordinates(), velocity.get_coordinates())
         ).all()
+        assert state.get_coordinates_subsets() == coordinates_broker.get_subsets()
 
     def test_in_frame(
         self,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -92,10 +92,10 @@ class State
     Velocity getVelocity() const;
 
     VectorXd getCoordinates() const;
+    
+    const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
     VectorXd extractCoordinates(const Shared<const CoordinatesSubset>& aSubetSPtr) const;
-
-    const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
     State inFrame(const Shared<const Frame>& aFrameSPtr) const;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -3,6 +3,7 @@
 #ifndef __OpenSpaceToolkit_Astrodynamics_Trajectory_State__
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_State__
 
+#include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Types/Size.hpp>
 
@@ -25,6 +26,7 @@ namespace trajectory
 
 using ostk::core::types::Shared;
 using ostk::core::types::Size;
+using ostk::core::ctnr::Array;
 
 using ostk::math::obj::VectorXd;
 
@@ -92,6 +94,8 @@ class State
     VectorXd getCoordinates() const;
 
     VectorXd extractCoordinates(const Shared<const CoordinatesSubset>& aSubetSPtr) const;
+
+    const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
     State inFrame(const Shared<const Frame>& aFrameSPtr) const;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -248,16 +248,6 @@ const Shared<const CoordinatesBroker>& State::accessCoordinatesBroker() const
     return this->coordinatesBrokerSPtr_;
 }
 
-const Array<Shared<const CoordinatesSubset>> State::getCoordinatesSubsets() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
-
-    return this->coordinatesBrokerSPtr_->getSubsets();
-}
-
 Size State::getSize() const
 {
     if (!this->isDefined())
@@ -301,6 +291,16 @@ Velocity State::getVelocity() const
 VectorXd State::getCoordinates() const
 {
     return this->accessCoordinates();
+}
+
+const Array<Shared<const CoordinatesSubset>> State::getCoordinatesSubsets() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->coordinatesBrokerSPtr_->getSubsets();
 }
 
 VectorXd State::extractCoordinates(const Shared<const CoordinatesSubset>& aSubetSPtr) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -248,6 +248,16 @@ const Shared<const CoordinatesBroker>& State::accessCoordinatesBroker() const
     return this->coordinatesBrokerSPtr_;
 }
 
+const Array<Shared<const CoordinatesSubset>> State::getCoordinatesSubsets() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->coordinatesBrokerSPtr_->getSubsets();
+}
+
 Size State::getSize() const
 {
     if (!this->isDefined())

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -7,6 +7,7 @@
 #include <Global.test.hpp>
 
 using ostk::core::types::Shared;
+using ostk::core::ctnr::Array;
 
 using ostk::math::obj::VectorXd;
 
@@ -809,6 +810,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Getters)
         EXPECT_EQ(position, state.getPosition());
         EXPECT_EQ(velocity, state.getVelocity());
         EXPECT_EQ(coordinates, state.getCoordinates());
+        EXPECT_EQ(state.getCoordinatesSubsets(), brokerSPtr->getSubsets());
         EXPECT_EQ(Frame::GCRF(), state.getFrame());
     }
 
@@ -852,6 +854,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Getters)
         EXPECT_ANY_THROW(State::Undefined().getPosition());
         EXPECT_ANY_THROW(State::Undefined().getVelocity());
         EXPECT_ANY_THROW(State::Undefined().getCoordinates());
+        EXPECT_ANY_THROW(State::Undefined().getCoordinatesSubsets());
         EXPECT_ANY_THROW(State::Undefined().getFrame());
     }
 }


### PR DESCRIPTION
Exposing the list of subsets would be useful for the OD changes in FDS toolbox, so we don't have to pass around the original broker they were created with.