### PR TITLE
feat: enrich StateBuilder capabilities

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -41,6 +41,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
         .def("get_coordinates_subsets", &StateBuilder::getCoordinatesSubsets)
         .def("get_frame", &StateBuilder::getFrame)
 
+        .def("expand", &StateBuilder::expand)
+        .def("contract", &StateBuilder::contract)
+
         .def_static("undefined", &StateBuilder::Undefined)
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -14,6 +14,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
     using ostk::astro::trajectory::State;
     using ostk::astro::trajectory::StateBuilder;
     using ostk::astro::trajectory::state::CoordinatesBroker;
+    using ostk::astro::trajectory::state::CoordinatesSubset;
 
     class_<StateBuilder>(aModule, "StateBuilder")
 
@@ -27,22 +28,38 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             arg("frame"),
             arg("coordinates_broker")
         )
+        .def(init<const State&>(), arg("state"))
 
         .def(self == self)
         .def(self != self)
+        .def(
+            "__add__",
+            [](const StateBuilder& aStateBuilder, const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr)
+            {
+                return aStateBuilder + aCoordinatesSubsetSPtr;
+            },
+            is_operator()
+        )
+        .def(
+            "__sub__",
+            [](const StateBuilder& aStateBuilder, const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr)
+            {
+                return aStateBuilder - aCoordinatesSubsetSPtr;
+            },
+            is_operator()
+        )
 
         .def("__str__", &(shiftToString<StateBuilder>))
         .def("__repr__", &(shiftToString<StateBuilder>))
 
         .def("is_defined", &StateBuilder::isDefined)
 
-        .def("build_state", &StateBuilder::buildState)
+        .def("build", &StateBuilder::build)
+        .def("reduce", &StateBuilder::reduce)
+        .def("expand", &StateBuilder::expand)
 
         .def("get_coordinates_subsets", &StateBuilder::getCoordinatesSubsets)
         .def("get_frame", &StateBuilder::getFrame)
-
-        .def("expand", &StateBuilder::expand)
-        .def("contract", &StateBuilder::contract)
 
         .def_static("undefined", &StateBuilder::Undefined)
 

--- a/bindings/python/test/trajectory/test_state_builder.py
+++ b/bindings/python/test/trajectory/test_state_builder.py
@@ -39,29 +39,28 @@ def coordinates_subsets() -> list[CoordinatesSubset]:
 
 
 @pytest.fixture
