### PR TITLE
feat: add functions to extract multiple subsets at once.

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -49,7 +49,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
         .def("get_coordinates_subsets", &State::getCoordinatesSubsets)
         .def("get_frame", &State::getFrame)
 
-        .def("extract_coordinates", &State::extractCoordinates, arg("coordinates_subset"))
+        .def(
+            "extract_coordinates",
+            overload_cast<const Shared<const CoordinatesSubset>&>(&State::extractCoordinates, const_),
+            arg("coordinates_subset")
+        )
+        .def(
+            "extract_coordinates",
+            overload_cast<const Array<Shared<const CoordinatesSubset>>&>(&State::extractCoordinates, const_),
+            arg("coordinates_subset_array")
+        )
 
         .def("in_frame", &State::inFrame, arg("frame"))
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -57,7 +57,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
         .def(
             "extract_coordinates",
             overload_cast<const Array<Shared<const CoordinatesSubset>>&>(&State::extractCoordinates, const_),
-            arg("coordinates_subset_array")
+            arg("coordinates_subsets")
         )
 
         .def("in_frame", &State::inFrame, arg("frame"))

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesBroker.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesBroker.cpp
@@ -45,6 +45,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
             arg("coordinates"),
             arg("coordinates_subset")
         )
+        .def(
+            "extract_coordinates",
+            overload_cast<const VectorXd&, const Array<Shared<const CoordinatesSubset>>&>(
+                &CoordinatesBroker::extractCoordinates, const_
+            ),
+            arg("coordinates"),
+            arg("coordinates_subsets")
+        )
 
         ;
 }

--- a/bindings/python/test/trajectory/state/test_coordinates_broker.py
+++ b/bindings/python/test/trajectory/state/test_coordinates_broker.py
@@ -57,15 +57,22 @@ class TestCoordinatesBroker:
     ):
         assert coordinates_broker.has_subset(coordinates_subsets[0])
 
-    def extract_coordinates(
+    def test_extract_coordinates(
         self,
         coordinates_broker: CoordinatesBroker,
         coordinates: list[float],
         coordinates_subsets: list[CoordinatesSubset],
     ):
-        assert coordinates_broker.extract_coordinates(
-            coordinates, coordinates_subsets[0]
-        ) == [1.0, 2.0]
-        assert coordinates_broker.extract_coordinates(
-            coordinates, coordinates_subsets[1]
-        ) == [3.0, 4.0, 5.0]
+        assert (
+            coordinates_broker.extract_coordinates(coordinates, coordinates_subsets[0])
+            == [1.0, 2.0]
+        ).all()
+        assert (
+            coordinates_broker.extract_coordinates(coordinates, coordinates_subsets[1])
+            == [3.0, 4.0, 5.0]
+        ).all()
+
+        assert (
+            coordinates_broker.extract_coordinates(coordinates, coordinates_subsets)
+            == [1.0, 2.0, 3.0, 4.0, 5.0]
+        ).all()

--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -128,7 +128,14 @@ class TestState:
     ):
         position_coordinates = state.extract_coordinates(CartesianPosition.default())
         velocity_coordinates = state.extract_coordinates(CartesianVelocity.default())
-        len(position_coordinates) == 3
-        len(velocity_coordinates) == 3
+
+        assert len(position_coordinates) == 3
+        assert len(velocity_coordinates) == 3
         assert (position_coordinates == state.get_position().get_coordinates()).all()
         assert (velocity_coordinates == state.get_velocity().get_coordinates()).all()
+
+        pv_coordinates = state.extract_coordinates(
+            [CartesianPosition.default(), CartesianVelocity.default()]
+        )
+        assert len(pv_coordinates) == 6
+        assert (pv_coordinates == state.get_coordinates()).all()

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -35,22 +35,22 @@ using ostk::physics::coord::Position;
 using ostk::physics::coord::Velocity;
 using ostk::physics::time::Instant;
 
-using ostk::astro::trajectory::state::CoordinatesBroker;
-using ostk::astro::trajectory::state::CoordinatesSubset;
+using ostk::astro::trajectory::State::CoordinatesBroker;
+using ostk::astro::trajectory::State::CoordinatesSubset;
 
