### PR TITLE
feat: add StateBuilder

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -11,6 +11,7 @@
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp>
+#include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp>
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule)
 {
@@ -56,6 +57,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
     OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameDirection(trajectory);
 
     OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(trajectory);
+    OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(trajectory);
     OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(trajectory);
     OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model(trajectory);
     OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(trajectory);

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -1,0 +1,47 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
+
+inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::module& aModule)
+{
+    using namespace pybind11;
+
+    using ostk::core::types::Shared;
+    using ostk::core::ctnr::Array;
+
+    using ostk::physics::coord::Frame;
+
+    using ostk::astro::trajectory::State;
+    using ostk::astro::trajectory::StateBuilder;
+    using ostk::astro::trajectory::state::CoordinatesBroker;
+
+    class_<StateBuilder>(aModule, "StateBuilder")
+
+        .def(
+            init<const Shared<const Frame>&, const Array<Shared<const CoordinatesSubset>>&>(),
+            arg("frame"),
+            arg("coordinates_subsets")
+        )
+        .def(
+            init<const Shared<const Frame>&, const Shared<const CoordinatesBroker>&>(),
+            arg("frame"),
+            arg("coordinates_broker")
+        )
+
+        .def(self == self)
+        .def(self != self)
+
+        .def("__str__", &(shiftToString<StateBuilder>))
+        .def("__repr__", &(shiftToString<StateBuilder>))
+
+        .def("is_defined", &StateBuilder::isDefined)
+
+        .def("state", &StateBuilder::buildState)
+
+        .def("get_coordinates_subsets", &StateBuilder::getCoordinatesSubsets)
+        .def("get_frame", &StateBuilder::getFrame)
+
+        .def_static("undefined", &StateBuilder::Undefined)
+
+        ;
+}

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -36,7 +36,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
         .def("is_defined", &StateBuilder::isDefined)
 
-        .def("state", &StateBuilder::buildState)
+        .def("build_state", &StateBuilder::buildState)
 
         .def("get_coordinates_subsets", &StateBuilder::getCoordinatesSubsets)
         .def("get_frame", &StateBuilder::getFrame)

--- a/bindings/python/test/trajectory/test_propagator.py
+++ b/bindings/python/test/trajectory/test_propagator.py
@@ -98,7 +98,18 @@ def environment(earth) -> Environment:
 
 
 @pytest.fixture