+def coordinates() -> list[float]:
+    return [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+@pytest.fixture
 def coordinates_broker(coordinates_subsets: list[CoordinatesSubset]) -> CoordinatesBroker:
     return CoordinatesBroker(coordinates_subsets)
 
 
 @pytest.fixture
+def state(
+    instant: Instant,
+    coordinates: list[float],
+    frame: Frame,
+    coordinates_broker: CoordinatesBroker,
+) -> State:
+    return State(instant, coordinates, frame, coordinates_broker)
+
+
+@pytest.fixture
 def state_builder(frame: Frame, coordinates_broker: CoordinatesBroker) -> State:
     return StateBuilder(frame, coordinates_broker)
-
-
-@pytest.fixture
-def coordinates_subsets_with_mass() -> list[CoordinatesSubset]:
-    return [
-        CartesianPosition.default(),
-        CartesianVelocity.default(),
-        CoordinatesSubset.mass(),
-    ]
-
-
-@pytest.fixture
-def state_builder_with_mass(
-    frame: Frame, coordinates_subsets_with_mass: list[CoordinatesSubset]
-) -> State:
-    return StateBuilder(frame, CoordinatesBroker(coordinates_subsets_with_mass))
 
 
 class TestStateBuilder:
@@ -85,17 +84,38 @@ class TestStateBuilder:
         assert isinstance(builder, StateBuilder)
         assert builder.is_defined()
 
+    def test_state_constructor(
+        self,
+        state: State,
+    ):
+        builder = StateBuilder(state)
+        assert builder is not None
+        assert isinstance(builder, StateBuilder)
+        assert builder.is_defined()
+
     def test_comparators(self, state_builder: StateBuilder):
         assert (state_builder == state_builder) is True
         assert (state_builder != state_builder) is False
 
-    def test_build_state(
+    def test_operators(
+        self,
+        state_builder: StateBuilder,
+    ):
+        added_builder: StateBuilder = state_builder + CoordinatesSubset.mass()
+        assert isinstance(added_builder, StateBuilder)
+        assert state_builder != added_builder
+
+        subtracted_builder: StateBuilder = state_builder - CartesianPosition.default()
+        assert isinstance(subtracted_builder, StateBuilder)
+        assert state_builder != subtracted_builder
+
+    def test_build(
         self,
         instant: Instant,
         state_builder: StateBuilder,
     ):
         coordinates = [1, 2, 3, 1, 2, 3]
-        state: State = state_builder.build_state(instant, coordinates)
+        state: State = state_builder.build(instant, coordinates)
 
         assert state is not None
         assert isinstance(state, State)
@@ -105,6 +125,40 @@ class TestStateBuilder:
         assert state.get_frame() == state_builder.get_frame()
         assert state.get_coordinates_subsets() == state_builder.get_coordinates_subsets()
 
+    def test_reduce(
+        self,
+        state: State,
+    ):
+        builder = StateBuilder(state.get_frame(), [CartesianPosition.default()])
+        reduced_state: State = builder.reduce(state)
+
+        assert isinstance(reduced_state, State)
+        assert state != reduced_state
+
+    def test_expand(
+        self,
+        state: State,
+    ):
+        builder = StateBuilder(
+            state.get_frame(),
+            [
+                CartesianPosition.default(),
+                CartesianVelocity.default(),
+                CoordinatesSubset.mass(),
+            ],
+        )
+        default_state: State = State(
+            state.get_instant(),
+            [100],
+            state.get_frame(),
+            CoordinatesBroker([CoordinatesSubset.mass()]),
+        )
+        expanded_state: State = builder.expand(state, default_state)
+
+        assert isinstance(expanded_state, State)
+        assert state != expanded_state
+        assert default_state != expanded_state
+
     def test_getters(
         self,
         state_builder: StateBuilder,
@@ -113,66 +167,3 @@ class TestStateBuilder:
     ):
         assert state_builder.get_frame() == frame
         assert state_builder.get_coordinates_subsets() == coordinates_broker.get_subsets()
-
-    def test_expand(
-        self,
-        state_builder: StateBuilder,
-    ):
-        expaned_state_builder: StateBuilder = state_builder.expand(
-            CoordinatesSubset.mass()
-        )
-
-        assert (state_builder == expaned_state_builder) is False
-        assert (state_builder != expaned_state_builder) is True
-
-        assert 2 == len(state_builder.get_coordinates_subsets())
-        assert CartesianPosition.default() == state_builder.get_coordinates_subsets()[0]
-        assert CartesianVelocity.default() == state_builder.get_coordinates_subsets()[1]
-
-        assert 3 == len(expaned_state_builder.get_coordinates_subsets())
-        assert (
-            CartesianPosition.default()
-            == expaned_state_builder.get_coordinates_subsets()[0]
-        )
-        assert (
-            CartesianVelocity.default()
-            == expaned_state_builder.get_coordinates_subsets()[1]
-        )
-        assert (
-            CoordinatesSubset.mass() == expaned_state_builder.get_coordinates_subsets()[2]
-        )
-
-    def test_contract(
-        self,
-        state_builder_with_mass: StateBuilder,
-    ):
-        contracted_state_builder: StateBuilder = state_builder_with_mass.contract(
-            CartesianVelocity.default()
-        )
-
-        assert (state_builder_with_mass == contracted_state_builder) is False
-        assert (state_builder_with_mass != contracted_state_builder) is True
-
-        assert 3 == len(state_builder_with_mass.get_coordinates_subsets())
-        assert (
-            CartesianPosition.default()
-            == state_builder_with_mass.get_coordinates_subsets()[0]
-        )
-        assert (
-            CartesianVelocity.default()
-            == state_builder_with_mass.get_coordinates_subsets()[1]
-        )
-        assert (
-            CoordinatesSubset.mass()
-            == state_builder_with_mass.get_coordinates_subsets()[2]
-        )
-
-        assert 2 == len(contracted_state_builder.get_coordinates_subsets())
-        assert (
-            CartesianPosition.default()
-            == contracted_state_builder.get_coordinates_subsets()[0]
-        )
-        assert (
-            CoordinatesSubset.mass()
-            == contracted_state_builder.get_coordinates_subsets()[1]
-        )

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp
@@ -41,7 +41,7 @@ class CoordinatesSubset
     /// @brief              Constructor
     ///
     ///                     The default CoordinatesSubset instance is frame-invariant and implements element-wise
-    ///                     addition/substraction.
+    ///                     addition/subtraction.
     /// @code
     ///                     CoordinateSubset coordinateSubset = {aName, aSize};
     /// @endcode

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
@@ -4,7 +4,10 @@
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder__
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
+#include <OpenSpaceToolkit/Core/Containers/Map.hpp>
+#include <OpenSpaceToolkit/Core/Types/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
+#include <OpenSpaceToolkit/Core/Types/Size.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
 
@@ -22,8 +25,11 @@ namespace astro
 namespace trajectory
 {
 
+using ostk::core::types::Integer;
 using ostk::core::types::Shared;
+using ostk::core::types::Size;
 using ostk::core::ctnr::Array;
+using ostk::core::ctnr::Map;
 
 using ostk::math::obj::VectorXd;
 
@@ -64,6 +70,13 @@ class StateBuilder
     /// @param                  [in] aStateBuilder The StateBuilder to compare to
     /// @return                 True if the  StateBuilders are equal, false otherwise
 
+    StateBuilder(const Shared<const Frame>& aFrameSPtr, const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr);
+
+    /// @brief                  Inequality operator.
+    ///
+    /// @param                  [in] aStateBuilder The StateBuilder to compare to
+    /// @return                 True if the  StateBuilders are not equal, false otherwise
+
     bool operator==(const StateBuilder& aStateBuilder) const;
 
     /// @brief                  Inequality operator.
@@ -73,19 +86,11 @@ class StateBuilder
 
     bool operator!=(const StateBuilder& aStateBuilder) const;
 
-    /// @brief                  Stream insertion operator.
-    ///
-    /// @param                  [in] anOutputStream The output stream to insert into
-    /// @param                  [in] aStateBuilder The StateBuilder to insert
-    /// @return                 The output stream with the StateBuilder inserted
-
-    friend std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder);
-
     /// @brief                  Check if the StateBuilder is defined.
     ///
     /// @return                 True if the StateBuilder is defined, false otherwise
 
-    bool isDefined() const;
+    // const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
 
     /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
     ///
@@ -93,21 +98,38 @@ class StateBuilder
 
     const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
 
+    /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
+    ///
+    /// @return                 A State linked to the Frame and Coordinates Broker of the StateBuilder
+
+    const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
+
+    const State build(
+        const State& aState,
+        const Map<const Shared<const CoordinatesSubset>, const VectorXd>& anAdditionalCoordinatesMap
+    ) const;
+
     /// @brief                  Accessor for the reference frame.
     ///
     /// @return                 The reference frame
 
-    const Shared<const Frame> accessFrame() const;
+    // bool isDefined() const;
 
     /// @brief                  Access the coordinates broker associated with the  StateBuilder.
     ///
     /// @return                 The coordinates broker associated to the State
 
-    const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
+    // const Shared<const Frame> accessFrame() const;
 
     /// @brief                  Get the reference frame associated with the  StateBuilder.
     ///
     /// @return                 The reference frame
+
+    const Shared<const Frame> accessFrame() const;
+
+    /// @brief                  Get the coordinates subsets of the  StateBuilder.
+    ///
+    /// @return                 The coordinates subsets
 
     Shared<const Frame> getFrame() const;
 
@@ -117,16 +139,32 @@ class StateBuilder
 
     const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
-    /// @brief Print the StateBuilder to an output stream.
+    /// @brief                  Print the StateBuilder to an output stream.
     ///
-    /// @param [in] anOutputStream The output stream to print to
-    /// @param [in] displayDecorator Whether or not to display the decorator
+    /// @param                  [in] anOutputStream The output stream to print to
+    /// @param                  [in] displayDecorator Whether or not to display the decorator
 
     void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
-    /// @brief Get an undefined StateBuilder.
+    /// @brief                  Return a new StateBuilder with the additional CoordinatesSubset.
     ///
-    /// @return An undefined StateBuilder
+    /// @param                  [in] aCoordinatesSubsetSPtr The CoordinatesSubset to append
+    ///
+    /// @return                 A new StateBuilder
+
+    const StateBuilder expand(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const;
+
+    /// @brief                   Return a new StateBuilder without the given CoordinatesSubset.
+    ///
+    /// @param                  [in] aCoordinatesSubsetSPtr The CoordinatesSubset to remove
+    ///
+    /// @return                 A new StateBuilder
+
+    const StateBuilder contract(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const;
+
+    /// @brief                  Get an undefined StateBuilder.
+    ///
+    /// @return                 An undefined StateBuilder
 
     static StateBuilder Undefined();
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
@@ -4,7 +4,6 @@
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder__
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
-#include <OpenSpaceToolkit/Core/Containers/Map.hpp>
 #include <OpenSpaceToolkit/Core/Types/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Types/Size.hpp>
@@ -29,7 +28,6 @@ using ostk::core::types::Integer;
 using ostk::core::types::Shared;
 using ostk::core::types::Size;
 using ostk::core::ctnr::Array;
-using ostk::core::ctnr::Map;
 
 using ostk::math::obj::VectorXd;
 
@@ -65,17 +63,16 @@ class StateBuilder
 
     StateBuilder(const Shared<const Frame>& aFrameSPtr, const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr);
 
+    /// @brief                  Constructor.
+    ///
+    /// @param                  [in] aState The state to be used as a template
+
+    StateBuilder(const State& aState);
+
     /// @brief                  Equality operator.
     ///
     /// @param                  [in] aStateBuilder The StateBuilder to compare to
     /// @return                 True if the  StateBuilders are equal, false otherwise
-
-    StateBuilder(const Shared<const Frame>& aFrameSPtr, const Shared<const CoordinatesBroker>& aCoordinatesBrokerSPtr);
-
-    /// @brief                  Inequality operator.
-    ///
-    /// @param                  [in] aStateBuilder The StateBuilder to compare to
-    /// @return                 True if the  StateBuilders are not equal, false otherwise
 
     bool operator==(const StateBuilder& aStateBuilder) const;
 
@@ -86,50 +83,72 @@ class StateBuilder
 
     bool operator!=(const StateBuilder& aStateBuilder) const;
 
+    /// @brief                  Return a new StateBuilder with the additional CoordinatesSubset.
+    ///
+    /// @param                  [in] aCoordinatesSubsetSPtr The CoordinatesSubset to append
+    ///
+    /// @return                 A new StateBuilder
+
+    const StateBuilder operator+(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const;
+
+    /// @brief                  Return a new StateBuilder without the given CoordinatesSubset.
+    ///
+    /// @param                  [in] aCoordinatesSubsetSPtr The CoordinatesSubset to remove
+    ///
+    /// @return                 A new StateBuilder
+
+    const StateBuilder operator-(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const;
+
+    /// @brief                  Stream insertion operator.
+    ///
+    /// @param                  [in] anOutputStream The output stream to insert into
+    /// @param                  [in] aStateBuilder The StateBuilder to insert
+    /// @return                 The output stream with the StateBuilder inserted
+
+    friend std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder);
+
     /// @brief                  Check if the StateBuilder is defined.
     ///
     /// @return                 True if the StateBuilder is defined, false otherwise
 
-    // const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
+    bool isDefined() const;
 
     /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
     ///
     /// @return                 A State linked to the Frame and Coordinates Broker of the StateBuilder
 
-    const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
+    const State build(const Instant& anInstant, const VectorXd& aCoordinates) const;
 
-    /// @brief                  Produce a State linked to the Frame and Coordinates Broker of the StateBuilder.
+    /// @brief                  Produce a State with the CoordinatesSubsets specified by the StateBuilder.
     ///
-    /// @return                 A State linked to the Frame and Coordinates Broker of the StateBuilder
+    /// @param                  [in] aState the state from which the coordinates will be taken.
+    /// @return                 A State with the CoordinatesSubsets of the StateBuilder.
 
-    const State buildState(const Instant& anInstant, const VectorXd& aCoordinates) const;
+    const State reduce(const State& aState) const;
 
-    const State build(
-        const State& aState,
-        const Map<const Shared<const CoordinatesSubset>, const VectorXd>& anAdditionalCoordinatesMap
-    ) const;
+    /// @brief                  Produce a State with the CoordinatesSubsets specified by the StateBuilder.
+    ///
+    /// @param                  [in] aState the state from which the coordinates will be taken.
+    /// @param                  [in] defaultState the state from which missing coordinates will be taken.
+    /// @return                 A State with the CoordinatesSubsets of the StateBuilder.
+
+    const State expand(const State& aState, const State& defaultState) const;
 
     /// @brief                  Accessor for the reference frame.
     ///
     /// @return                 The reference frame
 
-    // bool isDefined() const;
+    const Shared<const Frame> accessFrame() const;
 
     /// @brief                  Access the coordinates broker associated with the  StateBuilder.
     ///
     /// @return                 The coordinates broker associated to the State
 
-    // const Shared<const Frame> accessFrame() const;
+    const Shared<const CoordinatesBroker>& accessCoordinatesBroker() const;
 
     /// @brief                  Get the reference frame associated with the  StateBuilder.
     ///
     /// @return                 The reference frame
-
-    const Shared<const Frame> accessFrame() const;
-
-    /// @brief                  Get the coordinates subsets of the  StateBuilder.
-    ///
-    /// @return                 The coordinates subsets
 
     Shared<const Frame> getFrame() const;
 
@@ -139,32 +158,16 @@ class StateBuilder
 
     const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
-    /// @brief                  Print the StateBuilder to an output stream.
+    /// @brief Print the StateBuilder to an output stream.
     ///
-    /// @param                  [in] anOutputStream The output stream to print to
-    /// @param                  [in] displayDecorator Whether or not to display the decorator
+    /// @param [in] anOutputStream The output stream to print to
+    /// @param [in] displayDecorator Whether or not to display the decorator
 
     void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
-    /// @brief                  Return a new StateBuilder with the additional CoordinatesSubset.
+    /// @brief Get an undefined StateBuilder.
     ///
-    /// @param                  [in] aCoordinatesSubsetSPtr The CoordinatesSubset to append
-    ///
-    /// @return                 A new StateBuilder
-
-    const StateBuilder expand(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const;
-
-    /// @brief                   Return a new StateBuilder without the given CoordinatesSubset.
-    ///
-    /// @param                  [in] aCoordinatesSubsetSPtr The CoordinatesSubset to remove
-    ///
-    /// @return                 A new StateBuilder
-
-    const StateBuilder contract(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const;
-
-    /// @brief                  Get an undefined StateBuilder.
-    ///
-    /// @return                 An undefined StateBuilder
+    /// @return An undefined StateBuilder
 
     static StateBuilder Undefined();
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -101,6 +101,11 @@ bool State::operator==(const State& aState) const
         return false;
     }
 
+    if (this->getSize() != aState.getSize())
+    {
+        return false;
+    }
+
     for (const Shared<const CoordinatesSubset>& subset : this->coordinatesBrokerSPtr_->accessSubsets())
     {
         if (!aState.coordinatesBrokerSPtr_->hasSubset(subset))

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -27,6 +27,12 @@ StateBuilder::StateBuilder(
 {
 }
 
+StateBuilder::StateBuilder(const State& aState)
+    : frameSPtr_(aState.accessFrame()),
+      coordinatesBrokerSPtr_(aState.accessCoordinatesBroker())
+{
+}
+
 bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
 {
     if ((!this->isDefined()) || (!aStateBuilder.isDefined()))
@@ -52,6 +58,48 @@ bool StateBuilder::operator!=(const StateBuilder& aStateBuilder) const
     return !((*this) == aStateBuilder);
 }
 
+const StateBuilder StateBuilder::operator+(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
+
+    if (this->coordinatesBrokerSPtr_->hasSubset(aCoordinatesSubsetSPtr))
+    {
+        throw ostk::core::error::RuntimeError("Duplicate CoordinatesSubset: [{}]", aCoordinatesSubsetSPtr->getName());
+    }
+
+    Array<Shared<const CoordinatesSubset>> expandedSubsets = coordinatesBrokerSPtr_->getSubsets();
+    expandedSubsets.add(aCoordinatesSubsetSPtr);
+
+    return StateBuilder(this->frameSPtr_, expandedSubsets);
+}
+
+const StateBuilder StateBuilder::operator-(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
+
+    if (!this->coordinatesBrokerSPtr_->hasSubset(aCoordinatesSubsetSPtr))
+    {
+        throw ostk::core::error::RuntimeError("Missing CoordinatesSubset: [{}]", aCoordinatesSubsetSPtr->getName());
+    }
+
+    Array<Shared<const CoordinatesSubset>> contractedSubsets = Array<Shared<const CoordinatesSubset>>::Empty();
+    for (const auto& subset : this->coordinatesBrokerSPtr_->getSubsets())
+    {
+        if (subset != aCoordinatesSubsetSPtr)
+        {
+            contractedSubsets.add(subset);
+        }
+    }
+
+    return StateBuilder(this->frameSPtr_, contractedSubsets);
+}
+
 std::ostream& operator<<(std::ostream& anOutputStream, const StateBuilder& aStateBuilder)
 {
     aStateBuilder.print(anOutputStream);
@@ -64,7 +112,7 @@ bool StateBuilder::isDefined() const
     return (this->frameSPtr_ != nullptr) && this->frameSPtr_->isDefined() && (this->coordinatesBrokerSPtr_ != nullptr);
 }
 
-const State StateBuilder::buildState(const Instant& anInstant, const VectorXd& aCoordinates) const
+const State StateBuilder::build(const Instant& anInstant, const VectorXd& aCoordinates) const
 {
     if (!this->isDefined())
     {
@@ -74,9 +122,7 @@ const State StateBuilder::buildState(const Instant& anInstant, const VectorXd& a
     return {anInstant, aCoordinates, this->frameSPtr_, this->coordinatesBrokerSPtr_};
 }
 
-const State StateBuilder::build(
-    const State& aState, const Map<const Shared<const CoordinatesSubset>, const VectorXd>& anAdditionalCoordinatesMap
-) const
+const State StateBuilder::reduce(const State& aState) const
 {
     if (!this->isDefined())
     {
@@ -90,7 +136,7 @@ const State StateBuilder::build(
 
     if (aState.accessFrame() != this->frameSPtr_)
     {
-        throw ostk::core::error::runtime::Wrong("Frame");
+        throw ostk::core::error::runtime::Wrong("State Frame");
     }
 
     VectorXd coordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());
@@ -98,42 +144,83 @@ const State StateBuilder::build(
 
     for (const auto& subset : this->coordinatesBrokerSPtr_->getSubsets())
     {
-        Integer subsetDetections = 0;
-        VectorXd subsetCoordinates;
-
-        if (aState.accessCoordinatesBroker()->hasSubset(subset))
-        {
-            subsetDetections++;
-            subsetCoordinates = aState.extractCoordinates(subset);
-        }
-
-        const auto coordinatesMapIterator = anAdditionalCoordinatesMap.find(subset);
-        if (coordinatesMapIterator != anAdditionalCoordinatesMap.end())
-        {
-            subsetDetections++;
-            subsetCoordinates = coordinatesMapIterator->second;
-        }
-
-        if (subsetDetections == 0)
+        if (!aState.accessCoordinatesBroker()->hasSubset(subset))
         {
             throw ostk::core::error::RuntimeError("Missing CoordinatesSubset: [{}]", subset->getName());
         }
 
-        if (subsetDetections > 1)
+        const VectorXd subsetCoordinates = aState.extractCoordinates(subset);
+        coordinates.segment(nextIndex, subsetCoordinates.size()) = subsetCoordinates;
+        nextIndex += subsetCoordinates.size();
+    }
+
+    return this->build(aState.accessInstant(), coordinates);
+}
+
+const State StateBuilder::expand(const State& aState, const State& defaultState) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
+
+    if (!aState.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    if (aState.accessFrame() != this->frameSPtr_)
+    {
+        throw ostk::core::error::runtime::Wrong("State Frame");
+    }
+
+    if (!defaultState.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Default State");
+    }
+
+    if (defaultState.accessFrame() != this->frameSPtr_)
+    {
+        throw ostk::core::error::runtime::Wrong("Default State Frame");
+    }
+
+    VectorXd coordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());
+    Integer nextIndex = 0;
+    Integer nonDefaultSubsetDetections = 0;
+
+    for (const auto& subset : this->coordinatesBrokerSPtr_->getSubsets())
+    {
+        bool subsetDetected = false;
+        VectorXd subsetCoordinates;
+
+        if (aState.accessCoordinatesBroker()->hasSubset(subset))
         {
-            throw ostk::core::error::RuntimeError("Duplicate CoordinatesSubset: [{}]", subset->getName());
+            subsetDetected = true;
+            nonDefaultSubsetDetections++;
+            subsetCoordinates = aState.extractCoordinates(subset);
         }
 
-        if (Size(subsetCoordinates.size()) != subset->getSize())
+        if (!subsetDetected && defaultState.accessCoordinatesBroker()->hasSubset(subset))
         {
-            throw ostk::core::error::runtime::Wrong("CoordinatesSubset coordinates size");
+            subsetDetected = true;
+            subsetCoordinates = defaultState.extractCoordinates(subset);
+        }
+
+        if (!subsetDetected)
+        {
+            throw ostk::core::error::RuntimeError("Missing CoordinatesSubset: [{}]", subset->getName());
         }
 
         coordinates.segment(nextIndex, subsetCoordinates.size()) = subsetCoordinates;
         nextIndex += subsetCoordinates.size();
     }
 
-    return this->buildState(aState.accessInstant(), coordinates);
+    if (Size(nonDefaultSubsetDetections) != aState.accessCoordinatesBroker()->getNumberOfSubsets())
+    {
+        throw ostk::core::error::RuntimeError("The operation is not an expansion");
+    }
+
+    return this->build(aState.accessInstant(), coordinates);
 }
 
 const Shared<const Frame> StateBuilder::accessFrame() const
@@ -194,48 +281,6 @@ void StateBuilder::print(std::ostream& anOutputStream, bool displayDecorator) co
         }
     }
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
-}
-
-const StateBuilder StateBuilder::expand(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("StateBuilder");
-    }
-
-    if (this->coordinatesBrokerSPtr_->hasSubset(aCoordinatesSubsetSPtr))
-    {
-        throw ostk::core::error::RuntimeError("Duplicate CoordinatesSubset: [{}]", aCoordinatesSubsetSPtr->getName());
-    }
-
-    Array<Shared<const CoordinatesSubset>> expandedSubsets = coordinatesBrokerSPtr_->getSubsets();
-    expandedSubsets.add(aCoordinatesSubsetSPtr);
-
-    return StateBuilder(this->frameSPtr_, expandedSubsets);
-}
-
-const StateBuilder StateBuilder::contract(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("StateBuilder");
-    }
-
-    if (!this->coordinatesBrokerSPtr_->hasSubset(aCoordinatesSubsetSPtr))
-    {
-        throw ostk::core::error::RuntimeError("Missing CoordinatesSubset: [{}]", aCoordinatesSubsetSPtr->getName());
-    }
-
-    Array<Shared<const CoordinatesSubset>> contractedSubsets = Array<Shared<const CoordinatesSubset>>::Empty();
-    for (const auto& subset : this->coordinatesBrokerSPtr_->getSubsets())
-    {
-        if (subset != aCoordinatesSubsetSPtr)
-        {
-            contractedSubsets.add(subset);
-        }
-    }
-
-    return StateBuilder(this->frameSPtr_, contractedSubsets);
 }
 
 StateBuilder StateBuilder::Undefined()

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -74,6 +74,68 @@ const State StateBuilder::buildState(const Instant& anInstant, const VectorXd& a
     return {anInstant, aCoordinates, this->frameSPtr_, this->coordinatesBrokerSPtr_};
 }
 
+const State StateBuilder::build(
+    const State& aState, const Map<const Shared<const CoordinatesSubset>, const VectorXd>& anAdditionalCoordinatesMap
+) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
+
+    if (!aState.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    if (aState.accessFrame() != this->frameSPtr_)
+    {
+        throw ostk::core::error::runtime::Wrong("Frame");
+    }
+
+    VectorXd coordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());
+    Integer nextIndex = 0;
+
+    for (const auto& subset : this->coordinatesBrokerSPtr_->getSubsets())
+    {
+        Integer subsetDetections = 0;
+        VectorXd subsetCoordinates;
+
+        if (aState.accessCoordinatesBroker()->hasSubset(subset))
+        {
+            subsetDetections++;
+            subsetCoordinates = aState.extractCoordinates(subset);
+        }
+
+        const auto coordinatesMapIterator = anAdditionalCoordinatesMap.find(subset);
+        if (coordinatesMapIterator != anAdditionalCoordinatesMap.end())
+        {
+            subsetDetections++;
+            subsetCoordinates = coordinatesMapIterator->second;
+        }
+
+        if (subsetDetections == 0)
+        {
+            throw ostk::core::error::RuntimeError("Missing CoordinatesSubset: [{}]", subset->getName());
+        }
+
+        if (subsetDetections > 1)
+        {
+            throw ostk::core::error::RuntimeError("Duplicate CoordinatesSubset: [{}]", subset->getName());
+        }
+
+        if (Size(subsetCoordinates.size()) != subset->getSize())
+        {
+            throw ostk::core::error::runtime::Wrong("CoordinatesSubset coordinates size");
+        }
+
+        coordinates.segment(nextIndex, subsetCoordinates.size()) = subsetCoordinates;
+        nextIndex += subsetCoordinates.size();
+    }
+
+    return this->buildState(aState.accessInstant(), coordinates);
+}
+
 const Shared<const Frame> StateBuilder::accessFrame() const
 {
     if (!this->isDefined())
@@ -132,6 +194,48 @@ void StateBuilder::print(std::ostream& anOutputStream, bool displayDecorator) co
         }
     }
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+}
+
+const StateBuilder StateBuilder::expand(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
+
+    if (this->coordinatesBrokerSPtr_->hasSubset(aCoordinatesSubsetSPtr))
+    {
+        throw ostk::core::error::RuntimeError("Duplicate CoordinatesSubset: [{}]", aCoordinatesSubsetSPtr->getName());
+    }
+
+    Array<Shared<const CoordinatesSubset>> expandedSubsets = coordinatesBrokerSPtr_->getSubsets();
+    expandedSubsets.add(aCoordinatesSubsetSPtr);
+
+    return StateBuilder(this->frameSPtr_, expandedSubsets);
+}
+
+const StateBuilder StateBuilder::contract(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
+
+    if (!this->coordinatesBrokerSPtr_->hasSubset(aCoordinatesSubsetSPtr))
+    {
+        throw ostk::core::error::RuntimeError("Missing CoordinatesSubset: [{}]", aCoordinatesSubsetSPtr->getName());
+    }
+
+    Array<Shared<const CoordinatesSubset>> contractedSubsets = Array<Shared<const CoordinatesSubset>>::Empty();
+    for (const auto& subset : this->coordinatesBrokerSPtr_->getSubsets())
+    {
+        if (subset != aCoordinatesSubsetSPtr)
+        {
+            contractedSubsets.add(subset);
+        }
+    }
+
+    return StateBuilder(this->frameSPtr_, contractedSubsets);
 }
 
 StateBuilder StateBuilder::Undefined()

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.test.cpp
@@ -61,7 +61,7 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_AngularCondition : public ::
         VectorXd coordinates(1);
         coordinates << coordinate;
 
-        return defaultStateBuilder_.buildState(Instant::J2000(), coordinates);
+        return defaultStateBuilder_.build(Instant::J2000(), coordinates);
     }
 };
 

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BooleanCondition.test.cpp
@@ -65,7 +65,7 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_BooleanCondition : public ::
         VectorXd coordinates(1);
         coordinates << coordinate;
 
-        return defaultStateBuilder_.buildState(defaultInstant_, coordinates);
+        return defaultStateBuilder_.build(defaultInstant_, coordinates);
     }
 };
 

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.test.cpp
@@ -60,7 +60,7 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_RealCondition : public ::tes
         VectorXd coordinates(1);
         coordinates << coordinate;
 