-/// @brief                      Trajectory state
+/// @brief                      Trajectory State
 
 class State
 {
    public:
-    /// @brief              Constructor.
+    /// @brief                  Constructor.
     ///
-    /// @param              [in] anInstant An instant
-    /// @param              [in] aCoordinates The {cartesian-position, cartesian-velocity} coordinates at the instant
-    /// in International System of Units
-    /// @param              [in] aFrameSPtr The reference frame in which the coordinates are referenced to and resolved
-    /// in
-    /// @param              [in] aCoordinatesBrokerSPtr The coordinates broker associated to the coordinates
+    /// @param                  [in] anInstant An instant
+    /// @param                  [in] aCoordinates The {cartesian-position, cartesian-velocity} coordinates at the
+    /// instant in International System of Units
+    /// @param                  [in] aFrameSPtr The reference frame in which the coordinates are referenced to and
+    /// resolved in
+    /// @param                  [in] aCoordinatesBrokerSPtr The coordinates broker associated to the coordinates
 
     State(
         const Instant& anInstant,
@@ -59,47 +59,151 @@ class State
         const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr
     );
 
+    /// @brief                  Constructor.
+    ///
+    /// @param                  [in] anInstant An instant
+    /// @param                  [in] aPosition The cartesian position at the instant in International System of Units
+    /// @param                  [in] aVelocity The cartesian velocity at the instant in International System of Units
+
     State(const Instant& anInstant, const Position& aPosition, const Velocity& aVelocity);
+
+    /// @brief                  Equality operator.
+    ///
+    /// @param                  [in] aState The State to compare to
+    /// @return                 True if the States are equal, false otherwise
 
     bool operator==(const State& aState) const;
 
+    /// @brief                  Inequality operator.
+    ///
+    /// @param                  [in] aState The State to compare to
+    /// @return                 True if the States are not equal, false otherwise
+
     bool operator!=(const State& aState) const;
+
+    /// @brief                  Addition operator.
+    ///
+    /// @param                  [in] aState The State to add to this State
+    /// @return                 The sum of the two States
 
     State operator+(const State& aState) const;
 
+    /// @brief                  Subtraction operator.
+    ///
+    /// @param                  [in] aState The State to subtract from this State
+    /// @return                 The difference between the two States
+
     State operator-(const State& aState) const;
+
+    /// @brief                  Stream insertion operator.
+    ///
+    /// @param                  [in] anOutputStream The output stream to insert into
+    /// @param                  [in] aState The State to insert
+    /// @return                 The output stream with the State inserted
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const State& aState);
 
+    /// @brief                  Check if the State is defined.
+    ///
+    /// @return                 True if the State is defined, false otherwise
+
     bool isDefined() const;
+
+    /// @brief                  Accessor for the instant.
+    ///
+    /// @return                 The instant
 
     const Instant& accessInstant() const;
 
+    /// @brief                  Accessor for the reference frame.
+    ///
+    /// @return                 The reference frame
+
     const Shared<const Frame> accessFrame() const;
+
+    /// @brief                  Accessor for the coordinates.
+    ///
+    /// @return                 The coordinates
 
     const VectorXd& accessCoordinates() const;
 
+    /// @brief                  Access the coordinates broker associated with the State.
+    ///
+    /// @return                 The coordinates broker associated to the State
+
     const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
+
+    /// @brief                  Get the size of the State.
+    ///
+    /// @return                 The size of the State
 
     Size getSize() const;
 
+    /// @brief                  Get the instant associated with the State.
+    ///
+    /// @return                 The instant
     Instant getInstant() const;
+
+    /// @brief                  Get the reference frame associated with the State.
+    ///
+    /// @return                 The reference frame
 
     Shared<const Frame> getFrame() const;
 
+    /// @brief                  Get the cartesian position associated with the State (if present).
+    ///
+    /// @return                 The cartesian position
+
     Position getPosition() const;
+
+    /// @brief                  Get the cartesian velocity associated with the State (if present).
+    ///
+    /// @return                 The cartesian velocity
 
     Velocity getVelocity() const;
 
+    /// @brief                  Get the coordinates of the State.
+    ///
+    /// @return                 The coordinates
     VectorXd getCoordinates() const;
+
+    /// @brief                  Get the coordinates subsets of the State.
+    ///
+    /// @return                 The coordinates subsets
 
     const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