-def coordinates_broker():
+def coordinates_broker_7d():
+    return CoordinatesBroker(
+        [
+            CartesianPosition.default(),
+            CartesianVelocity.default(),
+            CoordinatesSubset.mass(),
+        ]
+    )
+
+
+@pytest.fixture
+def coordinates_broker_9d():
     return CoordinatesBroker(
         [
             CartesianPosition.default(),
@@ -112,7 +123,7 @@ def coordinates_broker():
 
 @pytest.fixture
 def state(
-    satellite_system: SatelliteSystem, coordinates_broker: CoordinatesBroker
+    satellite_system: SatelliteSystem, coordinates_broker_7d: CoordinatesBroker
 ) -> State:
     instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
 
@@ -128,12 +139,12 @@ def state(
         satellite_system.get_mass().in_kilograms() + propellant_mass,
     ]
 
-    return State(instant, coordinates, Frame.GCRF(), coordinates_broker)
+    return State(instant, coordinates, Frame.GCRF(), coordinates_broker_7d)
 
 
 @pytest.fixture
 def state_low_altitude(
-    satellite_system: SatelliteSystem, coordinates_broker: CoordinatesBroker
+    satellite_system: SatelliteSystem, coordinates_broker_9d: CoordinatesBroker
 ) -> State:
     instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
 
@@ -153,7 +164,7 @@ def state_low_altitude(
         cd,
     ]
 
-    return State(instant, coordinates, Frame.GCRF(), coordinates_broker)
+    return State(instant, coordinates, Frame.GCRF(), coordinates_broker_9d)
 
 
 @pytest.fixture

--- a/bindings/python/test/trajectory/test_state_builder.py
+++ b/bindings/python/test/trajectory/test_state_builder.py
@@ -79,7 +79,7 @@ class TestState:
         state_builder: StateBuilder,
     ):
         coordinates = [1, 2, 3, 1, 2, 3]
-        state: State = state_builder.state(instant, coordinates)
+        state: State = state_builder.build_state(instant, coordinates)
 
         assert state is not None
         assert isinstance(state, State)

--- a/bindings/python/test/trajectory/test_state_builder.py
+++ b/bindings/python/test/trajectory/test_state_builder.py
@@ -1,0 +1,99 @@
+# Apache License 2.0
+
+import pytest
+
+import numpy as np
+
+from ostk.physics.time import Instant
+from ostk.physics.time import DateTime
+from ostk.physics.time import Scale
+from ostk.physics.coordinate import Frame
+
+from ostk.astrodynamics.trajectory import (
+    State,
+    StateBuilder,
+)
+from ostk.astrodynamics.trajectory.state import (
+    CoordinatesBroker,
+    CoordinatesSubset,
+)
+from ostk.astrodynamics.trajectory.state.coordinates_subset import (
+    CartesianPosition,
+    CartesianVelocity,
+)
+
+
+@pytest.fixture()
+def instant() -> Instant:
+    return Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
+
+
+@pytest.fixture
+def frame() -> Frame:
+    return Frame.GCRF()
+
+
+@pytest.fixture
+def coordinates_subsets() -> list[CoordinatesSubset]:
+    return [CartesianPosition.default(), CartesianVelocity.default()]
+
+
+@pytest.fixture
+def coordinates_broker(coordinates_subsets: list[CoordinatesSubset]) -> CoordinatesBroker:
+    return CoordinatesBroker(coordinates_subsets)
+
+
+@pytest.fixture
+def state_builder(frame: Frame, coordinates_broker: CoordinatesBroker) -> State:
+    return StateBuilder(frame, coordinates_broker)
+
+
+class TestState:
+    def test_broker_constructor(
+        self,
+        frame: Frame,
+        coordinates_broker: CoordinatesBroker,
+    ):
+        builder = StateBuilder(frame, coordinates_broker)
+        assert builder is not None
+        assert isinstance(builder, StateBuilder)
+        assert builder.is_defined()
+
+    def test_subsets_constructor(
+        self,
+        frame: Frame,
+        coordinates_subsets: list[CoordinatesSubset],
+    ):
+        builder = StateBuilder(frame, coordinates_subsets)
+        assert builder is not None
+        assert isinstance(builder, StateBuilder)
+        assert builder.is_defined()
+
+    def test_comparators(self, state_builder: StateBuilder):
+        assert (state_builder == state_builder) is True
+        assert (state_builder != state_builder) is False
+
+    def test_build_state(
+        self,
+        instant: Instant,
+        state_builder: StateBuilder,
+    ):
+        coordinates = [1, 2, 3, 1, 2, 3]
+        state: State = state_builder.state(instant, coordinates)
+
+        assert state is not None
+        assert isinstance(state, State)
+        assert state.is_defined()
+        assert state.get_instant() == instant
+        assert (state.get_coordinates() == coordinates).all()
+        assert state.get_frame() == state_builder.get_frame()
+        assert state.get_coordinates_subsets() == state_builder.get_coordinates_subsets()
+
+    def test_getters(
+        self,
+        state_builder: StateBuilder,
+        frame: Frame,
+        coordinates_broker: CoordinatesBroker,
+    ):
+        assert state_builder.get_frame() == frame
+        assert state_builder.get_coordinates_subsets() == coordinates_broker.get_subsets()

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -35,8 +35,8 @@ using ostk::physics::coord::Position;
 using ostk::physics::coord::Velocity;
 using ostk::physics::time::Instant;
 
-using ostk::astro::trajectory::State::CoordinatesBroker;
-using ostk::astro::trajectory::State::CoordinatesSubset;
+using ostk::astro::trajectory::state::CoordinatesBroker;
+using ostk::astro::trajectory::state::CoordinatesSubset;
 
 /// @brief                      Trajectory State
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -35,8 +35,8 @@ using ostk::physics::coord::Position;
 using ostk::physics::coord::Velocity;
 using ostk::physics::time::Instant;
 
-using ostk::astro::trajectory::state::CoordinatesBroker;
-using ostk::astro::trajectory::state::CoordinatesSubset;
+using ostk::astro::trajectory::State::CoordinatesBroker;
+using ostk::astro::trajectory::State::CoordinatesSubset;
 
 /// @brief                      Trajectory State
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
@@ -1,7 +1,7 @@
 /// Apache License 2.0
 
-#ifndef __OpenSpaceToolkit_Astrodynamics_Trajectory_State__
-#define __OpenSpaceToolkit_Astrodynamics_Trajectory_State__
+#ifndef __OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder__
+#define __OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder__
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
@@ -16,6 +16,7 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 
 namespace ostk
 {
@@ -35,6 +36,7 @@ using ostk::physics::coord::Position;
 using ostk::physics::coord::Velocity;
 using ostk::physics::time::Instant;
 
+using ostk::astro::trajectory::State;
 using ostk::astro::trajectory::state::CoordinatesBroker;
 using ostk::astro::trajectory::state::CoordinatesSubset;
 
@@ -62,30 +64,30 @@ class StateBuilder
 
     StateBuilder(
         const Shared<const Frame>& aFrameSPtr,
-        const Shared<const CoordinatesBroker>>& aCoordinatesBroker
+        const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr
     );
 
-    // /// @brief                  Equality operator.
-    // ///
-    // /// @param                  [in] aStateBuilder The StateBuilder to compare to
-    // /// @return                 True if the States are equal, false otherwise
+    /// @brief                  Equality operator.
+    ///
+    /// @param                  [in] aStateBuilder The StateBuilder to compare to
+    /// @return                 True if the States are equal, false otherwise
 
-    // bool operator==(const StateBuilder& aStateBuilder) const;
+    bool operator==(const StateBuilder& aStateBuilder) const;
 
-    // /// @brief                  Inequality operator.
-    // ///
-    // /// @param                  [in] aStateBuilder The StateBuilder to compare to
-    // /// @return                 True if the States are not equal, false otherwise
+    /// @brief                  Inequality operator.
+    ///
+    /// @param                  [in] aStateBuilder The StateBuilder to compare to
+    /// @return                 True if the States are not equal, false otherwise
 
-    // bool operator!=(const StateBuilder& aStateBuilder) const;
+    bool operator!=(const StateBuilder& aStateBuilder) const;
 
-    // /// @brief                  Stream insertion operator.
-    // ///
-    // /// @param                  [in] anOutputStream The output stream to insert into
-    // /// @param                  [in] aStateBuilder The StateBuilder to insert
-    // /// @return                 The output stream with the StateBuilder inserted
+    /// @brief                  Stream insertion operator.
+    ///
+    /// @param                  [in] anOutputStream The output stream to insert into
+    /// @param                  [in] aStateBuilder The StateBuilder to insert
+    /// @return                 The output stream with the StateBuilder inserted
 
-    // friend std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder);
+    friend std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder);
 
     // /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
     // ///
@@ -93,60 +95,48 @@ class StateBuilder
 
     // const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
 
-    // /// @brief                  Check if the StateBuilder is defined.
-    // ///
-    // /// @return                 True if the StateBuilder is defined, false otherwise
+    /// @brief                  Check if the StateBuilder is defined.
+    ///
+    /// @return                 True if the StateBuilder is defined, false otherwise
 
-    // bool isDefined() const;
+    bool isDefined() const;
 
-    // /// @brief                  Accessor for the reference frame.
-    // ///
-    // /// @return                 The reference frame
+    /// @brief                  Accessor for the reference frame.
+    ///
+    /// @return                 The reference frame
 
-    // const Shared<const Frame> accessFrame() const;
+    const Shared<const Frame> accessFrame() const;
 
-    // /// @brief                  Access the coordinates broker associated with the State.
-    // ///
-    // /// @return                 The coordinates broker associated to the State
+    /// @brief                  Access the coordinates broker associated with the State.
+    ///
+    /// @return                 The coordinates broker associated to the State
 
-    // const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
+    const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
 
-    // /// @brief                  Get the size of the State.
-    // ///
-    // /// @return                 The size of the State
+    /// @brief                  Get the reference frame associated with the State.
+    ///
+    /// @return                 The reference frame
 
-    // Size getSize() const;
+    Shared<const Frame> getFrame() const;
 
-    // /// @brief                  Get the reference frame associated with the State.
-    // ///
-    // /// @return                 The reference frame
+    /// @brief                  Get the coordinates subsets of the State.
+    ///
+    /// @return                 The coordinates subsets
 
-    // Shared<const Frame> getFrame() const;
+    const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
-    // /// @brief                  Get the coordinates of the State.
-    // ///
-    // /// @return                 The coordinates
+    /// @brief Print the StateBuilder to an output stream.
+    ///
+    /// @param [in] anOutputStream The output stream to print to
+    /// @param [in] displayDecorator Whether or not to display the decorator
 
-    // VectorXd getCoordinates() const;
+    void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
-    // /// @brief                  Get the coordinates subsets of the State.
-    // ///
-    // /// @return                 The coordinates subsets
+    /// @brief Get an undefined StateBuilder.
+    ///
+    /// @return An undefined StateBuilder
 
-    // const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
-
-    // /// @brief Print the StateBuilder to an output stream.
-    // ///
-    // /// @param [in] anOutputStream The output stream to print to
-    // /// @param [in] displayDecorator Whether or not to display the decorator
-
-    // void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
-
-    // /// @brief Get an undefined StateBuilder.
-    // ///
-    // /// @return An undefined StateBuilder
-
-    // static StateBuilder Undefined();
+    static StateBuilder Undefined();
 
    private:
     Shared<const Frame> frameSPtr_;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
@@ -14,9 +14,9 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 
 namespace ostk
 {
@@ -49,11 +49,11 @@ class StateBuilder
     ///
     /// @param                  [in] aFrameSPtr The reference frame in which the coordinates are referenced to and
     /// resolved in
-    /// @param                  [in] aCoordinatesSubsetsArray The array of coordinates subsets defining the output States
+    /// @param                  [in] aCoordinatesSubsetsArray The array of coordinates subsets defining the output
+    /// States
 
     StateBuilder(
-        const Shared<const Frame>& aFrameSPtr,
-        const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
+        const Shared<const Frame>& aFrameSPtr, const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
     );
 
     /// @brief                  Constructor.
@@ -62,10 +62,7 @@ class StateBuilder
     /// resolved in
     /// @param                  [in] aCoordinatesBroker Shared pointer to an existing Coordinates Brokers
 
-    StateBuilder(
-        const Shared<const Frame>& aFrameSPtr,
-        const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr
-    );
+    StateBuilder(const Shared<const Frame>& aFrameSPtr, const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr);
 
     /// @brief                  Equality operator.
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
@@ -5,13 +5,10 @@
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
-#include <OpenSpaceToolkit/Core/Types/Size.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
-#include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
-#include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
@@ -26,14 +23,12 @@ namespace trajectory
 {
 
 using ostk::core::types::Shared;
-using ostk::core::types::Size;
 using ostk::core::ctnr::Array;
 
 using ostk::math::obj::VectorXd;
 
 using ostk::physics::coord::Frame;
-using ostk::physics::coord::Position;
-using ostk::physics::coord::Velocity;
+
 using ostk::physics::time::Instant;
 
 using ostk::astro::trajectory::State;
@@ -60,21 +55,21 @@ class StateBuilder
     ///
     /// @param                  [in] aFrameSPtr The reference frame in which the coordinates are referenced to and
     /// resolved in
-    /// @param                  [in] aCoordinatesBroker Shared pointer to an existing Coordinates Brokers
+    /// @param                  [in] aCoordinatesBroker Shared pointer to an existing Coordinates Broker
 
     StateBuilder(const Shared<const Frame>& aFrameSPtr, const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr);
 
     /// @brief                  Equality operator.
     ///
     /// @param                  [in] aStateBuilder The StateBuilder to compare to
-    /// @return                 True if the States are equal, false otherwise
+    /// @return                 True if the  StateBuilders are equal, false otherwise
 
     bool operator==(const StateBuilder& aStateBuilder) const;
 
     /// @brief                  Inequality operator.
     ///
     /// @param                  [in] aStateBuilder The StateBuilder to compare to
-    /// @return                 True if the States are not equal, false otherwise
+    /// @return                 True if the  StateBuilders are not equal, false otherwise
 
     bool operator!=(const StateBuilder& aStateBuilder) const;
 
@@ -86,17 +81,17 @@ class StateBuilder
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder);
 
-    // /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
-    // ///
-    // /// @return                 A State linked to the Frame and Coordinates Broker of the StateBuilder.
-
-    // const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
-
     /// @brief                  Check if the StateBuilder is defined.
     ///
     /// @return                 True if the StateBuilder is defined, false otherwise
 
     bool isDefined() const;
+
+    /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
+    ///
+    /// @return                 A State linked to the Frame and Coordinates Broker of the StateBuilder
+
+    const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
 
     /// @brief                  Accessor for the reference frame.
     ///
@@ -104,19 +99,19 @@ class StateBuilder
 
     const Shared<const Frame> accessFrame() const;
 
-    /// @brief                  Access the coordinates broker associated with the State.
+    /// @brief                  Access the coordinates broker associated with the  StateBuilder.
     ///
     /// @return                 The coordinates broker associated to the State
 
     const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
 
-    /// @brief                  Get the reference frame associated with the State.
+    /// @brief                  Get the reference frame associated with the  StateBuilder.
     ///
     /// @return                 The reference frame
 
     Shared<const Frame> getFrame() const;
 
-    /// @brief                  Get the coordinates subsets of the State.
+    /// @brief                  Get the coordinates subsets of the  StateBuilder.
     ///
     /// @return                 The coordinates subsets
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
@@ -1,0 +1,149 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkit_Astrodynamics_Trajectory_State__
+#define __OpenSpaceToolkit_Astrodynamics_Trajectory_State__
+
+#include <OpenSpaceToolkit/Core/Containers/Array.hpp>
+#include <OpenSpaceToolkit/Core/Types/Shared.hpp>
+#include <OpenSpaceToolkit/Core/Types/Size.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
+
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
+#include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace trajectory
+{
+
+using ostk::core::types::Shared;
+using ostk::core::types::Size;
+using ostk::core::ctnr::Array;
+
+using ostk::math::obj::VectorXd;
+
+using ostk::physics::coord::Frame;
+using ostk::physics::coord::Position;
+using ostk::physics::coord::Velocity;
+using ostk::physics::time::Instant;
+
+using ostk::astro::trajectory::state::CoordinatesBroker;
+using ostk::astro::trajectory::state::CoordinatesSubset;
+
+/// @brief                      Factory class to generate States with common reference frame and coordinates subsets
+
+class StateBuilder
+{
+   public:
+    /// @brief                  Constructor.
+    ///
+    /// @param                  [in] aFrameSPtr The reference frame in which the coordinates are referenced to and
+    /// resolved in
+    /// @param                  [in] aCoordinatesSubsetsArray The array of coordinates subsets defining the output States
+
+    StateBuilder(
+        const Shared<const Frame>& aFrameSPtr,
+        const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
+    );
+
+    /// @brief                  Equality operator.
+    ///
+    /// @param                  [in] aStateBuilder The StateBuilder to compare to
+    /// @return                 True if the States are equal, false otherwise
+
+    bool operator==(const StateBuilder& aStateBuilder) const;
+
+    /// @brief                  Inequality operator.
+    ///
+    /// @param                  [in] aStateBuilder The StateBuilder to compare to
+    /// @return                 True if the States are not equal, false otherwise
+
+    bool operator!=(const StateBuilder& aStateBuilder) const;
+
+    /// @brief                  Stream insertion operator.
+    ///
+    /// @param                  [in] anOutputStream The output stream to insert into
+    /// @param                  [in] aStateBuilder The StateBuilder to insert
+    /// @return                 The output stream with the StateBuilder inserted
+
+    friend std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder);
+
+    /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
+    ///
+    /// @return                 A State linked to the Frame and Coordinates Broker of the StateBuilder.
+
+    const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
+
+    /// @brief                  Check if the StateBuilder is defined.
+    ///
+    /// @return                 True if the StateBuilder is defined, false otherwise
+
+    bool isDefined() const;
+
+    /// @brief                  Accessor for the reference frame.
+    ///
+    /// @return                 The reference frame
+
+    const Shared<const Frame> accessFrame() const;
+
+    /// @brief                  Access the coordinates broker associated with the State.
+    ///
+    /// @return                 The coordinates broker associated to the State
+
+    const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
+
+    /// @brief                  Get the size of the State.
+    ///
+    /// @return                 The size of the State
+
+    Size getSize() const;
+
+    /// @brief                  Get the reference frame associated with the State.
+    ///
+    /// @return                 The reference frame
+
+    Shared<const Frame> getFrame() const;
+
+    /// @brief                  Get the coordinates of the State.
+    ///
+    /// @return                 The coordinates
+
+    VectorXd getCoordinates() const;
+
+    /// @brief                  Get the coordinates subsets of the State.
+    ///
+    /// @return                 The coordinates subsets
+
+    const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
+
+    /// @brief Print the StateBuilder to an output stream.
+    ///
+    /// @param [in] anOutputStream The output stream to print to
+    /// @param [in] displayDecorator Whether or not to display the decorator
+
+    void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
+
+    /// @brief Get an undefined StateBuilder.
+    ///
+    /// @return An undefined StateBuilder
+
+    static StateBuilder Undefined();
+
+   private:
+    Shared<const Frame> frameSPtr_;
+    Shared<const CoordinatesBroker> coordinatesBrokerSPtr_;
+};
+
+}  // namespace trajectory
+}  // namespace astro
+}  // namespace ostk
+
+#endif

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
@@ -54,88 +54,99 @@ class StateBuilder
         const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
     );
 
-    /// @brief                  Equality operator.
+    /// @brief                  Constructor.
     ///
-    /// @param                  [in] aStateBuilder The StateBuilder to compare to
-    /// @return                 True if the States are equal, false otherwise
+    /// @param                  [in] aFrameSPtr The reference frame in which the coordinates are referenced to and
+    /// resolved in
+    /// @param                  [in] aCoordinatesBroker Shared pointer to an existing Coordinates Brokers
 
-    bool operator==(const StateBuilder& aStateBuilder) const;
+    StateBuilder(
+        const Shared<const Frame>& aFrameSPtr,
+        const Shared<const CoordinatesBroker>>& aCoordinatesBroker
+    );
 
-    /// @brief                  Inequality operator.
-    ///
-    /// @param                  [in] aStateBuilder The StateBuilder to compare to
-    /// @return                 True if the States are not equal, false otherwise
+    // /// @brief                  Equality operator.
+    // ///
+    // /// @param                  [in] aStateBuilder The StateBuilder to compare to
+    // /// @return                 True if the States are equal, false otherwise
 
-    bool operator!=(const StateBuilder& aStateBuilder) const;
+    // bool operator==(const StateBuilder& aStateBuilder) const;
 
-    /// @brief                  Stream insertion operator.
-    ///
-    /// @param                  [in] anOutputStream The output stream to insert into
-    /// @param                  [in] aStateBuilder The StateBuilder to insert
-    /// @return                 The output stream with the StateBuilder inserted
+    // /// @brief                  Inequality operator.
+    // ///
+    // /// @param                  [in] aStateBuilder The StateBuilder to compare to
+    // /// @return                 True if the States are not equal, false otherwise
 
-    friend std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder);
+    // bool operator!=(const StateBuilder& aStateBuilder) const;
 
-    /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
-    ///
-    /// @return                 A State linked to the Frame and Coordinates Broker of the StateBuilder.
+    // /// @brief                  Stream insertion operator.
+    // ///
+    // /// @param                  [in] anOutputStream The output stream to insert into
+    // /// @param                  [in] aStateBuilder The StateBuilder to insert
+    // /// @return                 The output stream with the StateBuilder inserted
 
