### PR TITLE
feat: Python class meta-programming for State construction

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -41,6 +41,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
             arg("frame"),
             arg("coordinates_subsets")
         )
+        .def(init<const State&>(), arg("state"))
 
         .def(self == self)
         .def(self != self)

--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -104,7 +104,7 @@ class TestState:
         assert state is not None
         assert isinstance(state, State)
         assert state.is_defined()
-    
+
     def test_custom_class_generator(
         self,
         instant: Instant,

--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -105,7 +105,7 @@ class TestState:
         assert isinstance(state, State)
         assert state.is_defined()
 
-    def test_custom_class_generator(
+    def test_custom_state_class_generator(
         self,
         instant: Instant,
         position: Position,

--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -11,7 +11,7 @@ from ostk.physics.coordinate import Position
 from ostk.physics.coordinate import Velocity
 from ostk.physics.coordinate import Frame
 
-from ostk.astrodynamics.trajectory import State
+from ostk.astrodynamics.trajectory import State, StateBuilder
 from ostk.astrodynamics.trajectory.state import CoordinatesBroker
 from ostk.astrodynamics.trajectory.state.coordinates_subset import (
     CartesianPosition,
@@ -104,6 +104,38 @@ class TestState:
         assert state is not None
         assert isinstance(state, State)
         assert state.is_defined()
+    
+    def test_custom_class_generator(
+        self,
+        instant: Instant,
+        position: Position,
+        velocity: Velocity,
+        frame: Frame,
+    ):
+        state = State(
+            instant,
+            np.append(position.get_coordinates(), velocity.get_coordinates()),
+            frame,
+            [CartesianPosition.default(), CartesianVelocity.default()],
+        )
+
+        MySuperFunState: type = State.template(
+            frame,
+            [CartesianPosition.default(), CartesianVelocity.default()],
+        )
+
+        custom_state: MySuperFunState = MySuperFunState(
+            instant,
+            np.append(position.get_coordinates(), velocity.get_coordinates()),
+        )
+
+        assert custom_state is not None
+        assert isinstance(custom_state, MySuperFunState)
+        assert isinstance(state, State)
+        assert custom_state.is_defined()
+
+        assert custom_state == state
+        assert custom_state is not state
 
     def test_comparators(self, state: State):
         assert (state == state) is True

--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -11,7 +11,7 @@ from ostk.physics.coordinate import Position
 from ostk.physics.coordinate import Velocity
 from ostk.physics.coordinate import Frame
 
-from ostk.astrodynamics.trajectory import State, StateBuilder
+from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory.state import CoordinatesBroker
 from ostk.astrodynamics.trajectory.state.coordinates_subset import (
     CartesianPosition,

--- a/bindings/python/tools/python/ostk/astrodynamics/__init__.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/__init__.py
@@ -6,5 +6,6 @@ from .OpenSpaceToolkitAstrodynamicsPy import *
 
 from .pytrajectory.pystate import State as PyState
 
-trajectory.State = PyState # Override the pure c++ State class with the modified Python one
-
+trajectory.State = (
+    PyState  # Override the pure c++ State class with the modified Python one
+)

--- a/bindings/python/tools/python/ostk/astrodynamics/__init__.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/__init__.py
@@ -3,3 +3,8 @@
 from ostk.physics import *
 
 from .OpenSpaceToolkitAstrodynamicsPy import *
+
+from .pytrajectory.pystate import State as PyState
+
+trajectory.State = PyState # Override the pure c++ State class with the modified Python one
+

--- a/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/__init__.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/__init__.py
@@ -1,0 +1,1 @@
+# Apache License 2.0

--- a/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
@@ -9,29 +9,30 @@ from ostk.physics.time import Instant
 
 from ostk.astrodynamics.trajectory import State, StateBuilder
 
+
 @staticmethod
 def custom_class_generator(frame: Frame, coordinates_subsets: list) -> type:
     """
-        Emit a custom class type for States. This is meta-programming syntactic sugar on top of the StateBuilder class.
-    
-        StateType = State.template(frame, coordinates_subsets)
-        state = StateType(instant, coordinates)
+    Emit a custom class type for States. This is meta-programming syntactic sugar on top of the StateBuilder class.
 
-        is equivalent to 
+    StateType = State.template(frame, coordinates_subsets)
+    state = StateType(instant, coordinates)
 
-        state_builder = StateBuilder(frame, coordinates_subsets)
-        state = state_builder.build(instant, coordinates)
+    is equivalent to
+
+    state_builder = StateBuilder(frame, coordinates_subsets)
+    state = state_builder.build(instant, coordinates)
     """
 
     class StateTemplateType(State):
-
         state_builder: StateBuilder = StateBuilder(frame, coordinates_subsets)
 
         def __init__(self, instant: Instant, coordinates: np.ndarray):
             super().__init__(
                 StateTemplateType.state_builder.build_state(instant, coordinates)
             )
-    
+
     return StateTemplateType
+
 
 State.template = custom_class_generator

--- a/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
@@ -29,7 +29,7 @@ def custom_class_generator(frame: Frame, coordinates_subsets: list) -> type:
 
         def __init__(self, instant: Instant, coordinates: np.ndarray):
             super().__init__(
-                StateTemplateType.state_builder.build_state(instant, coordinates)
+                StateTemplateType.state_builder.build(instant, coordinates)
             )
 
     return StateTemplateType

--- a/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
@@ -9,10 +9,18 @@ from ostk.physics.time import Instant
 
 from ostk.astrodynamics.trajectory import State, StateBuilder
 
-
+@staticmethod
 def custom_class_generator(frame: Frame, coordinates_subsets: list) -> type:
     """
-        Custom class type generator for States. This is meta-programming syntactic sugar on top of the StateBuilder class.
+        Emit a custom class type for States. This is meta-programming syntactic sugar on top of the StateBuilder class.
+    
+        StateType = State.template(frame, coordinates_subsets)
+        state = StateType(instant, coordinates)
+
+        is equivalent to 
+
+        state_builder = StateBuilder(frame, coordinates_subsets)
+        state = state_builder.build(instant, coordinates)
     """
 
     class StateTemplateType(State):

--- a/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
@@ -1,0 +1,29 @@
+# Apache License 2.0
+
+
+# Python-only State functionality
+import numpy as np
+
+from ostk.physics.coordinate import Frame
+from ostk.physics.time import Instant
+
+from ostk.astrodynamics.trajectory import State, StateBuilder
+
+
+def custom_class_generator(frame: Frame, coordinates_subsets: list) -> type:
+    """
+        Custom class type generator for States. This is meta-programming syntactic sugar on top of the StateBuilder class.
+    """
+
+    class StateTemplateType(State):
+
+        state_builder: StateBuilder = StateBuilder(frame, coordinates_subsets)
+
+        def __init__(self, instant: Instant, coordinates: np.ndarray):
+            super().__init__(
+                StateTemplateType.state_builder.build_state(instant, coordinates)
+            )
+    
+    return StateTemplateType
+
+State.template = custom_class_generator

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -83,6 +83,12 @@ class State
 
     State(const Instant& anInstant, const Position& aPosition, const Velocity& aVelocity);
 
+    /// @brief                  Copy-assignment constructor
+    ///
+    /// @param                  [in] aState An existing State
+
+    State(const State& aState);
+
     /// @brief                  Equality operator.
     ///
     /// @param                  [in] aState The State to compare to

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -91,7 +91,7 @@ class State
 
     /// @brief                  Copy-assignment operator
     ///
-    /// @param                  [in] aState The State to compare to
+    /// @param                  [in] aState The State to copy
     /// @return                 The modified State
 
     State& operator=(const State& aState);

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -83,11 +83,18 @@ class State
 
     State(const Instant& anInstant, const Position& aPosition, const Velocity& aVelocity);
 
-    /// @brief                  Copy-assignment constructor
+    /// @brief                  Copy constructor.
     ///
     /// @param                  [in] aState An existing State
 
     State(const State& aState);
+
+    /// @brief                  Copy-assignment operator
+    ///
+    /// @param                  [in] aState The State to compare to
+    /// @return                 The modified State
+
+    State& operator=(const State& aState);
 
     /// @brief                  Equality operator.
     ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -84,6 +84,14 @@ State::State(const Instant& anInstant, const Position& aPosition, const Velocity
     this->coordinatesBrokerSPtr_ = coordinatesBrokerSPtr;
 }
 
+State::State(const State& aState)
+    : instant_(aState.instant_),
+      coordinates_(aState.coordinates_),
+      frameSPtr_(aState.frameSPtr_),
+      coordinatesBrokerSPtr_(aState.coordinatesBrokerSPtr_)
+{
+}
+
 bool State::operator==(const State& aState) const
 {
     if ((!this->isDefined()) || (!aState.isDefined()))

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -92,6 +92,18 @@ State::State(const State& aState)
 {
 }
 
+State& State::operator=(const State& aState)
+{
+    if (this != &aState)
+    {
+        instant_ = aState.instant_;
+        coordinates_ = aState.coordinates_;
+        frameSPtr_ = aState.frameSPtr_;
+        coordinatesBrokerSPtr_ = aState.coordinatesBrokerSPtr_;
+    }
+    return *this;
+}
+
 bool State::operator==(const State& aState) const
 {
     if ((!this->isDefined()) || (!aState.isDefined()))

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -123,6 +123,31 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Constructor)
     }
 }
 
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, CopyAssignmentOperator)
+{
+    // Create a state
+    const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    VectorXd coordinates(6);
+    coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+    const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+        CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+    );
+    State aState = {instant, coordinates, Frame::GCRF(), brokerSPtr};
+
+    // Copy the state
+    State anotherState = State::Undefined();
+    anotherState = aState;
+
+    // Check that the two states are equal
+    EXPECT_EQ(aState, anotherState);
+
+    // Modify the original state
+    aState = State::Undefined();
+
+    // Check that the two states are no longer equal
+    EXPECT_NE(aState, anotherState);
+}
+
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, EqualToOperator)
 {
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -104,6 +104,23 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Constructor)
 
         EXPECT_ANY_THROW(State state(instant, position, velocity););
     }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        VectorXd coordinates(6);