-        return defaultStateBuilder_.buildState(defaultInstant_, coordinates);
+        return defaultStateBuilder_.build(defaultInstant_, coordinates);
     }
 };
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -133,6 +133,28 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, EqualToOperator)
 
         const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
 
+        VectorXd anotherCoordinates(7);
+        anotherCoordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 100.0;
+        const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default(), CoordinatesSubset::Mass()})
+        );
+
+        const State anotherState = {instant, anotherCoordinates, Frame::GCRF(), brokerSPtr2};
+
+        EXPECT_FALSE(aState == anotherState);
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+        const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
+
+        const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+
         const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
             CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
         );
@@ -344,6 +366,28 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, NotEqualToOperator)
         const State anotherState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
 
         EXPECT_FALSE(aState != anotherState);
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+        const Shared<const CoordinatesBroker> brokerSPtr1 = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
+
+        const State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr1};
+
+        VectorXd anotherCoordinates(7);
+        anotherCoordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 100.0;
+        const Shared<const CoordinatesBroker> brokerSPtr2 = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default(), CoordinatesSubset::Mass()})
+        );
+
+        const State anotherState = {instant, anotherCoordinates, Frame::GCRF(), brokerSPtr2};
+
+        EXPECT_TRUE(aState != anotherState);
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -3,15 +3,11 @@
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianPosition.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubsets/CartesianVelocity.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 #include <Global.test.hpp>
 
 using ostk::core::types::Shared;
 using ostk::core::ctnr::Array;