-    const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
+    // friend std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder);
 
-    /// @brief                  Check if the StateBuilder is defined.
-    ///
-    /// @return                 True if the StateBuilder is defined, false otherwise
+    // /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
+    // ///
+    // /// @return                 A State linked to the Frame and Coordinates Broker of the StateBuilder.
 
-    bool isDefined() const;
+    // const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
 
-    /// @brief                  Accessor for the reference frame.
-    ///
-    /// @return                 The reference frame
+    // /// @brief                  Check if the StateBuilder is defined.
+    // ///
+    // /// @return                 True if the StateBuilder is defined, false otherwise
 
-    const Shared<const Frame> accessFrame() const;
+    // bool isDefined() const;
 
-    /// @brief                  Access the coordinates broker associated with the State.
-    ///
-    /// @return                 The coordinates broker associated to the State
+    // /// @brief                  Accessor for the reference frame.
+    // ///
+    // /// @return                 The reference frame
 
-    const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
+    // const Shared<const Frame> accessFrame() const;
 
-    /// @brief                  Get the size of the State.
-    ///
-    /// @return                 The size of the State
+    // /// @brief                  Access the coordinates broker associated with the State.
+    // ///
+    // /// @return                 The coordinates broker associated to the State
 
-    Size getSize() const;
+    // const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
 
-    /// @brief                  Get the reference frame associated with the State.
-    ///
-    /// @return                 The reference frame
+    // /// @brief                  Get the size of the State.
+    // ///
+    // /// @return                 The size of the State
 
-    Shared<const Frame> getFrame() const;
+    // Size getSize() const;
 
-    /// @brief                  Get the coordinates of the State.
-    ///
-    /// @return                 The coordinates
+    // /// @brief                  Get the reference frame associated with the State.
+    // ///
+    // /// @return                 The reference frame
 
-    VectorXd getCoordinates() const;
+    // Shared<const Frame> getFrame() const;
 
-    /// @brief                  Get the coordinates subsets of the State.
-    ///
-    /// @return                 The coordinates subsets
+    // /// @brief                  Get the coordinates of the State.
+    // ///
+    // /// @return                 The coordinates
 
-    const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
+    // VectorXd getCoordinates() const;
 
-    /// @brief Print the StateBuilder to an output stream.
-    ///
-    /// @param [in] anOutputStream The output stream to print to
-    /// @param [in] displayDecorator Whether or not to display the decorator
+    // /// @brief                  Get the coordinates subsets of the State.
+    // ///
+    // /// @return                 The coordinates subsets
 
-    void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
+    // const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
-    /// @brief Get an undefined StateBuilder.
-    ///
-    /// @return An undefined StateBuilder
+    // /// @brief Print the StateBuilder to an output stream.
+    // ///
+    // /// @param [in] anOutputStream The output stream to print to
+    // /// @param [in] displayDecorator Whether or not to display the decorator
 
-    static StateBuilder Undefined();
+    // void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
+
+    // /// @brief Get an undefined StateBuilder.
+    // ///
+    // /// @return An undefined StateBuilder
+
+    // static StateBuilder Undefined();
 
    private:
     Shared<const Frame> frameSPtr_;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -328,6 +328,11 @@ VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>&
     return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aCoordinatesSubsetsArray);
 }
 
+VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const
+{
+    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aCoordinatesSubsetsArray);
+}
+
 State State::inFrame(const Shared<const Frame>& aFrameSPtr) const
 {
     if ((aFrameSPtr == nullptr) || (!aFrameSPtr->isDefined()))

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -32,6 +32,10 @@ State::State(
       frameSPtr_(aFrameSPtr),
       coordinatesBrokerSPtr_(aCoordinatesBrokerSPtr)
 {
+    if (coordinatesBrokerSPtr_ && (Size)coordinates_.size() != coordinatesBrokerSPtr_->getNumberOfCoordinates())
+    {
+        throw ostk::core::error::runtime::Wrong("Number of Coordinates");
+    }
 }
 
 State::State(

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -328,11 +328,6 @@ VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>&
     return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aCoordinatesSubsetsArray);
 }
 
-VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const
-{
-    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aCoordinatesSubsetsArray);
-}
-
 State State::inFrame(const Shared<const Frame>& aFrameSPtr) const
 {
     if ((aFrameSPtr == nullptr) || (!aFrameSPtr->isDefined()))

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -1,7 +1,5 @@
 /// Apache License 2.0
 
-// #include <Eigen/Core>
-
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utilities.hpp>
 
@@ -321,11 +319,6 @@ const Array<Shared<const CoordinatesSubset>> State::getCoordinatesSubsets() cons
 VectorXd State::extractCoordinates(const Shared<const CoordinatesSubset>& aSubsetSPtr) const
 {
     return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aSubsetSPtr);
-}
-
-VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const
-{
-    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aCoordinatesSubsetsArray);
 }
 
 VectorXd State::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -1,7 +1,5 @@
 /// Apache License 2.0
 
-// #include <Eigen/Core>
-
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utilities.hpp>
 
@@ -27,13 +25,13 @@ StateBuilder::StateBuilder(
 )
     : 
       frameSPtr_(aFrameSPtr),
-      coordinatesBrokerSPtr_(Shared<CoordinatesBroker>(aCoordinatesSubsetsArray))
+      coordinatesBrokerSPtr_(std::make_shared<CoordinatesBroker>(CoordinatesBroker(aCoordinatesSubsetsArray)))
 {
 }
 
 StateBuilder::StateBuilder(
     const Shared<const Frame>& aFrameSPtr,
-    const Shared<const CoordinatesBroker>>& aCoordinatesBrokerSPtr
+    const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr
 )
     : 
       frameSPtr_(aFrameSPtr),
@@ -41,113 +39,119 @@ StateBuilder::StateBuilder(
 {
 }
 
-// bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
-// {
-//     if (this->frameSPtr_ != aState.frameSPtr_)
-//     {
-//         return false;
-//     }
+bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
+{
 
-//     for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
-//     {
-//         if (!aStateBuilder.coordinatesBrokerSPtr_->hasSubset(subset))
-//         {
-//             return false;
-//         }
-//     }
+    if ((!this->isDefined()) || (!aStateBuilder.isDefined()))
+    {
+        return false;
+    }
 
-//     for (const Shared<const CoordinatesSubset>& subset : aStateBuilder.coordinatesBrokerSPtr_->accessSubsets())
-//     {
-//         if (!this->coordinatesBrokerSPtr_->hasSubset(subset))
-//         {
-//             return false;
-//         }
-//     }
+    if (this->frameSPtr_ != aStateBuilder.frameSPtr_)
+    {
+        return false;
+    }
 
-//     return true;
-// }
+    for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
+    {
+        if (!aStateBuilder.coordinatesBrokerSPtr_->hasSubset(subset))
+        {
+            return false;
+        }
+    }
 
-// bool StateBuilder::operator!=(const StateBuilder& aStateBuilder) const
-// {
-//     return !((*this) == aStateBuilder);
-// }
+    for (const Shared<const CoordinatesSubset>& subset : aStateBuilder.coordinatesBrokerSPtr_->accessSubsets())
+    {
+        if (!this->coordinatesBrokerSPtr_->hasSubset(subset))
+        {
+            return false;
+        }
+    }
 
-// std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder)
-// {
-//     aStateBuilder.print(anOutputStream);
+    return true;
+}
 
-//     return anOutputStream;
-// }
+bool StateBuilder::operator!=(const StateBuilder& aStateBuilder) const
+{
+    return !((*this) == aStateBuilder);
+}
 
-// bool StateBuilder::isDefined() const
-// {
-//     return (this->frameSPtr_ != nullptr) && this->frameSPtr_->isDefined() && (this->coordinatesBrokerSPtr_ != nullptr);
-// }
+std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder)
+{
+    aStateBuilder.print(anOutputStream);
 
-// const Shared<const Frame> StateBuilder::accessFrame() const
-// {
-//     if (!this->isDefined())
-//     {
-//         throw ostk::core::error::runtime::Undefined("StateBuilder");
-//     }
+    return anOutputStream;
+}
 
-//     return this->frameSPtr_;
-// }
+bool StateBuilder::isDefined() const
+{
+    return (this->frameSPtr_ != nullptr) && this->frameSPtr_->isDefined() && (this->coordinatesBrokerSPtr_ != nullptr);
+}
 
-// const Shared<const CoordinatesBroker>& StateBuilder::accessCoordinatesBroker() const
-// {
-//     if (!this->isDefined())
-//     {
-//         throw ostk::core::error::runtime::Undefined("StateBuilder");
-//     }
+const Shared<const Frame> StateBuilder::accessFrame() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
 
-//     return this->coordinatesBrokerSPtr_;
-// }
+    return this->frameSPtr_;
+}
 
-// Shared<const Frame> StateBuilder::getFrame() const
-// {
-//     return this->accessFrame();
-// }
+const Shared<const CoordinatesBroker>& StateBuilder::accessCoordinatesBroker() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
 
-// const Array<Shared<const CoordinatesSubset>> StateBuilder::getCoordinatesSubsets() const
-// {
-//     if (!this->isDefined())
-//     {
-//         throw ostk::core::error::runtime::Undefined("StateBuilder");
-//     }
+    return this->coordinatesBrokerSPtr_;
+}
 
-//     return this->coordinatesBrokerSPtr_->getSubsets();
-// }
+Shared<const Frame> StateBuilder::getFrame() const
+{
+    return this->accessFrame();
+}
 
-// void StateBuilder::print(std::ostream& anOutputStream, bool displayDecorator) const
-// {
-//     using ostk::core::types::String;
+const Array<Shared<const CoordinatesSubset>> StateBuilder::getCoordinatesSubsets() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
 
-//     displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Trajectory :: State") : void();
+    return this->coordinatesBrokerSPtr_->getSubsets();
+}
 
