### PR TITLE
feat: add hasSubset method to State

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -59,6 +59,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
         .def("get_velocity", &State::getVelocity)
         .def("get_coordinates", &State::getCoordinates)
         .def("get_coordinates_subsets", &State::getCoordinatesSubsets)
+        .def("has_subset", &State::hasSubset, arg("subset"))
         .def("get_frame", &State::getFrame)
 
         .def(

--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -157,6 +157,8 @@ class TestState:
         assert state.get_instant() == instant
         assert state.get_position() == position
         assert state.get_velocity() == velocity
+        assert state.has_subset(CartesianPosition.default())
+        assert state.has_subset(CartesianVelocity.default())
         assert state.get_frame() == frame
         assert (
             state.get_coordinates()

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp
@@ -204,6 +204,14 @@ class State
 
     const Array<Shared<const CoordinatesSubset>> getCoordinatesSubsets() const;
 
+    /// @brief                  Check if the State has a given coordinates subset.
+    ///
+    /// @param                  [in] aCoordinatesSubsetSPtr the coordinates subset to be checked
+    ///
+    /// @return                 True if the coordinates subset is included in the State
+
+    bool hasSubset(const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr) const;
+
     /// @brief                  Extract the coordinates for a single subset.
     ///
     /// @param                  [in] aSubsetSPtr The subset to extract the coordinates for

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -345,6 +345,16 @@ const Array<Shared<const CoordinatesSubset>> State::getCoordinatesSubsets() cons
     return this->coordinatesBrokerSPtr_->getSubsets();
 }
 
+bool State::hasSubset(const Shared<const CoordinatesSubset>& aSubsetSPtr) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("State");
+    }
+
+    return this->coordinatesBrokerSPtr_->hasSubset(aSubsetSPtr);
+}
+
 VectorXd State::extractCoordinates(const Shared<const CoordinatesSubset>& aSubsetSPtr) const
 {
     return this->coordinatesBrokerSPtr_->extractCoordinates(this->accessCoordinates(), aSubsetSPtr);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -928,6 +928,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Getters)
         EXPECT_EQ(velocity, state.getVelocity());
         EXPECT_EQ(coordinates, state.getCoordinates());
         EXPECT_EQ(state.getCoordinatesSubsets(), brokerSPtr->getSubsets());
+        EXPECT_TRUE(state.hasSubset(CartesianPosition::Default()));
+        EXPECT_TRUE(state.hasSubset(CartesianVelocity::Default()));
         EXPECT_EQ(Frame::GCRF(), state.getFrame());
     }
 
@@ -944,6 +946,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Getters)
         EXPECT_EQ(instant, state.getInstant());
         EXPECT_EQ(position, state.getPosition());
         EXPECT_EQ(velocity, state.getVelocity());
+        EXPECT_TRUE(state.hasSubset(CartesianPosition::Default()));
+        EXPECT_TRUE(state.hasSubset(CartesianVelocity::Default()));
         EXPECT_EQ(coordinates, state.getCoordinates());
         EXPECT_EQ(Frame::GCRF(), state.getFrame());
     }
@@ -972,6 +976,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, Getters)
         EXPECT_ANY_THROW(State::Undefined().getVelocity());
         EXPECT_ANY_THROW(State::Undefined().getCoordinates());
         EXPECT_ANY_THROW(State::Undefined().getCoordinatesSubsets());
+        EXPECT_ANY_THROW(State::Undefined().hasSubset(CartesianPosition::Default()));
         EXPECT_ANY_THROW(State::Undefined().getFrame());
     }
 }


### PR DESCRIPTION
I find myself wanting to do this a lot:

```python
if state.has_subset(CartesianPosition.default()):
    coords = state.extract_coordinates(CartesianPosition.default())
```

But it's currently only exposed at the coordinates broker level.