-using ostk::core::ctnr::Map;
 
 using ostk::math::obj::VectorXd;
 
@@ -35,14 +31,11 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder : public ::testing:
     };
 
     const Array<Shared<const CoordinatesSubset>> posVelMassSubsets = {
-        CartesianPosition::Default(),
-        CartesianVelocity::Default(),
-        CoordinatesSubset::Mass(),
+        CartesianPosition::Default(), CartesianVelocity::Default(), CoordinatesSubset::Mass()
     };
 
     const Array<Shared<const CoordinatesSubset>> massPosSubsets = {
-        CoordinatesSubset::Mass(),
-        CartesianPosition::Default(),
+        CoordinatesSubset::Mass(), CartesianPosition::Default()
     };
 
     const Shared<const CoordinatesBroker> posVelBrokerSPtr =
@@ -63,6 +56,19 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Constructor)
 
     {
         EXPECT_NO_THROW(StateBuilder builder(Frame::GCRF(), posVelSubsets););
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+        const State state = State(instant, coordinates, Frame::GCRF(), posVelBrokerSPtr);
+
+        EXPECT_NO_THROW(StateBuilder builder(state));
+    }
+
+    {
+        EXPECT_ANY_THROW(StateBuilder builder(State::Undefined()));
     }
 }
 