-//     ostk::core::utils::Print::Line(anOutputStream)
-//         << "Frame:" << (this->frameSPtr_->isDefined() ? this->frameSPtr_->getName() : "Undefined");
+void StateBuilder::print(std::ostream& anOutputStream, bool displayDecorator) const
+{
+    using ostk::core::types::String;
 
-//     if (!this->isDefined())
-//     {
-//         ostk::core::utils::Print::Line(anOutputStream) << "Coordinates: Undefined";
-//     }
-//     else
-//     {
-//         const Array<Shared<const CoordinatesSubset>> subsets = this->coordinatesBrokerSPtr_->getSubsets();
+    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Trajectory :: StateBuilder") : void();
 
-//         for (const auto& subset : subsets)
-//         {
-//             ostk::core::utils::Print::Line(anOutputStream) << subset->getName();
-//         }
-//     }
-//     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
-// }
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Frame:" << (this->frameSPtr_->isDefined() ? this->frameSPtr_->getName() : "Undefined");
 
-// State StateBuilder::Undefined()
-// {
-//     return {Frame::Undefined(), nullptr};
-// }
+    if (!this->isDefined())
+    {
+        ostk::core::utils::Print::Line(anOutputStream) << "Coordinates Subsets: Undefined";
+    }
+    else
+    {
+        const Array<Shared<const CoordinatesSubset>> subsets = this->coordinatesBrokerSPtr_->getSubsets();
+
+        for (const auto& subset : subsets)
+        {
+            ostk::core::utils::Print::Line(anOutputStream) << subset->getName();
+        }
+    }
+    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+}
+
+StateBuilder StateBuilder::Undefined()
+{
+    return {Frame::Undefined(), nullptr};
+}
 
 }  // namespace trajectory
 }  // namespace astro

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -1,11 +1,7 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Core/Error.hpp>
-#include <OpenSpaceToolkit/Core/Utilities.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 namespace ostk
@@ -14,10 +10,6 @@ namespace astro
 {
 namespace trajectory
 {
-
-using ostk::core::types::Index;
-
-using ostk::astro::trajectory::state::CoordinatesSubset;
 
 StateBuilder::StateBuilder(
     const Shared<const Frame>& aFrameSPtr, const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
@@ -81,6 +73,16 @@ std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStat
 bool StateBuilder::isDefined() const
 {
     return (this->frameSPtr_ != nullptr) && this->frameSPtr_->isDefined() && (this->coordinatesBrokerSPtr_ != nullptr);
+}
+
+const State StateBuilder::buildState(const Instant& anInstant, const VectorXd& aCoordinates) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
+
+    return {anInstant, aCoordinates, this->frameSPtr_, this->coordinatesBrokerSPtr_};
 }
 
 const Shared<const Frame> StateBuilder::accessFrame() const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -1,0 +1,257 @@
+/// Apache License 2.0
+
+// #include <Eigen/Core>
+
+#include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Utilities.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.hpp>
+
+namespace ostk
+{
+namespace astro
+{
+namespace trajectory
+{
+
+using ostk::core::types::Index;
+
+using ostk::astro::trajectory::state::CoordinatesSubset;
+
+StateBuilder::StateBuilder(
+    const Shared<const Frame>& aFrameSPtr,
+    const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
+)
+    : 
+      frameSPtr_(aFrameSPtr),
+      coordinatesBrokerSPtr_(Shared<CoordinatesBroker>(aCoordinatesSubsetsArray))
+{
+}
+
+bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
+{
+    if ((!this->isDefined()) || (!aStateBuilder.isDefined()))
+    {
+        return false;
+    }
+
+    if (this->frameSPtr_ != aState.frameSPtr_)
+    {
+        return false;
+    }
+
+    for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
+    {
+        if (!aStateBuilder.coordinatesBrokerSPtr_->hasSubset(subset))
+        {
+            return false;
+        }
+
+        if (this->extractCoordinates(subset) != aStateBuilder.extractCoordinates(subset))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool StateBuilder::operator!=(const StateBuilder& aStateBuilder) const
+{
+    return !((*this) == aStateBuilder);
+}
+
+std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aState)
+{
+    aState.print(anOutputStream);
+
+    return anOutputStream;
+}
+
+bool StateBuilder::isDefined() const
+{
+    return this->instant_.isDefined() && this->coordinates_.isDefined() && (this->frameSPtr_ != nullptr) &&
+           this->frameSPtr_->isDefined() && (this->coordinatesBrokerSPtr_ != nullptr);
+}
+
+const Instant& StateBuilder::accessInstant() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->instant_;
+}
+
+const Shared<const Frame> StateBuilder::accessFrame() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->frameSPtr_;
+}
+
+const VectorXd& StateBuilder::accessCoordinates() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->coordinates_;
+}
+
+const Shared<const CoordinatesBroker>& StateBuilder::accessCoordinatesBroker() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->coordinatesBrokerSPtr_;
+}
+
+Size StateBuilder::getSize() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->coordinates_.size();
+}
+
+Instant StateBuilder::getInstant() const
+{
+    return this->accessInstant();
+}
+
+Shared<const Frame> StateBuilder::getFrame() const
+{
+    return this->accessFrame();
+}
+
+Position StateBuilder::getPosition() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return Position::Meters(this->extractCoordinates(CartesianPosition::Default()), this->frameSPtr_);
+}
+
+Velocity StateBuilder::getVelocity() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return Velocity::MetersPerSecond(this->extractCoordinates(CartesianVelocity::Default()), this->frameSPtr_);
+}
+
+VectorXd StateBuilder::getCoordinates() const
+{
+    return this->accessCoordinates();
+}
+
+const Array<Shared<const CoordinatesSubset>> StateBuilder::getCoordinatesSubsets() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->coordinatesBrokerSPtr_->getSubsets();
+}
+
+VectorXd StateBuilder::extractCoordinates(const Shared<const CoordinatesSubset>& aSubsetSPtr) const
+{
+    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aSubsetSPtr);
+}
+
+VectorXd StateBuilder::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const
+{
+    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aCoordinatesSubsetsArray);
+}
+
+State StateBuilder::inFrame(const Shared<const Frame>& aFrameSPtr) const
+{
+    if ((aFrameSPtr == nullptr) || (!aFrameSPtr->isDefined()))
+    {
+        throw ostk::core::error::runtime::Undefined("Frame");
+    }
+
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    if (aFrameSPtr == this->frameSPtr_)
+    {
+        return {this->instant_, this->coordinates_, this->frameSPtr_, this->coordinatesBrokerSPtr_};
+    }
+
+    VectorXd inFrameCoordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());
+    Index i = 0;
+    for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
+    {
+        const VectorXd subsetInFrame = subset->inFrame(
+            this->instant_, this->coordinates_, this->frameSPtr_, aFrameSPtr, this->coordinatesBrokerSPtr_
+        );
+
+        inFrameCoordinates.segment(i, subsetInFrame.size()) = subsetInFrame;
+        i += subsetInFrame.size();
+    }
+
+    return {
+        this->instant_,
+        inFrameCoordinates,
+        aFrameSPtr,
+        this->coordinatesBrokerSPtr_,
+    };
+}
+
+void StateBuilder::print(std::ostream& anOutputStream, bool displayDecorator) const
+{
+    using ostk::core::types::String;
+
+    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Trajectory :: State") : void();
+
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Instant:" << (this->instant_.isDefined() ? this->instant_.toString() : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Frame:" << (this->frameSPtr_->isDefined() ? this->frameSPtr_->getName() : "Undefined");
+
+    if (!this->isDefined())
+    {
+        ostk::core::utils::Print::Line(anOutputStream) << "Coordinates: Undefined";
+    }
+    else
+    {
+        const Array<Shared<const CoordinatesSubset>> subsets = this->coordinatesBrokerSPtr_->getSubsets();
+
+        for (const auto& subset : subsets)
+        {
+            ostk::core::utils::Print::Line(anOutputStream)
+                << subset->getName() << this->extractCoordinates(subset).toString(4);
+        }
+    }
+    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+}
+
+State StateBuilder::Undefined()
+{
+    return {Instant::Undefined(), VectorXd(0), Frame::Undefined(), nullptr};
+}
+
+}  // namespace trajectory
+}  // namespace astro
+}  // namespace ostk

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -3,10 +3,10 @@
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utilities.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 namespace ostk
 {
@@ -20,28 +20,23 @@ using ostk::core::types::Index;
 using ostk::astro::trajectory::state::CoordinatesSubset;
 
 StateBuilder::StateBuilder(
-    const Shared<const Frame>& aFrameSPtr,
-    const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
+    const Shared<const Frame>& aFrameSPtr, const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
 )
-    : 
-      frameSPtr_(aFrameSPtr),
+    : frameSPtr_(aFrameSPtr),
       coordinatesBrokerSPtr_(std::make_shared<CoordinatesBroker>(CoordinatesBroker(aCoordinatesSubsetsArray)))
 {
 }
 
 StateBuilder::StateBuilder(
-    const Shared<const Frame>& aFrameSPtr,
-    const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr
+    const Shared<const Frame>& aFrameSPtr, const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr
 )
-    : 
-      frameSPtr_(aFrameSPtr),
+    : frameSPtr_(aFrameSPtr),
       coordinatesBrokerSPtr_(aCoordinatesBrokerSPtr)
 {
 }
 
 bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
 {
-
     if ((!this->isDefined()) || (!aStateBuilder.isDefined()))
     {
         return false;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -39,20 +39,9 @@ bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
         return false;
     }
 
-    for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
+    if ((*this->coordinatesBrokerSPtr_) != (*aStateBuilder.coordinatesBrokerSPtr_))
     {
-        if (!aStateBuilder.coordinatesBrokerSPtr_->hasSubset(subset))
-        {
-            return false;
-        }
-    }
-
-    for (const Shared<const CoordinatesSubset>& subset : aStateBuilder.coordinatesBrokerSPtr_->accessSubsets())
-    {
-        if (!this->coordinatesBrokerSPtr_->hasSubset(subset))
-        {
-            return false;
-        }
+        return false;
     }
 
     return true;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -31,226 +31,123 @@ StateBuilder::StateBuilder(
 {
 }
 
-bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
+StateBuilder::StateBuilder(
+    const Shared<const Frame>& aFrameSPtr,
+    const Shared<const CoordinatesBroker>>& aCoordinatesBrokerSPtr
+)
+    : 
+      frameSPtr_(aFrameSPtr),
+      coordinatesBrokerSPtr_(aCoordinatesBrokerSPtr)
 {
-    if ((!this->isDefined()) || (!aStateBuilder.isDefined()))
-    {
-        return false;
-    }
-
-    if (this->frameSPtr_ != aState.frameSPtr_)
-    {
-        return false;
-    }
-
-    for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
-    {
-        if (!aStateBuilder.coordinatesBrokerSPtr_->hasSubset(subset))
-        {
-            return false;
-        }
-
-        if (this->extractCoordinates(subset) != aStateBuilder.extractCoordinates(subset))
-        {
-            return false;
-        }
-    }
-
-    return true;
 }
 
-bool StateBuilder::operator!=(const StateBuilder& aStateBuilder) const
-{
-    return !((*this) == aStateBuilder);
-}
+// bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
+// {
+//     if (this->frameSPtr_ != aState.frameSPtr_)
+//     {
+//         return false;
+//     }
 
-std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aState)
-{
-    aState.print(anOutputStream);
+//     for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
+//     {
+//         if (!aStateBuilder.coordinatesBrokerSPtr_->hasSubset(subset))
+//         {
+//             return false;
+//         }
+//     }
 
-    return anOutputStream;
-}
+//     for (const Shared<const CoordinatesSubset>& subset : aStateBuilder.coordinatesBrokerSPtr_->accessSubsets())
+//     {
+//         if (!this->coordinatesBrokerSPtr_->hasSubset(subset))
+//         {
+//             return false;
+//         }
+//     }
 
-bool StateBuilder::isDefined() const
-{
-    return this->instant_.isDefined() && this->coordinates_.isDefined() && (this->frameSPtr_ != nullptr) &&
-           this->frameSPtr_->isDefined() && (this->coordinatesBrokerSPtr_ != nullptr);
-}
+//     return true;
+// }
 
-const Instant& StateBuilder::accessInstant() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
+// bool StateBuilder::operator!=(const StateBuilder& aStateBuilder) const
+// {
+//     return !((*this) == aStateBuilder);
+// }
 
-    return this->instant_;
-}
+// std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder)
+// {
+//     aStateBuilder.print(anOutputStream);
 
-const Shared<const Frame> StateBuilder::accessFrame() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
+//     return anOutputStream;
+// }
 
-    return this->frameSPtr_;
-}
+// bool StateBuilder::isDefined() const
+// {
+//     return (this->frameSPtr_ != nullptr) && this->frameSPtr_->isDefined() && (this->coordinatesBrokerSPtr_ != nullptr);
+// }
 
-const VectorXd& StateBuilder::accessCoordinates() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
+// const Shared<const Frame> StateBuilder::accessFrame() const
+// {
+//     if (!this->isDefined())
+//     {
+//         throw ostk::core::error::runtime::Undefined("StateBuilder");
+//     }
 
-    return this->coordinates_;
-}
+//     return this->frameSPtr_;
+// }
 
-const Shared<const CoordinatesBroker>& StateBuilder::accessCoordinatesBroker() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
+// const Shared<const CoordinatesBroker>& StateBuilder::accessCoordinatesBroker() const
+// {
+//     if (!this->isDefined())
+//     {
+//         throw ostk::core::error::runtime::Undefined("StateBuilder");
+//     }
 
-    return this->coordinatesBrokerSPtr_;
-}
+//     return this->coordinatesBrokerSPtr_;
+// }
 
-Size StateBuilder::getSize() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
+// Shared<const Frame> StateBuilder::getFrame() const
+// {
+//     return this->accessFrame();
+// }
 
-    return this->coordinates_.size();
-}
+// const Array<Shared<const CoordinatesSubset>> StateBuilder::getCoordinatesSubsets() const
+// {
+//     if (!this->isDefined())
+//     {
+//         throw ostk::core::error::runtime::Undefined("StateBuilder");
+//     }
 