+        coordinates << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+        const Shared<const CoordinatesBroker> brokerSPtr = std::make_shared<CoordinatesBroker>(
+            CoordinatesBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
+
+        State state(instant, coordinates, Frame::GCRF(), brokerSPtr);
+        
+        EXPECT_NO_THROW(State anotherState(state));
+
+        const State anotherState(state);
+
+        EXPECT_EQ(state, anotherState);
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, EqualToOperator)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -114,7 +114,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Constructor)
         );
 
         State state(instant, coordinates, Frame::GCRF(), brokerSPtr);
-        
+
         EXPECT_NO_THROW(State anotherState(state));
 
         const State anotherState(state);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -136,6 +136,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, CopyAssignmentOperator)
 
     // Copy the state
     State anotherState = State::Undefined();
+
+    // Check that the two states are no longer equal
+    EXPECT_NE(aState, anotherState);
+
     anotherState = aState;
 
     // Check that the two states are equal


### PR DESCRIPTION
This MR is some Python-only syntactic sugar on top of the State Builder concept which allows for some nice syntax:
```python
MySuperFunState: type = State.template(
    frame,
    [CartesianPosition.default(), CartesianVelocity.default()],
)

states: MySuperFunState = [
    MySuperFunState(instant,coords) for instant,coords in zip(instants, coordinates)
]
```

The output StateTypeX classes are polymorphic to State and so can be used anywhere a State can.
This example is 100% equivalent to using a builder and is just a syntax alternative.

(other meta-programming features like auto-assigning `state.mass` to get the mass value will be in a follow-up)