-    VectorXd extractCoordinates(const Shared<const CoordinatesSubset>& aSubetSPtr) const;
+    /// @brief                  Extract the coordinates for a single subset.
+    ///
+    /// @param                  [in] aSubsetSPtr The subset to extract the coordinates for
+    /// @return                 The coordinates for the subset
+
+    VectorXd extractCoordinates(const Shared<const CoordinatesSubset>& aSubsetSPtr) const;
+
+    /// @brief Extract the coordinates for multiple subsets.
+    ///
+    /// @param [in] aCoordinatesSubsetsArray The array of subsets to extract the coordinates for
+    /// @return The coordinates for the subsets
+
+    VectorXd extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const;
+
+    /// @brief Transform the State to a different reference frame.
+    ///
+    /// @param [in] aFrameSPtr The reference frame to transform to
+    /// @return The transformed State
 
     State inFrame(const Shared<const Frame>& aFrameSPtr) const;
 
+    /// @brief Print the State to an output stream.
+    ///
+    /// @param [in] anOutputStream The output stream to print to
+    /// @param [in] displayDecorator Whether or not to display the decorator
+
     void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
+
+    /// @brief Get an undefined State.
+    ///
+    /// @return An undefined State
 
     static State Undefined();
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -142,6 +142,7 @@ class State
     /// @brief                  Get the instant associated with the State.
     ///
     /// @return                 The instant
+
     Instant getInstant() const;
 
     /// @brief                  Get the reference frame associated with the State.
@@ -165,6 +166,7 @@ class State
     /// @brief                  Get the coordinates of the State.
     ///
     /// @return                 The coordinates
+
     VectorXd getCoordinates() const;
 
     /// @brief                  Get the coordinates subsets of the State.

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -35,8 +35,8 @@ using ostk::physics::coord::Position;
 using ostk::physics::coord::Velocity;
 using ostk::physics::time::Instant;
 