-Instant StateBuilder::getInstant() const
-{
-    return this->accessInstant();
-}
+//     return this->coordinatesBrokerSPtr_->getSubsets();
+// }
 
-Shared<const Frame> StateBuilder::getFrame() const
-{
-    return this->accessFrame();
-}
+// void StateBuilder::print(std::ostream& anOutputStream, bool displayDecorator) const
+// {
+//     using ostk::core::types::String;
 
-Position StateBuilder::getPosition() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
+//     displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Trajectory :: State") : void();
 
-    return Position::Meters(this->extractCoordinates(CartesianPosition::Default()), this->frameSPtr_);
-}
+//     ostk::core::utils::Print::Line(anOutputStream)
+//         << "Frame:" << (this->frameSPtr_->isDefined() ? this->frameSPtr_->getName() : "Undefined");
 
-Velocity StateBuilder::getVelocity() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
+//     if (!this->isDefined())
+//     {
+//         ostk::core::utils::Print::Line(anOutputStream) << "Coordinates: Undefined";
+//     }
+//     else
+//     {
+//         const Array<Shared<const CoordinatesSubset>> subsets = this->coordinatesBrokerSPtr_->getSubsets();
 
-    return Velocity::MetersPerSecond(this->extractCoordinates(CartesianVelocity::Default()), this->frameSPtr_);
-}
+//         for (const auto& subset : subsets)
+//         {
+//             ostk::core::utils::Print::Line(anOutputStream) << subset->getName();
+//         }
+//     }
+//     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+// }
 
-VectorXd StateBuilder::getCoordinates() const
-{
-    return this->accessCoordinates();
-}
-
-const Array<Shared<const CoordinatesSubset>> StateBuilder::getCoordinatesSubsets() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
-
-    return this->coordinatesBrokerSPtr_->getSubsets();
-}
-
-VectorXd StateBuilder::extractCoordinates(const Shared<const CoordinatesSubset>& aSubsetSPtr) const
-{
-    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aSubsetSPtr);
-}
-
-VectorXd StateBuilder::extractCoordinates(const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray) const
-{
-    return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aCoordinatesSubsetsArray);
-}
-
-State StateBuilder::inFrame(const Shared<const Frame>& aFrameSPtr) const
-{
-    if ((aFrameSPtr == nullptr) || (!aFrameSPtr->isDefined()))
-    {
-        throw ostk::core::error::runtime::Undefined("Frame");
-    }
-
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("State");
-    }
-
-    if (aFrameSPtr == this->frameSPtr_)
-    {
-        return {this->instant_, this->coordinates_, this->frameSPtr_, this->coordinatesBrokerSPtr_};
-    }
-
-    VectorXd inFrameCoordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());
-    Index i = 0;
-    for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
-    {
-        const VectorXd subsetInFrame = subset->inFrame(
-            this->instant_, this->coordinates_, this->frameSPtr_, aFrameSPtr, this->coordinatesBrokerSPtr_
-        );
-
-        inFrameCoordinates.segment(i, subsetInFrame.size()) = subsetInFrame;
-        i += subsetInFrame.size();
-    }
-
-    return {
-        this->instant_,
-        inFrameCoordinates,
-        aFrameSPtr,
-        this->coordinatesBrokerSPtr_,
-    };
-}
-
-void StateBuilder::print(std::ostream& anOutputStream, bool displayDecorator) const
-{
-    using ostk::core::types::String;
-
-    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Trajectory :: State") : void();
-
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Instant:" << (this->instant_.isDefined() ? this->instant_.toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Frame:" << (this->frameSPtr_->isDefined() ? this->frameSPtr_->getName() : "Undefined");
-
-    if (!this->isDefined())
-    {
-        ostk::core::utils::Print::Line(anOutputStream) << "Coordinates: Undefined";
-    }
-    else
-    {
-        const Array<Shared<const CoordinatesSubset>> subsets = this->coordinatesBrokerSPtr_->getSubsets();
-
-        for (const auto& subset : subsets)
-        {
-            ostk::core::utils::Print::Line(anOutputStream)
-                << subset->getName() << this->extractCoordinates(subset).toString(4);
-        }
-    }
-    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
-}
-
-State StateBuilder::Undefined()
-{
-    return {Instant::Undefined(), VectorXd(0), Frame::Undefined(), nullptr};
-}
+// State StateBuilder::Undefined()
+// {
+//     return {Frame::Undefined(), nullptr};
+// }
 
 }  // namespace trajectory
 }  // namespace astro

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.test.cpp
@@ -13,6 +13,8 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 #include <Global.test.hpp>
 
@@ -30,6 +32,7 @@ using ostk::physics::units::Angle;
 
 using ostk::astro::eventcondition::AngularCondition;
 using ostk::astro::trajectory::State;
+using ostk::astro::trajectory::StateBuilder;
 using ostk::astro::trajectory::state::CoordinatesBroker;
 using ostk::astro::trajectory::state::CoordinatesSubset;
 
@@ -48,15 +51,17 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_AngularCondition : public ::
         defaultName_, defaultCriterion_, defaultEvaluator_, defaultTargetAngle_
     };
 
+    const Array<Shared<const CoordinatesSubset>> defaultSubsets_ = {
+        std::make_shared<CoordinatesSubset>(CoordinatesSubset("ANGLE", 1))
+    };
+    const StateBuilder defaultStateBuilder_ = StateBuilder(Frame::GCRF(), defaultSubsets_);
+
     const State generateState(const Real& coordinate)
     {
-        VectorXd coordinates;
-        coordinates.resize(1);
+        VectorXd coordinates(1);
         coordinates << coordinate;
-        const Shared<const CoordinatesBroker> defaultCoordinatesBroker =
-            std::make_shared<CoordinatesBroker>(CoordinatesBroker(Array<Shared<const CoordinatesSubset>>::Empty()));
 
-        return State(Instant::J2000(), coordinates, Frame::GCRF(), defaultCoordinatesBroker);
+        return defaultStateBuilder_.buildState(Instant::J2000(), coordinates);
     }
 };
 

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanCondition.test.cpp
@@ -13,6 +13,8 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 #include <Global.test.hpp>
 
@@ -28,6 +30,7 @@ using ostk::physics::coord::Frame;
 
 using ostk::astro::eventcondition::BooleanCondition;
 using ostk::astro::trajectory::State;
+using ostk::astro::trajectory::StateBuilder;
 using ostk::astro::trajectory::state::CoordinatesBroker;
 using ostk::astro::trajectory::state::CoordinatesSubset;
 
@@ -52,12 +55,17 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_BooleanCondition : public ::
     const Shared<const CoordinatesBroker> defaultCoordinatesBroker_ =
         std::make_shared<CoordinatesBroker>(CoordinatesBroker(Array<Shared<const CoordinatesSubset>>::Empty()));
 
+    const Array<Shared<const CoordinatesSubset>> defaultSubsets_ = {
+        std::make_shared<CoordinatesSubset>(CoordinatesSubset("ANGLE", 1))
+    };
+    const StateBuilder defaultStateBuilder_ = StateBuilder(defaultFrame_, defaultSubsets_);
+
     const State generateState(const Real& coordinate)
     {
-        VectorXd coordinates;
-        coordinates.resize(1);
+        VectorXd coordinates(1);
         coordinates << coordinate;
-        return State(defaultInstant_, coordinates, defaultFrame_, defaultCoordinatesBroker_);
+
+        return defaultStateBuilder_.buildState(defaultInstant_, coordinates);
     }
 };
 

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.test.cpp
@@ -13,6 +13,8 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesBroker.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 #include <Global.test.hpp>
 
@@ -28,6 +30,7 @@ using ostk::physics::coord::Frame;
 
 using ostk::astro::eventcondition::RealCondition;
 using ostk::astro::trajectory::State;
+using ostk::astro::trajectory::StateBuilder;
 using ostk::astro::trajectory::state::CoordinatesBroker;
 using ostk::astro::trajectory::state::CoordinatesSubset;
 
@@ -47,12 +50,17 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_RealCondition : public ::tes
     const Shared<const CoordinatesBroker> defaultCoordinatesBroker_ =
         std::make_shared<CoordinatesBroker>(CoordinatesBroker(Array<Shared<const CoordinatesSubset>>::Empty()));
 
+    const Array<Shared<const CoordinatesSubset>> defaultSubsets_ = {
+        std::make_shared<CoordinatesSubset>(CoordinatesSubset("REAL", 1))
+    };
+    const StateBuilder defaultStateBuilder_ = StateBuilder(defaultFrame_, defaultSubsets_);
+
     const State generateState(const Real& coordinate)
     {
-        VectorXd coordinates;
-        coordinates.resize(1);
+        VectorXd coordinates(1);
         coordinates << coordinate;
-        return State(defaultInstant_, coordinates, defaultFrame_, defaultCoordinatesBroker_);
+
+        return defaultStateBuilder_.buildState(defaultInstant_, coordinates);
     }
 };
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -56,6 +56,17 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Constructor)
 
     {
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(3);
+        coordinates << 1.0, 2.0, 3.0;
+        const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
+
+        EXPECT_THROW(State state(instant, coordinates, Frame::GCRF(), brokerSPtr), ostk::core::error::runtime::Wrong);
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -12,13 +12,11 @@ using ostk::core::ctnr::Array;
 using ostk::math::obj::VectorXd;
 
 using ostk::physics::coord::Frame;
-using ostk::physics::coord::Position;
-using ostk::physics::coord::Velocity;
 using ostk::physics::time::DateTime;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Scale;
-using ostk::physics::units::Length;
 
+using ostk::astro::trajectory::State;
 using ostk::astro::trajectory::StateBuilder;
 using ostk::astro::trajectory::state::CoordinatesBroker;
 using ostk::astro::trajectory::state::CoordinatesSubset;
@@ -228,6 +226,67 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, StreamOperator)
         EXPECT_NO_THROW(std::cout << StateBuilder::Undefined() << std::endl);
 
         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, BuildState)