@@ -220,6 +226,74 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, NotEqualToOperato
     }
 }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, AdditionOperator)
+{
+    {
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
+        const StateBuilder expandedStateBuilder = stateBuilder + CoordinatesSubset::Mass();
+
+        EXPECT_FALSE(stateBuilder == expandedStateBuilder);
+
+        const Array<Shared<const CoordinatesSubset>> subsets = stateBuilder.accessCoordinatesBroker()->accessSubsets();
+        EXPECT_EQ(2, subsets.size());
+        EXPECT_EQ(CartesianPosition::Default(), subsets[0]);
+        EXPECT_EQ(CartesianVelocity::Default(), subsets[1]);
+
+        const Array<Shared<const CoordinatesSubset>> expandedSubsets =
+            expandedStateBuilder.accessCoordinatesBroker()->accessSubsets();
+        EXPECT_EQ(3, expandedSubsets.size());
+        EXPECT_EQ(CartesianPosition::Default(), expandedSubsets[0]);
+        EXPECT_EQ(CartesianVelocity::Default(), expandedSubsets[1]);
+        EXPECT_EQ(CoordinatesSubset::Mass(), expandedSubsets[2]);
+    }
+
+    {
+        const StateBuilder stateBuilder = StateBuilder::Undefined();
+
+        EXPECT_ANY_THROW(stateBuilder + CartesianPosition::Default());
+    }
+
+    {
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
+
+        EXPECT_ANY_THROW(stateBuilder + CartesianPosition::Default());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, SubtractionOperator)
+{
+    {
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelMassBrokerSPtr);
+        const StateBuilder contractedStateBuilder = stateBuilder - CartesianVelocity::Default();
+
+        EXPECT_FALSE(stateBuilder == contractedStateBuilder);
+
+        const Array<Shared<const CoordinatesSubset>> subsets = stateBuilder.accessCoordinatesBroker()->accessSubsets();
+        EXPECT_EQ(3, subsets.size());
+        EXPECT_EQ(CartesianPosition::Default(), subsets[0]);
+        EXPECT_EQ(CartesianVelocity::Default(), subsets[1]);
+        EXPECT_EQ(CoordinatesSubset::Mass(), subsets[2]);
+
+        const Array<Shared<const CoordinatesSubset>> contractedSubsets =
+            contractedStateBuilder.accessCoordinatesBroker()->accessSubsets();
+        EXPECT_EQ(2, contractedSubsets.size());
+        EXPECT_EQ(CartesianPosition::Default(), contractedSubsets[0]);
+        EXPECT_EQ(CoordinatesSubset::Mass(), contractedSubsets[1]);
+    }
+
+    {
+        const StateBuilder stateBuilder = StateBuilder::Undefined();
+
+        EXPECT_ANY_THROW(stateBuilder - CartesianPosition::Default());
+    }
+
+    {
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
+
+        EXPECT_ANY_THROW(stateBuilder - CoordinatesSubset::Mass());
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, StreamOperator)
 {
     {
@@ -241,7 +315,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, StreamOperator)
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, BuildFromCoordinates)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Build)
 {
     {
         const StateBuilder stateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
@@ -250,7 +324,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, BuildFromCoordina
         VectorXd coordinates(6);
         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
 
-        const State state = stateBuilder.buildState(instant, coordinates);
+        const State state = stateBuilder.build(instant, coordinates);
 
         EXPECT_EQ(instant, state.accessInstant());
         EXPECT_EQ(coordinates, state.accessCoordinates());
@@ -268,13 +342,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, BuildFromCoordina
         VectorXd coordinates1(6);
         coordinates1 << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
 
-        const State state1 = stateBuilder.buildState(instant1, coordinates1);
+        const State state1 = stateBuilder.build(instant1, coordinates1);
 
         const Instant instant2 = Instant::DateTime(DateTime(2019, 1, 1, 0, 0, 0), Scale::UTC);
         VectorXd coordinates2(6);
         coordinates2 << 2.0, 3.0, 4.0, 5.0, 6.0, 7.0;
 
-        const State state2 = stateBuilder.buildState(instant2, coordinates2);
+        const State state2 = stateBuilder.build(instant2, coordinates2);
 
         EXPECT_NE(state1.accessInstant(), state2.accessInstant());
         EXPECT_NE(state1.accessCoordinates(), state2.accessCoordinates());
@@ -290,7 +364,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, BuildFromCoordina
         VectorXd coordinates(3);
         coordinates << 1.0, 2.0, 3.0;
 
-        EXPECT_ANY_THROW(stateBuilder.buildState(instant, coordinates));
+        EXPECT_ANY_THROW(stateBuilder.build(instant, coordinates));
     }
 
     {
@@ -298,135 +372,203 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, BuildFromCoordina
         VectorXd coordinates(6);
         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
 
-        EXPECT_ANY_THROW(StateBuilder::Undefined().buildState(instant, coordinates));
+        EXPECT_ANY_THROW(StateBuilder::Undefined().build(instant, coordinates));
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, BuildFromState)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Reduce)
 {
     {
-        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        VectorXd coordinates(6);
-        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-        const State aState = aStateBuilder.buildState(instant, coordinates);
+        VectorXd coordinates(7);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 100.0;
+        const State aState = State(instant, coordinates, Frame::GCRF(), posVelMassBrokerSPtr);
 
-        VectorXd massCoordinates(1);
-        massCoordinates << 100.0;
-        const Map<const Shared<const CoordinatesSubset>, const VectorXd> additionalCoordinatesMap = {
-            {CoordinatesSubset::Mass(), massCoordinates}
-        };
-        const StateBuilder anotherStateBuilder = {Frame::GCRF(), massPosBrokerSPtr};
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), massPosBrokerSPtr);
 