-using ostk::astro::trajectory::State::CoordinatesBroker;
-using ostk::astro::trajectory::State::CoordinatesSubset;
+using ostk::astro::trajectory::state::CoordinatesBroker;
+using ostk::astro::trajectory::state::CoordinatesSubset;
 
 /// @brief                      Trajectory State
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp
@@ -35,100 +35,111 @@ using ostk::astro::trajectory::state::CoordinatesSubset;
 class CoordinatesBroker
 {
    public:
-    /// @brief              Constructor
+    /// @brief                  Constructor
     ///
     /// @code
-    ///                     CoordinatesBroker coordinatesBroker();
+    ///                         CoordinatesBroker coordinatesBroker();
     /// @endcode
 
     CoordinatesBroker();
 
-    /// @brief              Constructor
+    /// @brief                  Constructor
     ///
     /// @code
-    ///                     CoordinatesBroker coordinatesBroker({asubsetSPtr, anotherSubsetSPtr});
+    ///                         CoordinatesBroker coordinatesBroker({asubsetSPtr, anotherSubsetSPtr});
     /// @endcode
     ///
-    /// @param              [in] aCoordinatesSubsetsArray the coordinates subsets to consider
+    /// @param                  [in] aCoordinatesSubsetsArray the coordinates subsets to consider
 
     CoordinatesBroker(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray);
 
-    /// @brief              Equal to operator
+    /// @brief                  Equal to operator
     ///
-    /// @param              [in] aCoordinatesBroker A coordinates broker
+    /// @param                  [in] aCoordinatesBroker A coordinates broker
     ///
-    /// @return             True if CoordinateBrokers equal
+    /// @return                 True if CoordinateBrokers equal
 
     bool operator==(const CoordinatesBroker& aCoordinatesBroker) const;
 
-    /// @brief              Not equal to operator
+    /// @brief                  Not equal to operator
     ///
-    /// @param              [in] aCoordinatesBroker A coordinates broker
+    /// @param                  [in] aCoordinatesBroker A coordinates broker
     ///
-    /// @return             True if CoordinateBrokers are not equal
+    /// @return                 True if CoordinateBrokers are not equal
 
     bool operator!=(const CoordinatesBroker& aCoordinatesBroker) const;
 
-    /// @brief              Return the considered coordinate subsets
+    /// @brief                  Return the considered coordinate subsets
     ///
-    /// @return             The considered coordinate subsets
+    /// @return                 The considered coordinate subsets
 
     const Array<Shared<const CoordinatesSubset>>& accessSubsets() const;
 
-    /// @brief              Return the total number of coordinates
+    /// @brief                  Return the total number of coordinates
     ///
-    /// @return             The total number of coordinates
+    /// @return                 The total number of coordinates
 
     Size getNumberOfCoordinates() const;
 
-    /// @brief              Return the total number of coordinate subsets
+    /// @brief                  Return the total number of coordinate subsets
     ///
-    /// @return             The total number of coordinate subsets
+    /// @return                 The total number of coordinate subsets
 
     Size getNumberOfSubsets() const;
 
-    /// @brief              Return the considered coordinate subsets
+    /// @brief                  Return the considered coordinate subsets
     ///
-    /// @return             The considered coordinate subsets
+    /// @return                 The considered coordinate subsets
 
     Array<Shared<const CoordinatesSubset>> getSubsets() const;
 
-    /// @brief              Add a coordinates subset to be considered, returning the starting index it will occupy (or
-    /// that it occupies if it was already added) in the state coordinates
+    /// @brief                  Add a coordinates subset to be considered, returning the starting index it will occupy
+    /// (or that it occupies if it was already added) in the state coordinates
     ///
-    /// @param              [in] aCoordinatesSubsetSPtr a coordinates subset to be considered
+    /// @param                  [in] aCoordinatesSubsetSPtr a coordinates subset to be considered
     ///
-    /// @return             The starting index of the subset in the state coordinates
+    /// @return                 The starting index of the subset in the state coordinates
 
     Index addSubset(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr);
 
-    /// @brief              Check if a coordinates subset has already been considered
+    /// @brief                  Check if a coordinates subset has already been considered
     ///
-    /// @param              [in] aCoordinatesSubsetSPtr the coordinates subset to be checked
+    /// @param                  [in] aCoordinatesSubsetSPtr the coordinates subset to be checked
     ///
-    /// @return             True if the coordinates subset is already considered
+    /// @return                 True if the coordinates subset is already considered
 
     bool hasSubset(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const;
 
-    /// @brief              Extract the coordinates of a given subset from the full coordinates vector
+    /// @brief                  Extract the coordinates of a given subset from the full coordinates vector
     ///
-    /// @param              [in] aFullCoordinatesVector the full coordinates vecctor
-    /// @param              [in] aCoordinatesSubset the coordinates subsets of interest
+    /// @param                  [in] aFullCoordinatesVector the full coordinates vecctor
+    /// @param                  [in] aCoordinatesSubset the coordinates subsets of interest
     ///
-    /// @return             The coordinates of the subset
+    /// @return                 The coordinates of the subset
 
     VectorXd extractCoordinates(const VectorXd& aFullCoordinatesVector, const CoordinatesSubset& aCoordinatesSubset)
         const;
 
-    /// @brief              Extract the coordinates of a given subset from the full coordinates vector
+    /// @brief                  Extract the coordinates of a given subset from the full coordinates vector
     ///
-    /// @param              [in] aFullCoordinatesVector the full coordinates vecctor
-    /// @param              [in] aCoordinatesSubsetSPtr the coordinates subsets of interest
+    /// @param                  [in] aFullCoordinatesVector the full coordinates vecctor
+    /// @param                  [in] aCoordinatesSubsetSPtr the coordinates subsets of interest
     ///
-    /// @return             The coordinates of the subset
+    /// @return                 The coordinates of the subset
 
     VectorXd extractCoordinates(
         const VectorXd& aFullCoordinatesVector, const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr
+    ) const;
+
+    /// @brief                  Extract the coordinates of an array of subsets from the full coordinates vector
+    ///
+    /// @param                  [in] aFullCoordinatesVector the full coordinates vecctor
+    /// @param                  [in] aCoordinatesSubsetsArray the array of coordinates subsets of interest
+    ///
+    /// @return                 The coordinates of the array of subsets in the same order as the input subsets
+
+    VectorXd extractCoordinates(
+        const VectorXd& aFullCoordinatesVector, const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
     ) const;
 
    private:

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -310,6 +310,11 @@ VectorXd State::extractCoordinates(const Shared<const CoordinatesSubset>& aSubet
     return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aSubetSPtr);
 }
 
+VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const
+{
+    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aCoordinatesSubsetsArray);
+}
+
 State State::inFrame(const Shared<const Frame>& aFrameSPtr) const
 {
     if ((aFrameSPtr == nullptr) || (!aFrameSPtr->isDefined()))

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -305,9 +305,9 @@ const Array<Shared<const CoordinatesSubset>> State::getCoordinatesSubsets() cons
     return this->coordinatesBrokerSPtr_->getSubsets();
 }
 