+{
+    {
+        const StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+        const State state = stateBuilder.buildState(instant, coordinates);
+
+        EXPECT_EQ(instant, state.accessInstant());
+        EXPECT_EQ(coordinates, state.accessCoordinates());
+        EXPECT_EQ(Frame::GCRF(), state.accessFrame());
+        EXPECT_EQ(posVelBrokerSPtr, state.accessCoordinatesBroker());
+
+        EXPECT_EQ(stateBuilder.accessFrame(), state.accessFrame());
+        EXPECT_EQ(stateBuilder.accessCoordinatesBroker(), state.accessCoordinatesBroker());
+    }
+
+    {
+        const StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+
+        const Instant instant1 = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates1(6);
+        coordinates1 << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+        const State state1 = stateBuilder.buildState(instant1, coordinates1);
+
+        const Instant instant2 = Instant::DateTime(DateTime(2019, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates2(6);
+        coordinates2 << 2.0, 3.0, 4.0, 5.0, 6.0, 7.0;
+
+        const State state2 = stateBuilder.buildState(instant2, coordinates2);
+
+        EXPECT_NE(state1.accessInstant(), state2.accessInstant());
+        EXPECT_NE(state1.accessCoordinates(), state2.accessCoordinates());
+
+        EXPECT_EQ(state1.accessFrame(), state2.accessFrame());
+        EXPECT_EQ(state1.accessCoordinatesBroker(), state2.accessCoordinatesBroker());
+    }
+
+    {
+        const StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(3);
+        coordinates << 1.0, 2.0, 3.0;
+
+        EXPECT_ANY_THROW(stateBuilder.buildState(instant, coordinates));
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+        EXPECT_ANY_THROW(StateBuilder::Undefined().buildState(instant, coordinates));
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -82,6 +82,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, EqualToOperator)
         const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelMassBrokerSPtr};
 
         EXPECT_FALSE(aStateBuilder == anotherStateBuilder);
+        EXPECT_FALSE(anotherStateBuilder == aStateBuilder);
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -1,6 +1,8 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.hpp>
 
 #include <Global.test.hpp>
 
@@ -17,28 +19,40 @@ using ostk::physics::time::Instant;
 using ostk::physics::time::Scale;
 using ostk::physics::units::Length;
 
+using ostk::astro::trajectory::StateBuilder;
 using ostk::astro::trajectory::state::CoordinatesBroker;
 using ostk::astro::trajectory::state::CoordinatesSubset;
-using ostk::astro::trajectory::State;
-using ostk::astro::trajectory::StateBuilder;
+using ostk::astro::trajectory::state::coordinatessubsets::CartesianPosition;
+using ostk::astro::trajectory::state::coordinatessubsets::CartesianVelocity;
+
 
 class OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder : public ::testing::Test
 {
    protected:
-    const Array<Shared<CoordinatesSubset>> posVelSubsets = {
+    const Array<Shared<const CoordinatesSubset>> posVelSubsets = {
+        CartesianPosition::Default(),
+        CartesianVelocity::Default()
+    };
+
+    const Array<Shared<const CoordinatesSubset>> posVelMassSubsets = {
         CartesianPosition::Default(),
         CartesianVelocity::Default(),
-    }
+        CoordinatesSubset::Mass(),
+    };
 
-    const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+    const Shared<const CoordinatesBroker> posVelBrokerSPtr = std::make_shared<CoordinatesBroker>(
         CoordinatesBroker(posVelSubsets)
+    );
+
+    const Shared<const CoordinatesBroker> posVelMassBrokerSPtr = std::make_shared<CoordinatesBroker>(
+        CoordinatesBroker(posVelMassSubsets)
     );
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Constructor)
 {
     {
-        EXPECT_NO_THROW(StateBuilder builder(Frame::GCRF(), brokerSPtr));  
+        EXPECT_NO_THROW(StateBuilder builder(Frame::GCRF(), posVelBrokerSPtr));  
     }
 
     {
@@ -46,662 +60,253 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Constructor)
     }
 }
 
-// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, EqualToOperator)
-// {
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, EqualToOperator)
+{
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
-//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+        EXPECT_TRUE(aStateBuilder == anotherStateBuilder);
+    }
 
-//         EXPECT_TRUE(aState == anotherState);
-//     }
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelSubsets};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+        EXPECT_TRUE(aStateBuilder == anotherStateBuilder);
+    }
 
-//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+        const StateBuilder anotherStateBuilder = {Frame::ITRF(), posVelBrokerSPtr};
 
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+        EXPECT_FALSE(aStateBuilder == anotherStateBuilder);
+    }
 
-//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelMassBrokerSPtr};
 
-//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+        EXPECT_FALSE(aStateBuilder == anotherStateBuilder);
+    }
 
-//         EXPECT_TRUE(aState == anotherState);
-//     }
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//     {
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+        const Shared<const CoordinatesBroker> posVelBrokerSPtr2 = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
 
-//         const Instant anInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelBrokerSPtr2};
 
-//         const State aState = {anInstant, coordinates, Frame::GCRF(), brokerSPtr};
+        EXPECT_TRUE(aStateBuilder == anotherStateBuilder);
+    }
 
-//         const Instant anotherInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC);
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const State anotherState = {anotherInstant, coordinates, Frame::GCRF(), brokerSPtr};
+        const Shared<const CoordinatesBroker> velPosBrokerSPtr = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianVelocity::Default(), CartesianPosition::Default()})
+        );
 
-//         EXPECT_FALSE(aState == anotherState);
-//     }
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), velPosBrokerSPtr};
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+        EXPECT_TRUE(aStateBuilder == anotherStateBuilder);
+    }
 
-//         VectorXd aCoordinates(6);
-//         aCoordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+    {
+        const StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const State aState = {instant, aCoordinates, Frame::GCRF(), brokerSPtr};
+        EXPECT_TRUE(stateBuilder == stateBuilder);
+    }
 
-//         VectorXd anotherCoordinates(6);
-//         anotherCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const State anotherState = {instant, anotherCoordinates, Frame::GCRF(), brokerSPtr};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         EXPECT_FALSE(aState == anotherState);
-//     }
+        EXPECT_TRUE(aStateBuilder == anotherStateBuilder);
+    }
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+        EXPECT_FALSE(StateBuilder::Undefined() == aStateBuilder);
+        EXPECT_FALSE(aStateBuilder == StateBuilder::Undefined());
+        EXPECT_FALSE(StateBuilder::Undefined() == StateBuilder::Undefined());
+    }
+}
 
-//         const State anotherState = {instant, coordinates, Frame::ITRF(), brokerSPtr};
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, NotEqualToOperator)
+{
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         EXPECT_FALSE(aState == anotherState);
-//     }
+        EXPECT_FALSE(aStateBuilder != anotherStateBuilder);
+    }
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelSubsets};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+        EXPECT_FALSE(aStateBuilder != anotherStateBuilder);
+    }
 
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+        const StateBuilder anotherStateBuilder = {Frame::ITRF(), posVelBrokerSPtr};
 
-//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+        EXPECT_TRUE(aStateBuilder != anotherStateBuilder);
+    }
 
-//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelMassBrokerSPtr};
 
-//         EXPECT_TRUE(aState == anotherState);
-//     }
+        EXPECT_TRUE(aStateBuilder != anotherStateBuilder);
+    }
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
+        const Shared<const CoordinatesBroker> posVelBrokerSPtr2 = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
 
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelBrokerSPtr2};
 
-//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianVelocity::Default(), CartesianPosition::Default()})
-//         );
+        EXPECT_FALSE(aStateBuilder != anotherStateBuilder);
+    }
 
-//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         EXPECT_FALSE(aState == anotherState);
-//     }
+        const Shared<const CoordinatesBroker> velPosBrokerSPtr = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianVelocity::Default(), CartesianPosition::Default()})
+        );
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), velPosBrokerSPtr};
 
-//         const State state = {instant, position, velocity};
+        EXPECT_FALSE(aStateBuilder != anotherStateBuilder);
+    }
 
-//         EXPECT_TRUE(state == state);
-//     }
+    {
+        const StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//     {
-//         const Position position = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        EXPECT_FALSE(stateBuilder != stateBuilder);
+    }
 
-//         const State aState = {instant, position, velocity};
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const State anotherState = {instant, position, velocity};
+        const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         EXPECT_TRUE(aState == anotherState);
-//     }
+        EXPECT_FALSE(aStateBuilder != anotherStateBuilder);
+    }
 
-//     {
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const Instant anInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        EXPECT_TRUE(StateBuilder::Undefined() != aStateBuilder);
+        EXPECT_TRUE(aStateBuilder != StateBuilder::Undefined());
+        EXPECT_TRUE(StateBuilder::Undefined() != StateBuilder::Undefined());
+    }
+}
 
-//         const State aState = {anInstant, position, velocity};
 
-//         const Instant anotherInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC);
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, StreamOperator)
+{
+    {
+        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         const State anotherState = {anotherInstant, position, velocity};
+        testing::internal::CaptureStdout();
 
-//         EXPECT_FALSE(aState == anotherState);
-//     }
+        EXPECT_NO_THROW(std::cout << aStateBuilder << std::endl);
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
 
-//         const Position aPosition = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+    {
+        testing::internal::CaptureStdout();
 
-//         const State aState = {instant, aPosition, velocity};
+        EXPECT_NO_THROW(std::cout << StateBuilder::Undefined() << std::endl);
 
-//         const Position anotherPosition = Position::Meters({1001.0, 2001.0, 3001.0}, Frame::GCRF());
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
 
-//         const State anotherState = {instant, anotherPosition, velocity};
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Accessors)
+{
+    {
+        const  StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
-//         EXPECT_FALSE(aState == anotherState);
-//     }
+        EXPECT_EQ(Frame::GCRF(), stateBuilder.accessFrame());
+        EXPECT_EQ(posVelBrokerSPtr, stateBuilder.accessCoordinatesBroker());
+    }
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+    {
+        const  StateBuilder stateBuilder = {Frame::GCRF(), posVelSubsets};
 
-//         const Position aPosition = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+        EXPECT_EQ(Frame::GCRF(), stateBuilder.accessFrame());
+        EXPECT_EQ(posVelSubsets, stateBuilder.accessCoordinatesBroker()->getSubsets());
+    }
 
-//         const State aState = {instant, aPosition, velocity};
+    {
+        EXPECT_ANY_THROW(StateBuilder::Undefined().accessFrame());
+        EXPECT_ANY_THROW(StateBuilder::Undefined().accessCoordinatesBroker());
+    }
+}
 
-//         const Position anotherPosition = aPosition.inUnit(Length::Unit::Foot);
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Getters)
+{
+    {
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
 
-//         const State anotherState = {instant, anotherPosition, velocity};
+        EXPECT_EQ(stateBuilder.getCoordinatesSubsets(), posVelBrokerSPtr->getSubsets());
+        EXPECT_EQ(Frame::GCRF(), stateBuilder.getFrame());
+    }
 
-//         EXPECT_TRUE(aState == anotherState);
-//     }
+    {
+        EXPECT_ANY_THROW(StateBuilder::Undefined().getCoordinatesSubsets());
+        EXPECT_ANY_THROW(StateBuilder::Undefined().getFrame());
+    }
+}
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, IsDefined)
+{
+    {
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
 
-//         const Velocity aVelocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+        EXPECT_TRUE(stateBuilder.isDefined());
+    }
 
-//         const State aState = {instant, position, aVelocity};
+    {
+        const StateBuilder stateBuilder = StateBuilder(nullptr, posVelBrokerSPtr);
 
-//         const Velocity anotherVelocity = Velocity::MetersPerSecond({11, 21, 31}, Frame::GCRF());
+        EXPECT_FALSE(stateBuilder.isDefined());
+    }
 
-//         const State anotherState = {instant, position, anotherVelocity};
+    {
+        const StateBuilder stateBuilder = StateBuilder(Frame::Undefined(), posVelBrokerSPtr);
 
-//         EXPECT_FALSE(aState == anotherState);
-//     }
+        EXPECT_FALSE(stateBuilder.isDefined());
+    }
 
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+    {
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), nullptr);
 
-//         const State state = {instant, position, velocity};
+        EXPECT_FALSE(stateBuilder.isDefined());
+    }
 
-//         EXPECT_FALSE(StateBuilder::Undefined() == state);
-//         EXPECT_FALSE(state == StateBuilder::Undefined());
-//         EXPECT_FALSE(StateBuilder::Undefined() == StateBuilder::Undefined());
-//     }
-// }
+    {
+        EXPECT_FALSE(StateBuilder::Undefined().isDefined());
+    }
+}
 
-// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, NotEqualToOperator)
-// {
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
-
-//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
-
-//         EXPECT_FALSE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-
-//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
-
-//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
-
-//         EXPECT_FALSE(aState != anotherState);
-//     }
-
-//     {
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         CoordinatesBroker broker = CoordinatesBroker();
-//         broker.addSubset(CartesianPosition::Default());
-//         broker.addSubset(CartesianVelocity::Default());
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<const CoordinatesBroker>(broker);
-
-//         const Instant anInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-
-//         const State aState = {anInstant, coordinates, Frame::GCRF(), brokerSPtr};
-
-//         const Instant anotherInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC);
-
-//         const State anotherState = {anotherInstant, coordinates, Frame::GCRF(), brokerSPtr};
-
-//         EXPECT_TRUE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         CoordinatesBroker broker = CoordinatesBroker();
-//         broker.addSubset(CartesianPosition::Default());
-//         broker.addSubset(CartesianVelocity::Default());
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<const CoordinatesBroker>(broker);
-
-//         VectorXd aCoordinates(6);
-//         aCoordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-
-//         const State aState = {instant, aCoordinates, Frame::GCRF(), brokerSPtr};
-
-//         VectorXd anotherCoordinates(6);
-//         anotherCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
-
-//         const State anotherState = {instant, anotherCoordinates, Frame::GCRF(), brokerSPtr};
-
-//         EXPECT_TRUE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
-
-//         const State anotherState = {instant, coordinates, Frame::ITRF(), brokerSPtr};
-
-//         EXPECT_TRUE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-
-//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
-
-//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
-
-//         EXPECT_FALSE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-
-//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
-
-//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianVelocity::Default(), CartesianPosition::Default()})
-//         );
-
-//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
-
-//         EXPECT_TRUE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
-
-//         const State state = {instant, position, velocity};
-
-//         EXPECT_FALSE(state != state);
-//     }
-
-//     {
-//         const Position position = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-
-//         const State aState = {instant, position, velocity};
-
-//         const State anotherState = {instant, position, velocity};
-
-//         EXPECT_FALSE(aState != anotherState);
-//     }
-
-//     {
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
-
-//         const Instant anInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-
-//         const State aState = {anInstant, position, velocity};
-
-//         const Instant anotherInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC);
-
-//         const State anotherState = {anotherInstant, position, velocity};
-
-//         EXPECT_TRUE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
-
-//         const Position aPosition = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
-
-//         const State aState = {instant, aPosition, velocity};
-
-//         const Position anotherPosition = Position::Meters({1001.0, 2001.0, 3001.0}, Frame::GCRF());
-
-//         const State anotherState = {instant, anotherPosition, velocity};
-
-//         EXPECT_TRUE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
-
-//         const Position aPosition = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
-
-//         const State aState = {instant, aPosition, velocity};
-
-//         const Position anotherPosition = aPosition.inUnit(Length::Unit::Foot);
-
-//         const State anotherState = {instant, anotherPosition, velocity};
-
-//         EXPECT_FALSE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
-
-//         const Velocity aVelocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
-
-//         const State aState = {instant, position, aVelocity};
-
-//         const Velocity anotherVelocity = Velocity::MetersPerSecond({11, 21, 31}, Frame::GCRF());
-
-//         const State anotherState = {instant, position, anotherVelocity};
-
-//         EXPECT_TRUE(aState != anotherState);
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
-
-//         const State state = {instant, position, velocity};
-
-//         EXPECT_TRUE(StateBuilder::Undefined() != state);
-//         EXPECT_TRUE(state != StateBuilder::Undefined());
-//         EXPECT_TRUE(StateBuilder::Undefined() != StateBuilder::Undefined());
-//     }
-// }
-
-// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, StreamOperator)
-// {
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
-
-//         const State state = {instant, position, velocity};
-
-//         testing::internal::CaptureStdout();
-
-//         EXPECT_NO_THROW(std::cout << state << std::endl);
-
-//         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
-//     }
-
-//     {
-//         testing::internal::CaptureStdout();
-
-//         EXPECT_NO_THROW(std::cout << StateBuilder::Undefined() << std::endl);
-
-//         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
-//     }
-// }
-
-// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Accessors)
-// {
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State state = {instant, coordinates, Frame::GCRF(), brokerSPtr};
-
-//         EXPECT_EQ(instant, state.accessInstant());
-//         EXPECT_EQ(coordinates, state.accessCoordinates());
-//         EXPECT_EQ(Frame::GCRF(), state.accessFrame());
-//         EXPECT_EQ(brokerSPtr, state.accessCoordinatesBroker());
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
-
-//         const State state = {instant, position.inUnit(Length::Unit::Foot), velocity};
-
-//         EXPECT_TRUE(position.accessCoordinates().isApprox(state.getPosition().accessCoordinates(), 1e-16));
-//     }
-
-//     {
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().accessInstant());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().accessCoordinates());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().accessFrame());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().accessCoordinatesBroker());
-//     }
-// }
-
-// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Getters)
-// {
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.0, 2.0, 3.0}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({4.0, 5.0, 6.0}, Frame::GCRF());
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State state = State(instant, coordinates, Frame::GCRF(), brokerSPtr);
-
-//         EXPECT_EQ(6, state.getSize());
-//         EXPECT_EQ(instant, state.getInstant());
-//         EXPECT_EQ(position, state.getPosition());
-//         EXPECT_EQ(velocity, state.getVelocity());
-//         EXPECT_EQ(coordinates, state.getCoordinates());
-//         EXPECT_EQ(state.getCoordinatesSubsets(), brokerSPtr->getSubsets());
-//         EXPECT_EQ(Frame::GCRF(), state.getFrame());
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.0, 2.0, 3.0}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({4.0, 5.0, 6.0}, Frame::GCRF());
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-
-//         const State state = {instant, position, velocity};
-
-//         EXPECT_EQ(6, state.getSize());
-//         EXPECT_EQ(instant, state.getInstant());
-//         EXPECT_EQ(position, state.getPosition());
-//         EXPECT_EQ(velocity, state.getVelocity());
-//         EXPECT_EQ(coordinates, state.getCoordinates());
-//         EXPECT_EQ(Frame::GCRF(), state.getFrame());
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.0, 2.0, 3.0}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({4.0, 5.0, 6.0}, Frame::GCRF());
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-
-//         const State state = {instant, position.inUnit(Length::Unit::Foot), velocity};
-
-//         EXPECT_EQ(6, state.getSize());
-//         EXPECT_EQ(instant, state.getInstant());
-//         EXPECT_TRUE(position.getCoordinates().isApprox(state.getPosition().getCoordinates(), 1e-12));
-//         EXPECT_EQ(velocity, state.getVelocity());
-//         EXPECT_TRUE(coordinates.isApprox(state.getCoordinates(), 1e-12));
-//         EXPECT_EQ(Frame::GCRF(), state.getFrame());
-//     }
-
-//     {
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().getSize());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().getInstant());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().getPosition());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().getVelocity());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().getCoordinates());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().getCoordinatesSubsets());
-//         EXPECT_ANY_THROW(StateBuilder::Undefined().getFrame());
-//     }
-// }
-
-// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, IsDefined)
-// {
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State state = State(instant, coordinates, Frame::GCRF(), brokerSPtr);
-
-//         EXPECT_TRUE(state.isDefined());
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State state = State(instant, coordinates, nullptr, brokerSPtr);
-
-//         EXPECT_FALSE(state.isDefined());
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
-//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
-//         );
-
-//         const State state = State(instant, coordinates, Frame::Undefined(), brokerSPtr);
-
-//         EXPECT_FALSE(state.isDefined());
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         VectorXd coordinates(6);
-//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-
-//         const State state = State(instant, coordinates, Frame::GCRF(), nullptr);
-
-//         EXPECT_FALSE(state.isDefined());
-//     }
-
-//     {
-//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
-
-//         const State state = {instant, position, velocity};
-
-//         EXPECT_TRUE(state.isDefined());
-//     }
-
-//     {
-//         const Instant instant = Instant::Undefined();
-//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
-//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
-
-//         const State state = {instant, position, velocity};
-
-//         EXPECT_FALSE(state.isDefined());
-//     }
-
-//     {
-//         EXPECT_FALSE(StateBuilder::Undefined().isDefined());
-//     }
-// }
-
-// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Undefined)
-// {
-//     {
-//         EXPECT_NO_THROW(StateBuilder::Undefined());
-//     }
-// }
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Undefined)
+{
+    {
+        EXPECT_NO_THROW(StateBuilder::Undefined());
+    }
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -1,0 +1,707 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::types::Shared;
+using ostk::core::ctnr::Array;
+
+using ostk::math::obj::VectorXd;
+
+using ostk::physics::coord::Frame;
+using ostk::physics::coord::Position;
+using ostk::physics::coord::Velocity;
+using ostk::physics::time::DateTime;
+using ostk::physics::time::Instant;
+using ostk::physics::time::Scale;
+using ostk::physics::units::Length;
+
+using ostk::astro::trajectory::state::CoordinatesBroker;
+using ostk::astro::trajectory::state::CoordinatesSubset;
+using ostk::astro::trajectory::State;
+using ostk::astro::trajectory::StateBuilder;
+
+class OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder : public ::testing::Test
+{
+   protected:
+    const Array<Shared<CoordinatesSubset>> posVelSubsets = {
+        CartesianPosition::Default(),
+        CartesianVelocity::Default(),
+    }
+
+    const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+        CoordinatesBroker(posVelSubsets)
+    );
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Constructor)
+{
+    {
+        EXPECT_NO_THROW(StateBuilder builder(Frame::GCRF(), brokerSPtr));  
+    }
+
+    {
+        EXPECT_NO_THROW(StateBuilder builder(Frame::GCRF(), posVelSubsets););
+    }
+}
+
+// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, EqualToOperator)
+// {
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         EXPECT_TRUE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+
+//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+
+//         EXPECT_TRUE(aState == anotherState);
+//     }
+
+//     {
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const Instant anInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+//         const State aState = {anInstant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         const Instant anotherInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC);
+
+//         const State anotherState = {anotherInstant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         EXPECT_FALSE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         VectorXd aCoordinates(6);
+//         aCoordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const State aState = {instant, aCoordinates, Frame::GCRF(), brokerSPtr};
+
+//         VectorXd anotherCoordinates(6);
+//         anotherCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+
+//         const State anotherState = {instant, anotherCoordinates, Frame::GCRF(), brokerSPtr};
+
+//         EXPECT_FALSE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         const State anotherState = {instant, coordinates, Frame::ITRF(), brokerSPtr};
+
+//         EXPECT_FALSE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+
+//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+
+//         EXPECT_TRUE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+
+//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianVelocity::Default(), CartesianPosition::Default()})
+//         );
+
+//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+
+//         EXPECT_FALSE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const State state = {instant, position, velocity};
+
+//         EXPECT_TRUE(state == state);
+//     }
+
+//     {
+//         const Position position = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+//         const State aState = {instant, position, velocity};
+
+//         const State anotherState = {instant, position, velocity};
+
+//         EXPECT_TRUE(aState == anotherState);
+//     }
+
+//     {
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const Instant anInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+//         const State aState = {anInstant, position, velocity};
+
+//         const Instant anotherInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC);
+
+//         const State anotherState = {anotherInstant, position, velocity};
+
+//         EXPECT_FALSE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+
+//         const Position aPosition = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+
+//         const State aState = {instant, aPosition, velocity};
+
+//         const Position anotherPosition = Position::Meters({1001.0, 2001.0, 3001.0}, Frame::GCRF());
+
+//         const State anotherState = {instant, anotherPosition, velocity};
+
+//         EXPECT_FALSE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+
+//         const Position aPosition = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+
+//         const State aState = {instant, aPosition, velocity};
+
+//         const Position anotherPosition = aPosition.inUnit(Length::Unit::Foot);
+
+//         const State anotherState = {instant, anotherPosition, velocity};
+
+//         EXPECT_TRUE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+
+//         const Velocity aVelocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+
+//         const State aState = {instant, position, aVelocity};
+
+//         const Velocity anotherVelocity = Velocity::MetersPerSecond({11, 21, 31}, Frame::GCRF());
+
+//         const State anotherState = {instant, position, anotherVelocity};
+
+//         EXPECT_FALSE(aState == anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const State state = {instant, position, velocity};
+
+//         EXPECT_FALSE(StateBuilder::Undefined() == state);
+//         EXPECT_FALSE(state == StateBuilder::Undefined());
+//         EXPECT_FALSE(StateBuilder::Undefined() == StateBuilder::Undefined());
+//     }
+// }
+
+// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, NotEqualToOperator)
+// {
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         EXPECT_FALSE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+
+//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+
+//         EXPECT_FALSE(aState != anotherState);
+//     }
+
+//     {
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         CoordinatesBroker broker = CoordinatesBroker();
+//         broker.addSubset(CartesianPosition::Default());
+//         broker.addSubset(CartesianVelocity::Default());
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<const CoordinatesBroker>(broker);
+
+//         const Instant anInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+//         const State aState = {anInstant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         const Instant anotherInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC);
+
+//         const State anotherState = {anotherInstant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         EXPECT_TRUE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         CoordinatesBroker broker = CoordinatesBroker();
+//         broker.addSubset(CartesianPosition::Default());
+//         broker.addSubset(CartesianVelocity::Default());
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<const CoordinatesBroker>(broker);
+
+//         VectorXd aCoordinates(6);
+//         aCoordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const State aState = {instant, aCoordinates, Frame::GCRF(), brokerSPtr};
+
+//         VectorXd anotherCoordinates(6);
+//         anotherCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+
+//         const State anotherState = {instant, anotherCoordinates, Frame::GCRF(), brokerSPtr};
+
+//         EXPECT_TRUE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         const State anotherState = {instant, coordinates, Frame::ITRF(), brokerSPtr};
+
+//         EXPECT_TRUE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+
+//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+
+//         EXPECT_FALSE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+
+//         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianVelocity::Default(), CartesianPosition::Default()})
+//         );
+
+//         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr2};
+
+//         EXPECT_TRUE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const State state = {instant, position, velocity};
+
+//         EXPECT_FALSE(state != state);
+//     }
+
+//     {
+//         const Position position = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+//         const State aState = {instant, position, velocity};
+
+//         const State anotherState = {instant, position, velocity};
+
+//         EXPECT_FALSE(aState != anotherState);
+//     }
+
+//     {
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const Instant anInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+//         const State aState = {anInstant, position, velocity};
+
+//         const Instant anotherInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC);
+
+//         const State anotherState = {anotherInstant, position, velocity};
+
+//         EXPECT_TRUE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+
+//         const Position aPosition = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+
+//         const State aState = {instant, aPosition, velocity};
+
+//         const Position anotherPosition = Position::Meters({1001.0, 2001.0, 3001.0}, Frame::GCRF());
+
+//         const State anotherState = {instant, anotherPosition, velocity};
+
+//         EXPECT_TRUE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Velocity velocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+
+//         const Position aPosition = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+
+//         const State aState = {instant, aPosition, velocity};
+
+//         const Position anotherPosition = aPosition.inUnit(Length::Unit::Foot);
+
+//         const State anotherState = {instant, anotherPosition, velocity};
+
+//         EXPECT_FALSE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1000.0, 2000.0, 3000.0}, Frame::GCRF());
+
+//         const Velocity aVelocity = Velocity::MetersPerSecond({10, 20, 30}, Frame::GCRF());
+
+//         const State aState = {instant, position, aVelocity};
+
+//         const Velocity anotherVelocity = Velocity::MetersPerSecond({11, 21, 31}, Frame::GCRF());
+
+//         const State anotherState = {instant, position, anotherVelocity};
+
+//         EXPECT_TRUE(aState != anotherState);
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const State state = {instant, position, velocity};
+
+//         EXPECT_TRUE(StateBuilder::Undefined() != state);
+//         EXPECT_TRUE(state != StateBuilder::Undefined());
+//         EXPECT_TRUE(StateBuilder::Undefined() != StateBuilder::Undefined());
+//     }
+// }
+
+// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, StreamOperator)
+// {
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const State state = {instant, position, velocity};
+
+//         testing::internal::CaptureStdout();
+
+//         EXPECT_NO_THROW(std::cout << state << std::endl);
+
+//         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+//     }
+
+//     {
+//         testing::internal::CaptureStdout();
+
+//         EXPECT_NO_THROW(std::cout << StateBuilder::Undefined() << std::endl);
+
+//         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+//     }
+// }
+
+// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Accessors)
+// {
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State state = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+
+//         EXPECT_EQ(instant, state.accessInstant());
+//         EXPECT_EQ(coordinates, state.accessCoordinates());
+//         EXPECT_EQ(Frame::GCRF(), state.accessFrame());
+//         EXPECT_EQ(brokerSPtr, state.accessCoordinatesBroker());
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const State state = {instant, position.inUnit(Length::Unit::Foot), velocity};
+
+//         EXPECT_TRUE(position.accessCoordinates().isApprox(state.getPosition().accessCoordinates(), 1e-16));
+//     }
+
+//     {
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().accessInstant());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().accessCoordinates());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().accessFrame());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().accessCoordinatesBroker());
+//     }
+// }
+
+// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Getters)
+// {
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.0, 2.0, 3.0}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({4.0, 5.0, 6.0}, Frame::GCRF());
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State state = State(instant, coordinates, Frame::GCRF(), brokerSPtr);
+
+//         EXPECT_EQ(6, state.getSize());
+//         EXPECT_EQ(instant, state.getInstant());
+//         EXPECT_EQ(position, state.getPosition());
+//         EXPECT_EQ(velocity, state.getVelocity());
+//         EXPECT_EQ(coordinates, state.getCoordinates());
+//         EXPECT_EQ(state.getCoordinatesSubsets(), brokerSPtr->getSubsets());
+//         EXPECT_EQ(Frame::GCRF(), state.getFrame());
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.0, 2.0, 3.0}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({4.0, 5.0, 6.0}, Frame::GCRF());
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const State state = {instant, position, velocity};
+
+//         EXPECT_EQ(6, state.getSize());
+//         EXPECT_EQ(instant, state.getInstant());
+//         EXPECT_EQ(position, state.getPosition());
+//         EXPECT_EQ(velocity, state.getVelocity());
+//         EXPECT_EQ(coordinates, state.getCoordinates());
+//         EXPECT_EQ(Frame::GCRF(), state.getFrame());
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.0, 2.0, 3.0}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({4.0, 5.0, 6.0}, Frame::GCRF());
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const State state = {instant, position.inUnit(Length::Unit::Foot), velocity};
+
+//         EXPECT_EQ(6, state.getSize());
+//         EXPECT_EQ(instant, state.getInstant());
+//         EXPECT_TRUE(position.getCoordinates().isApprox(state.getPosition().getCoordinates(), 1e-12));
+//         EXPECT_EQ(velocity, state.getVelocity());
+//         EXPECT_TRUE(coordinates.isApprox(state.getCoordinates(), 1e-12));
+//         EXPECT_EQ(Frame::GCRF(), state.getFrame());
+//     }
+
+//     {
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().getSize());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().getInstant());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().getPosition());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().getVelocity());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().getCoordinates());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().getCoordinatesSubsets());
+//         EXPECT_ANY_THROW(StateBuilder::Undefined().getFrame());
+//     }
+// }
+
+// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, IsDefined)
+// {
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State state = State(instant, coordinates, Frame::GCRF(), brokerSPtr);
+
+//         EXPECT_TRUE(state.isDefined());
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State state = State(instant, coordinates, nullptr, brokerSPtr);
+
+//         EXPECT_FALSE(state.isDefined());
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+//         const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+//             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+//         );
+
+//         const State state = State(instant, coordinates, Frame::Undefined(), brokerSPtr);
+
+//         EXPECT_FALSE(state.isDefined());
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         VectorXd coordinates(6);
+//         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+//         const State state = State(instant, coordinates, Frame::GCRF(), nullptr);
+
+//         EXPECT_FALSE(state.isDefined());
+//     }
+
+//     {
+//         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const State state = {instant, position, velocity};
+
+//         EXPECT_TRUE(state.isDefined());
+//     }
+
+//     {
+//         const Instant instant = Instant::Undefined();
+//         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
+//         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
+
+//         const State state = {instant, position, velocity};
+
+//         EXPECT_FALSE(state.isDefined());
+//     }
+
+//     {
+//         EXPECT_FALSE(StateBuilder::Undefined().isDefined());
+//     }
+// }
+
+// TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Undefined)
+// {
+//     {
+//         EXPECT_NO_THROW(StateBuilder::Undefined());
+//     }
+// }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -1,8 +1,8 @@
 /// Apache License 2.0
 
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 #include <Global.test.hpp>
 