-        const State anotherState = anotherStateBuilder.build(aState, additionalCoordinatesMap);
+        const State anotherState = stateBuilder.reduce(aState);
 
         VectorXd expectedAnotherCoordinates(4);
         expectedAnotherCoordinates << 100.0, 1.0, 2.0, 3.0;
 
         EXPECT_FALSE(aState == anotherState);
+        EXPECT_EQ(aState.accessInstant(), anotherState.accessInstant());
         EXPECT_EQ(aState.accessFrame(), anotherState.accessFrame());
         EXPECT_EQ(coordinates, aState.accessCoordinates());
         EXPECT_EQ(expectedAnotherCoordinates, anotherState.accessCoordinates());
     }
 
     {
-        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
-        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        VectorXd coordinates(6);
-        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-        const State aState = aStateBuilder.buildState(instant, coordinates);
+        const State aState = State::Undefined();
 
-        VectorXd massCoordinates(1);
-        massCoordinates << 100.0;
-        const Map<const Shared<const CoordinatesSubset>, const VectorXd> additionalCoordinatesMap = {
-            {CoordinatesSubset::Mass(), massCoordinates}
-        };
-        const StateBuilder anotherStateBuilder = StateBuilder::Undefined();  // Undefined should cause an error
+        const StateBuilder stateBuilder = StateBuilder(Frame::ITRF(), massPosBrokerSPtr);  // Undefined
 
-        EXPECT_ANY_THROW(anotherStateBuilder.build(aState, additionalCoordinatesMap));
+        EXPECT_ANY_THROW(stateBuilder.reduce(aState));
     }
 
     {
-        const State aState = State::Undefined();  // Undefined should cause the error
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(7);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 100.0;
+        const State aState = State(instant, coordinates, Frame::GCRF(), posVelMassBrokerSPtr);
 
-        VectorXd massCoordinates(1);
-        massCoordinates << 100.0;
-        const Map<const Shared<const CoordinatesSubset>, const VectorXd> additionalCoordinatesMap = {
-            {CoordinatesSubset::Mass(), massCoordinates}
-        };
-        const StateBuilder anotherStateBuilder = {Frame::GCRF(), massPosBrokerSPtr};
+        const StateBuilder stateBuilder = StateBuilder::Undefined();  // Undefined
 
-        EXPECT_ANY_THROW(anotherStateBuilder.build(aState, additionalCoordinatesMap));
+        EXPECT_ANY_THROW(stateBuilder.reduce(aState));
     }
 
     {
-        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        VectorXd coordinates(6);
-        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-        const State aState = aStateBuilder.buildState(instant, coordinates);
+        VectorXd coordinates(7);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 100.0;
+        const State aState = State(instant, coordinates, Frame::GCRF(), posVelMassBrokerSPtr);
 
-        VectorXd massCoordinates(1);
-        massCoordinates << 100.0;
-        const Map<const Shared<const CoordinatesSubset>, const VectorXd> additionalCoordinatesMap = {
-            {CoordinatesSubset::Mass(), massCoordinates}
-        };
-        const StateBuilder anotherStateBuilder = {
-            Frame::ITRF(), massPosBrokerSPtr
-        };  // Different Frame should cause an error
+        const StateBuilder stateBuilder = StateBuilder(Frame::ITRF(), massPosBrokerSPtr);  // Different Frame
 
-        EXPECT_ANY_THROW(anotherStateBuilder.build(aState, additionalCoordinatesMap));
+        EXPECT_ANY_THROW(stateBuilder.reduce(aState));
     }
 
     {
-        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
         VectorXd coordinates(6);
         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-        const State aState = aStateBuilder.buildState(instant, coordinates);
+        const State aState = State(instant, coordinates, Frame::GCRF(), posVelBrokerSPtr);  // Missing Mass
 
-        const Map<const Shared<const CoordinatesSubset>, const VectorXd> additionalCoordinatesMap = {
-        };  // Missing mass should cause an error
-        const StateBuilder anotherStateBuilder = {Frame::GCRF(), massPosBrokerSPtr};
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), massPosBrokerSPtr);
 