-VectorXd State::extractCoordinates(const Shared<const CoordinatesSubset>& aSubetSPtr) const
+VectorXd State::extractCoordinates(const Shared<const CoordinatesSubset>& aSubsetSPtr) const
 {
-    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aSubetSPtr);
+    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aSubsetSPtr);
 }
 
 VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.cpp
@@ -1,6 +1,7 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Types/Size.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp>
 
@@ -113,6 +114,28 @@ VectorXd CoordinatesBroker::extractCoordinates(
     return aFullCoordinatesVector.segment(
         this->getSubsetIndex(aCoordinatesSubset.getId()), aCoordinatesSubset.getSize()
     );
+}
+
+VectorXd CoordinatesBroker::extractCoordinates(
+    const VectorXd& aFullCoordinatesVector, const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
+) const
+{
+    Size coordinatesSubsetsSize = 0;
+    for (const auto subset : aCoordinatesSubsetsArray)
+    {
+        coordinatesSubsetsSize += subset->getSize();
+    }
+
+    VectorXd coordinatesSubsetsVector(coordinatesSubsetsSize);
+
+    int startIndex = 0;
+    for (const auto subset : aCoordinatesSubsetsArray)
+    {
+        coordinatesSubsetsVector.segment(startIndex, subset->getSize()) =
+            aFullCoordinatesVector.segment(this->getSubsetIndex(subset->getId()), subset->getSize());
+        startIndex += subset->getSize();
+    }
+    return coordinatesSubsetsVector;
 }
 
 VectorXd CoordinatesBroker::extractCoordinates(

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.cpp
@@ -121,7 +121,7 @@ VectorXd CoordinatesBroker::extractCoordinates(
 ) const
 {
     Size coordinatesSubsetsSize = 0;
-    for (const auto subset : aCoordinatesSubsetsArray)
+    for (const auto& subset : aCoordinatesSubsetsArray)
     {
         coordinatesSubsetsSize += subset->getSize();
     }
@@ -129,12 +129,14 @@ VectorXd CoordinatesBroker::extractCoordinates(
     VectorXd coordinatesSubsetsVector(coordinatesSubsetsSize);
 
     int startIndex = 0;
-    for (const auto subset : aCoordinatesSubsetsArray)
+    for (const auto& subset : aCoordinatesSubsetsArray)
     {
         coordinatesSubsetsVector.segment(startIndex, subset->getSize()) =
             aFullCoordinatesVector.segment(this->getSubsetIndex(subset->getId()), subset->getSize());
+
         startIndex += subset->getSize();
     }
+
     return coordinatesSubsetsVector;
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -957,6 +957,27 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, ExtractCoordinates)
         EXPECT_EQ(coordinates.segment(0, 3), aState.extractCoordinates(CartesianPosition::Default()));
         EXPECT_EQ(coordinates.segment(3, 3), aState.extractCoordinates(CartesianVelocity::Default()));
     }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+        const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
+        const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+
+        const Array<Shared<const CoordinatesSubset>> positionSubset = {CartesianPosition::Default()};
+        EXPECT_EQ(coordinates.segment(0, 3), aState.extractCoordinates(positionSubset));
+
+        const Array<Shared<const CoordinatesSubset>> velocitySubset = {CartesianVelocity::Default()};
+        EXPECT_EQ(coordinates.segment(3, 3), aState.extractCoordinates(velocitySubset));
+
+        const Array<Shared<const CoordinatesSubset>> positionAndVelocitySubset = {
+            CartesianPosition::Default(), CartesianVelocity::Default()
+        };
+        EXPECT_EQ(coordinates, aState.extractCoordinates(positionAndVelocitySubset));
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, InFrame)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -974,7 +974,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, ExtractCoordinates)
         EXPECT_EQ(coordinates.segment(3, 3), aState.extractCoordinates(velocitySubset));
 
         const Array<Shared<const CoordinatesSubset>> positionAndVelocitySubset = {
-            CartesianPosition::Default(), CartesianVelocity::Default()
+            CartesianPosition::Default(),
+            CartesianVelocity::Default(),
         };
         EXPECT_EQ(coordinates, aState.extractCoordinates(positionAndVelocitySubset));
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.test.cpp
@@ -10,6 +10,7 @@
 using ostk::core::types::Shared;
 using ostk::core::types::Size;
 using ostk::core::types::String;
