### PR TITLE
feat: add State constructor with Array of Subsets

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -30,6 +30,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
             arg("frame"),
             arg("coordinates_broker")
         )
+        .def(
+            init<
+                const Instant&,
+                const VectorXd&,
+                const Shared<const Frame>&,
+                const Array<Shared<const CoordinatesSubset>>&>(),
+            arg("instant"),
+            arg("coordinates"),
+            arg("frame"),
+            arg("coordinates_subsets")
+        )
 
         .def(self == self)
         .def(self != self)

--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -87,6 +87,24 @@ class TestState:
         assert isinstance(state, State)
         assert state.is_defined()
 
+    def test_subsets_constructor(
+        self,
+        instant: Instant,
+        position: Position,
+        velocity: Velocity,
+        frame: Frame,
+    ):
+        state = State(
+            instant,
+            np.append(position.get_coordinates(), velocity.get_coordinates()),
+            frame,
+            [CartesianPosition.default(), CartesianVelocity.default()],
+        )
+
+        assert state is not None
+        assert isinstance(state, State)
+        assert state.is_defined()
+
     def test_comparators(self, state: State):
         assert (state == state) is True
         assert (state != state) is False

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -59,7 +59,8 @@ class State
     );
 
     /// @brief                  Constructor. This constructor makes a new Coordinates Broker under the hood for every
-    /// State.
+    /// State. When possible, users should prefer passing in an existing Coordinates Broker or using a StateBuilder to
+    /// reduce memory footprint when constructing many states.
     ///
     /// @param                  [in] anInstant An instant
     /// @param                  [in] aCoordinates The coordinates at the instant in International System of Units

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -43,11 +43,10 @@ using ostk::astro::trajectory::state::CoordinatesSubset;
 class State
 {
    public:
-    /// @brief                  Constructor.
+    /// @brief                  Constructor with a pre-defined Coordinates Broker.
     ///
     /// @param                  [in] anInstant An instant
-    /// @param                  [in] aCoordinates The {cartesian-position, cartesian-velocity} coordinates at the
-    /// instant in International System of Units
+    /// @param                  [in] aCoordinates The coordinates at the instant in International System of Units
     /// @param                  [in] aFrameSPtr The reference frame in which the coordinates are referenced to and
     /// resolved in
     /// @param                  [in] aCoordinatesBrokerSPtr The coordinates broker associated to the coordinates
@@ -59,7 +58,23 @@ class State
         const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr
     );
 
-    /// @brief                  Constructor.
+    /// @brief                  Constructor. This constructor makes a new Coordinates Broker under the hood for every
+    /// State.
+    ///
+    /// @param                  [in] anInstant An instant
+    /// @param                  [in] aCoordinates The coordinates at the instant in International System of Units
+    /// @param                  [in] aFrameSPtr The reference frame in which the coordinates are referenced to and
+    /// resolved in
+    /// @param                  [in] aCoordinatesSubsetsArray The coordinates subsets associated to the coordinates
+
+    State(
+        const Instant& anInstant,
+        const VectorXd& aCoordinates,
+        const Shared<const Frame>& aFrameSPtr,
+        const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
+    );
+
+    /// @brief                  Utility constructor for Position/Velocity only.
     ///
     /// @param                  [in] anInstant An instant
     /// @param                  [in] aPosition The cartesian position at the instant in International System of Units

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -36,6 +36,19 @@ State::State(
 {
 }
 
+State::State(
+    const Instant& anInstant,
+    const VectorXd& aCoordinates,
+    const Shared<const Frame>& aFrameSPtr,
+    const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetsArray
+)
+    : instant_(anInstant),
+      coordinates_(aCoordinates),
+      frameSPtr_(aFrameSPtr),
+      coordinatesBrokerSPtr_(std::make_shared<CoordinatesBroker>(CoordinatesBroker(aCoordinatesSubsetsArray)))
+{
+}
+
 State::State(const Instant& anInstant, const Position& aPosition, const Velocity& aVelocity)
     : instant_(anInstant)
 {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -47,6 +47,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Constructor)
             CartesianPosition::Default(), CartesianVelocity::Default()
         };
         EXPECT_NO_THROW(State state(instant, coordinates, Frame::GCRF(), subsets));
+
+        const State state(instant, coordinates, Frame::GCRF(), subsets);
+
+        EXPECT_EQ(state.extractCoordinates(CartesianPosition::Default()), coordinates.segment(0, 3));
+        EXPECT_EQ(state.extractCoordinates(CartesianVelocity::Default()), coordinates.segment(3, 3));
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -40,6 +40,17 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Constructor)
 
     {
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+        const Array<Shared<const CoordinatesSubset>> subsets = {
+            CartesianPosition::Default(), CartesianVelocity::Default()
+        };
+        EXPECT_NO_THROW(State state(instant, coordinates, Frame::GCRF(), subsets));
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
         const Position position = Position::Meters({1.2, 3.4, 5.6}, Frame::GCRF());
         const Velocity velocity = Velocity::MetersPerSecond({7.8, 9.0, 1.2}, Frame::GCRF());
 


### PR DESCRIPTION
Adds a constructor to the State class to directly build a custom State from an Array of Subsets.

This constructor will presumably cause a larger memory footprint, but is more straightforward to use than the Broker constructor.

This downfall should be mitigated in Python with the introduction of the CustomState meta-class stuff. 