### PR TITLE
feat: update State printing to support extended state

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+// #include <Eigen/Core>
+
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utilities.hpp>
 
@@ -353,11 +355,24 @@ void State::print(std::ostream& anOutputStream, bool displayDecorator) const
 
     ostk::core::utils::Print::Line(anOutputStream)
         << "Instant:" << (this->instant_.isDefined() ? this->instant_.toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Position:" << (this->isDefined() ? this->getPosition().toString(12) : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Velocity:" << (this->isDefined() ? this->getVelocity().toString(12) : "Undefined");
 
+    if (!this->isDefined())
+    {
+        ostk::core::utils::Print::Line(anOutputStream) << "Coordinates: Undefined";
+    }
+    else
+    {
+        const Array<Shared<const CoordinatesSubset>> subsets = this->coordinatesBrokerSPtr_->getSubsets();
+
+        ostk::core::utils::Print::Line(anOutputStream) << "Coordinates: " << this->accessCoordinates().toString(4);
+
+        ostk::core::utils::Print::Line(anOutputStream) << "Where:";
+        for (auto subset : subsets)
+        {
+            ostk::core::utils::Print::Line(anOutputStream)
+                << subset->getName() << this->extractCoordinates(subset).toString(4);
+        }
+    }
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -355,6 +355,8 @@ void State::print(std::ostream& anOutputStream, bool displayDecorator) const
 
     ostk::core::utils::Print::Line(anOutputStream)
         << "Instant:" << (this->instant_.isDefined() ? this->instant_.toString() : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Frame:" << (this->frameSPtr_->isDefined() ? this->frameSPtr_->getName() : "Undefined");
 
     if (!this->isDefined())
     {

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -366,9 +366,6 @@ void State::print(std::ostream& anOutputStream, bool displayDecorator) const
     {
         const Array<Shared<const CoordinatesSubset>> subsets = this->coordinatesBrokerSPtr_->getSubsets();
 
-        ostk::core::utils::Print::Line(anOutputStream) << "Coordinates: " << this->accessCoordinates().toString(4);
-
-        ostk::core::utils::Print::Line(anOutputStream) << "Where:";
         for (const auto& subset : subsets)
         {
             ostk::core::utils::Print::Line(anOutputStream)

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -369,7 +369,7 @@ void State::print(std::ostream& anOutputStream, bool displayDecorator) const
         ostk::core::utils::Print::Line(anOutputStream) << "Coordinates: " << this->accessCoordinates().toString(4);
 
         ostk::core::utils::Print::Line(anOutputStream) << "Where:";
-        for (auto subset : subsets)
+        for (const auto& subset : subsets)
         {
             ostk::core::utils::Print::Line(anOutputStream)
                 << subset->getName() << this->extractCoordinates(subset).toString(4);


### PR DESCRIPTION
When printing the State, you currently see:
```
-- Trajectory :: State -----------------------------------------------------------------------------
    Instant:                                 2018-01-01 00:00:00 [UTC]                
    Position:                                [1.200000000000, 3.400000000000, 5.600000000000] [m] @ GCRF 
    Velocity:                                [7.800000000000, 9.000000000000, 1.200000000000] [m/s] @ GCRF 
----------------------------------------------------------------------------------------------------
```

This updates the print to support extending the state beyond position/velocity. So now it looks like:
```
-- Trajectory :: State -----------------------------------------------------------------------------
    Instant:                                 2018-01-01 00:00:00 [UTC]                
    Frame:                                   GCRF                                     
    CARTESIAN_POSITION                       [1.2000, 3.4000, 5.6000]                 
    CARTESIAN_VELOCITY                       [7.8000, 9.0000, 1.2000]                 
----------------------------------------------------------------------------------------------------
```