+using ostk::core::ctnr::Array;
 
 using ostk::math::obj::VectorXd;
 
@@ -345,5 +346,56 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinatesBroker, Extrac
         EXPECT_EQ(5.0, subset_3_coordinates(2));
 
         EXPECT_ANY_THROW(broker.extractCoordinates(fullCoordinatesVector, subset_4));
+    }
+
+    {
+        CoordinatesBroker broker = CoordinatesBroker();
+        broker.addSubset(subset_1);
+        broker.addSubset(subset_2);
+        broker.addSubset(subset_3);
+
+        VectorXd fullCoordinatesVector(6);
+        fullCoordinatesVector << 0.0, 1.0, 2.0, 3.0, 4.0, 5.0;
+
+        Array<Shared<const CoordinatesSubset>> subsets_1 = {subset_1};
+        const VectorXd subset_1_coordinates = broker.extractCoordinates(fullCoordinatesVector, subsets_1);
+        EXPECT_EQ(1, subset_1_coordinates.size());
+        EXPECT_EQ(0.0, subset_1_coordinates(0));
+
+        Array<Shared<const CoordinatesSubset>> subsets_12 = {subset_1, subset_2};
+        const VectorXd subset_12_coordinates = broker.extractCoordinates(fullCoordinatesVector, subsets_12);
+        EXPECT_EQ(3, subset_12_coordinates.size());
+        EXPECT_EQ(0.0, subset_12_coordinates(0));
+        EXPECT_EQ(1.0, subset_12_coordinates(1));
+        EXPECT_EQ(2.0, subset_12_coordinates(2));
+
+        Array<Shared<const CoordinatesSubset>> subsets_13 = {subset_1, subset_3};
+        const VectorXd subset_13_coordinates = broker.extractCoordinates(fullCoordinatesVector, subsets_13);
+        EXPECT_EQ(4, subset_13_coordinates.size());
+        EXPECT_EQ(0.0, subset_13_coordinates(0));
+        EXPECT_EQ(3.0, subset_13_coordinates(1));
+        EXPECT_EQ(4.0, subset_13_coordinates(2));
+        EXPECT_EQ(5.0, subset_13_coordinates(3));
+
+        Array<Shared<const CoordinatesSubset>> subsets_31 = {subset_3, subset_1};
+        const VectorXd subset_31_coordinates = broker.extractCoordinates(fullCoordinatesVector, subsets_31);
+        EXPECT_EQ(4, subset_31_coordinates.size());
+        EXPECT_EQ(3.0, subset_31_coordinates(0));
+        EXPECT_EQ(4.0, subset_31_coordinates(1));
+        EXPECT_EQ(5.0, subset_31_coordinates(2));
+        EXPECT_EQ(0.0, subset_31_coordinates(3));
+
+        Array<Shared<const CoordinatesSubset>> subsets_123 = {subset_1, subset_2, subset_3};
+        const VectorXd subset_123_coordinates = broker.extractCoordinates(fullCoordinatesVector, subsets_123);
+        EXPECT_EQ(6, subset_123_coordinates.size());
+        EXPECT_EQ(0.0, subset_123_coordinates(0));
+        EXPECT_EQ(1.0, subset_123_coordinates(1));
+        EXPECT_EQ(2.0, subset_123_coordinates(2));
+        EXPECT_EQ(3.0, subset_123_coordinates(3));
+        EXPECT_EQ(4.0, subset_123_coordinates(4));
+        EXPECT_EQ(5.0, subset_123_coordinates(5));
+
+        Array<Shared<const CoordinatesSubset>> subsets_14 = {subset_1, subset_4};
+        EXPECT_ANY_THROW(broker.extractCoordinates(fullCoordinatesVector, subsets_14));
     }
 }


### PR DESCRIPTION
Add 
    `VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const;`

and
```
    VectorXd CoordinatesBroker::extractCoordinates(
        const VectorXd& aFullCoordinatesVector, const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
    ) const;
```

to allow extracting multiple subsets at once. 

This is a preliminary step for whatever State::contract/slice/etc. function we implement.

Also add doc-strings to the State class.