-        EXPECT_ANY_THROW(anotherStateBuilder.build(aState, additionalCoordinatesMap));
+        EXPECT_ANY_THROW(stateBuilder.reduce(aState));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Expand)
+{
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(4);
+        coordinates << 100.0, 1.0, 2.0, 3.0;
+        const State aState = State(instant, coordinates, Frame::GCRF(), massPosBrokerSPtr);
+
+        VectorXd defaultCoordinates(6);
+        defaultCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+        const State defaultState = State(instant, defaultCoordinates, Frame::GCRF(), posVelBrokerSPtr);
+
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelMassBrokerSPtr);
+
+        const State anotherState = stateBuilder.expand(aState, defaultState);
+
+        VectorXd expectedAnotherCoordinates(7);
+        expectedAnotherCoordinates << 1.0, 2.0, 3.0, -4.0, -5.0, -6.0, 100.0;
+
+        EXPECT_FALSE(aState == anotherState);
+        EXPECT_FALSE(defaultState == anotherState);
+        EXPECT_EQ(aState.accessInstant(), anotherState.accessInstant());
+        EXPECT_EQ(aState.accessFrame(), anotherState.accessFrame());
+        EXPECT_EQ(coordinates, aState.accessCoordinates());
+        EXPECT_EQ(defaultCoordinates, defaultState.accessCoordinates());
+        EXPECT_EQ(expectedAnotherCoordinates, anotherState.accessCoordinates());
     }
 
     {
-        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        VectorXd coordinates(6);
-        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-        const State aState = aStateBuilder.buildState(instant, coordinates);
+        const State aState = State::Undefined();  // Undefined
 
-        VectorXd massCoordinates(1);
-        massCoordinates << 100.0;
-        VectorXd posCoordinates(3);
-        posCoordinates << -1.0, -2.0, -3.0;
-        const Map<const Shared<const CoordinatesSubset>, const VectorXd> additionalCoordinatesMap = {
-            {CoordinatesSubset::Mass(), massCoordinates},
-            {CartesianPosition::Default(), posCoordinates}  // Duplicate Cartesian position should cause an error
-        };
-        const StateBuilder anotherStateBuilder = {Frame::GCRF(), massPosBrokerSPtr};
+        VectorXd defaultCoordinates(6);
+        defaultCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+        const State defaultState = State(instant, defaultCoordinates, Frame::GCRF(), posVelBrokerSPtr);
 
-        EXPECT_ANY_THROW(anotherStateBuilder.build(aState, additionalCoordinatesMap));
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelMassBrokerSPtr);
+
+        EXPECT_ANY_THROW(stateBuilder.expand(aState, defaultState));
     }
 
     {
-        const StateBuilder aStateBuilder = {Frame::GCRF(), posVelBrokerSPtr};
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(4);
+        coordinates << 100.0, 1.0, 2.0, 3.0;
+        const State aState = State(instant, coordinates, Frame::GCRF(), massPosBrokerSPtr);
+
+        const State defaultState = State::Undefined();  // Undefined
+
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelMassBrokerSPtr);
+
+        EXPECT_ANY_THROW(stateBuilder.expand(aState, defaultState));
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(4);
+        coordinates << 100.0, 1.0, 2.0, 3.0;
+        const State aState = State(instant, coordinates, Frame::GCRF(), massPosBrokerSPtr);
+
+        VectorXd defaultCoordinates(6);
+        defaultCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+        const State defaultState = State(instant, defaultCoordinates, Frame::GCRF(), posVelBrokerSPtr);
+
+        const StateBuilder stateBuilder = StateBuilder::Undefined();  // Undefined
+
+        EXPECT_ANY_THROW(stateBuilder.expand(aState, defaultState));
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(4);
+        coordinates << 100.0, 1.0, 2.0, 3.0;
+        const State aState = State(instant, coordinates, Frame::ITRF(), massPosBrokerSPtr);  // Different Frame
+
+        VectorXd defaultCoordinates(6);
+        defaultCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+        const State defaultState = State(instant, defaultCoordinates, Frame::GCRF(), posVelBrokerSPtr);
+
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelMassBrokerSPtr);
+
+        EXPECT_ANY_THROW(stateBuilder.expand(aState, defaultState));
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(4);
+        coordinates << 100.0, 1.0, 2.0, 3.0;
+        const State aState = State(instant, coordinates, Frame::GCRF(), massPosBrokerSPtr);
+
+        VectorXd defaultCoordinates(6);
+        defaultCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+        const State defaultState =
+            State(instant, defaultCoordinates, Frame::ITRF(), posVelBrokerSPtr);  // Different Frame
+
+        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelMassBrokerSPtr);
+
+        EXPECT_ANY_THROW(stateBuilder.expand(aState, defaultState));
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(4);
+        coordinates << 100.0, 1.0, 2.0, 3.0;
+        const State aState = State(instant, coordinates, Frame::GCRF(), massPosBrokerSPtr);
+
+        VectorXd defaultCoordinates(6);
+        defaultCoordinates << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0;
+        const State defaultState = State(instant, defaultCoordinates, Frame::GCRF(), posVelBrokerSPtr);
+
+        const StateBuilder stateBuilder = StateBuilder(Frame::ITRF(), posVelMassBrokerSPtr);  // Different Frame
+
+        EXPECT_ANY_THROW(stateBuilder.expand(aState, defaultState));
+    }
+
+    {
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
         VectorXd coordinates(6);
         coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-        const State aState = aStateBuilder.buildState(instant, coordinates);
+        const State aState = State(instant, coordinates, Frame::GCRF(), posVelBrokerSPtr);
 
-        VectorXd massCoordinates(2);  // Mass coordinates size should cause an error
-        massCoordinates << 100.0, 200.0;
-        const Map<const Shared<const CoordinatesSubset>, const VectorXd> additionalCoordinatesMap = {
-            {CoordinatesSubset::Mass(), massCoordinates}
-        };
-        const StateBuilder anotherStateBuilder = {Frame::GCRF(), massPosBrokerSPtr};
+        VectorXd defaultCoordinates(4);
+        defaultCoordinates << 100.0, -1.0, -2.0, -3.0;
+        const State defaultState = State(instant, defaultCoordinates, Frame::GCRF(), massPosBrokerSPtr);
 
-        EXPECT_ANY_THROW(anotherStateBuilder.build(aState, additionalCoordinatesMap));
+        const StateBuilder stateBuilder =
+            StateBuilder(Frame::GCRF(), massPosBrokerSPtr);  // Not an expansion (missing velocity)
+
+        EXPECT_ANY_THROW(stateBuilder.expand(aState, defaultState));
     }
 }
 