@@ -25,13 +25,11 @@ using ostk::astro::trajectory::state::CoordinatesSubset;
 using ostk::astro::trajectory::state::coordinatessubsets::CartesianPosition;
 using ostk::astro::trajectory::state::coordinatessubsets::CartesianVelocity;
 
-
 class OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder : public ::testing::Test
 {
    protected:
     const Array<Shared<const CoordinatesSubset>> posVelSubsets = {
-        CartesianPosition::Default(),
-        CartesianVelocity::Default()
+        CartesianPosition::Default(), CartesianVelocity::Default()
     };
 
     const Array<Shared<const CoordinatesSubset>> posVelMassSubsets = {
@@ -40,19 +38,17 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder : public ::testing:
         CoordinatesSubset::Mass(),
     };
 
-    const Shared<const CoordinatesBroker> posVelBrokerSPtr = std::make_shared<CoordinatesBroker>(
-        CoordinatesBroker(posVelSubsets)
-    );
+    const Shared<const CoordinatesBroker> posVelBrokerSPtr =
+        std::make_shared<CoordinatesBroker>(CoordinatesBroker(posVelSubsets));
 
-    const Shared<const CoordinatesBroker> posVelMassBrokerSPtr = std::make_shared<CoordinatesBroker>(
-        CoordinatesBroker(posVelMassSubsets)
-    );
+    const Shared<const CoordinatesBroker> posVelMassBrokerSPtr =
+        std::make_shared<CoordinatesBroker>(CoordinatesBroker(posVelMassSubsets));
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Constructor)
 {
     {
-        EXPECT_NO_THROW(StateBuilder builder(Frame::GCRF(), posVelBrokerSPtr));  
+        EXPECT_NO_THROW(StateBuilder builder(Frame::GCRF(), posVelBrokerSPtr));
     }
 
     {
@@ -214,7 +210,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, NotEqualToOperato
     }
 }
 
-
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, StreamOperator)
 {
     {
@@ -239,14 +234,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, StreamOperator)
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Accessors)
 {
     {
-        const  StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+        const StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
 
         EXPECT_EQ(Frame::GCRF(), stateBuilder.accessFrame());
         EXPECT_EQ(posVelBrokerSPtr, stateBuilder.accessCoordinatesBroker());
     }
 
     {
-        const  StateBuilder stateBuilder = {Frame::GCRF(), posVelSubsets};
+        const StateBuilder stateBuilder = {Frame::GCRF(), posVelSubsets};
 
         EXPECT_EQ(Frame::GCRF(), stateBuilder.accessFrame());
         EXPECT_EQ(posVelSubsets, stateBuilder.accessCoordinatesBroker()->getSubsets());

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -82,7 +82,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, EqualToOperator)
         const StateBuilder anotherStateBuilder = {Frame::GCRF(), posVelMassBrokerSPtr};
 
         EXPECT_FALSE(aStateBuilder == anotherStateBuilder);
-        EXPECT_FALSE(anotherStateBuilder == aStateBuilder);
     }
 
     {
@@ -106,7 +105,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, EqualToOperator)
 
         const StateBuilder anotherStateBuilder = {Frame::GCRF(), velPosBrokerSPtr};
 
-        EXPECT_TRUE(aStateBuilder == anotherStateBuilder);
+        EXPECT_FALSE(aStateBuilder == anotherStateBuilder);
     }
 
     {
@@ -183,7 +182,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, NotEqualToOperato
 
         const StateBuilder anotherStateBuilder = {Frame::GCRF(), velPosBrokerSPtr};
 
-        EXPECT_FALSE(aStateBuilder != anotherStateBuilder);
+        EXPECT_TRUE(aStateBuilder != anotherStateBuilder);
     }
 
     {


### PR DESCRIPTION
Adds a StateBuilder class to enable creating batches of States that share the same `Coordinates Broker`, without a user needing to interact with the `CoordinateBroker` concept at all.

The main function is 
- `StateBuilder::buildState(Instant, VectorXd)` [Cpp]
- `StateBuilder.state(Instant, np.ndarray)` [Python]

and the flow in Python looks like:

```python
builder: StateBuilder = StateBuilder(
   Frame.gcrf(),
   [CartesianPosition.default(), CartesianVelocity.default()]
)

start_instant = Instant.date_time(datetime(2022, 1, 1))
start_coords = np.array([1,2,3,4,5,6])

states = []
for i in range(100):
    states.append(builder.state(
        start_instant+Duration.seconds(i),
        start_coords*i,
    ))
```

The MR is largely boilerplate copied from the `State` class. New functionality is mostly in the `buildState` method.