@@ -444,6 +586,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Accessors)
 
         EXPECT_EQ(Frame::GCRF(), stateBuilder.accessFrame());
         EXPECT_EQ(posVelSubsets, stateBuilder.accessCoordinatesBroker()->getSubsets());
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+        const State state = State(instant, coordinates, Frame::GCRF(), posVelBrokerSPtr);
+
+        const StateBuilder stateBuilder = {state};
+        EXPECT_EQ(Frame::GCRF(), stateBuilder.accessFrame());
+        EXPECT_EQ(posVelBrokerSPtr, stateBuilder.accessCoordinatesBroker());
     }
 
     {
@@ -495,74 +648,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, IsDefined)
 
     {
         EXPECT_FALSE(StateBuilder::Undefined().isDefined());
-    }
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Expand)
-{
-    {
-        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
-        const StateBuilder expandedStateBuilder = stateBuilder.expand(CoordinatesSubset::Mass());
-
-        EXPECT_FALSE(stateBuilder == expandedStateBuilder);
-
-        const Array<Shared<const CoordinatesSubset>> subsets = stateBuilder.accessCoordinatesBroker()->accessSubsets();
-        EXPECT_EQ(2, subsets.size());
-        EXPECT_EQ(CartesianPosition::Default(), subsets[0]);
-        EXPECT_EQ(CartesianVelocity::Default(), subsets[1]);
-
-        const Array<Shared<const CoordinatesSubset>> expandedSubsets =
-            expandedStateBuilder.accessCoordinatesBroker()->accessSubsets();
-        EXPECT_EQ(3, expandedSubsets.size());
-        EXPECT_EQ(CartesianPosition::Default(), expandedSubsets[0]);
-        EXPECT_EQ(CartesianVelocity::Default(), expandedSubsets[1]);
-        EXPECT_EQ(CoordinatesSubset::Mass(), expandedSubsets[2]);
-    }
-
-    {
-        const StateBuilder stateBuilder = StateBuilder::Undefined();
-
-        EXPECT_ANY_THROW(stateBuilder.expand(CartesianPosition::Default()));
-    }
-
-    {
-        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
-
-        EXPECT_ANY_THROW(stateBuilder.expand(CartesianPosition::Default()));
-    }
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Contract)
-{
-    {
-        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelMassBrokerSPtr);
-        const StateBuilder contractedStateBuilder = stateBuilder.contract(CartesianVelocity::Default());
-
-        EXPECT_FALSE(stateBuilder == contractedStateBuilder);
-
-        const Array<Shared<const CoordinatesSubset>> subsets = stateBuilder.accessCoordinatesBroker()->accessSubsets();
-        EXPECT_EQ(3, subsets.size());
-        EXPECT_EQ(CartesianPosition::Default(), subsets[0]);
-        EXPECT_EQ(CartesianVelocity::Default(), subsets[1]);
-        EXPECT_EQ(CoordinatesSubset::Mass(), subsets[2]);
-
-        const Array<Shared<const CoordinatesSubset>> contractedSubsets =
-            contractedStateBuilder.accessCoordinatesBroker()->accessSubsets();
-        EXPECT_EQ(2, contractedSubsets.size());
-        EXPECT_EQ(CartesianPosition::Default(), contractedSubsets[0]);
-        EXPECT_EQ(CoordinatesSubset::Mass(), contractedSubsets[1]);
-    }
-
-    {
-        const StateBuilder stateBuilder = StateBuilder::Undefined();
-
-        EXPECT_ANY_THROW(stateBuilder.contract(CartesianPosition::Default()));
-    }
-
-    {
-        const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
-
-        EXPECT_ANY_THROW(stateBuilder.contract(CoordinatesSubset::Mass()));
     }
 }
 


### PR DESCRIPTION
Add `StateBuilder` features:
- StateBuilder +/- CoordinateSubset operators
- State reduction
- State expansion

Additional:
- Renaming `buildState` -> `build`
- Fix minor "bug" where `State` == comparator was not assessing number of coordinates
