### PR TITLE
docs: add python docstrings

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -27,6 +27,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
             )doc"
         );
 
+        enum_<Access::Type>(
+            access_class,
+            "Type",
+            R"doc(
+                Access type.
+            )doc"
+        )
+
+            .value("Undefined", Access::Type::Undefined, "Undefined")
+            .value("Complete", Access::Type::Complete, "Complete")
+            .value("Partial", Access::Type::Partial, "Partial")
+
+            ;
+
         access_class
 
             .def(
@@ -161,9 +175,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     
                     Returns:
                         Access: An undefined Access object.
-                    
-                    Group:
-                        Static methods
+
                 )doc"
             )
 
@@ -178,26 +190,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     
                     Returns:
                         str: A string representation of the type.
-                    
-                    Group:
-                        Static methods
+
                 )doc",
                 arg("type")
             )
-
-            ;
-
-        enum_<Access::Type>(
-            access_class,
-            "Type",
-            R"doc(
-                Access type.
-            )doc"
-        )
-
-            .value("Undefined", Access::Type::Undefined, "Undefined")
-            .value("Complete", Access::Type::Complete, "Complete")
-            .value("Partial", Access::Type::Partial, "Partial")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -61,7 +61,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Check if the Access object is defined.
                     
                     Returns:
-                       is_defined (bool): True if defined, False otherwise.
+                       bool: True if defined, False otherwise.
                  )docs"
             )
 
@@ -72,7 +72,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Check if the access is complete.
                     
                     Returns:
-                        is_complete (bool): True if complete, False otherwise.
+                        bool: True if complete, False otherwise.
                  )docs"
             )
 
@@ -83,7 +83,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Get the type of the access.
 
                     Returns:
-                        type (Access::Type): The type of the access.
+                        Access.Type: The type of the access.
                 )docs"
             )
 
@@ -94,7 +94,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Get the acquisition of signal of the access.
 
                     Returns:
-                        acquisition_of_signal (Instant): The acquisition of signal of the access.
+                        Instant: The acquisition of signal of the access.
                 )docs"
             )
 
@@ -105,7 +105,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Get the time of closest approach of the access.
 
                     Returns:
-                        time_of_closest_approach (Instant): The time of closest approach of the access.
+                        Instant: The time of closest approach of the access.
                 )docs"
             )
 
@@ -116,7 +116,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Get the loss of signal of the access.
 
                     Returns:
-                       loss_of_signal (Instant): The loss of signal of the access.
+                       Instant: The loss of signal of the access.
                 )docs"
             )
 
@@ -127,7 +127,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Get the interval of the access.
 
                     Returns:
-                       interval (Interval): The interval of the access.
+                       Interval: The interval of the access.
                 )docs"
             )
 
@@ -138,7 +138,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Get the duration of the access.
 
                     Returns:
-                       duration (Duration): The duration of the access.
+                       Duration: The duration of the access.
                 )docs"
             )
 
@@ -149,7 +149,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Get the maximum elevation of the access.
 
                     Returns:
-                      max_elevation (Angle): The maximum elevation of the access.
+                      Angle: The maximum elevation of the access.
                 )docs"
             )
 
@@ -160,7 +160,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     Creates an undefined Access object.
                     
                     Returns:
-                        access (Access): An undefined Access object.
+                        Access: An undefined Access object.
                     
                     Group:
                         Static methods
@@ -177,7 +177,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                         type (Access.Type): The type of the access.
                     
                     Returns:
-                        access_type (str): A string representation of the type.
+                        str: A string representation of the type.
                     
                     Group:
                         Static methods

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                 This class encapsulates the concept of visibility access between two trajectories.
                 
                 Group:
-                    astrodynamics
+                    access
             )doc"
         );
 
@@ -175,7 +175,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     
                     Returns:
                         Access: An undefined Access object.
-
                 )doc"
             )
 
@@ -190,7 +189,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     
                     Returns:
                         str: A string representation of the type.
-
                 )doc",
                 arg("type")
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -17,21 +17,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
         class_<Access> access_class(
             aModule,
             "Access",
-            R"docs(
+            R"doc(
                 Object-to-object visibility
                 
                 This class encapsulates the concept of visibility access between two trajectories.
                 
                 Group:
                     astrodynamics
-            )docs"
+            )doc"
         );
 
         access_class
 
             .def(
                 init<const Access::Type&, const Instant&, const Instant&, const Instant&, const Angle&>(),
-                R"docs(
+                R"doc(
                     Constructs an Access object.
                     
                     Args:
@@ -40,7 +40,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                         time_of_closest_approach (Instant): The time of closest approach between objects
                         loss_of_signal (Instant): The instant when the signal is lost
                         max_elevation (Angle): The maximum elevation angle during the access
-                )docs",
+                )doc",
                 arg("type"),
                 arg("acquisition_of_signal"),
                 arg("time_of_closest_approach"),
@@ -57,106 +57,106 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
             .def(
                 "is_defined",
                 &Access::isDefined,
-                R"docs(
+                R"doc(
                     Check if the Access object is defined.
                     
                     Returns:
                        bool: True if defined, False otherwise.
-                 )docs"
+                 )doc"
             )
 
             .def(
                 "is_complete",
                 &Access::isComplete,
-                R"docs(
+                R"doc(
                     Check if the access is complete.
                     
                     Returns:
                         bool: True if complete, False otherwise.
-                 )docs"
+                 )doc"
             )
 
             .def(
                 "get_type",
                 &Access::getType,
-                R"docs(
+                R"doc(
                     Get the type of the access.
 
                     Returns:
                         Access.Type: The type of the access.
-                )docs"
+                )doc"
             )
 
             .def(
                 "get_acquisition_of_signal",
                 &Access::getAcquisitionOfSignal,
-                R"docs(
+                R"doc(
                     Get the acquisition of signal of the access.
 
                     Returns:
                         Instant: The acquisition of signal of the access.
-                )docs"
+                )doc"
             )
 
             .def(
                 "get_time_of_closest_approach",
                 &Access::getTimeOfClosestApproach,
-                R"docs(
+                R"doc(
                     Get the time of closest approach of the access.
 
                     Returns:
                         Instant: The time of closest approach of the access.
-                )docs"
+                )doc"
             )
 
             .def(
                 "get_loss_of_signal",
                 &Access::getLossOfSignal,
-                R"docs(
+                R"doc(
                     Get the loss of signal of the access.
 
                     Returns:
                        Instant: The loss of signal of the access.
-                )docs"
+                )doc"
             )
 
             .def(
                 "get_interval",
                 &Access::getInterval,
-                R"docs(
+                R"doc(
                     Get the interval of the access.
 
                     Returns:
                        Interval: The interval of the access.
-                )docs"
+                )doc"
             )
 
             .def(
                 "get_duration",
                 &Access::getDuration,
-                R"docs(
+                R"doc(
                     Get the duration of the access.
 
                     Returns:
                        Duration: The duration of the access.
-                )docs"
+                )doc"
             )
 
             .def(
                 "get_max_elevation",
                 &Access::getMaxElevation,
-                R"docs(
+                R"doc(
                     Get the maximum elevation of the access.
 
                     Returns:
                       Angle: The maximum elevation of the access.
-                )docs"
+                )doc"
             )
 
             .def_static(
                 "undefined",
                 &Access::Undefined,
-                R"docs(
+                R"doc(
                     Creates an undefined Access object.
                     
                     Returns:
@@ -164,13 +164,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     
                     Group:
                         Static methods
-                )docs"
+                )doc"
             )
 
             .def_static(
                 "string_from_type",
                 &Access::StringFromType,
-                R"docs(
+                R"doc(
                     Returns a string representation of the Access type.
     
                     Args:
@@ -181,7 +181,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                     
                     Group:
                         Static methods
-                )docs",
+                )doc",
                 arg("type")
             )
 
@@ -190,9 +190,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
         enum_<Access::Type>(
             access_class,
             "Type",
-            R"docs(
+            R"doc(
                 Access type.
-            )docs"
+            )doc"
         )
 
             .value("Undefined", Access::Type::Undefined, "Undefined")

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -14,12 +14,33 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
     using ostk::astro::Access;
 
     {
-        class_<Access> access_class(aModule, "Access");
+        class_<Access> access_class(
+            aModule,
+            "Access",
+            R"docs(
+                Object-to-object visibility
+                
+                This class encapsulates the concept of visibility access between two trajectories.
+                
+                Group:
+                    astrodynamics
+            )docs"
+        );
 
         access_class
 
             .def(
                 init<const Access::Type&, const Instant&, const Instant&, const Instant&, const Angle&>(),
+                R"docs(
+                    Constructs an Access object.
+                    
+                    Args:
+                        type (Access.Type): Type of the access (Complete, Partial, Undefined)
+                        acquisition_of_signal (Instant): The instant when the signal is first acquired
+                        time_of_closest_approach (Instant): The time of closest approach between objects
+                        loss_of_signal (Instant): The instant when the signal is lost
+                        max_elevation (Angle): The maximum elevation angle during the access
+                )docs",
                 arg("type"),
                 arg("acquisition_of_signal"),
                 arg("time_of_closest_approach"),
@@ -33,28 +54,150 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
             .def("__str__", &(shiftToString<Access>))
             .def("__repr__", &(shiftToString<Access>))
 
-            .def("is_defined", &Access::isDefined)
-            .def("is_complete", &Access::isComplete)
+            .def(
+                "is_defined",
+                &Access::isDefined,
+                R"docs(
+                    Check if the Access object is defined.
+                    
+                    Returns:
+                       is_defined (bool): True if defined, False otherwise.
+                 )docs"
+            )
 
-            .def("get_type", &Access::getType)
-            .def("get_acquisition_of_signal", &Access::getAcquisitionOfSignal)
-            .def("get_time_of_closest_approach", &Access::getTimeOfClosestApproach)
-            .def("get_loss_of_signal", &Access::getLossOfSignal)
-            .def("get_interval", &Access::getInterval)
-            .def("get_duration", &Access::getDuration)
-            .def("get_max_elevation", &Access::getMaxElevation)
+            .def(
+                "is_complete",
+                &Access::isComplete,
+                R"docs(
+                    Check if the access is complete.
+                    
+                    Returns:
+                        is_complete (bool): True if complete, False otherwise.
+                 )docs"
+            )
 
-            .def_static("undefined", &Access::Undefined)
+            .def(
+                "get_type",
+                &Access::getType,
+                R"docs(
+                    Get the type of the access.
 
-            .def_static("string_from_type", &Access::StringFromType, arg("type"))
+                    Returns:
+                        type (Access::Type): The type of the access.
+                )docs"
+            )
+
+            .def(
+                "get_acquisition_of_signal",
+                &Access::getAcquisitionOfSignal,
+                R"docs(
+                    Get the acquisition of signal of the access.
+
+                    Returns:
+                        acquisition_of_signal (Instant): The acquisition of signal of the access.
+                )docs"
+            )
+
+            .def(
+                "get_time_of_closest_approach",
+                &Access::getTimeOfClosestApproach,
+                R"docs(
+                    Get the time of closest approach of the access.
+
+                    Returns:
+                        time_of_closest_approach (Instant): The time of closest approach of the access.
+                )docs"
+            )
+
+            .def(
+                "get_loss_of_signal",
+                &Access::getLossOfSignal,
+                R"docs(
+                    Get the loss of signal of the access.
+
+                    Returns:
+                       loss_of_signal (Instant): The loss of signal of the access.
+                )docs"
+            )
+
+            .def(
+                "get_interval",
+                &Access::getInterval,
+                R"docs(
+                    Get the interval of the access.
+
+                    Returns:
+                       interval (Interval): The interval of the access.
+                )docs"
+            )
+
+            .def(
+                "get_duration",
+                &Access::getDuration,
+                R"docs(
+                    Get the duration of the access.
+
+                    Returns:
+                       duration (Duration): The duration of the access.
+                )docs"
+            )
+
+            .def(
+                "get_max_elevation",
+                &Access::getMaxElevation,
+                R"docs(
+                    Get the maximum elevation of the access.
+
+                    Returns:
+                      max_elevation (Angle): The maximum elevation of the access.
+                )docs"
+            )
+
+            .def_static(
+                "undefined",
+                &Access::Undefined,
+                R"docs(
+                    Creates an undefined Access object.
+                    
+                    Returns:
+                        access (Access): An undefined Access object.
+                    
+                    Group:
+                        Static methods
+                )docs"
+            )
+
+            .def_static(
+                "string_from_type",
+                &Access::StringFromType,
+                R"docs(
+                    Returns a string representation of the Access type.
+    
+                    Args:
+                        type (Access.Type): The type of the access.
+                    
+                    Returns:
+                        access_type (str): A string representation of the type.
+                    
+                    Group:
+                        Static methods
+                )docs",
+                arg("type")
+            )
 
             ;
 
-        enum_<Access::Type>(access_class, "Type")
+        enum_<Access::Type>(
+            access_class,
+            "Type",
+            R"docs(
+                Access type.
+            )docs"
+        )
 
-            .value("Undefined", Access::Type::Undefined)
-            .value("Complete", Access::Type::Complete)
-            .value("Partial", Access::Type::Partial)
+            .value("Undefined", Access::Type::Undefined, "Undefined")
+            .value("Complete", Access::Type::Complete, "Complete")
+            .value("Partial", Access::Type::Partial, "Partial")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
@@ -20,7 +20,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
     using ostk::astro::access::Generator;
     using ostk::astro::trajectory::State;
 
-    class_<Generator, Shared<Generator>>(aModule, "Generator")
+    class_<Generator, Shared<Generator>>(
+        aModule,
+        "Generator",
+        R"doc(
+            An access generator.
+            
+            Group:
+                Access
+        )doc"
+    )
 
         .def(
             init<
@@ -30,6 +39,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
                 std::function<bool(const State&, const State&)>&,
                 const Duration&,
                 const Duration&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    environment (Environment): The environment.
+                    aer_filter (function): The AER filter.
+                    access_filter (function): The access filter.
+                    state_filter (function): The state filter.
+                    step (Duration): The step.
+                    tolerance (Duration): The tolerance.
+
+            )doc",
             arg("environment"),
             arg("aer_filter") = none(),
             arg("access_filter") = none(),
@@ -38,39 +59,202 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
             arg("tolerance") = DEFAULT_TOLERANCE
         )
 
-        .def("is_defined", &Generator::isDefined)
+        .def("is_defined", &Generator::isDefined, R"doc(
+            Check if the generator is defined.
 
-        .def("get_step", &Generator::getStep)
-        .def("get_tolerance", &Generator::getTolerance)
-        .def("get_aer_filter", &Generator::getAerFilter)
-        .def("get_access_filter", &Generator::getAccessFilter)
-        .def("get_state_filter", &Generator::getStateFilter)
+            Returns:
+                bool: True if the generator is defined, False otherwise.
 
-        .def("get_condition_function", &Generator::getConditionFunction, arg("from_trajectory"), arg("to_trajectory"))
+        )doc")
+
+        .def("get_step", &Generator::getStep, R"doc(
+            Get the step.
+
+            Returns:
+                Duration: The step.
+
+        )doc")
+        .def("get_tolerance", &Generator::getTolerance, R"doc(
+            Get the tolerance.
+
+            Returns:
+                Duration: The tolerance.
+
+        )doc")
+        .def("get_aer_filter", &Generator::getAerFilter, R"doc(
+            Get the AER filter.
+
+            Returns:
+                function: The AER filter.
+
+        )doc")
+        .def("get_access_filter", &Generator::getAccessFilter, R"doc(
+            Get the access filter.
+
+            Returns:
+                function: The access filter.
+
+        )doc")
+        .def("get_state_filter", &Generator::getStateFilter, R"doc(
+            Get the state filter.
+
+            Returns:
+                function: The state filter.
+
+        )doc")
+
+        .def(
+            "get_condition_function",
+            &Generator::getConditionFunction,
+            R"doc(
+            Get the condition function.
+
+            Args:
+                from_trajectory (State): The state at the start of the interval.
+                to_trajectory (State): The state at the end of the interval.
+
+            Returns:
+                function: The condition function.
+
+        )doc",
+            arg("from_trajectory"),
+            arg("to_trajectory")
+        )
         .def(
             "compute_accesses",
             &Generator::computeAccesses,
+            R"doc(
+                Compute the accesses.
+
+                Args:
+                    interval (Interval): The interval.
+                    from_trajectory (State): The state at the start of the interval.
+                    to_trajectory (State): The state at the end of the interval.
+
+                Returns:
+                    Accesses: The accesses.
+
+            )doc",
             arg("interval"),
             arg("from_trajectory"),
             arg("to_trajectory")
         )
-        .def("set_step", &Generator::setStep, arg("step"))
-        .def("set_tolerance", &Generator::setTolerance, arg("tolerance"))
-        .def("set_aer_filter", &Generator::setAerFilter, arg("aer_filter"))
-        .def("set_access_filter", &Generator::setAccessFilter, arg("access_filter"))
-        .def("set_state_filter", &Generator::setStateFilter, arg("state_filter"))
+        .def(
+            "set_step",
+            &Generator::setStep,
+            R"doc(
+            Set the step.
 
-        .def_static("undefined", &Generator::Undefined)
+            Args:
+                step (Duration): The step.
+
+        )doc",
+            arg("step")
+        )
+        .def(
+            "set_tolerance",
+            &Generator::setTolerance,
+            R"doc(
+            Set the tolerance.
+
+            Args:
+                tolerance (Duration): The tolerance.
+
+        )doc",
+            arg("tolerance")
+        )
+        .def(
+            "set_aer_filter",
+            &Generator::setAerFilter,
+            R"doc(
+            Set the AER filter.
+
+            Args:
+                aer_filter (function): The AER filter.
+
+        )doc",
+            arg("aer_filter")
+        )
+        .def(
+            "set_access_filter",
+            &Generator::setAccessFilter,
+            R"doc(
+            Set the access filter.
+
+            Args:
+                access_filter (function): The access filter.
+
+        )doc",
+            arg("access_filter")
+        )
+        .def(
+            "set_state_filter",
+            &Generator::setStateFilter,
+            R"doc(
+            Set the state filter.
+
+            Args:
+                state_filter (function): The state filter.
+
+        )doc",
+            arg("state_filter")
+        )
+
+        .def_static("undefined", &Generator::Undefined, R"doc(
+            Get an undefined generator.
+
+            Returns:
+                Generator: An undefined generator.
+            
+            Group:
+                Static methods
+
+        )doc")
         .def_static(
             "aer_ranges",
             &Generator::AerRanges,
+            R"doc(
+                Create an AER generator with ranges.
+
+                Args:
+                    azimuth_range (Interval): The azimuth range.
+                    elevation_range (Interval): The elevation range.
+                    range_range (Interval): The range range.
+                    environment (Environment): The environment.
+
+                Returns:
+                    Generator: The AER generator.
+                
+                Group:
+                    Static methods
+
+            )doc",
             arg("azimuth_range"),
             arg("elevation_range"),
             arg("range_range"),
             arg("environment")
         )
         .def_static(
-            "aer_mask", &Generator::AerMask, arg("azimuth_elevation_mask"), arg("range_range"), arg("environment")
+            "aer_mask",
+            &Generator::AerMask,
+            R"doc(
+                Create an AER generator with a mask.
+
+                Args:
+                    azimuth_elevation_mask (Interval): The azimuth-elevation mask.
+                    range_range (Interval): The range range.
+                    environment (Environment): The environment.
+
+                Returns:
+                    Generator: The AER generator.
+                
+                Group:
+                    Static methods
+
+            )doc",
+            arg("azimuth_elevation_mask"),
+            arg("range_range"),
+            arg("environment")
         )
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
@@ -59,49 +59,73 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
             arg("tolerance") = DEFAULT_TOLERANCE
         )
 
-        .def("is_defined", &Generator::isDefined, R"doc(
-            Check if the generator is defined.
+        .def(
+            "is_defined",
+            &Generator::isDefined,
+            R"doc(
+                Check if the generator is defined.
 
-            Returns:
-                bool: True if the generator is defined, False otherwise.
+                Returns:
+                    bool: True if the generator is defined, False otherwise.
 
-        )doc")
+            )doc"
+        )
 
-        .def("get_step", &Generator::getStep, R"doc(
-            Get the step.
+        .def(
+            "get_step",
+            &Generator::getStep,
+            R"doc(
+                Get the step.
 
-            Returns:
-                Duration: The step.
+                Returns:
+                    Duration: The step.
 
-        )doc")
-        .def("get_tolerance", &Generator::getTolerance, R"doc(
-            Get the tolerance.
+            )doc"
+        )
+        .def(
+            "get_tolerance",
+            &Generator::getTolerance,
+            R"doc(
+                Get the tolerance.
 
-            Returns:
-                Duration: The tolerance.
+                Returns:
+                    Duration: The tolerance.
 
-        )doc")
-        .def("get_aer_filter", &Generator::getAerFilter, R"doc(
-            Get the AER filter.
+            )doc"
+        )
+        .def(
+            "get_aer_filter",
+            &Generator::getAerFilter,
+            R"doc(
+                Get the AER filter.
 
-            Returns:
-                function: The AER filter.
+                Returns:
+                    function: The AER filter.
 
-        )doc")
-        .def("get_access_filter", &Generator::getAccessFilter, R"doc(
-            Get the access filter.
+            )doc"
+        )
+        .def(
+            "get_access_filter",
+            &Generator::getAccessFilter,
+            R"doc(
+                Get the access filter.
 
-            Returns:
-                function: The access filter.
+                Returns:
+                    function: The access filter.
 
-        )doc")
-        .def("get_state_filter", &Generator::getStateFilter, R"doc(
-            Get the state filter.
+            )doc"
+        )
+        .def(
+            "get_state_filter",
+            &Generator::getStateFilter,
+            R"doc(
+                Get the state filter.
 
-            Returns:
-                function: The state filter.
+                Returns:
+                    function: The state filter.
 
-        )doc")
+            )doc"
+        )
 
         .def(
             "get_condition_function",
@@ -200,16 +224,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
             arg("state_filter")
         )
 
-        .def_static("undefined", &Generator::Undefined, R"doc(
-            Get an undefined generator.
+        .def_static(
+            "undefined",
+            &Generator::Undefined,
+            R"doc(
+                Get an undefined generator.
 
-            Returns:
-                Generator: An undefined generator.
-            
-            Group:
-                Static methods
+                Returns:
+                    Generator: An undefined generator.
+                
+                Group:
+                    Static methods
 
-        )doc")
+            )doc"
+        )
         .def_static(
             "aer_ranges",
             &Generator::AerRanges,

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
@@ -27,7 +27,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
             An access generator.
             
             Group:
-                Access
+                access
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
@@ -232,10 +232,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
 
                 Returns:
                     Generator: An undefined generator.
-                
-                Group:
-                    Static methods
-
             )doc"
         )
         .def_static(
@@ -252,10 +248,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
 
                 Returns:
                     Generator: The AER generator.
-                
-                Group:
-                    Static methods
-
             )doc",
             arg("azimuth_range"),
             arg("elevation_range"),
@@ -275,10 +267,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
 
                 Returns:
                     Generator: The AER generator.
-                
-                Group:
-                    Static methods
-
             )doc",
             arg("azimuth_elevation_mask"),
             arg("range_range"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Conjunction/Messages/CCSDS/CDM.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Conjunction/Messages/CCSDS/CDM.cpp
@@ -44,7 +44,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
         "ObjectType",
         R"doc(
             Object type.
-
         )doc"
     )
 
@@ -69,7 +68,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                     relative_metadata (CDM::RelativeMetadata): The relative metadata.
                     objects_metadata_array (Array<CDM::Metadata>): The objects metadata array.
                     objects_data_array (Array<CDM::Data>): The objects data array.
-
             )doc",
             arg("header"),
             arg("relative_metadata"),
@@ -158,7 +156,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                     index (int): The index of the object data.
 
                 Returns:
-                    CDM::Data: The object data.
+                    Data: The object data.
 
             )doc",
             arg("index")
@@ -170,7 +168,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                 Get the CCSDS CDM version.
 
                 Returns:
-                    std::string: The CCSDS CDM version.
+                    str: The CCSDS CDM version.
 
             )doc"
         )
@@ -192,7 +190,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                 Get the originator.
 
                 Returns:
-                    std::string: The originator.
+                    str: The originator.
 
             )doc"
         )
@@ -203,7 +201,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                 Get the message for.
 
                 Returns:
-                    std::string: The message for.
+                    str: The message for.
 
             )doc"
         )
@@ -214,7 +212,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                 Get the message ID.
 
                 Returns:
-                    std::string: The message ID.
+                    str: The message ID.
 
             )doc"
         )
@@ -280,7 +278,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                 Get the collision probability method.
 
                 Returns:
-                    std::string: The collision probability method.
+                    str: The collision probability method.
 
             )doc"
         )
@@ -293,9 +291,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
 
                 Returns:
                     CDM: An undefined CDM.
-
-                Group:
-                    Static members
             )doc"
         )
         .def_static(
@@ -306,10 +301,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
 
                 Returns:
                     Dictionary: The CDM dictionary.
-
-                Group:
-                    Static members
-
             )doc",
             arg("dictionary")
         )
@@ -324,10 +315,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
 
                 Returns:
                     CDM: The parsed CDM.
-
-                Group:
-                    Static members
-
             )doc",
             arg("string")
         )
@@ -342,10 +329,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
 
             Returns:
                 CDM: The loaded CDM.
-
-                Group:
-                    Static members
-
         )doc",
             arg("file")
         )
@@ -360,10 +343,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
 
                 Returns:
                     CDM::ObjectType: The object type.
-
-                Group:
-                    Static members
-
             )doc",
             arg("string")
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Conjunction/Messages/CCSDS/CDM.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Conjunction/Messages/CCSDS/CDM.cpp
@@ -39,6 +39,23 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
         )doc"
     );
 
+    enum_<CDM::ObjectType>(
+        cdm,
+        "ObjectType",
+        R"doc(
+            Object type.
+
+        )doc"
+    )
+
+        .value("Payload", CDM::ObjectType::Payload, "Payload")
+        .value("RocketBody", CDM::ObjectType::RocketBody, "Rocket Body")
+        .value("Debris", CDM::ObjectType::Debris, "Debris")
+        .value("Unknown", CDM::ObjectType::Unknown, "Unknown")
+        .value("Other", CDM::ObjectType::Other, "Other")
+
+        ;
+
     cdm
 
         .def(
@@ -354,24 +371,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
         ;
 
     ;
-
-    enum_<CDM::ObjectType>(
-        cdm,
-        "ObjectType",
-        R"doc(
-            Object type.
-
-            Defined in CCSDS 502.0-B-2, Annex A.2.1.
-        )doc"
-    )
-
-        .value("Payload", CDM::ObjectType::Payload, "Payload")
-        .value("RocketBody", CDM::ObjectType::RocketBody, "Rocket Body")
-        .value("Debris", CDM::ObjectType::Debris, "Debris")
-        .value("Unknown", CDM::ObjectType::Unknown, "Unknown")
-        .value("Other", CDM::ObjectType::Other, "Other")
-
-        ;
 
     class_<CDM::Header>(
         cdm,

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Conjunction/Messages/CCSDS/CDM.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Conjunction/Messages/CCSDS/CDM.cpp
@@ -35,7 +35,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
 
             Group:
-                Conjunction
+                ccsds
         )doc"
     );
 
@@ -382,7 +382,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
 
             Group:
-                CCSDS
+                ccsds
         )doc"
     )
 
@@ -462,7 +462,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
 
             Group:
-                CCSDS
+                ccsds
         )doc"
     )
 
@@ -648,7 +648,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
 
             Group:
-                CCSDS
+                ccsds
         )doc"
     )
 
@@ -894,7 +894,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
 
             Group:
-                CCSDS
+                ccsds
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Conjunction/Messages/CCSDS/CDM.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Conjunction/Messages/CCSDS/CDM.cpp
@@ -26,61 +26,380 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
     using ostk::astro::conjunction::messages::ccsds::CDM;
     using ostk::astro::trajectory::State;
 
-    class_<CDM> cdm(aModule, "CDM");
+    class_<CDM> cdm(
+        aModule,
+        "CDM",
+        R"doc(
+            Conjunction Data Message.
+
+            Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
+
+            Group:
+                Conjunction
+        )doc"
+    );
 
     cdm
 
         .def(
             init<const CDM::Header&, const CDM::RelativeMetadata, const Array<CDM::Metadata>, const Array<CDM::Data> >(
             ),
+            R"doc(
+                Constructor.
+
+                Args:
+                    header (CDM::Header): The CDM header.
+                    relative_metadata (CDM::RelativeMetadata): The relative metadata.
+                    objects_metadata_array (Array<CDM::Metadata>): The objects metadata array.
+                    objects_data_array (Array<CDM::Data>): The objects data array.
+
+            )doc",
             arg("header"),
             arg("relative_metadata"),
             arg("objects_metadata_array"),
             arg("objects_data_array")
         )
 
-        .def("is_defined", &CDM::isDefined)
+        .def(
+            "is_defined",
+            &CDM::isDefined,
+            R"doc(
+                Check if the CDM is defined.
 
-        .def("get_header", &CDM::getHeader)
-        .def("get_relative_metadata", &CDM::getRelativeMetadata)
-        .def("get_metadata_array", &CDM::getMetadataArray)
-        .def("get_data_array", &CDM::getDataArray)
-        .def("get_object_metadata_at", &CDM::getObjectMetadataAt, arg("index"))
-        .def("get_object_data_at", &CDM::getObjectDataAt, arg("index"))
-        .def("get_ccsds_cdm_version", &CDM::getCCSDSCDMVersion)
-        .def("get_creation_instant", &CDM::getCreationDate)
-        .def("get_originator", &CDM::getOriginator)
-        .def("get_message_for", &CDM::getMessageFor)
-        .def("get_message_id", &CDM::getMessageId)
-        .def("get_time_of_closest_approach", &CDM::getTCA)
-        .def("get_miss_distance", &CDM::getMissDistance)
-        .def("get_relative_position", &CDM::getRelativePosition)
-        .def("get_relative_velocity", &CDM::getRelativeVelocity)
-        .def("get_collision_probability", &CDM::getCollisionProbability)
-        .def("get_collision_probability_method", &CDM::getCollisionProbabilityMethod)
+                Returns:
+                    bool: True if the CDM is defined, False otherwise.
 
-        .def_static("undefined", &CDM::Undefined)
-        .def_static("dictionary", &CDM::Dictionary, arg("dictionary"))
-        .def_static("parse", &CDM::Parse, arg("string"))
-        .def_static("load", &CDM::Load, arg("file"))
-        .def_static("object_type_from_string", &CDM::ObjectTypeFromString, arg("string"))
+            )doc"
+        )
+
+        .def(
+            "get_header",
+            &CDM::getHeader,
+            R"doc(
+                Get the CDM header.
+
+            Returns:
+                CDM::Header: The CDM header.
+
+            )doc"
+        )
+        .def(
+            "get_relative_metadata",
+            &CDM::getRelativeMetadata,
+            R"doc(
+                Get the relative metadata.
+
+            Returns:
+                CDM::RelativeMetadata: The relative metadata.
+
+            )doc"
+        )
+        .def(
+            "get_metadata_array",
+            &CDM::getMetadataArray,
+            R"doc(
+                Get the objects metadata array.
+
+            Returns:
+                Array<CDM::Metadata>: The objects metadata array.
+
+            )doc"
+        )
+        .def(
+            "get_data_array",
+            &CDM::getDataArray,
+            R"doc(
+                Get the objects data array.
+
+            Returns:
+                Array<CDM::Data>: The objects data array.
+
+            )doc"
+        )
+        .def(
+            "get_object_metadata_at",
+            &CDM::getObjectMetadataAt,
+            R"doc(
+                Get the object metadata at the specified index.
+
+                Args:
+                    index (int): The index of the object metadata.
+
+                Returns:
+                    CDM::Metadata: The object metadata.
+
+            )doc",
+            arg("index")
+        )
+        .def(
+            "get_object_data_at",
+            &CDM::getObjectDataAt,
+            R"doc(
+                Get the object data at the specified index.
+
+                Args:
+                    index (int): The index of the object data.
+
+                Returns:
+                    CDM::Data: The object data.
+
+            )doc",
+            arg("index")
+        )
+        .def(
+            "get_ccsds_cdm_version",
+            &CDM::getCCSDSCDMVersion,
+            R"doc(
+                Get the CCSDS CDM version.
+
+                Returns:
+                    std::string: The CCSDS CDM version.
+
+            )doc"
+        )
+        .def(
+            "get_creation_instant",
+            &CDM::getCreationDate,
+            R"doc(
+                Get the creation instant.
+
+                Returns:
+                    Instant: The creation instant.
+
+            )doc"
+        )
+        .def(
+            "get_originator",
+            &CDM::getOriginator,
+            R"doc(
+                Get the originator.
+
+                Returns:
+                    std::string: The originator.
+
+            )doc"
+        )
+        .def(
+            "get_message_for",
+            &CDM::getMessageFor,
+            R"doc(
+                Get the message for.
+
+                Returns:
+                    std::string: The message for.
+
+            )doc"
+        )
+        .def(
+            "get_message_id",
+            &CDM::getMessageId,
+            R"doc(
+                Get the message ID.
+
+                Returns:
+                    std::string: The message ID.
+
+            )doc"
+        )
+        .def(
+            "get_time_of_closest_approach",
+            &CDM::getTCA,
+            R"doc(
+                Get the time of closest approach.
+
+                Returns:
+                    Instant: The time of closest approach.
+
+            )doc"
+        )
+        .def(
+            "get_miss_distance",
+            &CDM::getMissDistance,
+            R"doc(
+                Get the miss distance.
+
+                Returns:
+                    Distance: The miss distance.
+
+            )doc"
+        )
+        .def(
+            "get_relative_position",
+            &CDM::getRelativePosition,
+            R"doc(
+                Get the relative position.
+
+                Returns:
+                    Position: The relative position.
+
+            )doc"
+        )
+        .def(
+            "get_relative_velocity",
+            &CDM::getRelativeVelocity,
+            R"doc(
+                Get the relative velocity.
+
+                Returns:
+                    Velocity: The relative velocity.
+
+            )doc"
+        )
+        .def(
+            "get_collision_probability",
+            &CDM::getCollisionProbability,
+            R"doc(
+                Get the collision probability.
+
+                Returns:
+                    Probability: The collision probability.
+
+            )doc"
+        )
+        .def(
+            "get_collision_probability_method",
+            &CDM::getCollisionProbabilityMethod,
+            R"doc(
+                Get the collision probability method.
+
+                Returns:
+                    std::string: The collision probability method.
+
+            )doc"
+        )
+
+        .def_static(
+            "undefined",
+            &CDM::Undefined,
+            R"doc(
+                Get an undefined CDM.
+
+                Returns:
+                    CDM: An undefined CDM.
+
+                Group:
+                    Static members
+            )doc"
+        )
+        .def_static(
+            "dictionary",
+            &CDM::Dictionary,
+            R"doc(
+                Get the CDM dictionary.
+
+                Returns:
+                    Dictionary: The CDM dictionary.
+
+                Group:
+                    Static members
+
+            )doc",
+            arg("dictionary")
+        )
+        .def_static(
+            "parse",
+            &CDM::Parse,
+            R"doc(
+                Parse a CDM from a string.
+
+                Args:
+                    string (str): The string to parse.
+
+                Returns:
+                    CDM: The parsed CDM.
+
+                Group:
+                    Static members
+
+            )doc",
+            arg("string")
+        )
+        .def_static(
+            "load",
+            &CDM::Load,
+            R"doc(
+            Load a CDM from a file.
+
+            Args:
+                file (str): The file to load.
+
+            Returns:
+                CDM: The loaded CDM.
+
+                Group:
+                    Static members
+
+        )doc",
+            arg("file")
+        )
+        .def_static(
+            "object_type_from_string",
+            &CDM::ObjectTypeFromString,
+            R"doc(
+                Get the object type from a string.
+
+                Args:
+                    string (str): The string to get the object type from.
+
+                Returns:
+                    CDM::ObjectType: The object type.
+
+                Group:
+                    Static members
+
+            )doc",
+            arg("string")
+        )
 
         ;
 
-    enum_<CDM::ObjectType>(cdm, "ObjectType")
+    ;
 
-        .value("Payload", CDM::ObjectType::Payload)
-        .value("RocketBody", CDM::ObjectType::RocketBody)
-        .value("Debris", CDM::ObjectType::Debris)
-        .value("Unknown", CDM::ObjectType::Unknown)
-        .value("Other", CDM::ObjectType::Other)
+    enum_<CDM::ObjectType>(
+        cdm,
+        "ObjectType",
+        R"doc(
+            Object type.
+
+            Defined in CCSDS 502.0-B-2, Annex A.2.1.
+        )doc"
+    )
+
+        .value("Payload", CDM::ObjectType::Payload, "Payload")
+        .value("RocketBody", CDM::ObjectType::RocketBody, "Rocket Body")
+        .value("Debris", CDM::ObjectType::Debris, "Debris")
+        .value("Unknown", CDM::ObjectType::Unknown, "Unknown")
+        .value("Other", CDM::ObjectType::Other, "Other")
 
         ;
 
-    class_<CDM::Header>(cdm, "Header")
+    class_<CDM::Header>(
+        cdm,
+        "Header",
+        R"doc(
+            Conjunction Data Message header.
+
+            Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
+
+            Group:
+                CCSDS
+        )doc"
+    )
 
         .def(
             init<const String&, const String&, const Instant&, const String&, const String&, const String&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    ccsds_cdm_version (str): The CCSDS CDM version.
+                    comment (str): The comment.
+                    creation_date (Instant): The creation date.
+                    originator (str): The originator.
+                    message_for (str): The message for.
+                    message_id (str): The message ID.
+
+            )doc",
             arg("ccsds_cdm_version"),
             arg("comment") = String::Empty(),
             arg("creation_date"),
@@ -89,16 +408,63 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             arg("message_id")
         )
 
-        .def_readonly("ccsds_cdm_version", &CDM::Header::ccsdsCdmVersion)
-        .def_readonly("comment", &CDM::Header::comment)
-        .def_readonly("creation_date", &CDM::Header::creationDate)
-        .def_readonly("originator", &CDM::Header::originator)
-        .def_readonly("message_for", &CDM::Header::messageFor)
-        .def_readonly("message_id", &CDM::Header::messageId)
+        .def_readonly(
+            "ccsds_cdm_version",
+            &CDM::Header::ccsdsCdmVersion,
+            R"doc(
+                The CCSDS CDM version.
+            )doc"
+        )
+        .def_readonly(
+            "comment",
+            &CDM::Header::comment,
+            R"doc(
+                The comment.
+            )doc"
+        )
+        .def_readonly(
+            "creation_date",
+            &CDM::Header::creationDate,
+            R"doc(
+                The creation date.
+            )doc"
+        )
+        .def_readonly(
+            "originator",
+            &CDM::Header::originator,
+            R"doc(
+                The originator.
+            )doc"
+        )
+        .def_readonly(
+            "message_for",
+            &CDM::Header::messageFor,
+            R"doc(
+                The message for.
+            )doc"
+        )
+        .def_readonly(
+            "message_id",
+            &CDM::Header::messageId,
+            R"doc(
+                The message ID.
+            )doc"
+        )
 
         ;
 
-    class_<CDM::RelativeMetadata>(cdm, "RelativeMetadata")
+    class_<CDM::RelativeMetadata>(
+        cdm,
+        "RelativeMetadata",
+        R"doc(
+            Relative metadata.
+
+            Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
+
+            Group:
+                CCSDS
+        )doc"
+    )
 
         .def(
             init<
@@ -118,6 +484,28 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                 const Instant&,
                 const Real&,
                 const String&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    comment (str): The comment.
+                    time_of_closest_approach (Instant): The time of closest approach.
+                    miss_distance (Distance): The miss distance.
+                    relative_position (Position): The relative position.
+                    relative_velocity (Velocity): The relative velocity.
+                    start_screen_period (Instant): The start screen period.
+                    end_screen_period (Instant): The end screen period.
+                    screen_volume_frame (str): The screen volume frame.
+                    screen_volume_shape (str): The screen volume shape.
+                    screen_volume_x (float): The screen volume x.
+                    screen_volume_y (float): The screen volume y.
+                    screen_volume_z (float): The screen volume z.
+                    screen_entry_time (Instant): The screen entry time.
+                    screen_exit_time (Instant): The screen exit time.
+                    collision_probability (Probability): The collision probability.
+                    collision_probability_method (str): The collision probability method.
+
+            )doc",
             arg("comment") = String::Empty(),
             arg("time_of_closest_approach"),
             arg("miss_distance"),
@@ -136,26 +524,133 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             arg("collision_probability_method")
         )
 
-        .def_readonly("comment", &CDM::RelativeMetadata::comment)
-        .def_readonly("time_of_closest_approach", &CDM::RelativeMetadata::TCA)
-        .def_readonly("miss_distance", &CDM::RelativeMetadata::missDistance)
-        .def_readonly("relative_position", &CDM::RelativeMetadata::relativePosition)
-        .def_readonly("relative_velocity", &CDM::RelativeMetadata::relativeVelocity)
-        .def_readonly("start_screen_period", &CDM::RelativeMetadata::startScreenPeriod)
-        .def_readonly("end_screen_period", &CDM::RelativeMetadata::endScreenPeriod)
-        .def_readonly("screen_volume_frame", &CDM::RelativeMetadata::screenVolumeFrame)
-        .def_readonly("screen_volume_shape", &CDM::RelativeMetadata::screenVolumeShape)
-        .def_readonly("screen_volume_x", &CDM::RelativeMetadata::screenVolumeX)
-        .def_readonly("screen_volume_y", &CDM::RelativeMetadata::screenVolumeY)
-        .def_readonly("screen_volume_z", &CDM::RelativeMetadata::screenVolumeZ)
-        .def_readonly("screen_entry_time", &CDM::RelativeMetadata::screenEntryTime)
-        .def_readonly("screen_exit_time", &CDM::RelativeMetadata::screenExitTime)
-        .def_readonly("collision_probability", &CDM::RelativeMetadata::collisionProbability)
-        .def_readonly("collision_probability_method", &CDM::RelativeMetadata::collisionProbabilityMethod)
+        .def_readonly(
+            "comment",
+            &CDM::RelativeMetadata::comment,
+            R"doc(
+                The comment.
+            )doc"
+        )
+        .def_readonly(
+            "time_of_closest_approach",
+            &CDM::RelativeMetadata::TCA,
+            R"doc(
+                The time of closest approach.
+            )doc"
+        )
+        .def_readonly(
+            "miss_distance",
+            &CDM::RelativeMetadata::missDistance,
+            R"doc(
+                The miss distance.
+            )doc"
+        )
+        .def_readonly(
+            "relative_position",
+            &CDM::RelativeMetadata::relativePosition,
+            R"doc(
+                The relative position.
+            )doc"
+        )
+        .def_readonly(
+            "relative_velocity",
+            &CDM::RelativeMetadata::relativeVelocity,
+            R"doc(
+                The relative velocity.
+            )doc"
+        )
+        .def_readonly(
+            "start_screen_period",
+            &CDM::RelativeMetadata::startScreenPeriod,
+            R"doc(
+                The start screen period.
+            )doc"
+        )
+        .def_readonly(
+            "end_screen_period",
+            &CDM::RelativeMetadata::endScreenPeriod,
+            R"doc(
+                The end screen period.
+            )doc"
+        )
+        .def_readonly(
+            "screen_volume_frame",
+            &CDM::RelativeMetadata::screenVolumeFrame,
+            R"doc(
+                The screen volume frame.
+            )doc"
+        )
+        .def_readonly(
+            "screen_volume_shape",
+            &CDM::RelativeMetadata::screenVolumeShape,
+            R"doc(
+                The screen volume shape.
+            )doc"
+        )
+        .def_readonly(
+            "screen_volume_x",
+            &CDM::RelativeMetadata::screenVolumeX,
+            R"doc(
+                The screen volume x.
+            )doc"
+        )
+        .def_readonly(
+            "screen_volume_y",
+            &CDM::RelativeMetadata::screenVolumeY,
+            R"doc(
+                The screen volume y.
+            )doc"
+        )
+        .def_readonly(
+            "screen_volume_z",
+            &CDM::RelativeMetadata::screenVolumeZ,
+            R"doc(
+                The screen volume z.
+            )doc"
+        )
+        .def_readonly(
+            "screen_entry_time",
+            &CDM::RelativeMetadata::screenEntryTime,
+            R"doc(
+                The screen entry time.
+            )doc"
+        )
+        .def_readonly(
+            "screen_exit_time",
+            &CDM::RelativeMetadata::screenExitTime,
+            R"doc(
+                The screen exit time.
+            )doc"
+        )
+        .def_readonly(
+            "collision_probability",
+            &CDM::RelativeMetadata::collisionProbability,
+            R"doc(
+                The collision probability.
+            )doc"
+        )
+        .def_readonly(
+            "collision_probability_method",
+            &CDM::RelativeMetadata::collisionProbabilityMethod,
+            R"doc(
+                The collision probability method.
+            )doc"
+        )
 
         ;
 
-    class_<CDM::Metadata>(cdm, "Metadata")
+    class_<CDM::Metadata>(
+        cdm,
+        "Metadata",
+        R"doc(
+            Conjunction Data Message metadata.
+
+            Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
+
+            Group:
+                CCSDS
+        )doc"
+    )
 
         .def(
             init<
@@ -181,6 +676,34 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                 const bool&,
                 const bool&,
                 const bool&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    comment (str): The comment.
+                    object (str): The object.
+                    object_designator (int): The object designator.
+                    catalog_name (str): The catalog name.
+                    object_name (str): The object name.
+                    international_designator (str): The international designator.
+                    object_type (ObjectType): The object type.
+                    operator_contact_position (str): The operator contact position.
+                    operator_organization (str): The operator organization.
+                    operator_phone (str): The operator phone.
+                    operator_email (str): The operator email.
+                    ephemeris_name (str): The ephemeris name.
+                    covariance_method (str): The covariance method.
+                    maneuverable (str): The maneuverable.
+                    orbit_center (str): The orbit center.
+                    reference_frame (str): The reference frame.
+                    gravity_model (str): The gravity model.
+                    atmospheric_model (str): The atmospheric model.
+                    n_body_perturbations (str): The n-body perturbations.
+                    solar_radiation_pressure (bool): The solar radiation pressure.
+                    earth_tides (bool): The earth tides.
+                    in_track_thrust (bool): The in-track thrust.
+
+            )doc",
             arg("comment") = String::Empty(),
             arg("object"),
             arg("object_designator"),
@@ -205,32 +728,175 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             arg("in_track_thrust") = false
         )
 
-        .def_readonly("comment", &CDM::Metadata::comment)
-        .def_readonly("object", &CDM::Metadata::object)
-        .def_readonly("object_designator", &CDM::Metadata::objectDesignator)
-        .def_readonly("catalog_name", &CDM::Metadata::catalogName)
-        .def_readonly("object_name", &CDM::Metadata::objectName)
-        .def_readonly("international_designator", &CDM::Metadata::internationalDesignator)
-        .def_readonly("object_type", &CDM::Metadata::objectType)
-        .def_readonly("operator_contact_position", &CDM::Metadata::operatorContactPosition)
-        .def_readonly("operator_organization", &CDM::Metadata::operatorOrgnization)
-        .def_readonly("operator_phone", &CDM::Metadata::operatorPhone)
-        .def_readonly("operator_email", &CDM::Metadata::operatorEmail)
-        .def_readonly("ephemeris_name", &CDM::Metadata::ephemerisName)
-        .def_readonly("covariance_method", &CDM::Metadata::covarianceMethod)
-        .def_readonly("maneuverable", &CDM::Metadata::maneuverable)
-        .def_readonly("orbit_center", &CDM::Metadata::orbitCenter)
-        .def_readonly("reference_frame", &CDM::Metadata::refFrame)
-        .def_readonly("gravity_model", &CDM::Metadata::gravityModel)
-        .def_readonly("atmospheric_model", &CDM::Metadata::atmosphericModel)
-        .def_readonly("n_body_perturbations", &CDM::Metadata::nBodyPerturbations)
-        .def_readonly("solar_radiation_pressure", &CDM::Metadata::solarRadiationPressure)
-        .def_readonly("earth_tides", &CDM::Metadata::earthTides)
-        .def_readonly("in_track_thrust", &CDM::Metadata::inTrackThrust)
+        .def_readonly(
+            "comment",
+            &CDM::Metadata::comment,
+            R"doc(
+                The comment.
+            )doc"
+        )
+        .def_readonly(
+            "object",
+            &CDM::Metadata::object,
+            R"doc(
+                The object.
+            )doc"
+        )
+        .def_readonly(
+            "object_designator",
+            &CDM::Metadata::objectDesignator,
+            R"doc(
+                The object designator.
+            )doc"
+        )
+        .def_readonly(
+            "catalog_name",
+            &CDM::Metadata::catalogName,
+            R"doc(
+                The catalog name.
+            )doc"
+        )
+        .def_readonly(
+            "object_name",
+            &CDM::Metadata::objectName,
+            R"doc(
+                The object name.
+            )doc"
+        )
+        .def_readonly(
+            "international_designator",
+            &CDM::Metadata::internationalDesignator,
+            R"doc(
+                The international designator.
+            )doc"
+        )
+        .def_readonly(
+            "object_type",
+            &CDM::Metadata::objectType,
+            R"doc(
+                The object type.
+            )doc"
+        )
+        .def_readonly(
+            "operator_contact_position",
+            &CDM::Metadata::operatorContactPosition,
+            R"doc(
+                The operator contact position.
+            )doc"
+        )
+        .def_readonly(
+            "operator_organization",
+            &CDM::Metadata::operatorOrgnization,
+            R"doc(
+                The operator organization.
+            )doc"
+        )
+        .def_readonly(
+            "operator_phone",
+            &CDM::Metadata::operatorPhone,
+            R"doc(
+                The operator phone.
+            )doc"
+        )
+        .def_readonly(
+            "operator_email",
+            &CDM::Metadata::operatorEmail,
+            R"doc(
+                The operator email.
+            )doc"
+        )
+        .def_readonly(
+            "ephemeris_name",
+            &CDM::Metadata::ephemerisName,
+            R"doc(
+                The ephemeris name.
+            )doc"
+        )
+        .def_readonly(
+            "covariance_method",
+            &CDM::Metadata::covarianceMethod,
+            R"doc(
+                The covariance method.
+            )doc"
+        )
+        .def_readonly(
+            "maneuverable",
+            &CDM::Metadata::maneuverable,
+            R"doc(
+                The maneuverable.
+            )doc"
+        )
+        .def_readonly(
+            "orbit_center",
+            &CDM::Metadata::orbitCenter,
+            R"doc(
+                The orbit center.
+            )doc"
+        )
+        .def_readonly(
+            "reference_frame",
+            &CDM::Metadata::refFrame,
+            R"doc(
+                The reference frame.
+            )doc"
+        )
+        .def_readonly(
+            "gravity_model",
+            &CDM::Metadata::gravityModel,
+            R"doc(
+                The gravity model.
+            )doc"
+        )
+        .def_readonly(
+            "atmospheric_model",
+            &CDM::Metadata::atmosphericModel,
+            R"doc(
+                The atmospheric model.
+            )doc"
+        )
+        .def_readonly(
+            "n_body_perturbations",
+            &CDM::Metadata::nBodyPerturbations,
+            R"doc(
+                The n-body perturbations.
+            )doc"
+        )
+        .def_readonly(
+            "solar_radiation_pressure",
+            &CDM::Metadata::solarRadiationPressure,
+            R"doc(
+                The solar radiation pressure.
+            )doc"
+        )
+        .def_readonly(
+            "earth_tides",
+            &CDM::Metadata::earthTides,
+            R"doc(
+                The earth tides.
+            )doc"
+        )
+        .def_readonly(
+            "in_track_thrust",
+            &CDM::Metadata::inTrackThrust,
+            R"doc(
+                The in-track thrust.
+            )doc"
+        )
 
         ;
 
-    class_<CDM::Data>(cdm, "Data")
+    class_<CDM::Data>(
+        cdm,
+        "Data",
+        R"doc(
+            Conjunction Data Message data.
+
+            Ref: https://public.ccsds.org/Pubs/508x0b1e2s.pdf
+
+            Group:
+                CCSDS
+        )doc"
+    )
 
         .def(
             init<
@@ -254,6 +920,32 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
                 const Real&,
                 const State&,
                 const MatrixXd&>(),
+            R"doc(
+            Constructor.
+
+            Args:
+                time_last_observation_start (Instant): The time of the last observation start.
+                time_last_observation_end (Instant): The time of the last observation end.
+                recommended_od_span (Duration): The recommended OD span.
+                actual_od_span (Duration): The actual OD span.
+                observations_available (int): The number of observations available.
+                observations_used (int): The number of observations used.
+                tracks_available (int): The number of tracks available.
+                tracks_used (int): The number of tracks used.
+                residuals_accepted (float): The residuals accepted.
+                weighted_rms (float): The weighted RMS.
+                area_pc (float): The area PC.
+                area_drag (float): The area drag.
+                area_srp (float): The area SRP.
+                mass (Mass): The mass.
+                cd_area_over_mass (float): The CD area over mass.
+                cr_area_over_mass (float): The CR area over mass.
+                thrust_acceleration (float): The thrust acceleration.
+                sedr (float): The SEDR.
+                state (State): The state.
+                covariance_matrix (MatrixXd): The covariance matrix.
+
+        )doc",
             arg("time_last_observation_start"),
             arg("time_last_observation_end"),
             arg("recommended_od_span"),
@@ -276,26 +968,146 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Conjunction_Messages_CCSDS_CDM(pybin
             arg("covariance_matrix") = MatrixXd::Zero(9, 9)
         )
 
-        .def_readonly("time_last_observation_start", &CDM::Data::timeLastObStart)
-        .def_readonly("time_last_observation_end", &CDM::Data::timeLastObEnd)
-        .def_readonly("recommended_od_span", &CDM::Data::recommendedODSpan)
-        .def_readonly("actual_od_span", &CDM::Data::actualODSpan)
-        .def_readonly("observations_available", &CDM::Data::obsAvailable)
-        .def_readonly("observations_used", &CDM::Data::obsUsed)
-        .def_readonly("tracks_available", &CDM::Data::tracksAvailable)
-        .def_readonly("tracks_used", &CDM::Data::tracksUsed)
-        .def_readonly("residuals_accepted", &CDM::Data::residualsAccepted)
-        .def_readonly("weighted_rms", &CDM::Data::weightedRMS)
-        .def_readonly("area_pc", &CDM::Data::areaPC)
-        .def_readonly("area_drag", &CDM::Data::areaDrag)
-        .def_readonly("area_srp", &CDM::Data::areaSRP)
-        .def_readonly("mass", &CDM::Data::mass)
-        .def_readonly("cd_area_over_mass", &CDM::Data::cdAreaOverMass)
-        .def_readonly("cr_area_over_mass", &CDM::Data::crAreaOverMass)
-        .def_readonly("thrust_acceleration", &CDM::Data::thrustAcceleration)
-        .def_readonly("sedr", &CDM::Data::SEDR)
-        .def_readonly("state", &CDM::Data::state)
-        .def_readonly("covariance_matrix", &CDM::Data::covarianceMatrix)
+        .def_readonly(
+            "time_last_observation_start",
+            &CDM::Data::timeLastObStart,
+            R"doc(
+                The time of the last observation start.
+            )doc"
+        )
+        .def_readonly(
+            "time_last_observation_end",
+            &CDM::Data::timeLastObEnd,
+            R"doc(
+                The time of the last observation end.
+            )doc"
+        )
+        .def_readonly(
+            "recommended_od_span",
+            &CDM::Data::recommendedODSpan,
+            R"doc(
+                The recommended OD span.
+            )doc"
+        )
+        .def_readonly(
+            "actual_od_span",
+            &CDM::Data::actualODSpan,
+            R"doc(
+                The actual OD span.
+            )doc"
+        )
+        .def_readonly(
+            "observations_available",
+            &CDM::Data::obsAvailable,
+            R"doc(
+                The number of observations available.
+            )doc"
+        )
+        .def_readonly(
+            "observations_used",
+            &CDM::Data::obsUsed,
+            R"doc(
+                The number of observations used.
+            )doc"
+        )
+        .def_readonly(
+            "tracks_available",
+            &CDM::Data::tracksAvailable,
+            R"doc(
+                The number of tracks available.
+            )doc"
+        )
+        .def_readonly(
+            "tracks_used",
+            &CDM::Data::tracksUsed,
+            R"doc(
+                The number of tracks used.
+            )doc"
+        )
+        .def_readonly(
+            "residuals_accepted",
+            &CDM::Data::residualsAccepted,
+            R"doc(
+                The residuals accepted.
+            )doc"
+        )
+        .def_readonly(
+            "weighted_rms",
+            &CDM::Data::weightedRMS,
+            R"doc(
+                The weighted RMS.
+            )doc"
+        )
+        .def_readonly(
+            "area_pc",
+            &CDM::Data::areaPC,
+            R"doc(
+                The area PC.
+            )doc"
+        )
+        .def_readonly(
+            "area_drag",
+            &CDM::Data::areaDrag,
+            R"doc(
+                The area drag.
+            )doc"
+        )
+        .def_readonly(
+            "area_srp",
+            &CDM::Data::areaSRP,
+            R"doc(
+                The area SRP.
+            )doc"
+        )
+        .def_readonly(
+            "mass",
+            &CDM::Data::mass,
+            R"doc(
+                The mass.
+            )doc"
+        )
+        .def_readonly(
+            "cd_area_over_mass",
+            &CDM::Data::cdAreaOverMass,
+            R"doc(
+                The CD area over mass.
+            )doc"
+        )
+        .def_readonly(
+            "cr_area_over_mass",
+            &CDM::Data::crAreaOverMass,
+            R"doc(
+                The CR area over mass.
+            )doc"
+        )
+        .def_readonly(
+            "thrust_acceleration",
+            &CDM::Data::thrustAcceleration,
+            R"doc(
+                The thrust acceleration.
+            )doc"
+        )
+        .def_readonly(
+            "sedr",
+            &CDM::Data::SEDR,
+            R"doc(
+                The SEDR.
+            )doc"
+        )
+        .def_readonly(
+            "state",
+            &CDM::Data::state,
+            R"doc(
+                The state.
+            )doc"
+        )
+        .def_readonly(
+            "covariance_matrix",
+            &CDM::Data::covarianceMatrix,
+            R"doc(
+                The covariance matrix.
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics.cpp
@@ -69,21 +69,122 @@ class PyDynamics : public Dynamics
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics(pybind11::module& aModule)
 {
-    class_<Dynamics, PyDynamics, Shared<Dynamics>>(aModule, "Dynamics")
+    class_<Dynamics, PyDynamics, Shared<Dynamics>>(
+        aModule,
+        "Dynamics",
+        R"doc(
+            Abstract interface class for dynamics.
+            
+            Can inherit and provide the virtual methods:
+                - is_defined
+                - get_read_coordinates_subsets
+                - get_write_coordinates_subsets
+                - compute_contribution
+            to create a custom dynamics class
 
-        .def(init<const String&>(), arg("name"))
+            Group:
+                astrodynamics
+            
+        )doc"
+    )
 
-        .def("get_name", &Dynamics::getName)
+        .def(
+            init<const String&>(),
+            arg("name"),
+            R"doc(
+                Construct a new `Dynamics` object.
+
+                Args:
+                    name (str): The name of the dynamics.
+
+                Returns:
+                    dynamics (Dynamics): The new `Dynamics` object.
+            )doc"
+        )
+
+        .def(
+            "get_name",
+            &Dynamics::getName,
+            R"doc(
+                Get the name of the dynamics.
+
+                Returns:
+                    name (str): The name of the dynamics.
+            )doc"
+        )
 
         .def("__str__", &(shiftToString<Dynamics>))
         .def("__repr__", &(shiftToString<Dynamics>))
 
-        .def("is_defined", &Dynamics::isDefined)
-        .def("get_read_coordinates_subsets", &Dynamics::getReadCoordinatesSubsets)
-        .def("get_write_coordinates_subsets", &Dynamics::getWriteCoordinatesSubsets)
-        .def("compute_contribution", &Dynamics::computeContribution, arg("instant"), arg("state_vector"), arg("frame"))
+        .def(
+            "is_defined",
+            &Dynamics::isDefined,
+            R"doc(
+                Check if the dynamics is defined.
 
-        .def_static("from_environment", &Dynamics::FromEnvironment, arg("environment"))
+                Returns:
+                    is_defined (bool): True if the dynamics is defined, False otherwise.
+            )doc"
+        )
+
+        .def(
+            "get_read_coordinates_subsets",
+            &Dynamics::getReadCoordinatesSubsets,
+            R"doc(
+                Get the coordinates subsets that the dynamics reads.
+
+                Returns:
+                    read_coordinates_subsets (Array<CoordinatesSubset>): The coordinates subsets that the dynamics reads.
+            )doc"
+        )
+
+        .def(
+            "get_write_coordinates_subsets",
+            &Dynamics::getWriteCoordinatesSubsets,
+            R"doc(
+                Get the coordinates subsets that the dynamics writes.
+
+                Returns:
+                    write_coordinates_subsets (Array<CoordinatesSubset>): The coordinates subsets that the dynamics writes.
+            )doc"
+        )
+
+        .def(
+            "compute_contribution",
+            &Dynamics::computeContribution,
+            arg("instant"),
+            arg("state_vector"),
+            arg("frame"),
+            R"doc(
+                Compute the contribution of the dynamics at a given instant.
+
+                Args:
+                    instant (Instant): The instant at which to compute the contribution.
+                    state_vector (numpy.ndarray): The state vector at the instant.
+                    frame (Frame): The reference frame in which to compute the contribution.
+
+                Returns:
+                    contribution (numpy.ndarray): The contribution of the dynamics at the instant.
+            )doc"
+        )
+
+        .def_static(
+            "from_environment",
+            &Dynamics::FromEnvironment,
+            arg("environment"),
+            R"doc(
+                Create a `Dynamics` object from an environment.
+
+                Args:
+                    environment (Environment): The environment to create the dynamics from.
+
+                Returns:
+                    dynamics (Dynamics): The `Dynamics` object created from the environment.
+                
+                Group:
+                    Static methods
+            )doc"
+        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics.cpp
@@ -83,8 +83,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics(pybind11::module& aModule)
             to create a custom dynamics class
 
             Group:
-                astrodynamics
-            
+                dynamics
         )doc"
     )
 
@@ -180,9 +179,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics(pybind11::module& aModule)
 
                 Returns:
                     dynamics (Dynamics): The `Dynamics` object created from the environment.
-                
-                Group:
-                    Static methods
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/AtmosphericDrag.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/AtmosphericDrag.cpp
@@ -14,7 +14,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_AtmosphericDrag(pybind11::m
     using ostk::astro::dynamics::AtmosphericDrag;
 
     {
-        class_<AtmosphericDrag, Dynamics, Shared<AtmosphericDrag>>(aModule, "AtmosphericDrag")
+        class_<AtmosphericDrag, Dynamics, Shared<AtmosphericDrag>>(
+            aModule,
+            "AtmosphericDrag",
+            R"doc(
+                The atmospheric drag dynamics.
+
+                Group:
+                    dynamics
+            )doc"
+        )
             .def(
                 init<const Shared<Celestial>&>(),
                 arg("celestial"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/AtmosphericDrag.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/AtmosphericDrag.cpp
@@ -15,15 +15,63 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_AtmosphericDrag(pybind11::m
 
     {
         class_<AtmosphericDrag, Dynamics, Shared<AtmosphericDrag>>(aModule, "AtmosphericDrag")
-            .def(init<const Shared<Celestial>&>(), arg("celestial"))
+            .def(
+                init<const Shared<Celestial>&>(),
+                arg("celestial"),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        celestial (Celestial): The celestial body.
+
+                )doc"
+            )
 
             .def("__str__", &(shiftToString<AtmosphericDrag>))
             .def("__repr__", &(shiftToString<AtmosphericDrag>))
 
-            .def("is_defined", &AtmosphericDrag::isDefined)
+            .def(
+                "is_defined",
+                &AtmosphericDrag::isDefined,
+                R"doc(
+                    Check if the atmospheric drag is defined.
 
-            .def("get_celestial", &AtmosphericDrag::getCelestial)
+                    Returns:
+                        bool: True if the atmospheric drag is defined, False otherwise.
 
-            .def("compute_contribution", &AtmosphericDrag::computeContribution, arg("instant"), arg("x"), arg("frame"));
+                )doc"
+            )
+
+            .def(
+                "get_celestial",
+                &AtmosphericDrag::getCelestial,
+                R"doc(
+                    Get the celestial body.
+
+                    Returns:
+                        Celestial: The celestial body.
+
+                )doc"
+            )
+
+            .def(
+                "compute_contribution",
+                &AtmosphericDrag::computeContribution,
+                arg("instant"),
+                arg("x"),
+                arg("frame"),
+                R"doc(
+                    Compute the contribution of the atmospheric drag to the state vector.
+
+                    Args:
+                        instant (Instant): The instant of the state vector.
+                        x (numpy.ndarray): The state vector.
+                        frame (Frame): The reference frame.
+
+                    Returns:
+                        numpy.ndarray: The contribution of the atmospheric drag to the state vector.
+
+                )doc"
+            );
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/CentralBodyGravity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/CentralBodyGravity.cpp
@@ -14,18 +14,73 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_CentralBodyGravity(pybind11
     using ostk::astro::dynamics::CentralBodyGravity;
 
     {
-        class_<CentralBodyGravity, Dynamics, Shared<CentralBodyGravity>>(aModule, "CentralBodyGravity")
-            .def(init<const Shared<Celestial>&>(), arg("celestial"))
+        class_<CentralBodyGravity, Dynamics, Shared<CentralBodyGravity>>(
+            aModule,
+            "CentralBodyGravity",
+            R"doc(
+                The central-body gravity model.
+
+                Group:
+                    Dynamics
+            )doc"
+        )
+            .def(
+                init<const Shared<Celestial>&>(),
+                arg("celestial"),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        celestial (Celestial): The central body.
+
+                )doc"
+            )
 
             .def("__str__", &(shiftToString<CentralBodyGravity>))
             .def("__repr__", &(shiftToString<CentralBodyGravity>))
 
-            .def("is_defined", &CentralBodyGravity::isDefined)
+            .def(
+                "is_defined",
+                &CentralBodyGravity::isDefined,
+                R"doc(
+                    Check if the central-body gravity is defined.
 
-            .def("get_celestial", &CentralBodyGravity::getCelestial)
+                    Returns:
+                        bool: True if the central-body gravity is defined, False otherwise.
+
+                )doc"
+            )
 
             .def(
-                "compute_contribution", &CentralBodyGravity::computeContribution, arg("instant"), arg("x"), arg("frame")
+                "get_celestial",
+                &CentralBodyGravity::getCelestial,
+                R"doc(
+                    Get the central body.
+
+                    Returns:
+                        Celestial: The central body.
+
+                )doc"
+            )
+
+            .def(
+                "compute_contribution",
+                &CentralBodyGravity::computeContribution,
+                arg("instant"),
+                arg("x"),
+                arg("frame"),
+                R"doc(
+                    Compute the contribution of the central-body gravity to the state vector.
+
+                    Args:
+                        instant (Instant): The instant of the state vector.
+                        x (numpy.ndarray): The state vector.
+                        frame (Frame): The reference frame.
+
+                    Returns:
+                        numpy.ndarray: The contribution of the central-body gravity to the state vector.
+
+                )doc"
             );
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/CentralBodyGravity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/CentralBodyGravity.cpp
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_CentralBodyGravity(pybind11
                 The central-body gravity model.
 
                 Group:
-                    Dynamics
+                    dynamics
             )doc"
         )
             .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/PositionDerivative.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/PositionDerivative.cpp
@@ -14,16 +14,57 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_PositionDerivative(pybind11
     using ostk::astro::dynamics::PositionDerivative;
 
     {
-        class_<PositionDerivative, Dynamics, Shared<PositionDerivative>>(aModule, "PositionDerivative")
-            .def(init<>())
+        class_<PositionDerivative, Dynamics, Shared<PositionDerivative>>(
+            aModule,
+            "PositionDerivative",
+            R"doc(
+                The position derivative model.
+
+                Group:
+                    Dynamics
+            )doc"
+        )
+            .def(
+                init<>(),
+                R"doc(
+                    Constructor.
+
+                )doc"
+            )
 
             .def("__str__", &(shiftToString<PositionDerivative>))
             .def("__repr__", &(shiftToString<PositionDerivative>))
 
-            .def("is_defined", &PositionDerivative::isDefined)
+            .def(
+                "is_defined",
+                &PositionDerivative::isDefined,
+                R"doc(
+                    Check if the position derivative is defined.
+
+                    Returns:
+                        bool: True if the position derivative is defined, False otherwise.
+
+                )doc"
+            )
 
             .def(
-                "compute_contribution", &PositionDerivative::computeContribution, arg("instant"), arg("x"), arg("frame")
+                "compute_contribution",
+                &PositionDerivative::computeContribution,
+                arg("instant"),
+                arg("x"),
+                arg("frame"),
+                R"doc(
+                    Compute the contribution of the position derivative to the state vector.
+
+                    Args:
+                        instant (Instant): The instant of the state vector.
+                        x (numpy.ndarray): The state vector.
+                        frame (Frame): The reference frame.
+
+                    Returns:
+                        numpy.ndarray: The contribution of the position derivative to the state vector.
+                    
+                )doc"
             );
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/PositionDerivative.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/PositionDerivative.cpp
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_PositionDerivative(pybind11
                 The position derivative model.
 
                 Group:
-                    Dynamics
+                    dynamics
             )doc"
         )
             .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/ThirdBodyGravity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/ThirdBodyGravity.cpp
@@ -14,18 +14,73 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_ThirdBodyGravity(pybind11::
     using ostk::astro::dynamics::ThirdBodyGravity;
 
     {
-        class_<ThirdBodyGravity, Dynamics, Shared<ThirdBodyGravity>>(aModule, "ThirdBodyGravity")
-            .def(init<const Shared<Celestial>&>(), arg("celestial"))
+        class_<ThirdBodyGravity, Dynamics, Shared<ThirdBodyGravity>>(
+            aModule,
+            "ThirdBodyGravity"
+            R"doc(
+                The third-body gravity model.
+
+                Group:
+                    Dynamics
+            )doc"
+        )
+            .def(
+                init<const Shared<Celestial>&>(),
+                arg("celestial"),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        celestial (Celestial): The celestial body.
+
+                )doc"
+            )
 
             .def("__str__", &(shiftToString<ThirdBodyGravity>))
             .def("__repr__", &(shiftToString<ThirdBodyGravity>))
 
-            .def("is_defined", &ThirdBodyGravity::isDefined)
+            .def(
+                "is_defined",
+                &ThirdBodyGravity::isDefined,
+                R"doc(
+                    Check if the third-body gravity is defined.
 
-            .def("get_celestial", &ThirdBodyGravity::getCelestial)
+                    Returns:
+                        bool: True if the third-body gravity is defined, False otherwise.
+
+                )doc"
+            )
 
             .def(
-                "compute_contribution", &ThirdBodyGravity::computeContribution, arg("instant"), arg("x"), arg("frame")
+                "get_celestial",
+                &ThirdBodyGravity::getCelestial,
+                R"doc(
+                    Get the celestial body.
+
+                    Returns:
+                        Celestial: The celestial body.
+
+                )doc"
+            )
+
+            .def(
+                "compute_contribution",
+                &ThirdBodyGravity::computeContribution,
+                arg("instant"),
+                arg("x"),
+                arg("frame"),
+                R"doc(
+                    Compute the contribution of the third-body gravity to the state vector.
+
+                    Args:
+                        instant (Instant): The instant of the state vector.
+                        x (numpy.ndarray): The state vector.
+                        frame (Frame): The reference frame.
+
+                    Returns:
+                        numpy.ndarray: The contribution of the third-body gravity to the state vector.
+
+                )doc"
             );
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/ThirdBodyGravity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/ThirdBodyGravity.cpp
@@ -16,12 +16,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_ThirdBodyGravity(pybind11::
     {
         class_<ThirdBodyGravity, Dynamics, Shared<ThirdBodyGravity>>(
             aModule,
-            "ThirdBodyGravity"
+            "ThirdBodyGravity",
             R"doc(
-                The third-body gravity model.
+                The third body gravity model.
 
                 Group:
-                    Dynamics
+                    dynamics
             )doc"
         )
             .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster.cpp
@@ -67,18 +67,91 @@ class PyThruster : public Thruster
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Thruster(pybind11::module& aModule)
 {
-    class_<Thruster, PyThruster, Dynamics, Shared<Thruster>>(aModule, "Thruster")
+    class_<Thruster, PyThruster, Dynamics, Shared<Thruster>>(
+        aModule,
+        "Thruster",
+        R"doc(
+            Abstract Thruster Class.
 
-        .def(init<const SatelliteSystem&, const String&>(), arg("satellite_system"), arg("name") = String::Empty())
+            Base class to derive other thruster classes from. Cannot be instantiated.
 
-        .def("get_name", &Thruster::getName)
-        .def("get_satelltite_system", &Thruster::getSatelliteSystem)
+            Group:
+                Dynamics
+        )doc"
+    )
+
+        .def(
+            init<const SatelliteSystem&, const String&>(),
+            arg("satellite_system"),
+            arg("name") = String::Empty(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    satellite_system (SatelliteSystem): The satellite system.
+                    name (str): The name of the thruster.
+
+            )doc"
+        )
+
+        .def(
+            "get_name",
+            &Thruster::getName,
+            R"doc(
+                Get the name of the thruster.
+
+                Returns:
+                    str: The name of the thruster.
+
+            )doc"
+        )
+
+        .def(
+            "get_satelltite_system",
+            &Thruster::getSatelliteSystem,
+            R"doc(
+                Get the satellite system of the thruster.
+
+                Returns:
+                    SatelliteSystem: The satellite system.
+
+            )doc"
+        )
 
         .def("__str__", &(shiftToString<Thruster>))
         .def("__repr__", &(shiftToString<Thruster>))
 
-        .def("is_defined", &Thruster::isDefined)
-        .def("compute_contribution", &Thruster::computeContribution, arg("instant"), arg("state_vector"), arg("frame"))
+        .def(
+            "is_defined",
+            &Thruster::isDefined,
+            R"doc(
+                Check if the thruster is defined.
+
+                Returns:
+                    bool: True if the thruster is defined, False otherwise.
+
+            )doc"
+        )
+
+        .def(
+            "compute_contribution",
+            &Thruster::computeContribution,
+            arg("instant"),
+            arg("state_vector"),
+            arg("frame"),
+            R"doc(
+                Compute the contribution of the thruster to the state vector.
+
+                Args:
+                    instant (Instant): The instant of the state vector.
+                    state_vector (numpy.ndarray): The state vector.
+                    frame (Frame): The reference frame.
+
+                Returns:
+                    numpy.ndarray: The contribution of the thruster to the state vector.
+
+            )doc"
+        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster.cpp
@@ -76,7 +76,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Thruster(pybind11::module& 
             Base class to derive other thruster classes from. Cannot be instantiated.
 
             Group:
-                Dynamics
+                dynamics
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster/ConstantThrust.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster/ConstantThrust.cpp
@@ -25,7 +25,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Thruster_ConstantThrust(pyb
                 Constant Thrust, Constant Direction dynamics.
 
                 Group:
-                    Thruster
+                    thruster
             )doc"
         )
             .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster/ConstantThrust.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster/ConstantThrust.cpp
@@ -18,30 +18,117 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Thruster_ConstantThrust(pyb
     using ostk::astro::flight::system::SatelliteSystem;
 
     {
-        class_<ConstantThrust, Thruster, Shared<ConstantThrust>>(aModule, "ConstantThrust")
+        class_<ConstantThrust, Thruster, Shared<ConstantThrust>>(
+            aModule,
+            "ConstantThrust",
+            R"doc(
+                Constant Thrust, Constant Direction dynamics.
+
+                Group:
+                    Thruster
+            )doc"
+        )
             .def(
                 init<const SatelliteSystem&, const LocalOrbitalFrameDirection&, const String&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        satellite_system (SatelliteSystem): The satellite system.
+                        thrust_direction (LocalOrbitalFrameDirection): The thrust direction.
+                        name (str, optional): The name of the thruster.
+
+                )doc",
                 arg("satellite_system"),
                 arg("thrust_direction"),
                 arg("name") = String::Empty()
             )
 
-            // .def("__str__", &(shiftToString<ConstantThrust>))
-            // .def("__repr__", &(shiftToString<ConstantThrust>))
+            .def(
+                "is_defined",
+                &ConstantThrust::isDefined,
+                R"doc(
+                    Check if the constant thrust is defined.
 
-            .def("is_defined", &ConstantThrust::isDefined)
+                    Returns:
+                        bool: True if the constant thrust is defined, False otherwise.
 
-            // .def("get_thrust", &ConstantThrust::getThrust)
-            .def("get_local_thrust_direction", &ConstantThrust::getLocalThrustDirection)
+                )doc"
+            )
 
-            .def("get_read_coordinates_subsets", &ConstantThrust::getReadCoordinatesSubsets)
-            .def("get_write_coordinates_subsets", &ConstantThrust::getWriteCoordinatesSubsets)
+            .def(
+                "get_local_thrust_direction",
+                &ConstantThrust::getLocalThrustDirection,
+                R"doc(
+                    Get the local thrust direction.
 
-            .def("compute_contribution", &ConstantThrust::computeContribution, arg("instant"), arg("x"), arg("frame"))
+                    Returns:
+                        LocalOrbitalFrameDirection: The local thrust direction.
+
+                )doc"
+            )
+
+            .def(
+                "get_read_coordinates_subsets",
+                &ConstantThrust::getReadCoordinatesSubsets,
+                R"doc(
+                    Get the subsets of coordinates read by the constant thrust.
+
+                    Returns:
+                        list: The subsets of coordinates read by the constant thrust.
+
+                )doc"
+            )
+
+            .def(
+                "get_write_coordinates_subsets",
+                &ConstantThrust::getWriteCoordinatesSubsets,
+                R"doc(
+                    Get the subsets of coordinates written by the constant thrust.
+
+                    Returns:
+                        list: The subsets of coordinates written by the constant thrust.
+
+                )doc"
+            )
+
+            .def(
+                "compute_contribution",
+                &ConstantThrust::computeContribution,
+                arg("instant"),
+                arg("x"),
+                arg("frame"),
+                R"doc(
+                    Compute the contribution of the constant thrust to the state vector.
+
+                    Args:
+                        instant (Instant): The instant of the state vector.
+                        x (numpy.ndarray): The state vector.
+                            frame (Frame): The reference frame.
+
+                    Returns:
+                        numpy.ndarray: The contribution of the constant thrust to the state vector.
+
+                )doc"
+            )
 
             .def_static(
                 "intrack",
                 &ConstantThrust::Intrack,
+                R"doc(
+                    Create a constant thrust in the in-track direction.
+
+                    Args:
+                        satellite_system (SatelliteSystem): The satellite system.
+                        velocity_direction (bool, optional): If True, the thrust is applied in the velocity direction. Otherwise, it is applied in the opposite direction.
+                        frame (Frame, optional): The reference frame.
+
+                    Returns:
+                        ConstantThrust: The constant thrust.
+
+                    Group:
+                        Static methods
+                )doc",
                 arg("satellite_system"),
                 arg("velocity_direction") = true,
                 arg("frame") = Frame::GCRF()

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster/ConstantThrust.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster/ConstantThrust.cpp
@@ -25,7 +25,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Thruster_ConstantThrust(pyb
                 Constant Thrust, Constant Direction dynamics.
 
                 Group:
-                    thruster
+                    dynamics
             )doc"
         )
             .def(
@@ -125,9 +125,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Thruster_ConstantThrust(pyb
 
                     Returns:
                         ConstantThrust: The constant thrust.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("satellite_system"),
                 arg("velocity_direction") = true,

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
@@ -38,19 +38,62 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition(pybind11::module& aMo
 {
     {
         class_<EventCondition, PyEventCondition, Shared<EventCondition>> eventCondition_class(
-            aModule, "EventCondition"
+            aModule,
+            "EventCondition",
+            R"doc(
+                An Event Condition defines a criterion that can be evaluated based on a current/previous state vectors and times
+
+                Group:
+                    astrodynamics
+            )doc"
         );
 
         eventCondition_class
 
-            .def(init<const String&>(), arg("name"))
+            .def(
+                init<const String&>(),
+                arg("name"),
+                R"doc(
+                    Construct a new `EventCondition` object.
+
+                    Args:
+                        name (str): The name of the event condition.
+
+                    Returns:
+                        event_condition (EventCondition): The new `EventCondition` object.
+                )doc"
+            )
 
             .def("__str__", &(shiftToString<EventCondition>))
             .def("__repr__", &(shiftToString<EventCondition>))
 
-            .def("get_name", &EventCondition::getName)
+            .def(
+                "get_name",
+                &EventCondition::getName,
+                R"doc(
+                    Get the name of the event condition.
 
-            .def("is_satisfied", &EventCondition::isSatisfied, arg("current_state"), arg("previous_state"))
+                    Returns:
+                       name (str): The name of the event condition.
+                )doc"
+            )
+
+            .def(
+                "is_satisfied",
+                &EventCondition::isSatisfied,
+                arg("current_state"),
+                arg("previous_state"),
+                R"doc(
+                    Check if the event condition is satisfied.
+
+                    Args:
+                        current_state (State): The current state.
+                        previous_state (State): The previous state.
+
+                    Returns:
+                       is_satisfied (bool): True if the event condition is satisfied, False otherwise.
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
@@ -44,7 +44,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition(pybind11::module& aMo
                 An Event Condition defines a criterion that can be evaluated based on a current/previous state vectors and times
 
                 Group:
-                    astrodynamics
+                    event-condition
             )doc"
         );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp
@@ -32,6 +32,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
             )doc"
         );
 
+        enum_<AngularCondition::Criterion>(
+            angularCondition,
+            "Criterion",
+            R"doc(
+                Angular condition criterion.
+
+            )doc"
+        )
+
+            .value("PositiveCrossing", AngularCondition::Criterion::PositiveCrossing)
+            .value("NegativeCrossing", AngularCondition::Criterion::NegativeCrossing)
+            .value("AnyCrossing", AngularCondition::Criterion::AnyCrossing)
+            .value("WithinRange", AngularCondition::Criterion::WithinRange)
+
+            ;
+
         angularCondition
 
             .def(
@@ -45,7 +61,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
 
                     Args:
                         name (str): The name of the condition.
-                        criterion (Criterion): The criterion of the condition.
+                        criterion (ostk.astrodynamics.event_condition.AngularCondition.Criterion): The criterion of the condition.
                         evaluator (function): The evaluator of the condition.
                         target_angle (Angle): The target angle of the condition.
 
@@ -66,7 +82,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
                     Get the criterion of the condition.
 
                     Returns:
-                        Criterion: The criterion of the condition.
+                        ostk.astrodynamics.event_condition.AngularCondition.Criterion: The criterion of the condition.
 
                 )doc"
             )
@@ -154,7 +170,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
                     Get the string representation of a criterion.
 
                     Args:
-                        criterion (Criterion): The criterion.
+                        criterion (ostk.astrodynamics.event_condition.AngularCondition.Criterion): The criterion.
 
                     Returns:
                         str: The string representation of the criterion.
@@ -164,15 +180,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
                 )doc",
                 arg("criterion")
             )
-
-            ;
-
-        enum_<AngularCondition::Criterion>(angularCondition, "Criterion")
-
-            .value("PositiveCrossing", AngularCondition::Criterion::PositiveCrossing)
-            .value("NegativeCrossing", AngularCondition::Criterion::NegativeCrossing)
-            .value("AnyCrossing", AngularCondition::Criterion::AnyCrossing)
-            .value("WithinRange", AngularCondition::Criterion::WithinRange)
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp
@@ -28,7 +28,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
                 An Angular Event Condition.
 
                 Group:
-                    Event Condition
+                    event-condition
             )doc"
         );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp
@@ -22,7 +22,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
 {
     {
         class_<AngularCondition, EventCondition, Shared<AngularCondition>> angularCondition(
-            aModule, "AngularCondition"
+            aModule,
+            "AngularCondition",
+            R"doc(
+                An Angular Event Condition.
+
+                Group:
+                    Event Condition
+            )doc"
         );
 
         angularCondition
@@ -33,6 +40,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
                     const AngularCondition::Criterion&,
                     std::function<Real(const State&)>,
                     const Angle&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        name (str): The name of the condition.
+                        criterion (Criterion): The criterion of the condition.
+                        evaluator (function): The evaluator of the condition.
+                        target_angle (Angle): The target angle of the condition.
+
+                )doc",
                 arg("name"),
                 arg("criterion"),
                 arg("evaluator"),
@@ -42,17 +59,111 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
             .def("__str__", &(shiftToString<AngularCondition>))
             .def("__repr__", &(shiftToString<AngularCondition>))
 
-            .def("get_criterion", &AngularCondition::getCriterion)
-            .def("get_evaluator", &AngularCondition::getEvaluator)
-            .def("get_target_angle", &AngularCondition::getTargetAngle)
-            .def("get_target_range", &AngularCondition::getTargetRange)
+            .def(
+                "get_criterion",
+                &AngularCondition::getCriterion,
+                R"doc(
+                    Get the criterion of the condition.
 
-            .def("is_satisfied", &AngularCondition::isSatisfied, arg("current_state"), arg("previous_state"))
+                    Returns:
+                        Criterion: The criterion of the condition.
+
+                )doc"
+            )
+
+            .def(
+                "get_evaluator",
+                &AngularCondition::getEvaluator,
+                R"doc(
+                    Get the evaluator of the condition.
+
+                    Returns:
+                        function: The evaluator of the condition.
+
+                )doc"
+            )
+
+            .def(
+                "get_target_angle",
+                &AngularCondition::getTargetAngle,
+                R"doc(
+                    Get the target angle of the condition.
+
+                    Returns:
+                        Angle: The target angle of the condition.
+
+                )doc"
+            )
+
+            .def(
+                "get_target_range",
+                &AngularCondition::getTargetRange,
+                R"doc(
+                    Get the target range of the condition.
+
+                    Returns:
+                        tuple: The target range of the condition.
+
+                )doc"
+            )
+
+            .def(
+                "is_satisfied",
+                &AngularCondition::isSatisfied,
+                R"doc(
+                    Check if the condition is satisfied.
+
+                    Args:
+                        current_state (State): The current state.
+                        previous_state (State): The previous state.
+
+                    Returns:
+                        bool: True if the condition is satisfied, False otherwise.
+
+                )doc",
+                arg("current_state"),
+                arg("previous_state")
+            )
 
             .def_static(
-                "within_range", &AngularCondition::WithinRange, arg("name"), arg("evaluator"), arg("target_range")
+                "within_range",
+                &AngularCondition::WithinRange,
+                R"doc(
+                    Create an angular condition that is satisfied when the angle is within a range.
+
+                    Args:
+                        name (str): The name of the condition.
+                        evaluator (function): The evaluator of the condition.
+                        target_range (tuple): The target range of the condition.
+
+                    Returns:
+                        AngularCondition: The angular condition.
+
+                    Group:
+                        Static methods
+                )doc",
+                arg("name"),
+                arg("evaluator"),
+                arg("target_range")
             )
-            .def_static("string_from_criterion", &AngularCondition::StringFromCriterion, arg("criterion"))
+
+            .def_static(
+                "string_from_criterion",
+                &AngularCondition::StringFromCriterion,
+                R"doc(
+                    Get the string representation of a criterion.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+
+                    Returns:
+                        str: The string representation of the criterion.
+
+                    Group:
+                        Static methods
+                )doc",
+                arg("criterion")
+            )
 
             ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp
@@ -155,8 +155,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
                     Returns:
                         AngularCondition: The angular condition.
 
-                    Group:
-                        Static methods
                 )doc",
                 arg("name"),
                 arg("evaluator"),
@@ -175,8 +173,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_AngularCondition(pybi
                     Returns:
                         str: The string representation of the criterion.
 
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion")
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanCondition.cpp
@@ -18,10 +18,31 @@ using ostk::astro::trajectory::State;
 
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BooleanCondition(pybind11::module& aModule)
 {
-    class_<BooleanCondition, RealCondition, Shared<BooleanCondition>>(aModule, "BooleanCondition")
+    class_<BooleanCondition, RealCondition, Shared<BooleanCondition>>(
+        aModule,
+        "BooleanCondition",
+        R"doc(
+            A Boolean Event Condition.
+
+            Group:
+                Event Condition
+        )doc"
+    )
 
         .def(
             init<const String&, const RealCondition::Criterion&, std::function<bool(const State&)>, const bool&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    name (str): The name of the condition.
+                    criterion (Criterion): The criterion of the condition.
+                    evaluator (function): The evaluator of the condition.
+                    is_inverse (bool): Whether the condition is inverse.
+
+                Group:
+                    Constructors
+            )doc",
             arg("name"),
             arg("criterion"),
             arg("evaluator"),
@@ -31,11 +52,51 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BooleanCondition(pybi
         .def("__str__", &(shiftToString<BooleanCondition>))
         .def("__repr__", &(shiftToString<BooleanCondition>))
 
-        .def("is_inversed", &BooleanCondition::isInversed)
+        .def(
+            "is_inversed",
+            &BooleanCondition::isInversed,
+            R"doc(
+                Check if the condition is inverse.
 
-        .def("evaluate", &BooleanCondition::evaluate, arg("state"))
+                Returns:
+                    bool: True if the condition is inverse, False otherwise.
 
-        .def("is_satisfied", &BooleanCondition::isSatisfied, arg("current_state"), arg("previous_state"))
+            )doc"
+        )
+
+        .def(
+            "evaluate",
+            &BooleanCondition::evaluate,
+            R"doc(
+                Evaluate the condition.
+
+                Args:
+                    state (State): The state.
+
+                Returns:
+                    bool: True if the condition is satisfied, False otherwise.
+
+            )doc",
+            arg("state")
+        )
+
+        .def(
+            "is_satisfied",
+            &BooleanCondition::isSatisfied,
+            R"doc(
+                Check if the condition is satisfied.
+
+                Args:
+                    current_state (State): The current state.
+                    previous_state (State): The previous state.
+
+                Returns:
+                    bool: True if the condition is satisfied, False otherwise.
+
+            )doc",
+            arg("current_state"),
+            arg("previous_state")
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanCondition.cpp
@@ -25,7 +25,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BooleanCondition(pybi
             A Boolean Event Condition.
 
             Group:
-                Event Condition
+                event-condition
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
@@ -18,11 +18,35 @@ using ostk::astro::eventcondition::COECondition;
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11::module& aModule)
 {
     {
-        class_<COECondition>(aModule, "COECondition")
+        class_<COECondition>(
+            aModule,
+            "COECondition",
+            R"doc(
+                A COE Event Condition.
+
+                Group:
+                    Event Condition
+            )doc"
+        )
 
             .def_static(
                 "semi_major_axis",
                 &COECondition::SemiMajorAxis,
+                R"doc(
+                    Create a COE condition based on the semi-major axis.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        semi_major_axis (float): The semi-major axis.
+                        gravitational_parameter (float): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+
+                    Group:
+                        Static methods
+                )doc",
                 arg("criterion"),
                 arg("frame"),
                 arg("semi_major_axis"),
@@ -32,6 +56,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "eccentricity",
                 &COECondition::Eccentricity,
+                R"doc(
+                    Create a COE condition based on the eccentricity.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        eccentricity (float): The eccentricity.
+                        gravitational_parameter (float): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+
+                    Group:
+                        Static methods
+                )doc",
                 arg("criterion"),
                 arg("frame"),
                 arg("eccentricity"),
@@ -41,6 +80,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "inclination",
                 &COECondition::Inclination,
+                R"doc(
+                    Create a COE condition based on the inclination.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        inclination (float): The inclination.
+                        gravitational_parameter (float): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+
+                    Group:
+                        Static methods
+                )doc",
                 arg("criterion"),
                 arg("frame"),
                 arg("inclination"),
@@ -48,18 +102,71 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             )
 
             .def_static(
-                "aop", &COECondition::Aop, arg("criterion"), arg("frame"), arg("aop"), arg("gravitational_parameter")
+                "aop",
+                &COECondition::Aop,
+                R"doc(
+                    Create a COE condition based on the argument of perigee.
 
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        aop (float): The argument of perigee.
+                        gravitational_parameter (float): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+
+                    Group:
+                        Static methods
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("aop"),
+                arg("gravitational_parameter")
             )
 
             .def_static(
-                "raan", &COECondition::Raan, arg("criterion"), arg("frame"), arg("raan"), arg("gravitational_parameter")
+                "raan",
+                &COECondition::Raan,
+                R"doc(
+                    Create a COE condition based on the right ascension of the ascending node.
 
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        raan (float): The right ascension of the ascending node.
+                        gravitational_parameter (float): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+
+                    Group:
+                        Static methods
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("raan"),
+                arg("gravitational_parameter")
             )
 
             .def_static(
                 "true_anomaly",
                 &COECondition::TrueAnomaly,
+                R"doc(
+                    Create a COE condition based on the true anomaly.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        true_anomaly (float): The true anomaly.
+                        gravitational_parameter (float): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+
+                    Group:
+                        Static methods
+                )doc",
                 arg("criterion"),
                 arg("frame"),
                 arg("true_anomaly"),
@@ -69,6 +176,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "mean_anomaly",
                 &COECondition::MeanAnomaly,
+                R"doc(
+                    Create a COE condition based on the mean anomaly.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        mean_anomaly (float): The mean anomaly.
+                        gravitational_parameter (float): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+
+                    Group:
+                        Static methods
+                )doc",
                 arg("criterion"),
                 arg("frame"),
                 arg("mean_anomaly"),
@@ -78,6 +200,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "eccentric_anomaly",
                 &COECondition::EccentricAnomaly,
+                R"doc(
+                    Create a COE condition based on the eccentric anomaly.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        eccentric_anomaly (float): The eccentric anomaly.
+                        gravitational_parameter (float): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+
+                    Group:
+                        Static methods
+                )doc",
                 arg("criterion"),
                 arg("frame"),
                 arg("eccentric_anomaly"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
@@ -25,7 +25,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 A COE Event Condition.
 
                 Group:
-                    Event Condition
+                    event-condition
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
@@ -43,9 +43,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
                     Returns:
                         COECondition: The COE condition.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -67,9 +64,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
                     Returns:
                         COECondition: The COE condition.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -91,9 +85,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
                     Returns:
                         COECondition: The COE condition.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -115,9 +106,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
                     Returns:
                         COECondition: The COE condition.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -139,9 +127,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
                     Returns:
                         COECondition: The COE condition.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -163,9 +148,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
                     Returns:
                         COECondition: The COE condition.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -187,9 +169,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
                     Returns:
                         COECondition: The COE condition.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -211,9 +190,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
                     Returns:
                         COECondition: The COE condition.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("criterion"),
                 arg("frame"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/InstantCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/InstantCondition.cpp
@@ -14,11 +14,46 @@ using ostk::astro::eventcondition::InstantCondition;
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_InstantCondition(pybind11::module& aModule)
 {
     {
-        class_<InstantCondition, RealCondition, Shared<InstantCondition>>(aModule, "InstantCondition")
+        class_<InstantCondition, RealCondition, Shared<InstantCondition>>(
+            aModule,
+            "InstantCondition",
+            R"doc(
+                An Instant Event Condition.
 
-            .def(init<const RealCondition::Criterion&, const Instant&>(), arg("criterion"), arg("instant"))
+                Group:
+                    Event Condition
+            )doc"
+        )
 
-            .def("get_instant", &InstantCondition::getInstant)
+            .def(
+                init<const RealCondition::Criterion&, const Instant&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        instant (Instant): The instant.
+
+                    Group:
+                        Constructors
+                )doc",
+                arg("criterion"),
+                arg("instant")
+            )
+
+            .def(
+                "get_instant",
+                &InstantCondition::getInstant,
+                R"doc(
+                    Get the instant.
+
+                    Returns:
+                        Instant: The instant.
+
+                    Group:
+                        Methods
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/InstantCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/InstantCondition.cpp
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_InstantCondition(pybi
                 An Instant Event Condition.
 
                 Group:
-                    Event Condition
+                    event-condition
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp
@@ -27,6 +27,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalCondition(pybi
             )doc"
         );
 
+        enum_<LogicalCondition::Type>(
+            logicalCondition,
+            "Type",
+            R"doc(
+                Logical Condition Type.
+                    - Disjunctive (Or)
+                    - Conjucntive (And)
+            )doc"
+        )
+
+            .value("And", LogicalCondition::Type::And, "And")
+            .value("Or", LogicalCondition::Type::Or, "Or")
+
+            ;
+
         logicalCondition
 
             .def(
@@ -70,21 +85,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalCondition(pybi
 
                 )doc"
             )
-
-            ;
-
-        enum_<LogicalCondition::Type>(
-            logicalCondition,
-            "Type",
-            R"doc(
-                Logical Condition Type.
-                    - Disjunctive (Or)
-                    - Conjucntive (And)
-            )doc"
-        )
-
-            .value("And", LogicalCondition::Type::And, "And")
-            .value("Or", LogicalCondition::Type::Or, "Or")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalCondition(pybi
                 A Logical Event Condition. This class is used to combine multiple event conditions into a single set.
 
                 Group:
-                    Event Condition
+                    event-condition
             )doc"
         );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp
@@ -17,27 +17,74 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalCondition(pybi
 {
     {
         class_<LogicalCondition, EventCondition, Shared<LogicalCondition>> logicalCondition(
-            aModule, "LogicalCondition"
+            aModule,
+            "LogicalCondition",
+            R"doc(
+                A Logical Event Condition. This class is used to combine multiple event conditions into a single set.
+
+                Group:
+                    Event Condition
+            )doc"
         );
 
         logicalCondition
 
             .def(
                 init<const String&, const LogicalCondition::Type&, const Array<Shared<EventCondition>>&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        name (str): The name of the condition.
+                        type (Type): The type of the logical condition.
+                        event_conditions (List[EventCondition]): The list of event conditions.
+
+                    Group:
+                        Constructors
+                )doc",
                 arg("name"),
                 arg("type"),
                 arg("event_conditions")
             )
 
-            .def("get_type", &LogicalCondition::getType)
-            .def("get_event_conditions", &LogicalCondition::getEventConditions)
+            .def(
+                "get_type",
+                &LogicalCondition::getType,
+                R"doc(
+                    Get the type of the logical condition.
+
+                    Returns:
+                        Type: The type of the logical condition.
+
+                )doc"
+            )
+
+            .def(
+                "get_event_conditions",
+                &LogicalCondition::getEventConditions,
+                R"doc(
+                    Get the list of event conditions.
+
+                    Returns:
+                        List[EventCondition]: The list of event conditions.
+
+                )doc"
+            )
 
             ;
 
-        enum_<LogicalCondition::Type>(logicalCondition, "Type")
+        enum_<LogicalCondition::Type>(
+            logicalCondition,
+            "Type",
+            R"doc(
+                Logical Condition Type.
+                    - Disjunctive (Or)
+                    - Conjucntive (And)
+            )doc"
+        )
 
-            .value("And", LogicalCondition::Type::And)
-            .value("Or", LogicalCondition::Type::Or)
+            .value("And", LogicalCondition::Type::And, "And")
+            .value("Or", LogicalCondition::Type::Or, "Or")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp
@@ -37,7 +37,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalCondition(pybi
                     Args:
                         name (str): The name of the condition.
                         type (Type): The type of the logical condition.
-                        event_conditions (List[EventCondition]): The list of event conditions.
+                        event_conditions (list[EventCondition]): The list of event conditions.
 
                     Group:
                         Constructors
@@ -66,7 +66,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalCondition(pybi
                     Get the list of event conditions.
 
                     Returns:
-                        List[EventCondition]: The list of event conditions.
+                        list[EventCondition]: The list of event conditions.
 
                 )doc"
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp
@@ -19,40 +19,162 @@ using ostk::astro::trajectory::State;
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_RealCondition(pybind11::module& aModule)
 {
     {
-        class_<RealCondition, EventCondition, Shared<RealCondition>> realCondition(aModule, "RealCondition");
+        class_<RealCondition, EventCondition, Shared<RealCondition>> realCondition(
+            aModule,
+            "RealCondition",
+            R"doc(
+                A Real Event Condition.
+
+                Group:
+                    Event Condition
+            )doc"
+        );
 
         realCondition
 
             .def(
                 init<const String&, const RealCondition::Criterion&, std::function<Real(const State&)>, const Real&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        name (str): The name of the condition.
+                        criterion (Criterion): The criterion of the condition.
+                        evaluator (function): The evaluator of the condition.
+                        target (float): The target value of the condition.
+
+                )doc",
                 arg("name"),
                 arg("criterion"),
                 arg("evaluator"),
                 arg("target") = 0.0
             )
 
-            .def("__str__", &(shiftToString<RealCondition>))
-            .def("__repr__", &(shiftToString<RealCondition>))
+            .def(
+                "__str__",
+                &(shiftToString<RealCondition>),
+                R"doc(
+                    Return a string representation of the real condition.
 
-            .def("get_target", &RealCondition::getTarget)
-            .def("get_criterion", &RealCondition::getCriterion)
-            .def("get_evaluator", &RealCondition::getEvaluator)
+                    Returns:
+                        str: The string representation.
 
-            .def("evaluate", &RealCondition::evaluate, arg("state"))
+                )doc"
+            )
 
-            .def("is_satisfied", &RealCondition::isSatisfied, arg("current_state"), arg("previous_state"))
+            .def(
+                "__repr__",
+                &(shiftToString<RealCondition>),
+                R"doc(
+                    Return a string representation of the real condition.
 
-            .def_static("string_from_criterion", &RealCondition::StringFromCriterion, arg("criterion"))
+                    Returns:
+                        str: The string representation.
+
+                )doc"
+            )
+
+            .def(
+                "get_target",
+                &RealCondition::getTarget,
+                R"doc(
+                    Get the target value of the condition.
+
+                    Returns:
+                        float: The target value.
+
+                )doc"
+            )
+
+            .def(
+                "get_criterion",
+                &RealCondition::getCriterion,
+                R"doc(
+                    Get the criterion of the condition.
+
+                    Returns:
+                        Criterion: The criterion.
+
+                )doc"
+            )
+
+            .def(
+                "get_evaluator",
+                &RealCondition::getEvaluator,
+                R"doc(
+                    Get the evaluator of the condition.
+
+                    Returns:
+                        function: The evaluator.
+
+                )doc"
+            )
+
+            .def(
+                "evaluate",
+                &RealCondition::evaluate,
+                R"doc(
+                    Evaluate the condition.
+
+                    Args:
+                        state (State): The state.
+
+                    Returns:
+                        bool: True if the condition is satisfied, False otherwise.
+
+                )doc",
+                arg("state")
+            )
+
+            .def(
+                "is_satisfied",
+                &RealCondition::isSatisfied,
+                R"doc(
+                    Check if the condition is satisfied.
+
+                    Args:
+                        current_state (State): The current state.
+                        previous_state (State): The previous state.
+
+                    Returns:
+                        bool: True if the condition is satisfied, False otherwise.
+
+                )doc",
+                arg("current_state"),
+                arg("previous_state")
+            )
+
+            .def_static(
+                "string_from_criterion",
+                &RealCondition::StringFromCriterion,
+                R"doc(
+                    Get the string representation of a criterion.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+
+                    Returns:
+                        str: The string representation.
+
+                )doc",
+                arg("criterion")
+            )
 
             ;
 
-        enum_<RealCondition::Criterion>(realCondition, "Criterion")
+        enum_<RealCondition::Criterion>(
+            realCondition,
+            "Criterion",
+            R"doc(
+                The Criterion that defines how the condition is satisfied.
+            )doc"
+        )
 
-            .value("PositiveCrossing", RealCondition::Criterion::PositiveCrossing)
-            .value("NegativeCrossing", RealCondition::Criterion::NegativeCrossing)
-            .value("AnyCrossing", RealCondition::Criterion::AnyCrossing)
-            .value("StrictlyPositive", RealCondition::Criterion::StrictlyPositive)
-            .value("StrictlyNegative", RealCondition::Criterion::StrictlyNegative)
+            .value("PositiveCrossing", RealCondition::Criterion::PositiveCrossing, "The positive crossing criterion")
+            .value("NegativeCrossing", RealCondition::Criterion::NegativeCrossing, "The negative crossing criterion")
+            .value("AnyCrossing", RealCondition::Criterion::AnyCrossing, "The any crossing criterion")
+            .value("StrictlyPositive", RealCondition::Criterion::StrictlyPositive, "The strictly positive criterion")
+            .value("StrictlyNegative", RealCondition::Criterion::StrictlyNegative, "The strictly negative criterion")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp
@@ -26,7 +26,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_RealCondition(pybind1
                 A Real Event Condition.
 
                 Group:
-                    Event Condition
+                    event-condition
             )doc"
         );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp
@@ -171,7 +171,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_RealCondition(pybind1
 
                     Returns:
                         str: The string representation.
-
                 )doc",
                 arg("criterion")
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp
@@ -30,6 +30,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_RealCondition(pybind1
             )doc"
         );
 
+        enum_<RealCondition::Criterion>(
+            realCondition,
+            "Criterion",
+            R"doc(
+                The Criterion that defines how the condition is satisfied.
+            )doc"
+        )
+
+            .value("PositiveCrossing", RealCondition::Criterion::PositiveCrossing, "The positive crossing criterion")
+            .value("NegativeCrossing", RealCondition::Criterion::NegativeCrossing, "The negative crossing criterion")
+            .value("AnyCrossing", RealCondition::Criterion::AnyCrossing, "The any crossing criterion")
+            .value("StrictlyPositive", RealCondition::Criterion::StrictlyPositive, "The strictly positive criterion")
+            .value("StrictlyNegative", RealCondition::Criterion::StrictlyNegative, "The strictly negative criterion")
+
+            ;
+
         realCondition
 
             .def(
@@ -159,22 +175,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_RealCondition(pybind1
                 )doc",
                 arg("criterion")
             )
-
-            ;
-
-        enum_<RealCondition::Criterion>(
-            realCondition,
-            "Criterion",
-            R"doc(
-                The Criterion that defines how the condition is satisfied.
-            )doc"
-        )
-
-            .value("PositiveCrossing", RealCondition::Criterion::PositiveCrossing, "The positive crossing criterion")
-            .value("NegativeCrossing", RealCondition::Criterion::NegativeCrossing, "The negative crossing criterion")
-            .value("AnyCrossing", RealCondition::Criterion::AnyCrossing, "The any crossing criterion")
-            .value("StrictlyPositive", RealCondition::Criterion::StrictlyPositive, "The strictly positive criterion")
-            .value("StrictlyNegative", RealCondition::Criterion::StrictlyNegative, "The strictly negative criterion")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -26,7 +26,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
             Spacecraft Flight Profile.
 
             Group:
-                flight
+                profile
         )doc"
     )
 
@@ -37,9 +37,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Args:
                     model (Model): The profile model.
-
-                Group:
-                    Constructors
             )doc",
             arg("model")
         )
@@ -55,9 +52,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Returns:
                     bool: True if the profile is defined, False otherwise.
-
-                Group:
-                    Methods
             )doc"
         )
 
@@ -72,9 +66,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Returns:
                     State: The state of the profile at the given instant.
-
-                Group:
-                    Methods
             )doc",
             arg("instant")
         )
@@ -90,9 +81,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Returns:
                     list: The states of the profile at the given instants.
-
-                Group:
-                    Methods
             )doc",
             arg("instants")
         )
@@ -108,9 +96,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Returns:
                     Frame: The axes of the profile at the given instant.
-
-                Group:
-                    Methods
             )doc",
             arg("instant")
         )
@@ -126,9 +111,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Returns:
                     Frame: The body frame of the profile.
-
-                Group:
-                    Methods
             )doc",
             arg("frame_name")
         )
@@ -141,9 +123,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Returns:
                     Profile: The undefined profile.
-
-                Group:
-                    Static methods
             )doc"
         )
 
@@ -159,9 +138,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Returns:
                     Profile: The inertial pointing profile.
-
-                Group:
-                    Static methods
             )doc",
             arg("trajectory"),
             arg("quaternion")
@@ -179,9 +155,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
                 Returns:
                     Profile: The nadir pointing profile.
-
-                Group:
-                    Static methods
             )doc",
             arg("orbit"),
             arg("orbital_frame_type")

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -19,23 +19,173 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
     using ostk::astro::flight::profile::Model;
     using ostk::astro::flight::profile::State;
 
-    class_<Profile>(aModule, "Profile")
+    class_<Profile>(
+        aModule,
+        "Profile",
+        R"doc(
+            Spacecraft Flight Profile.
 
-        .def(init<const Model&>(), arg("model"))
+            Group:
+                Flight
+        )doc"
+    )
+
+        .def(
+            init<const Model&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    model (Model): The profile model.
+
+                Group:
+                    Constructors
+            )doc",
+            arg("model")
+        )
 
         .def("__str__", &(shiftToString<Profile>))
         .def("__repr__", &(shiftToString<Profile>))
 
-        .def("is_defined", &Profile::isDefined)
+        .def(
+            "is_defined",
+            &Profile::isDefined,
+            R"doc(
+                Check if the profile is defined.
 
-        .def("get_state_at", &Profile::getStateAt, arg("instant"))
-        .def("get_states_at", &Profile::getStatesAt, arg("instants"))
-        .def("get_axes_at", &Profile::getAxesAt, arg("instant"))
-        .def("get_body_frame", &Profile::getBodyFrame, arg("frame_name"))
+                Returns:
+                    bool: True if the profile is defined, False otherwise.
 
-        .def_static("undefined", &Profile::Undefined)
-        .def_static("inertial_pointing", &Profile::InertialPointing, arg("trajectory"), arg("quaternion"))
-        .def_static("nadir_pointing", &Profile::NadirPointing, arg("orbit"), arg("orbital_frame_type"))
+                Group:
+                    Methods
+            )doc"
+        )
+
+        .def(
+            "get_state_at",
+            &Profile::getStateAt,
+            R"doc(
+                Get the state of the profile at a given instant.
+
+                Args:
+                    instant (Instant): The instant.
+
+                Returns:
+                    State: The state of the profile at the given instant.
+
+                Group:
+                    Methods
+            )doc",
+            arg("instant")
+        )
+
+        .def(
+            "get_states_at",
+            &Profile::getStatesAt,
+            R"doc(
+                Get the states of the profile at given instants.
+
+                Args:
+                    instants (list): The instants.
+
+                Returns:
+                    list: The states of the profile at the given instants.
+
+                Group:
+                    Methods
+            )doc",
+            arg("instants")
+        )
+
+        .def(
+            "get_axes_at",
+            &Profile::getAxesAt,
+            R"doc(
+                Get the axes of the profile at a given instant.
+
+                Args:
+                    instant (Instant): The instant.
+
+                Returns:
+                    Frame: The axes of the profile at the given instant.
+
+                Group:
+                    Methods
+            )doc",
+            arg("instant")
+        )
+
+        .def(
+            "get_body_frame",
+            &Profile::getBodyFrame,
+            R"doc(
+                Get the body frame of the profile.
+
+                Args:
+                    frame_name (str): The name of the frame.
+
+                Returns:
+                    Frame: The body frame of the profile.
+
+                Group:
+                    Methods
+            )doc",
+            arg("frame_name")
+        )
+
+        .def_static(
+            "undefined",
+            &Profile::Undefined,
+            R"doc(
+                Create an undefined profile.
+
+                Returns:
+                    Profile: The undefined profile.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+
+        .def_static(
+            "inertial_pointing",
+            &Profile::InertialPointing,
+            R"doc(
+                Create an inertial pointing profile.
+
+                Args:
+                    trajectory (Trajectory): The trajectory.
+                    quaternion (Quaternion): The quaternion.
+
+                Returns:
+                    Profile: The inertial pointing profile.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("trajectory"),
+            arg("quaternion")
+        )
+
+        .def_static(
+            "nadir_pointing",
+            &Profile::NadirPointing,
+            R"doc(
+                Create a nadir pointing profile.
+
+                Args:
+                    orbit (Orbit): The orbit.
+                    orbital_frame_type (OrbitalFrameType): The type of the orbital frame.
+
+                Returns:
+                    Profile: The nadir pointing profile.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("orbit"),
+            arg("orbital_frame_type")
+        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -26,7 +26,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
             Spacecraft Flight Profile.
 
             Group:
-                Flight
+                flight
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model.cpp
@@ -8,7 +8,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model(pybind11::modul
 
     using ostk::astro::flight::profile::Model;
 
-    class_<Model>(aModule, "Model")
+    class_<Model>(
+        aModule,
+        "Model",
+        R"doc(
+            A flight profile model.
+
+            Group:
+                profile
+        )doc"
+    )
 
         .def(
             "__eq__",
@@ -28,12 +37,74 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model(pybind11::modul
         .def("__str__", &(shiftToString<Model>))
         .def("__repr__", &(shiftToString<Model>))
 
-        .def("is_defined", &Model::isDefined)
+        .def(
+            "is_defined",
+            &Model::isDefined,
+            R"doc(
+                Check if the model is defined.
 
-        .def("calculate_state_at", &Model::calculateStateAt, arg("instant"))
-        .def("calculate_states_at", &Model::calculateStatesAt, arg("instants"))
-        .def("get_axes_at", &Model::getAxesAt, arg("instant"))
-        .def("get_body_frame", &Model::getBodyFrame, arg("frame_name"))
+                Returns:
+                    bool: True if the model is defined, False otherwise.
+            )doc"
+        )
 
-        ;
+        .def(
+            "calculate_state_at",
+            &Model::calculateStateAt,
+            R"doc(
+                Calculate the state of the model at a specific instant.
+
+                Args:
+                    instant (Instant): The instant at which to calculate the state.
+
+                Returns:
+                    State: The state of the model at the specified instant.
+            )doc",
+            arg("instant")
+        )
+
+        .def(
+            "calculate_states_at",
+            &Model::calculateStatesAt,
+            R"doc(
+                Calculate the states of the model at specific instants.
+
+                Args:
+                    instants (list[Instant]): The instants at which to calculate the states.
+
+                Returns:
+                    list[State]: The states of the model at the specified instants.
+            )doc",
+            arg("instants")
+        )
+
+        .def(
+            "get_axes_at",
+            &Model::getAxesAt,
+            R"doc(
+                Get the axes of the model at a specific instant.
+
+                Args:
+                    instant (Instant): The instant at which to get the axes.
+
+                Returns:
+                    numpy.ndarray: The axes of the model at the specified instant.
+            )doc",
+            arg("instant")
+        )
+
+        .def(
+            "get_body_frame",
+            &Model::getBodyFrame,
+            R"doc(
+                Get the body frame of the model with the specified name.
+
+                Args:
+                    frame_name (str): The name of the body frame.
+
+                Returns:
+                    Frame: The body frame of the model with the specified name.
+            )doc",
+            arg("frame_name")
+        );
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Models/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Models/Tabulated.cpp
@@ -12,19 +12,116 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Models_Tabulated(pybi
     using ostk::astro::flight::profile::State;
     using ostk::astro::flight::profile::models::Tabulated;
 
-    class_<Tabulated, Model>(aModule, "Tabulated")
+    class_<Tabulated, Model>(
+        aModule,
+        "Tabulated",
+        R"doc(
+            A flight profile model defined by a set of states.
 
-        .def(init<Array<State>&>(), arg("states"))
+            Group:
+                profile
+        )doc"
+    )
 
-        .def("__str__", &(shiftToString<State>))
-        .def("__repr__", &(shiftToString<State>))
+        .def(
+            init<Array<State>&>(),
+            R"doc(
+                Constructor.
 
-        .def("is_defined", &Tabulated::isDefined)
+                Args:
+                    states (Array[State]): The states of the model.
+             )doc",
+            arg("states")
+        )
 
-        .def("get_interval", &Tabulated::getInterval)
-        .def("calculate_state_at", &Tabulated::calculateStateAt, arg("instant"))
-        .def("get_axes_at", &Tabulated::getAxesAt, arg("instant"))
-        .def("get_body_frame", &Tabulated::getBodyFrame, arg("frame_name"))
+        .def(
+            "__str__",
+            &(shiftToString<State>),
+            R"doc(
+                Convert the model to a string.
+
+                Returns:
+                    str: The string representation of the model.
+             )doc"
+        )
+
+        .def(
+            "__repr__",
+            &(shiftToString<State>),
+            R"doc(
+                Convert the model to a string.
+
+                Returns:
+                    str: The string representation of the model.
+             )doc"
+        )
+
+        .def(
+            "is_defined",
+            &Tabulated::isDefined,
+            R"doc(
+                Check if the model is defined.
+
+                Returns:
+                    bool: True if the model is defined, False otherwise.
+             )doc"
+        )
+
+        .def(
+            "get_interval",
+            &Tabulated::getInterval,
+            R"doc(
+                Get the interval of the model.
+
+                Returns:
+                    Interval: The interval of the model.
+             )doc"
+        )
+
+        .def(
+            "calculate_state_at",
+            &Tabulated::calculateStateAt,
+            R"doc(
+                Calculate the state of the model at a specific instant.
+
+                Args:
+                    instant (Instant): The instant at which to calculate the state.
+
+                Returns:
+                    State: The state of the model at the specified instant.
+             )doc",
+            arg("instant")
+        )
+
+        .def(
+            "get_axes_at",
+            &Tabulated::getAxesAt,
+            R"doc(
+                Get the axes of the model at a specific instant.
+
+                Args:
+                    instant (Instant): The instant at which to get the axes.
+
+                Returns:
+                    numpy.ndarray: The axes of the model at the specified instant.
+             )doc",
+            arg("instant")
+        )
+
+        .def(
+            "get_body_frame",
+            &Tabulated::getBodyFrame,
+            R"doc(
+                Get the body frame of the model with the specified name.
+
+                Args:
+                    frame_name (str): The name of the body frame.
+
+                Returns:
+                    Frame: The body frame of the model with the specified name.
+             )doc",
+            arg("frame_name")
+        )
 
         // .def_static("load", &Tabulated::Load, arg("file"))
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Models/Transform.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Models/Transform.cpp
@@ -16,22 +16,134 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Models_Transform(pybi
     using ostk::astro::flight::profile::State;
     using ostk::astro::flight::profile::models::Transform;
 
-    class_<Transform, Model>(aModule, "Transform")
+    class_<Transform, Model>(
+        aModule,
+        "Transform",
+        R"doc(
+            A flight profile model defined by a transform.
 
-        .def(init<const DynamicProvider&, const Shared<const Frame>&>(), arg("dynamic_provider"), arg("frame"))
+            Group:
+                profile
+        )doc"
+    )
+
+        .def(
+            init<const DynamicProvider&, const Shared<const Frame>&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    dynamic_provider (DynamicProvider): The dynamic provider of the transform.
+                    frame (Frame): The frame of the transform.
+
+             )doc",
+            arg("dynamic_provider"),
+            arg("frame")
+        )
 
         .def("__str__", &(shiftToString<State>))
         .def("__repr__", &(shiftToString<State>))
 
-        .def("is_defined", &Transform::isDefined)
+        .def(
+            "is_defined",
+            &Transform::isDefined,
+            R"doc(
+                Check if the model is defined.
 
-        .def("calculate_state_at", &Transform::calculateStateAt, arg("instant"))
-        .def("get_axes_at", &Transform::getAxesAt, arg("instant"))
-        .def("get_body_frame", &Transform::getBodyFrame, arg("frame_name"))
+                Returns:
+                    bool: True if the model is defined, False otherwise.
+             )doc"
+        )
 
-        .def_static("undefined", &Transform::Undefined)
-        .def_static("inertial_pointing", &Transform::InertialPointing, arg("trajectory"), arg("quaternion"))
-        .def_static("nadir_pointing", &Transform::NadirPointing, arg("orbit"), arg("orbital_frame_type"))
+        .def(
+            "calculate_state_at",
+            &Transform::calculateStateAt,
+            R"doc(
+                Calculate the state of the model at a specific instant.
+
+                Args:
+                    instant (Instant): The instant at which to calculate the state.
+
+                Returns:
+                    State: The state of the model at the specified instant.
+             )doc",
+            arg("instant")
+        )
+
+        .def(
+            "get_axes_at",
+            &Transform::getAxesAt,
+            R"doc(
+                Get the axes of the model at a specific instant.
+
+                Args:
+                    instant (Instant): The instant at which to get the axes.
+
+                Returns:
+                    numpy.ndarray: The axes of the model at the specified instant.
+             )doc",
+            arg("instant")
+        )
+
+        .def(
+            "get_body_frame",
+            &Transform::getBodyFrame,
+            R"doc(
+                Get the body frame of the model with the specified name.
+
+                Args:
+                    frame_name (str): The name of the body frame.
+
+                Returns:
+                    Frame: The body frame of the model with the specified name.
+             )doc",
+            arg("frame_name")
+        )
+
+        .def_static(
+            "undefined",
+            &Transform::Undefined,
+            R"doc(
+                Get an undefined transform.
+
+                Returns:
+                    Transform: The undefined transform.
+             )doc"
+        )
+
+        .def_static(
+            "inertial_pointing",
+            &Transform::InertialPointing,
+            R"doc(
+                Create a transform for inertial pointing.
+
+                Args:
+                    trajectory (Trajectory): The trajectory to point at.
+                    quaternion (Quaternion): The quaternion to rotate the axes by.
+
+                Returns:
+                    Transform: The transform for inertial pointing.
+             )doc",
+            arg("trajectory"),
+            arg("quaternion")
+        )
+
+        .def_static(
+            "nadir_pointing",
+            &Transform::NadirPointing,
+            R"doc(
+                Create a transform for nadir pointing.
+
+                Args:
+                    orbit (Orbit): The orbit to point at.
+                    orbital_frame_type (OrbitalFrameType): The type of the orbital frame.
+
+                Returns:
+                    Transform: The transform for nadir pointing.
+             )doc",
+            arg("orbit"),
+            arg("orbital_frame_type")
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/State.cpp
@@ -162,9 +162,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_State(pybind11::modul
 
                 Returns:
                     undefined_state (State): The undefined state.
-
-                Group:
-                    Static methods
              )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/State.cpp
@@ -18,7 +18,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_State(pybind11::modul
 
     using ostk::astro::flight::profile::State;
 
-    class_<State>(aModule, "State")
+    class_<State>(
+        aModule,
+        "State",
+        R"doc(
+            Flight profile state.
+
+            Group:
+                profile
+        )doc"
+    )
 
         .def(
             init<
@@ -28,6 +37,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_State(pybind11::modul
                 const Quaternion&,
                 const Vector3d&,
                 const Shared<const Frame>&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    instant (Instant): The instant of the state.
+                    position (Position): The position of the state.
+                    velocity (Velocity): The velocity of the state.
+                    attitude (Quaternion): The attitude of the state.
+                    angular_velocity (Vector3d): The angular velocity of the state.
+                    reference_frame (Frame): The reference frame of the state.
+            )doc",
             arg("instant"),
             arg("position"),
             arg("velocity"),
@@ -42,17 +62,111 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_State(pybind11::modul
         .def("__str__", &(shiftToString<State>))
         .def("__repr__", &(shiftToString<State>))
 
-        .def("is_defined", &State::isDefined)
+        .def(
+            "is_defined",
+            &State::isDefined,
+            R"doc(
+                Check if the state is defined.
 
-        .def("get_instant", &State::getInstant)
-        .def("get_position", &State::getPosition)
-        .def("get_velocity", &State::getVelocity)
-        .def("get_attitude", &State::getAttitude)
-        .def("get_angular_velocity", &State::getAngularVelocity)
-        .def("get_frame", &State::getFrame)
-        .def("in_frame", &State::inFrame, arg("frame"))
+                Returns:
+                    bool: True if the state is defined, False otherwise.
+             )doc"
+        )
 
-        .def_static("undefined", &State::Undefined)
+        .def(
+            "get_instant",
+            &State::getInstant,
+            R"doc(
+                Get the instant of the state.
+
+                Returns:
+                    Instant: The instant of the state.
+             )doc"
+        )
+
+        .def(
+            "get_position",
+            &State::getPosition,
+            R"doc(
+                Get the position of the state.
+
+                Returns:
+                    Position: The position of the state.
+             )doc"
+        )
+
+        .def(
+            "get_velocity",
+            &State::getVelocity,
+            R"doc(
+                Get the velocity of the state.
+
+                Returns:
+                    Velocity: The velocity of the state.
+             )doc"
+        )
+
+        .def(
+            "get_attitude",
+            &State::getAttitude,
+            R"doc(
+                Get the attitude of the state.
+
+                Returns:
+                    Quaternion: The attitude of the state.
+             )doc"
+        )
+
+        .def(
+            "get_angular_velocity",
+            &State::getAngularVelocity,
+            R"doc(
+                Get the angular velocity of the state.
+
+                Returns:
+                    Vector3d: The angular velocity of the state.
+             )doc"
+        )
+
+        .def(
+            "get_frame",
+            &State::getFrame,
+            R"doc(
+                Get the reference frame of the state.
+
+                Returns:
+                    Frame: The reference frame of the state.
+             )doc"
+        )
+
+        .def(
+            "in_frame",
+            &State::inFrame,
+            R"doc(
+                Convert the state to a different reference frame.
+
+                Args:
+                    frame (Frame): The reference frame to convert the state to.
+
+                Returns:
+                    State: The state in the new reference frame.
+             )doc",
+            arg("frame")
+        )
+
+        .def_static(
+            "undefined",
+            &State::Undefined,
+            R"doc(
+                Get an undefined state.
+
+                Returns:
+                    undefined_state (State): The undefined state.
+
+                Group:
+                    Static methods
+             )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System.cpp
@@ -27,7 +27,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System(pybind11::module& aMod
                 .. warning:: This class is an abstract class and cannot be instantiated.
 
                 Group:
-                    flight
+                    system
             )doc"
         )
 
@@ -95,9 +95,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System(pybind11::module& aMod
 
                     Returns:
                         System: The undefined system.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System.cpp
@@ -27,7 +27,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System(pybind11::module& aMod
                 .. warning:: This class is an abstract class and cannot be instantiated.
 
                 Group:
-                    Flight
+                    flight
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System.cpp
@@ -16,9 +16,34 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System(pybind11::module& aMod
     using ostk::astro::flight::System;
 
     {
-        class_<System>(aModule, "System")
+        class_<System>(
+            aModule,
+            "System",
+            R"doc(
+                A flight system.
 
-            .def(init<const Mass&, const Composite&>(), arg("mass"), arg("geometry"))
+                Provides the interface for flight systems.
+
+                .. warning:: This class is an abstract class and cannot be instantiated.
+
+                Group:
+                    Flight
+            )doc"
+        )
+
+            .def(
+                init<const Mass&, const Composite&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        mass (Mass): The mass of the system.
+                        geometry (Composite): The geometry of the system.
+
+                )doc",
+                arg("mass"),
+                arg("geometry")
+            )
 
             .def(self == self)
             .def(self != self)
@@ -26,12 +51,55 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System(pybind11::module& aMod
             .def("__str__", &(shiftToString<System>))
             .def("__repr__", &(shiftToString<System>))
 
-            .def("is_defined", &System::isDefined)
+            .def(
+                "is_defined",
+                &System::isDefined,
+                R"doc(
+                    Check if the system is defined.
 
-            .def("get_mass", &System::getMass)
-            .def("get_geometry", &System::getGeometry)
+                    Returns:
+                        bool: True if the system is defined, False otherwise.
 
-            .def_static("undefined", &System::Undefined)
+                )doc"
+            )
+
+            .def(
+                "get_mass",
+                &System::getMass,
+                R"doc(
+                    Get the mass of the system.
+
+                    Returns:
+                        Mass: The mass of the system.
+
+                )doc"
+            )
+
+            .def(
+                "get_geometry",
+                &System::getGeometry,
+                R"doc(
+                    Get the geometry of the system.
+
+                    Returns:
+                        Composite: The geometry of the system.
+
+                )doc"
+            )
+
+            .def_static(
+                "undefined",
+                &System::Undefined,
+                R"doc(
+                    Create an undefined system.
+
+                    Returns:
+                        System: The undefined system.
+
+                    Group:
+                        Static methods
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
@@ -48,8 +48,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
                     Construct a propulsion system.
 
                     Args:
-                        thrust (Real): Thrust in Newton.
-                        specific_impulse (Real): Specific impulse in Seconds.
+                        thrust (float): Thrust in Newton.
+                        specific_impulse (float): Specific impulse in Seconds.
                 )doc",
                 arg("thrust_si_unit"),
                 arg("specific_impulse_si_unit")

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
@@ -24,7 +24,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
                 A propulsion system.
 
                 Group:
-                    System
+                    system
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
@@ -17,7 +17,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
     using ostk::astro::flight::system::PropulsionSystem;
 
     {
-        class_<PropulsionSystem>(aModule, "PropulsionSystem")
+        class_<PropulsionSystem>(
+            aModule,
+            "PropulsionSystem",
+            R"doc(
+                A propulsion system.
+
+                Group:
+                    System
+            )doc"
+        )
 
             // .def(
             //     init([](const Real& thrust, const Unit& thrustUnit, const Real& specificImpulse, const Unit&
@@ -33,7 +42,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
             //     arg("specific_unit")
             // )
 
-            .def(init<const Real&, const Real&>(), arg("thrust_si_unit"), arg("specific_impulse_si_unit"))
+            .def(
+                init<const Real&, const Real&>(),
+                R"doc(
+                    Construct a propulsion system.
+
+                    Args:
+                        thrust (Real): Thrust in Newton.
+                        specific_impulse (Real): Specific impulse in Seconds.
+                )doc",
+                arg("thrust_si_unit"),
+                arg("specific_impulse_si_unit")
+            )
 
             .def(self == self)
             .def(self != self)
@@ -41,15 +61,43 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
             // .def("__str__", &(shiftToString<PropulsionSystem>))
             // .def("__repr__", &(shiftToString<PropulsionSystem>))
 
-            .def("is_defined", &PropulsionSystem::isDefined)
+            .def(
+                "is_defined",
+                &PropulsionSystem::isDefined,
+                R"doc(
+                    Check if the propulsion system is defined.
+
+                    Returns:
+                        bool: True if the propulsion system is defined, False otherwise.
+                )doc"
+            )
 
             // .def("get_thrust", &PropulsionSystem::getThrust)
             // .def("get_specific_impulse", &PropulsionSystem::getSpecificImpulse)
             // .def("get_mass_flow_rate", &PropulsionSystem::getMassFlowRate) Scalar output
             // .def("get_acceleration", &PropulsionSystem::getAcceleration, arg("mass"))
 
-            .def_static("undefined", &PropulsionSystem::Undefined)
-            .def_static("default", &PropulsionSystem::Default)
+            .def_static(
+                "undefined",
+                &PropulsionSystem::Undefined,
+                R"doc(
+                    Return an undefined propulsion system.
+
+                    Returns:
+                        PropulsionSystem: An undefined propulsion system.
+                )doc"
+            )
+            .def_static(
+                "default",
+                &PropulsionSystem::Default,
+                R"doc(
+                    Return a default propulsion system.
+
+                    Returns:
+                        PropulsionSystem: A default propulsion system.
+                )doc"
+
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/SatelliteSystem.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/SatelliteSystem.cpp
@@ -116,9 +116,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_SatelliteSystem(pybind
 
                     Returns:
                         SatelliteSystem: The undefined satellite system.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 
@@ -130,9 +127,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_SatelliteSystem(pybind
 
                     Returns:
                         SatelliteSystem: The default satellite system.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/SatelliteSystem.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/SatelliteSystem.cpp
@@ -25,7 +25,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_SatelliteSystem(pybind
                 A Satellite System.
 
                 Group:
-                    System
+                    system
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/SatelliteSystem.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/SatelliteSystem.cpp
@@ -18,11 +18,34 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_SatelliteSystem(pybind
     using ostk::astro::flight::system::SatelliteSystem;
 
     {
-        class_<SatelliteSystem, System>(aModule, "SatelliteSystem")
+        class_<SatelliteSystem, System>(
+            aModule,
+            "SatelliteSystem",
+            R"doc(
+                A Satellite System.
+
+                Group:
+                    System
+            )doc"
+        )
 
             .def(
                 init<const Mass&, const Composite&, const Matrix3d&, const Real&, const Real&, const PropulsionSystem&>(
                 ),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        mass (Mass): The mass of the satellite system.
+                        satellite_geometry (Composite): The geometry of the satellite system.
+                        inertia_tensor (Matrix3d): The inertia tensor of the satellite system.
+                        cross_sectional_surface_area (float): The cross-sectional surface area of the satellite system.
+                        drag_coefficient (float): The drag coefficient of the satellite system.
+                        propulsion_system (PropulsionSystem): The propulsion system of the satellite system.
+
+                    Group:
+                        Constructors
+                )doc",
                 arg("mass"),
                 arg("satellite_geometry"),
                 arg("inertia_tensor"),
@@ -37,14 +60,81 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_SatelliteSystem(pybind
             .def("__str__", &(shiftToString<SatelliteSystem>))
             .def("__repr__", &(shiftToString<SatelliteSystem>))
 
-            .def("is_defined", &SatelliteSystem::isDefined)
+            .def(
+                "is_defined",
+                &SatelliteSystem::isDefined,
+                R"doc(
+                    Check if the satellite system is defined.
 
-            .def("get_inertia_tensor", &SatelliteSystem::getInertiaTensor)
-            .def("get_cross_sectional_surface_area", &SatelliteSystem::getCrossSectionalSurfaceArea)
-            .def("get_drag_coefficient", &SatelliteSystem::getDragCoefficient)
+                    Returns:
+                        bool: True if the satellite system is defined, False otherwise.
 
-            .def_static("undefined", &SatelliteSystem::Undefined)
-            .def_static("default", &SatelliteSystem::Default)
+                )doc"
+            )
+
+            .def(
+                "get_inertia_tensor",
+                &SatelliteSystem::getInertiaTensor,
+                R"doc(
+                    Get the inertia tensor of the satellite system.
+
+                    Returns:
+                        Matrix3d: The inertia tensor of the satellite system.
+
+                )doc"
+            )
+
+            .def(
+                "get_cross_sectional_surface_area",
+                &SatelliteSystem::getCrossSectionalSurfaceArea,
+                R"doc(
+                    Get the cross-sectional surface area of the satellite system.
+
+                    Returns:
+                        float: The cross-sectional surface area of the satellite system.
+
+                )doc"
+            )
+
+            .def(
+                "get_drag_coefficient",
+                &SatelliteSystem::getDragCoefficient,
+                R"doc(
+                    Get the drag coefficient of the satellite system.
+
+                    Returns:
+                        float: The drag coefficient of the satellite system.
+
+                )doc"
+            )
+
+            .def_static(
+                "undefined",
+                &SatelliteSystem::Undefined,
+                R"doc(
+                    Create an undefined satellite system.
+
+                    Returns:
+                        SatelliteSystem: The undefined satellite system.
+
+                    Group:
+                        Static methods
+                )doc"
+            )
+
+            .def_static(
+                "default",
+                &SatelliteSystem::Default,
+                R"doc(
+                    Create a default satellite system.
+
+                    Returns:
+                        SatelliteSystem: The default satellite system.
+
+                    Group:
+                        Static methods
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
@@ -29,8 +29,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
             R"doc(
                 The root of the function.
 
-                Returns:
-                    root (float): The root of the function.
+                Type:
+                    float
             )doc"
         )
         .def_readwrite(
@@ -39,8 +39,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
             R"doc(
                 The number of iterations required to find the root.
 
-                Returns:
-                    iteration_count (int): The number of iterations required to find the root.
+                Type:
+                    int
             )doc"
         )
         .def_readwrite(
@@ -49,8 +49,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
             R"doc(
                 Whether the root solver has converged.
 
-                Returns:
-                    has_converged (bool): Whether the root solver has converged.
+                Type:
+                    bool
             )doc"
         )
 
@@ -73,8 +73,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                     Constructor.
 
                     Args:
-                        maximum_iteration_count (int): The maximum number of iterations allowed.
-                        tolerance (float): The tolerance of the root solver.
+                        int: The maximum number of iterations allowed.
+                        float: The tolerance of the root solver.
 
                 )doc",
                 arg("maximum_iteration_count"),
@@ -91,7 +91,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                     Get the tolerance of the root solver.
 
                     Returns:
-                        tolerance (float): The tolerance of the root solver.
+                        float: The tolerance of the root solver.
                  )doc"
             )
             .def(
@@ -101,7 +101,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                     Get the maximum number of iterations allowed.
 
                     Returns:
-                        maximum_iteration_count (int): The maximum number of iterations allowed.
+                        int: The maximum number of iterations allowed.
                 )doc"
             )
 
@@ -123,7 +123,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                         is_rising (bool): Whether the function is rising.
 
                     Returns:
-                        solution (RootSolverSolution): The solution to the root.
+                        RootSolverSolution: The solution to the root.
 
                 )doc",
                 arg("function"),
@@ -149,7 +149,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                         upper_bound (float): The upper bound of the root.
 
                     Returns:
-                        solution (RootSolverSolution): The solution to the root.
+                        RootSolverSolution: The solution to the root.
 
                 )doc",
                 arg("function"),
@@ -175,7 +175,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                         upper_bound (float): The upper bound of the root.
 
                     Returns:
-                        solution (RootSolverSolution): The solution to the root.
+                        RootSolverSolution: The solution to the root.
 
                 )doc",
                 arg("function"),
@@ -190,7 +190,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                     Return the default root solver.
 
                     Returns:
-                        root_solver (RootSolver): The default root solver.
+                        RootSolver: The default root solver.
 
                     Group:
                         Static methods

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
@@ -13,7 +13,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
 
     typedef std::function<double(const double&)> pythonFunctionSignature;
 
-    class_<RootSolver::Solution>(aModule, "RootSolverSolution")
+    class_<RootSolver::Solution>(
+        aModule,
+        "RootSolverSolution",
+        R"doc(
+            A root solver solution.
+
+            Group:
+                astrodynamics
+        )doc"
+    )
         .def_readwrite(
             "root",
             &RootSolver::Solution::root,
@@ -43,10 +52,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                 Returns:
                     has_converged (bool): Whether the root solver has converged.
             )doc"
-        );
+        )
+
+        ;
 
     {
-        class_<RootSolver>(aModule, "RootSolver")
+        class_<RootSolver>(
+            aModule,
+            "RootSolver",
+            R"doc(
+                A root solver is an algorithm for finding a zero-crossing of a function.
+
+                Group:
+                    astrodynamics
+            )doc"
+        )
             .def(
                 init<const Size&, const Real&>(),
                 R"doc(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
@@ -20,7 +20,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
             A root solver solution.
 
             Group:
-                astrodynamics
+                solvers
         )doc"
     )
         .def_readwrite(
@@ -64,7 +64,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                 A root solver is an algorithm for finding a zero-crossing of a function.
 
                 Group:
-                    astrodynamics
+                    solvers
             )doc"
         )
             .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
@@ -191,9 +191,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
 
                     Returns:
                         RootSolver: The default root solver.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/RootSolver.cpp
@@ -14,33 +14,98 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
     typedef std::function<double(const double&)> pythonFunctionSignature;
 
     class_<RootSolver::Solution>(aModule, "RootSolverSolution")
+        .def_readwrite(
+            "root",
+            &RootSolver::Solution::root,
+            R"doc(
+                The root of the function.
 
-        .def_readwrite("root", &RootSolver::Solution::root)
-        .def_readwrite("iteration_count", &RootSolver::Solution::iterationCount)
-        .def_readwrite("has_converged", &RootSolver::Solution::hasConverged)
+                Returns:
+                    root (float): The root of the function.
+            )doc"
+        )
+        .def_readwrite(
+            "iteration_count",
+            &RootSolver::Solution::iterationCount,
+            R"doc(
+                The number of iterations required to find the root.
 
-        ;
+                Returns:
+                    iteration_count (int): The number of iterations required to find the root.
+            )doc"
+        )
+        .def_readwrite(
+            "has_converged",
+            &RootSolver::Solution::hasConverged,
+            R"doc(
+                Whether the root solver has converged.
+
+                Returns:
+                    has_converged (bool): Whether the root solver has converged.
+            )doc"
+        );
 
     {
         class_<RootSolver>(aModule, "RootSolver")
+            .def(
+                init<const Size&, const Real&>(),
+                R"doc(
+                    Constructor.
 
-            .def(init<const Size&, const Real&>(), arg("maximum_iteration_count"), arg("tolerance"))
+                    Args:
+                        maximum_iteration_count (int): The maximum number of iterations allowed.
+                        tolerance (float): The tolerance of the root solver.
+
+                )doc",
+                arg("maximum_iteration_count"),
+                arg("tolerance")
+            )
 
             .def("__str__", &(shiftToString<RootSolver>))
             .def("__repr__", &(shiftToString<RootSolver>))
 
-            .def("get_tolerance", &RootSolver::getTolerance)
-            .def("get_maximum_iteration_count", &RootSolver::getMaximumIterationCount)
+            .def(
+                "get_tolerance",
+                &RootSolver::getTolerance,
+                R"doc(
+                    Get the tolerance of the root solver.
+
+                    Returns:
+                        tolerance (float): The tolerance of the root solver.
+                 )doc"
+            )
+            .def(
+                "get_maximum_iteration_count",
+                &RootSolver::getMaximumIterationCount,
+                R"doc(
+                    Get the maximum number of iterations allowed.
+
+                    Returns:
+                        maximum_iteration_count (int): The maximum number of iterations allowed.
+                )doc"
+            )
 
             .def(
                 "bracket_and_solve",
                 +[](const RootSolver& aRootSolver,
                     const pythonFunctionSignature& aFunction,
                     const Real& anInitialGuess,
-                    const bool& isRising)
+                    const bool& isRising) -> RootSolver::Solution
                 {
                     return aRootSolver.bracketAndSolve(aFunction, anInitialGuess, isRising);
                 },
+                R"doc(
+                    Bracket and solve the root of a function.
+
+                    Args:
+                        function (callable): The function to solve.
+                        initial_guess (float): The initial guess for the root.
+                        is_rising (bool): Whether the function is rising.
+
+                    Returns:
+                        solution (RootSolverSolution): The solution to the root.
+
+                )doc",
                 arg("function"),
                 arg("initial_guess"),
                 arg("is_rising")
@@ -51,10 +116,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                 +[](const RootSolver& aRootSolver,
                     const pythonFunctionSignature& aFunction,
                     const Real& aLowerBound,
-                    const Real& anUpperBound)
+                    const Real& anUpperBound) -> RootSolver::Solution
                 {
                     return aRootSolver.solve(aFunction, aLowerBound, anUpperBound);
                 },
+                R"doc(
+                    Solve the root of a function.
+
+                    Args:
+                        function (callable): The function to solve.
+                        lower_bound (float): The lower bound of the root.
+                        upper_bound (float): The upper bound of the root.
+
+                    Returns:
+                        solution (RootSolverSolution): The solution to the root.
+
+                )doc",
                 arg("function"),
                 arg("lower_bound"),
                 arg("upper_bound")
@@ -65,16 +142,40 @@ inline void OpenSpaceToolkitAstrodynamicsPy_RootSolver(pybind11::module& aModule
                 +[](const RootSolver& aRootSolver,
                     const pythonFunctionSignature& aFunction,
                     const Real& aLowerBound,
-                    const Real& anUpperBound)
+                    const Real& anUpperBound) -> RootSolver::Solution
                 {
                     return aRootSolver.bisection(aFunction, aLowerBound, anUpperBound);
                 },
+                R"doc(
+                    Solve the root of a function using the bisection method.
+
+                    Args:
+                        function (callable): The function to solve.
+                        lower_bound (float): The lower bound of the root.
+                        upper_bound (float): The upper bound of the root.
+
+                    Returns:
+                        solution (RootSolverSolution): The solution to the root.
+
+                )doc",
                 arg("function"),
                 arg("lower_bound"),
                 arg("upper_bound")
             )
 
-            .def_static("default", &RootSolver::Default)
+            .def_static(
+                "default",
+                &RootSolver::Default,
+                R"doc(
+                    Return the default root solver.
+
+                    Returns:
+                        root_solver (RootSolver): The default root solver.
+
+                    Group:
+                        Static methods
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/TemporalConditionSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/TemporalConditionSolver.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_TemporalConditionSolver(pybi
             Given a set of conditions and a time interval, the solver computes all sub-intervals over which conditions are met.
 
             Group:
-                Solvers
+                solvers
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/TemporalConditionSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/TemporalConditionSolver.cpp
@@ -16,24 +16,81 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_TemporalConditionSolver(pybi
 
     using ostk::astro::solvers::TemporalConditionSolver;
 
-    class_<TemporalConditionSolver>(aModule, "TemporalConditionSolver")
+    class_<TemporalConditionSolver>(
+        aModule,
+        "TemporalConditionSolver",
+        R"doc(
+            Given a set of conditions and a time interval, the solver computes all sub-intervals over which conditions are met.
+
+            Group:
+                Solvers
+        )doc"
+    )
 
         .def(
             init<const Duration&, const Duration&, const Size&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    time_step (Duration): The time step.
+                    tolerance (Duration): The tolerance of the solver.
+                    maximum_iteration_count (int): The maximum number of iterations allowed.
+
+            )doc",
             arg("time_step"),
             arg("tolerance"),
             arg("maximum_iteration_count") = DEFAULT_MAXIMUM_ITERATION_COUNT
         )
 
-        .def("get_time_step", &TemporalConditionSolver::getTimeStep)
-        .def("get_tolerance", &TemporalConditionSolver::getTolerance)
-        .def("get_maximum_iteration_count", &TemporalConditionSolver::getMaximumIterationCount)
+        .def(
+            "get_time_step",
+            &TemporalConditionSolver::getTimeStep,
+            R"doc(
+                Get the time step.
+
+                Returns:
+                    Duration: The time step.
+            )doc"
+        )
+
+        .def(
+            "get_tolerance",
+            &TemporalConditionSolver::getTolerance,
+            R"doc(
+                Get the tolerance.
+
+                Returns:
+                    Duration: The tolerance.
+            )doc"
+        )
+
+        .def(
+            "get_maximum_iteration_count",
+            &TemporalConditionSolver::getMaximumIterationCount,
+            R"doc(
+                Get the maximum number of iterations allowed.
+
+                Returns:
+                    int: The maximum number of iterations allowed.
+            )doc"
+        )
 
         .def(
             "solve",
             overload_cast<const TemporalConditionSolver::Condition&, const Interval&>(
                 &TemporalConditionSolver::solve, const_
             ),
+            R"doc(
+                Solve a temporal condition.
+
+                Args:
+                    condition (function): The condition to solve.
+                    interval (Interval): The interval to solve the condition over.
+
+                Returns:
+                    Duration: The time at which the condition is satisfied.
+            )doc",
             arg("condition"),
             arg("interval")
         )
@@ -43,6 +100,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_TemporalConditionSolver(pybi
             overload_cast<const Array<TemporalConditionSolver::Condition>&, const Interval&>(
                 &TemporalConditionSolver::solve, const_
             ),
+            R"doc(
+                Solve an array of temporal conditions.
+
+                Args:
+                    conditions (list): The conditions to solve.
+                    interval (Interval): The interval to solve the conditions over.
+
+                Returns:
+                    list: The times at which the conditions are satisfied.
+            )doc",
             arg("conditions"),
             arg("interval")
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -53,7 +53,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
                 Construct a `Trajectory` object from an array of states.
 
                 Args:
-                    states (Array[State]): The states of the trajectory.
+                    states (list[State]): The states of the trajectory.
 
                 Returns:
                     Trajectory: The `Trajectory` object.
@@ -100,10 +100,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
                 Get the states of the trajectory at a given set of instants.
 
                 Args:
-                    instants (Array[Instant]): The instants.
+                    instants (list[Instant]): The instants.
 
                 Returns:
-                    Array[State]: The states of the trajectory at the given instants.
+                    list[State]: The states of the trajectory at the given instants.
             )doc",
             arg("instants")
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -29,7 +29,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
             Path followed by an object through space as a function of time.
 
             Group:
-                astrodynamics
+                trajectory
         )doc"
     )
 
@@ -116,9 +116,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
 
                 Returns:
                     Trajectory: The undefined `Trajectory` object.
-
-                Group:
-                    Static methods
             )doc"
         )
 
@@ -133,9 +130,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
 
                 Returns:
                     Trajectory: The `Trajectory` object representing the position.
-                
-                Group:
-                    Static methods
             )doc",
             arg("position")
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -22,10 +22,44 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
     using ostk::astro::Trajectory;
     using ostk::astro::trajectory::State;
 
-    class_<Trajectory>(aModule, "Trajectory")
+    class_<Trajectory>(
+        aModule,
+        "Trajectory",
+        R"doc(
+            Path followed by an object through space as a function of time.
 
-        .def(init<const ostk::astro::trajectory::Model&>(), arg("model"))
-        .def(init<const Array<State>&>(), arg("states"))
+            Group:
+                astrodynamics
+        )doc"
+    )
+
+        .def(
+            init<const ostk::astro::trajectory::Model&>(),
+            R"doc(
+                Construct a `Trajectory` object from a model.
+
+                Args:
+                    model (trajectory.Model): The model of the trajectory.
+
+                Returns:
+                    Trajectory: The `Trajectory` object.
+            )doc",
+            arg("model")
+        )
+
+        .def(
+            init<const Array<State>&>(),
+            R"doc(
+                Construct a `Trajectory` object from an array of states.
+
+                Args:
+                    states (Array[State]): The states of the trajectory.
+
+                Returns:
+                    Trajectory: The `Trajectory` object.
+            )doc",
+            arg("states")
+        )
 
         .def(self == self)
         .def(self != self)
@@ -33,15 +67,78 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
         .def("__str__", &(shiftToString<Trajectory>))
         .def("__repr__", &(shiftToString<Trajectory>))
 
-        .def("is_defined", &Trajectory::isDefined)
+        .def(
+            "is_defined",
+            &Trajectory::isDefined,
+            R"doc(
+                Check if the trajectory is defined.
 
-        // .def("access_model", &Trajectory::accessModel, return_value_policy<reference_existing_object>())
+                Returns:
+                    bool: True if the trajectory is defined, False otherwise.
+            )doc"
+        )
 
-        .def("get_state_at", &Trajectory::getStateAt, arg("instant"))
-        .def("get_states_at", &Trajectory::getStatesAt, arg("instants"))
+        .def(
+            "get_state_at",
+            &Trajectory::getStateAt,
+            R"doc(
+                Get the state of the trajectory at a given instant.
 
-        .def_static("undefined", &Trajectory::Undefined)
-        .def_static("position", &Trajectory::Position, arg("position"))
+                Args:
+                    instant (Instant): The instant.
+
+                Returns:
+                    State: The state of the trajectory at the given instant.
+            )doc",
+            arg("instant")
+        )
+
+        .def(
+            "get_states_at",
+            &Trajectory::getStatesAt,
+            R"doc(
+                Get the states of the trajectory at a given set of instants.
+
+                Args:
+                    instants (Array[Instant]): The instants.
+
+                Returns:
+                    Array[State]: The states of the trajectory at the given instants.
+            )doc",
+            arg("instants")
+        )
+
+        .def_static(
+            "undefined",
+            &Trajectory::Undefined,
+            R"doc(
+                Create an undefined `Trajectory` object.
+
+                Returns:
+                    Trajectory: The undefined `Trajectory` object.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+
+        .def_static(
+            "position",
+            &Trajectory::Position,
+            R"doc(
+                Create a `Trajectory` object representing a position.
+
+                Args:
+                    position (Position): The position.
+
+                Returns:
+                    Trajectory: The `Trajectory` object representing the position.
+                
+                Group:
+                    Static methods
+            )doc",
+            arg("position")
+        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameDirection.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameDirection.cpp
@@ -81,9 +81,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameDirectio
 
                 Returns:
                     LocalOrbitalFrameDirection: The undefined local orbital frame direction.
-
-                Group:
-                    Static methods
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameDirection.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameDirection.cpp
@@ -17,7 +17,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameDirectio
 
             Group:
                 trajectory
-
         )doc"
     )
         .def(
@@ -39,7 +38,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameDirectio
         .def(self == self)
         .def(self != self)
 
-        .def("is_defined", &LocalOrbitalFrameDirection::isDefined,
+        .def(
+            "is_defined",
+            &LocalOrbitalFrameDirection::isDefined,
             R"doc(
                 Check if the local orbital frame direction is defined.
 
@@ -49,7 +50,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameDirectio
             )doc"
         )
 
-        .def("get_value", &LocalOrbitalFrameDirection::getValue,
+        .def(
+            "get_value",
+            &LocalOrbitalFrameDirection::getValue,
             R"doc(
                 Get the vector expressed in the local orbital frame.
 
@@ -58,7 +61,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameDirectio
 
             )doc"
         )
-        .def("get_local_orbital_frame_factory", &LocalOrbitalFrameDirection::getLocalOrbitalFrameFactory,
+        .def(
+            "get_local_orbital_frame_factory",
+            &LocalOrbitalFrameDirection::getLocalOrbitalFrameFactory,
             R"doc(
                 Get the local orbital frame factory that defines the frame.
 
@@ -68,7 +73,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameDirectio
             )doc"
         )
 
-        .def_static("undefined", &LocalOrbitalFrameDirection::Undefined,
+        .def_static(
+            "undefined",
+            &LocalOrbitalFrameDirection::Undefined,
             R"doc(
                 Get an undefined local orbital frame direction.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameDirection.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameDirection.cpp
@@ -9,23 +9,76 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameDirectio
     using ostk::astro::trajectory::LocalOrbitalFrameDirection;
     using ostk::astro::trajectory::LocalOrbitalFrameFactory;
 
-    class_<LocalOrbitalFrameDirection>(aModule, "LocalOrbitalFrameDirection")
+    class_<LocalOrbitalFrameDirection>(
+        aModule,
+        "LocalOrbitalFrameDirection",
+        R"doc(
+            A local orbital frame direction.
 
+            Group:
+                trajectory
+
+        )doc"
+    )
         .def(
             init<const ostk::math::obj::Vector3d&, const Shared<const LocalOrbitalFrameFactory>&>(),
             arg("vector"),
-            arg("local_orbital_frame_factory")
+            arg("local_orbital_frame_factory"),
+            R"doc(
+                Construct a new `LocalOrbitalFrameDirection` object.
+
+                Args:
+                    vector (numpy.ndarray): The vector expressed in the local orbital frame.
+                    local_orbital_frame_factory (LocalOrbitalFrameFactory): The local orbital frame factory that defines the frame.
+
+                Returns:
+                    LocalOrbitalFrameDirection: The new `LocalOrbitalFrameDirection` object.
+            )doc"
         )
 
         .def(self == self)
         .def(self != self)
 
-        .def("is_defined", &LocalOrbitalFrameDirection::isDefined)
+        .def("is_defined", &LocalOrbitalFrameDirection::isDefined,
+            R"doc(
+                Check if the local orbital frame direction is defined.
 
-        .def("get_value", &LocalOrbitalFrameDirection::getValue)
-        .def("get_local_orbital_frame_factory", &LocalOrbitalFrameDirection::getLocalOrbitalFrameFactory)
+                Returns:
+                    bool: True if the local orbital frame direction is defined, False otherwise.
 
-        .def_static("undefined", &LocalOrbitalFrameDirection::Undefined)
+            )doc"
+        )
+
+        .def("get_value", &LocalOrbitalFrameDirection::getValue,
+            R"doc(
+                Get the vector expressed in the local orbital frame.
+
+                Returns:
+                    Vector3d: The vector expressed in the local orbital frame.
+
+            )doc"
+        )
+        .def("get_local_orbital_frame_factory", &LocalOrbitalFrameDirection::getLocalOrbitalFrameFactory,
+            R"doc(
+                Get the local orbital frame factory that defines the frame.
+
+                Returns:
+                    LocalOrbitalFrameFactory: The local orbital frame factory that defines the frame.
+
+            )doc"
+        )
+
+        .def_static("undefined", &LocalOrbitalFrameDirection::Undefined,
+            R"doc(
+                Get an undefined local orbital frame direction.
+
+                Returns:
+                    LocalOrbitalFrameDirection: The undefined local orbital frame direction.
+
+                Group:
+                    Static methods
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -14,7 +14,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
 
     using ostk::astro::trajectory::LocalOrbitalFrameFactory;
 
-    class_<LocalOrbitalFrameFactory, Shared<LocalOrbitalFrameFactory>>(aModule, "LocalOrbitalFrameFactory")
+    class_<LocalOrbitalFrameFactory, Shared<LocalOrbitalFrameFactory>>(
+        aModule,
+        "LocalOrbitalFrameFactory",
+        R"doc(
+            The local orbital frame factory.
+
+            Group:
+                trajectory
+        )doc"
+    )
         .def(
             "is_defined",
             &LocalOrbitalFrameFactory::isDefined,
@@ -24,6 +33,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
                 Returns:
                     Frame: True if the local orbital frame factory is defined, False otherwise.
 
+                Group:
+                    trajectory
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -66,9 +66,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
 
                 Returns:
                     LocalOrbitalFrameFactory: The undefined local orbital frame factory.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -83,9 +80,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
 
                 Returns:
                     LocalOrbitalFrameFactory: The NED local orbital frame factory.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -100,9 +94,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
 
                 Returns:
                     LocalOrbitalFrameFactory: The LVLH local orbital frame factory.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -117,9 +108,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
 
                 Returns:
                     LocalOrbitalFrameFactory: The VVLH local orbital frame factory.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -134,9 +122,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
 
                 Returns:
                     LocalOrbitalFrameFactory: The QSW local orbital frame factory.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -151,9 +136,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
 
                 Returns:
                     LocalOrbitalFrameFactory: The TNW local orbital frame factory.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -168,9 +150,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
 
                 Returns:
                     LocalOrbitalFrameFactory: The VNC local orbital frame factory.
-
-                Group:
-                    Static methods
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -15,24 +15,153 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
     using ostk::astro::trajectory::LocalOrbitalFrameFactory;
 
     class_<LocalOrbitalFrameFactory, Shared<LocalOrbitalFrameFactory>>(aModule, "LocalOrbitalFrameFactory")
+        .def(
+            "is_defined",
+            &LocalOrbitalFrameFactory::isDefined,
+            R"doc(
+                Check if the local orbital frame factory is defined.
 
-        .def("is_defined", &LocalOrbitalFrameFactory::isDefined)
+                Returns:
+                    Frame: True if the local orbital frame factory is defined, False otherwise.
+
+            )doc"
+        )
 
         .def(
             "generate_frame",
             &LocalOrbitalFrameFactory::generateFrame,
             arg("instant"),
             arg("position_vector"),
-            arg("velocity_vector")
+            arg("velocity_vector"),
+            R"doc(
+                Generate a local orbital frame.
+
+                Args:
+                    instant (Instant): The instant.
+                    position_vector (numpy.ndarray): The position vector.
+                    velocity_vector (numpy.ndarray): The velocity vector.
+
+                Returns:
+                    Frame: The local orbital frame.
+
+            )doc"
         )
 
-        .def_static("undefined", &LocalOrbitalFrameFactory::Undefined)
-        .def_static("NED", &LocalOrbitalFrameFactory::NED, arg("parent_frame"))
-        .def_static("LVLH", &LocalOrbitalFrameFactory::LVLH, arg("parent_frame"))
-        .def_static("VVLH", &LocalOrbitalFrameFactory::VVLH, arg("parent_frame"))
-        .def_static("QSW", &LocalOrbitalFrameFactory::QSW, arg("parent_frame"))
-        .def_static("TNW", &LocalOrbitalFrameFactory::TNW, arg("parent_frame"))
-        .def_static("VNC", &LocalOrbitalFrameFactory::VNC, arg("parent_frame"))
+        .def_static(
+            "undefined",
+            &LocalOrbitalFrameFactory::Undefined,
+            R"doc(
+                Get an undefined local orbital frame factory.
+
+                Returns:
+                    LocalOrbitalFrameFactory: The undefined local orbital frame factory.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "NED",
+            &LocalOrbitalFrameFactory::NED,
+            arg("parent_frame"),
+            R"doc(
+                Get a North-East-Down (NED) local orbital frame factory.
+
+                Args:
+                    parent_frame (Frame): The parent frame.
+
+                Returns:
+                    LocalOrbitalFrameFactory: The NED local orbital frame factory.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "LVLH",
+            &LocalOrbitalFrameFactory::LVLH,
+            arg("parent_frame"),
+            R"doc(
+                Get a Local Vertical Local Horizontal (LVLH) local orbital frame factory.
+
+                Args:
+                    parent_frame (Frame): The parent frame.
+
+                Returns:
+                    LocalOrbitalFrameFactory: The LVLH local orbital frame factory.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "VVLH",
+            &LocalOrbitalFrameFactory::VVLH,
+            arg("parent_frame"),
+            R"doc(
+                Get a Velocity Local Vertical Local Horizontal (VVLH) local orbital frame factory.
+
+                Args:
+                    parent_frame (Frame): The parent frame.
+
+                Returns:
+                    LocalOrbitalFrameFactory: The VVLH local orbital frame factory.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "QSW",
+            &LocalOrbitalFrameFactory::QSW,
+            arg("parent_frame"),
+            R"doc(
+                Get a Quasi-Satellite World (QSW) local orbital frame factory.
+
+                Args:
+                    parent_frame (Frame): The parent frame.
+
+                Returns:
+                    LocalOrbitalFrameFactory: The QSW local orbital frame factory.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "TNW",
+            &LocalOrbitalFrameFactory::TNW,
+            arg("parent_frame"),
+            R"doc(
+                Get a Topocentric North-West-Up (TNW) local orbital frame factory.
+
+                Args:
+                    parent_frame (Frame): The parent frame.
+
+                Returns:
+                    LocalOrbitalFrameFactory: The TNW local orbital frame factory.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "VNC",
+            &LocalOrbitalFrameFactory::VNC,
+            arg("parent_frame"),
+            R"doc(
+                Get a Velocity-Normal-Co-normal (VNC) local orbital frame factory.
+
+                Args:
+                    parent_frame (Frame): The parent frame.
+
+                Returns:
+                    LocalOrbitalFrameFactory: The VNC local orbital frame factory.
+
+                Group:
+                    Static methods
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameTransformProvider.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameTransformProvider.cpp
@@ -26,6 +26,25 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameTransfor
         );
     // TBI: can't make this linked with Shared<Provider>
 
+    enum_<LocalOrbitalFrameTransformProvider::Type>(
+        localOrbitalFrameTransformProviderClass,
+        "Type",
+        R"doc(
+            The local orbital frame type.
+        )doc"
+    )
+
+        .value("Undefined", LocalOrbitalFrameTransformProvider::Type::Undefined, "Undefined")
+        .value("NED", LocalOrbitalFrameTransformProvider::Type::NED, "North-East-Down")
+        .value("LVLH", LocalOrbitalFrameTransformProvider::Type::LVLH, "Local Vertical-Local Horizontal")
+        .value("LVLHGD", LocalOrbitalFrameTransformProvider::Type::LVLHGD, "Local Vertical-Local Horizontal Geodetic")
+        .value("VVLH", LocalOrbitalFrameTransformProvider::Type::VVLH, "Vertical-Local Horizontal")
+        .value("QSW", LocalOrbitalFrameTransformProvider::Type::QSW, "Quasi-Satellite West")
+        .value("TNW", LocalOrbitalFrameTransformProvider::Type::TNW, "Topocentric North-West")
+        .value("VNC", LocalOrbitalFrameTransformProvider::Type::VNC, "Velocity-Normal-Co-normal")
+
+        ;
+
     localOrbitalFrameTransformProviderClass
 
         .def(
@@ -53,25 +72,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameTransfor
             )doc",
             arg("instant")
         )
-
-        ;
-
-    enum_<LocalOrbitalFrameTransformProvider::Type>(
-        localOrbitalFrameTransformProviderClass,
-        "Type",
-        R"doc(
-            The local orbital frame type.
-        )doc"
-    )
-
-        .value("Undefined", LocalOrbitalFrameTransformProvider::Type::Undefined, "Undefined")
-        .value("NED", LocalOrbitalFrameTransformProvider::Type::NED, "North-East-Down")
-        .value("LVLH", LocalOrbitalFrameTransformProvider::Type::LVLH, "Local Vertical-Local Horizontal")
-        .value("LVLHGD", LocalOrbitalFrameTransformProvider::Type::LVLHGD, "Local Vertical-Local Horizontal Geodetic")
-        .value("VVLH", LocalOrbitalFrameTransformProvider::Type::VVLH, "Vertical-Local Horizontal")
-        .value("QSW", LocalOrbitalFrameTransformProvider::Type::QSW, "Quasi-Satellite West")
-        .value("TNW", LocalOrbitalFrameTransformProvider::Type::TNW, "Topocentric North-West")
-        .value("VNC", LocalOrbitalFrameTransformProvider::Type::VNC, "Velocity-Normal-Co-normal")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameTransformProvider.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameTransformProvider.cpp
@@ -13,27 +13,65 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameTransfor
     using ostk::astro::trajectory::LocalOrbitalFrameTransformProvider;
 
     class_<LocalOrbitalFrameTransformProvider, Shared<LocalOrbitalFrameTransformProvider>>
-        localOrbitalFrameTransformProviderClass(aModule, "LocalOrbitalFrameTransformProvider");
+        localOrbitalFrameTransformProviderClass(
+            aModule,
+            "LocalOrbitalFrameTransformProvider",
+            R"doc(
+                Local orbital frame transform provider, frame provider.
+                Generates a specific transform based on instant, position, velocity and a LOF type.
+
+                Group:
+                    trajectory
+            )doc"
+        );
     // TBI: can't make this linked with Shared<Provider>
 
     localOrbitalFrameTransformProviderClass
 
-        .def("is_defined", &LocalOrbitalFrameTransformProvider::isDefined)
+        .def(
+            "is_defined",
+            &LocalOrbitalFrameTransformProvider::isDefined,
+            R"doc(
+                Returns true if the provider is defined.
 
-        .def("get_transform_at", &LocalOrbitalFrameTransformProvider::getTransformAt, arg("instant"))
+                Returns:
+                    bool: True if the provider is defined.
+            )doc"
+        )
+
+        .def(
+            "get_transform_at",
+            &LocalOrbitalFrameTransformProvider::getTransformAt,
+            R"doc(
+                Returns the transform at a given instant.
+
+                Args:
+                    instant (Instant): The instant.
+
+                Returns:
+                    Transform: The transform at the given instant.
+            )doc",
+            arg("instant")
+        )
 
         ;
 
-    enum_<LocalOrbitalFrameTransformProvider::Type>(localOrbitalFrameTransformProviderClass, "Type")
+    enum_<LocalOrbitalFrameTransformProvider::Type>(
+        localOrbitalFrameTransformProviderClass,
+        "Type",
+        R"doc(
+            The local orbital frame type.
+        )doc"
+    )
 
-        .value("Undefined", LocalOrbitalFrameTransformProvider::Type::Undefined)
-        .value("NED", LocalOrbitalFrameTransformProvider::Type::NED)
-        .value("LVLH", LocalOrbitalFrameTransformProvider::Type::LVLH)
-        .value("LVLHGD", LocalOrbitalFrameTransformProvider::Type::LVLHGD)
-        .value("VVLH", LocalOrbitalFrameTransformProvider::Type::VVLH)
-        .value("QSW", LocalOrbitalFrameTransformProvider::Type::QSW)
-        .value("TNW", LocalOrbitalFrameTransformProvider::Type::TNW)
-        .value("VNC", LocalOrbitalFrameTransformProvider::Type::VNC)
+        .value("Undefined", LocalOrbitalFrameTransformProvider::Type::Undefined, "Undefined")
+        .value("NED", LocalOrbitalFrameTransformProvider::Type::NED, "North-East-Down")
+        .value("LVLH", LocalOrbitalFrameTransformProvider::Type::LVLH, "Local Vertical-Local Horizontal")
+        .value("LVLHGD", LocalOrbitalFrameTransformProvider::Type::LVLHGD, "Local Vertical-Local Horizontal Geodetic")
+        .value("VVLH", LocalOrbitalFrameTransformProvider::Type::VVLH, "Vertical-Local Horizontal")
+        .value("QSW", LocalOrbitalFrameTransformProvider::Type::QSW, "Quasi-Satellite West")
+        .value("TNW", LocalOrbitalFrameTransformProvider::Type::TNW, "Topocentric North-West")
+        .value("VNC", LocalOrbitalFrameTransformProvider::Type::VNC, "Velocity-Normal-Co-normal")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model.cpp
@@ -8,8 +8,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model(pybind11::module &a
 
     using BaseModel = ostk::astro::trajectory::Model;
 
-    class_<BaseModel>(aModule, "Model")
+    class_<BaseModel>(
+        aModule,
+        "Model",
+        R"doc(
+            Orbital model.
 
+            Group:
+                trajectory
+        )doc"
+    )
         .def(
             "__eq__",
             [](const BaseModel &self, const BaseModel &other)
@@ -28,10 +36,39 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model(pybind11::module &a
         .def("__str__", &(shiftToString<BaseModel>))
         .def("__repr__", &(shiftToString<BaseModel>))
 
-        .def("is_defined", &BaseModel::isDefined)
+        .def("is_defined", &BaseModel::isDefined,
+            R"doc(
+                Check if the model is defined.
 
-        .def("calculate_state_at", &BaseModel::calculateStateAt, arg("instant"))
-        .def("calculate_states_at", &BaseModel::calculateStatesAt, arg("instants"))
+                Returns:
+                    bool: True if the model is defined, False otherwise.
+
+            )doc"
+        )
+
+        .def("calculate_state_at", &BaseModel::calculateStateAt, arg("instant"),
+            R"doc(
+                Calculate the state at a given instant.
+
+                Args:
+                    instant (Instant): The instant.
+
+                Returns:
+                    State: The state at the given instant.
+
+            )doc"
+        )
+        .def("calculate_states_at", &BaseModel::calculateStatesAt, arg("instants"),
+            R"doc(
+                Calculate the states at given instants.
+
+                @param instants The instants.
+
+                Returns:
+                    Array<State>: The states at the given instants.
+
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -40,6 +40,25 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
             )doc"
         );
 
+        enum_<Orbit::FrameType>(
+            orbit_class,
+            "FrameType",
+            R"doc(
+                The local orbital frame type.
+            )doc"
+        )
+
+            .value("Undefined", Orbit::FrameType::Undefined, "Undefined")
+            .value("NED", Orbit::FrameType::NED, "North-East-Down")
+            .value("LVLH", Orbit::FrameType::LVLH, "Local Vertical-Local Horizontal")
+            .value("LVLHGD", Orbit::FrameType::LVLHGD, "Local Vertical-Local Horizontal Geodetic")
+            .value("VVLH", Orbit::FrameType::VVLH, "Vertical-Local Horizontal")
+            .value("QSW", Orbit::FrameType::QSW, "Quasi-Satellite West")
+            .value("TNW", Orbit::FrameType::TNW, "Topocentric North-West")
+            .value("VNC", Orbit::FrameType::VNC, "Velocity-Normal-Co-normal")
+
+            ;
+
         orbit_class
 
             .def(
@@ -356,25 +375,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                         Static methods
                 )doc"
             )
-
-            ;
-
-        enum_<Orbit::FrameType>(
-            orbit_class,
-            "FrameType",
-            R"doc(
-                The local orbital frame type.
-            )doc"
-        )
-
-            .value("Undefined", Orbit::FrameType::Undefined, "Undefined")
-            .value("NED", Orbit::FrameType::NED, "North-East-Down")
-            .value("LVLH", Orbit::FrameType::LVLH, "Local Vertical-Local Horizontal")
-            .value("LVLHGD", Orbit::FrameType::LVLHGD, "Local Vertical-Local Horizontal Geodetic")
-            .value("VVLH", Orbit::FrameType::VVLH, "Vertical-Local Horizontal")
-            .value("QSW", Orbit::FrameType::QSW, "Quasi-Satellite West")
-            .value("TNW", Orbit::FrameType::TNW, "Topocentric North-West")
-            .value("VNC", Orbit::FrameType::VNC, "Velocity-Normal-Co-normal")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -29,74 +29,241 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
     using ostk::astro::trajectory::orbit::models::SGP4;
 
     {
-        class_<Orbit, ostk::astro::Trajectory> orbit_class(aModule, "Orbit");
+        class_<Orbit, ostk::astro::Trajectory> orbit_class(
+            aModule,
+            "Orbit",
+            R"doc(
+                Gravitationally curved trajectory of an object.
+
+                Group:
+                    trajectory
+            )doc"
+        );
 
         orbit_class
 
             .def(
                 init<const ostk::astro::trajectory::orbit::Model&, const Shared<const Celestial>&>(),
                 arg("model"),
-                arg("celestial_object")
+                arg("celestial_object"),
+                R"doc(
+                    Constructs an `Orbit` object.
+
+                    Args:
+                        model (orbit.Model): The orbit model.
+                        celestial_object (Celestial): The celestial object.
+
+                )doc"
             )
 
             .def(
                 init<const Array<State>&, const Integer&, const Shared<const Celestial>&>(),
                 arg("states"),
                 arg("initial_revolution_number"),
-                arg("celestial_object")
+                arg("celestial_object"),
+                R"doc(
+                    Constructs an `Orbit` object.
+
+                    Args:
+                        states (Array<State>): The states.
+                        initial_revolution_number (Integer): The initial revolution number.
+                        celestial_object (Celestial): The celestial object.
+
+                )doc"
             )
 
-            .def(self == self)
+            .def(self == self, R"doc(
+                    Check if two `Orbit` objects are equal.
+
+                    Args:
+                        self (Orbit): The first `Orbit` object.
+                        other (Orbit): The second `Orbit` object.
+
+                    Returns:
+                        bool: True if the two `Orbit` objects are equal, False otherwise.
+
+                )doc"
+            )
             .def(self != self)
 
             .def("__str__", &(shiftToString<Orbit>))
             .def("__repr__", &(shiftToString<Orbit>))
 
-            .def("is_defined", &Orbit::isDefined)
+            .def("is_defined", &Orbit::isDefined, R"doc(
+                    Check if the `Orbit` object is defined.
 
-            .def("access_model", &Orbit::accessModel, return_value_policy::reference)  // [TBR]
+                    Args:
+                        self (Orbit): The `Orbit` object.
+
+                    Returns:
+                        bool: True if the `Orbit` object is defined, False otherwise.
+
+                )doc"
+            )
+
+            .def("access_model", &Orbit::accessModel, return_value_policy::reference, R"doc(
+                    Access the orbit model.
+
+                    Args:
+                        self (Orbit): The `Orbit` object.
+
+                    Returns:
+                        orbit.Model: The orbit model.
+
+                )doc"
+            )
             .def(
                 "access_kepler_model",
                 +[](const Orbit& anOrbit) -> const Kepler&
                 {
                     return anOrbit.accessModel().as<Kepler>();
                 },
-                return_value_policy::reference
-            )  // [TBR]
+                return_value_policy::reference,
+                R"doc(
+                    Access the Kepler orbit model.
+
+                    Args:
+                        self (Orbit): The `Orbit` object.
+
+                    Returns:
+                       Kepler: The Kepler orbit model.
+
+                )doc"
+            )
             .def(
                 "access_sgp4_model",
                 +[](const Orbit& anOrbit) -> const SGP4&
                 {
                     return anOrbit.accessModel().as<SGP4>();
                 },
-                return_value_policy::reference
-            )  // [TBR]
+                return_value_policy::reference,
+                R"doc(
+                    Access the SGP4 orbit model.
+
+                    Args:
+                        self (Orbit): The `Orbit` object.
+
+                    Returns:
+                        SGP4: The SGP4 orbit model.
+
+                )doc"
+            )
             .def(
                 "access_propagated_model",
                 +[](const Orbit& anOrbit) -> const Propagated&
                 {
                     return anOrbit.accessModel().as<Propagated>();
                 },
-                return_value_policy::reference
-            )  // [TBR]
+                return_value_policy::reference,
+                R"doc(
+                    Access the propagated orbit model.
+
+                    Args:
+                        self (Orbit): The `Orbit` object.
+
+                    Returns:
+                        Propagated: The propagated orbit model.
+
+                )doc"
+            )
             .def(
                 "access_tabulated_model",
                 +[](const Orbit& anOrbit) -> const Tabulated&
                 {
                     return anOrbit.accessModel().as<Tabulated>();
                 },
-                return_value_policy::reference
-            )  // [TBR]
+                return_value_policy::reference,
+                R"doc(
+                    Access the tabulated orbit model.
 
-            .def("get_revolution_number_at", &Orbit::getRevolutionNumberAt, arg("instant"))
-            .def("get_pass_at", &Orbit::getPassAt, arg("instant"))
-            .def("get_pass_with_revolution_number", &Orbit::getPassWithRevolutionNumber, arg("revolution_number"))
-            .def("get_orbital_frame", &Orbit::getOrbitalFrame, arg("frame_type"))
+                    Args:
+                        self (Orbit): The `Orbit` object.
 
-            .def_static("undefined", &Orbit::Undefined)
+                    Returns:
+                        Tabulated: The tabulated orbit model.
+
+                )doc"
+            )
+
+            .def("get_revolution_number_at", &Orbit::getRevolutionNumberAt, arg("instant"), R"doc(
+                    Get the revolution number at a given instant.
+
+                    Args:
+                        self (Orbit): The `Orbit` object.
+                        instant (Instant): The instant.
+
+                    Returns:
+                        int: The revolution number.
+
+                )doc"
+            )
+            .def("get_pass_at", &Orbit::getPassAt, arg("instant"), R"doc(
+                    Get the pass at a given instant.
+
+                    Args:
+                        self (Orbit): The `Orbit` object.
+                        instant (Instant): The instant.
+
+                    Returns:
+                        ostk::astro::trajectory::orbit::Pass: The pass.
+
+                )doc"
+            )
+            .def("get_pass_with_revolution_number", &Orbit::getPassWithRevolutionNumber, arg("revolution_number"), R"doc(
+                    Get the pass with a given revolution number.
+
+                    Args:
+                        self (Orbit): The `Orbit` object.
+                        revolution_number (int): The revolution number.
+
+                    Returns:
+                        Pass: The pass.
+
+                )doc"
+            )
+            .def("get_orbital_frame", &Orbit::getOrbitalFrame, arg("frame_type"), R"doc(
+                    Get the orbital frame.
+
+                    Args:
+                        self (Orbit): The `Orbit` object.
+                        frame_type (Orbit::FrameType): The frame type.
+
+                    Returns:
+                        Frame: The orbital frame.
+
+                )doc"
+            )
+
+            .def_static("undefined", &Orbit::Undefined, R"doc(
+                    Get an undefined `Orbit` object.
+
+                    Returns:
+                        Orbit: The undefined `Orbit` object.
+
+                )doc")
 
             .def_static(
-                "circular", &Orbit::Circular, arg("epoch"), arg("altitude"), arg("inclination"), arg("celestial_object")
+                "circular",
+                &Orbit::Circular,
+                arg("epoch"),
+                arg("altitude"),
+                arg("inclination"),
+                arg("celestial_object"),
+                R"doc(
+                    Create a circular `Orbit` object.
+
+                    Args:
+                        epoch (Instant): The epoch.
+                        altitude (double): The altitude.
+                        inclination (double): The inclination.
+                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+
+                    Returns:
+                        Orbit: The circular `Orbit` object.
+
+                    Group:
+                        Static methods
+                )doc"
             )
 
             .def_static(
@@ -105,7 +272,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 arg("epoch"),
                 arg("apoapsis_altitude"),
                 arg("periapsis_altitude"),
-                arg("celestial_object")
+                arg("celestial_object"),
+                R"doc(
+                    Create an equatorial `Orbit` object.
+
+                    Args:
+                        epoch (Instant): The epoch.
+                        apoapsis_altitude (double): The apoapsis altitude.
+                        periapsis_altitude (double): The periapsis altitude.
+                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+
+                    Returns:
+                        Orbit: The equatorial `Orbit` object.
+
+                    Group:
+                        Static methods
+                )doc"
             )
 
             .def_static(
@@ -113,7 +295,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 &Orbit::CircularEquatorial,
                 arg("epoch"),
                 arg("altitude"),
-                arg("celestial_object")
+                arg("celestial_object"),
+                R"doc(
+                    Create a circular equatorial `Orbit` object.
+
+                    Args:
+                        epoch (Instant): The epoch.
+                        altitude (double): The altitude.
+                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+
+                    Returns:
+                        Orbit: The circular equatorial `Orbit` object.
+
+                    Group:
+                        Static methods
+                )doc"
             )
 
             .def_static(
@@ -122,7 +318,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 arg("epoch"),
                 arg("inclination"),
                 arg("longitude"),
-                arg("celestial_object")
+                arg("celestial_object"),
+                R"doc(
+                    Create a geosynchronous `Orbit` object.
+
+                    Args:
+                        epoch (Instant): The epoch.
+                        inclination (double): The inclination.
+                        longitude (double): The longitude.
+                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+
+                    Returns:
+                        Orbit: The geosynchronous `Orbit` object.
+
+                    Group:
+                        Static methods
+                )doc"
             )
 
             .def_static(
@@ -131,21 +342,42 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 arg("epoch"),
                 arg("altitude"),
                 arg("local_time_at_descending_node"),
-                arg("celestial_object")
+                arg("celestial_object"),
+                R"doc(
+                    Create a sun-synchronous `Orbit` object.
+
+                    Args:
+                        epoch (Instant): The epoch.
+                        altitude (double): The altitude.
+                        local_time_at_descending_node (double): The local time at descending node.
+                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+
+                    Returns:
+                        Orbit: The sun-synchronous `Orbit` object.
+
+                    Group:
+                        Static methods
+                )doc"
             )
 
             ;
 
-        enum_<Orbit::FrameType>(orbit_class, "FrameType")
+        enum_<Orbit::FrameType>(
+            orbit_class,
+            "FrameType",
+            R"doc(
+                The local orbital frame type.
+            )doc"
+        )
 
-            .value("Undefined", Orbit::FrameType::Undefined)
-            .value("NED", Orbit::FrameType::NED)
-            .value("LVLH", Orbit::FrameType::LVLH)
-            .value("LVLHGD", Orbit::FrameType::LVLHGD)
-            .value("VVLH", Orbit::FrameType::VVLH)
-            .value("QSW", Orbit::FrameType::QSW)
-            .value("TNW", Orbit::FrameType::TNW)
-            .value("VNC", Orbit::FrameType::VNC)
+            .value("Undefined", Orbit::FrameType::Undefined, "Undefined")
+            .value("NED", Orbit::FrameType::NED, "North-East-Down")
+            .value("LVLH", Orbit::FrameType::LVLH, "Local Vertical-Local Horizontal")
+            .value("LVLHGD", Orbit::FrameType::LVLHGD, "Local Vertical-Local Horizontal Geodetic")
+            .value("VVLH", Orbit::FrameType::VVLH, "Vertical-Local Horizontal")
+            .value("QSW", Orbit::FrameType::QSW, "Quasi-Satellite West")
+            .value("TNW", Orbit::FrameType::TNW, "Topocentric North-West")
+            .value("VNC", Orbit::FrameType::VNC, "Velocity-Normal-Co-normal")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -72,28 +72,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 )doc"
             )
 
-            .def(self == self, R"doc(
-                    Check if two `Orbit` objects are equal.
-
-                    Args:
-                        self (Orbit): The first `Orbit` object.
-                        other (Orbit): The second `Orbit` object.
-
-                    Returns:
-                        bool: True if the two `Orbit` objects are equal, False otherwise.
-
-                )doc"
-            )
+            .def(self == self)
             .def(self != self)
 
             .def("__str__", &(shiftToString<Orbit>))
             .def("__repr__", &(shiftToString<Orbit>))
 
-            .def("is_defined", &Orbit::isDefined, R"doc(
+            .def(
+                "is_defined",
+                &Orbit::isDefined,
+                R"doc(
                     Check if the `Orbit` object is defined.
-
-                    Args:
-                        self (Orbit): The `Orbit` object.
 
                     Returns:
                         bool: True if the `Orbit` object is defined, False otherwise.
@@ -101,11 +90,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 )doc"
             )
 
-            .def("access_model", &Orbit::accessModel, return_value_policy::reference, R"doc(
+            .def(
+                "access_model",
+                &Orbit::accessModel,
+                return_value_policy::reference,
+                R"doc(
                     Access the orbit model.
-
-                    Args:
-                        self (Orbit): The `Orbit` object.
 
                     Returns:
                         orbit.Model: The orbit model.
@@ -122,9 +112,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 R"doc(
                     Access the Kepler orbit model.
 
-                    Args:
-                        self (Orbit): The `Orbit` object.
-
                     Returns:
                        Kepler: The Kepler orbit model.
 
@@ -139,9 +126,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 return_value_policy::reference,
                 R"doc(
                     Access the SGP4 orbit model.
-
-                    Args:
-                        self (Orbit): The `Orbit` object.
 
                     Returns:
                         SGP4: The SGP4 orbit model.
@@ -158,9 +142,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 R"doc(
                     Access the propagated orbit model.
 
-                    Args:
-                        self (Orbit): The `Orbit` object.
-
                     Returns:
                         Propagated: The propagated orbit model.
 
@@ -176,71 +157,87 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 R"doc(
                     Access the tabulated orbit model.
 
-                    Args:
-                        self (Orbit): The `Orbit` object.
-
                     Returns:
                         Tabulated: The tabulated orbit model.
 
                 )doc"
             )
 
-            .def("get_revolution_number_at", &Orbit::getRevolutionNumberAt, arg("instant"), R"doc(
+            .def(
+                "get_revolution_number_at",
+                &Orbit::getRevolutionNumberAt,
+                R"doc(
                     Get the revolution number at a given instant.
 
                     Args:
-                        self (Orbit): The `Orbit` object.
                         instant (Instant): The instant.
 
                     Returns:
                         int: The revolution number.
 
-                )doc"
+                )doc",
+                arg("instant")
             )
-            .def("get_pass_at", &Orbit::getPassAt, arg("instant"), R"doc(
+            .def(
+                "get_pass_at",
+                &Orbit::getPassAt,
+                R"doc(
                     Get the pass at a given instant.
 
                     Args:
-                        self (Orbit): The `Orbit` object.
                         instant (Instant): The instant.
 
                     Returns:
                         ostk::astro::trajectory::orbit::Pass: The pass.
 
-                )doc"
+                )doc",
+                arg("instant")
             )
-            .def("get_pass_with_revolution_number", &Orbit::getPassWithRevolutionNumber, arg("revolution_number"), R"doc(
+            .def(
+                "get_pass_with_revolution_number",
+                &Orbit::getPassWithRevolutionNumber,
+                R"doc(
                     Get the pass with a given revolution number.
 
                     Args:
-                        self (Orbit): The `Orbit` object.
                         revolution_number (int): The revolution number.
 
                     Returns:
                         Pass: The pass.
 
-                )doc"
+                )doc",
+                arg("revolution_number")
             )
-            .def("get_orbital_frame", &Orbit::getOrbitalFrame, arg("frame_type"), R"doc(
+            .def(
+                "get_orbital_frame",
+                &Orbit::getOrbitalFrame,
+                R"doc(
                     Get the orbital frame.
 
                     Args:
-                        self (Orbit): The `Orbit` object.
                         frame_type (Orbit::FrameType): The frame type.
 
                     Returns:
                         Frame: The orbital frame.
 
-                )doc"
+                )doc",
+                arg("frame_type")
             )
 
-            .def_static("undefined", &Orbit::Undefined, R"doc(
+            .def_static(
+                "undefined",
+                &Orbit::Undefined,
+                R"doc(
                     Get an undefined `Orbit` object.
 
                     Returns:
                         Orbit: The undefined `Orbit` object.
+                    
+                    Group:
+                        Static method
 
-                )doc")
+                )doc"
+            )
 
             .def_static(
                 "circular",
@@ -256,7 +253,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                         epoch (Instant): The epoch.
                         altitude (double): The altitude.
                         inclination (double): The inclination.
-                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+                        celestial_object (Celestial): The celestial object.
 
                     Returns:
                         Orbit: The circular `Orbit` object.
@@ -280,7 +277,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                         epoch (Instant): The epoch.
                         apoapsis_altitude (double): The apoapsis altitude.
                         periapsis_altitude (double): The periapsis altitude.
-                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+                        celestial_object (Celestial): The celestial object.
 
                     Returns:
                         Orbit: The equatorial `Orbit` object.
@@ -302,7 +299,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                     Args:
                         epoch (Instant): The epoch.
                         altitude (double): The altitude.
-                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+                        celestial_object (Celestial): The celestial object.
 
                     Returns:
                         Orbit: The circular equatorial `Orbit` object.
@@ -326,7 +323,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                         epoch (Instant): The epoch.
                         inclination (double): The inclination.
                         longitude (double): The longitude.
-                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+                        celestial_object (Celestial): The celestial object.
 
                     Returns:
                         Orbit: The geosynchronous `Orbit` object.
@@ -350,7 +347,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                         epoch (Instant): The epoch.
                         altitude (double): The altitude.
                         local_time_at_descending_node (double): The local time at descending node.
-                        celestial_object (ostk::physics::env::obj::Celestial): The celestial object.
+                        celestial_object (Celestial): The celestial object.
 
                     Returns:
                         Orbit: The sun-synchronous `Orbit` object.

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -36,7 +36,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
                 Gravitationally curved trajectory of an object.
 
                 Group:
-                    trajectory
+                    orbit
             )doc"
         );
 
@@ -251,10 +251,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                     Returns:
                         Orbit: The undefined `Orbit` object.
-                    
-                    Group:
-                        Static method
-
                 )doc"
             )
 
@@ -276,9 +272,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                     Returns:
                         Orbit: The circular `Orbit` object.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 
@@ -300,9 +293,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                     Returns:
                         Orbit: The equatorial `Orbit` object.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 
@@ -322,9 +312,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                     Returns:
                         Orbit: The circular equatorial `Orbit` object.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 
@@ -346,9 +333,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                     Returns:
                         Orbit: The geosynchronous `Orbit` object.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 
@@ -370,9 +354,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                     Returns:
                         Orbit: The sun-synchronous `Orbit` object.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
@@ -30,7 +30,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
                 `SpaceX OPM <https://public.ccsds.org/Pubs/502x0b3e1.pdf>`_.
 
             Group:
-                SpaceX
+                spacex
         )doc"
     );
 
@@ -45,8 +45,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
                     header (Header): The header of the OPM message.
                     deployments (list[Deployment]): The deployments of the OPM message.
 
-                Group:
-                    Constructors
             )doc",
             arg("header"),
             arg("deployments")
@@ -195,7 +193,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
             The header of the SpaceX OPM message.
 
             Group:
-                SpaceX
+                spacex
         )doc"
     )
 
@@ -245,7 +243,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
             The deployment of the SpaceX OPM message.
 
             Group:
-                SpaceX
+                spacex
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
@@ -30,7 +30,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
                 `SpaceX OPM <https://public.ccsds.org/Pubs/502x0b3e1.pdf>`_.
 
             Group:
-                spacex
+                ccsds
         )doc"
     );
 
@@ -123,10 +123,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
 
                 Returns:
                     opm (OPM): An undefined OPM message.
-
-                Group:
-                    Static methods
-
             )doc"
         )
         .def_static(
@@ -140,10 +136,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
 
                 Returns:
                     opm (OPM): The OPM message.
-
-                Group:
-                    Static methods
-
             )doc",
             arg("dictionary")
         )
@@ -158,10 +150,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
 
                 Returns:
                     opm (OPM): The OPM message.
-
-                Group:
-                    Static methods
-
             )doc",
             arg("string")
         )
@@ -176,10 +164,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
 
                 Returns:
                     opm (OPM): The OPM message.
-
-                Group:
-                    Static methods
-
             )doc",
             arg("file")
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
@@ -43,7 +43,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
 
                 Args:
                     header (Header): The header of the OPM message.
-                    deployments (Array[Deployment]): The deployments of the OPM message.
+                    deployments (list[Deployment]): The deployments of the OPM message.
 
                 Group:
                     Constructors
@@ -82,7 +82,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
                 Get the deployments of the OPM message.
 
                 Returns:
-                    deployments (Array[Deployment]): The deployments of the OPM message.
+                    deployments (list[Deployment]): The deployments of the OPM message.
 
             )doc"
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Messages/SpaceX/OPM.cpp
@@ -20,36 +20,234 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
 
     using ostk::astro::trajectory::orbit::messages::spacex::OPM;
 
-    class_<OPM> opm(aModule, "OPM");
+    class_<OPM> opm(
+        aModule,
+        "OPM",
+        R"doc(
+            The SpaceX OPM message.
+
+            See Also:
+                `SpaceX OPM <https://public.ccsds.org/Pubs/502x0b3e1.pdf>`_.
+
+            Group:
+                SpaceX
+        )doc"
+    );
 
     opm
 
-        .def(init<const OPM::Header&, const Array<OPM::Deployment>&>(), arg("header"), arg("deployments"))
+        .def(
+            init<const OPM::Header&, const Array<OPM::Deployment>&>(),
+            R"doc(
+                Constructor.
 
-        .def("is_defined", &OPM::isDefined)
+                Args:
+                    header (Header): The header of the OPM message.
+                    deployments (Array[Deployment]): The deployments of the OPM message.
 
-        .def("get_header", &OPM::getHeader)
-        .def("get_deployments", &OPM::getDeployments)
-        .def("get_deployment_at", &OPM::getDeploymentAt, arg("index"))
-        .def("get_deployment_with_name", &OPM::getDeploymentWithName, arg("name"))
+                Group:
+                    Constructors
+            )doc",
+            arg("header"),
+            arg("deployments")
+        )
 
-        .def_static("undefined", &OPM::Undefined)
-        .def_static("dictionary", &OPM::Dictionary, arg("dictionary"))
-        .def_static("parse", &OPM::Parse, arg("string"))
-        .def_static("load", &OPM::Load, arg("file"))
+        .def(
+            "is_defined",
+            &OPM::isDefined,
+            R"doc(
+                Check if the OPM message is defined.
+
+                Returns:
+                    is_defined (bool): True if the OPM message is defined, False otherwise.
+
+            )doc"
+        )
+
+        .def(
+            "get_header",
+            &OPM::getHeader,
+            R"doc(
+                Get the header of the OPM message.
+
+                Returns:
+                    header (Header): The header of the OPM message.
+
+            )doc"
+        )
+        .def(
+            "get_deployments",
+            &OPM::getDeployments,
+            R"doc(
+                Get the deployments of the OPM message.
+
+                Returns:
+                    deployments (Array[Deployment]): The deployments of the OPM message.
+
+            )doc"
+        )
+        .def(
+            "get_deployment_at",
+            &OPM::getDeploymentAt,
+            arg("index"),
+            R"doc(
+                Get the deployment at a given index.
+
+                Args:
+                    index (int): The index of the deployment.
+
+                Returns:
+                    deployment (Deployment): The deployment at the given index.
+
+            )doc"
+        )
+        .def(
+            "get_deployment_with_name",
+            &OPM::getDeploymentWithName,
+            R"doc(
+                Get the deployment with a given name.
+
+                Args:
+                    name (str): The name of the deployment.
+
+                Returns:
+                    deployment (Deployment): The deployment with the given name.
+
+            )doc",
+            arg("name")
+        )
+
+        .def_static(
+            "undefined",
+            &OPM::Undefined,
+            R"doc(
+                Return an undefined OPM message.
+
+                Returns:
+                    opm (OPM): An undefined OPM message.
+
+                Group:
+                    Static methods
+
+            )doc"
+        )
+        .def_static(
+            "dictionary",
+            &OPM::Dictionary,
+            R"doc(
+                Build an OPM message from a dictionary.
+
+                Args:
+                    dictionary (dict): The dictionary containing the OPM message information.
+
+                Returns:
+                    opm (OPM): The OPM message.
+
+                Group:
+                    Static methods
+
+            )doc",
+            arg("dictionary")
+        )
+        .def_static(
+            "parse",
+            &OPM::Parse,
+            R"doc(
+                Parse an OPM message from a string.
+
+                Args:
+                    string (str): The string containing the OPM message.
+
+                Returns:
+                    opm (OPM): The OPM message.
+
+                Group:
+                    Static methods
+
+            )doc",
+            arg("string")
+        )
+        .def_static(
+            "load",
+            &OPM::Load,
+            R"doc(
+                Load an OPM message from a file.
+
+                Args:
+                    file (str): The path to the file containing the OPM message.
+
+                Returns:
+                    opm (OPM): The OPM message.
+
+                Group:
+                    Static methods
+
+            )doc",
+            arg("file")
+        )
 
         ;
 
-    class_<OPM::Header>(opm, "Header")
+    class_<OPM::Header>(
+        opm,
+        "Header",
+        R"doc(
+            The header of the SpaceX OPM message.
 
-        .def(init<const Instant&, const Instant&>(), arg("generation_date"), arg("launch_date"))
+            Group:
+                SpaceX
+        )doc"
+    )
 
-        .def_readonly("generation_date", &OPM::Header::generationDate)
-        .def_readonly("launch_date", &OPM::Header::launchDate)
+        .def(
+            init<const Instant&, const Instant&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    generation_date (Instant): The date at which the OPM message was generated.
+                    launch_date (Instant): The date at which the spacecraft was launched.
+
+            )doc",
+            arg("generation_date"),
+            arg("launch_date")
+        )
+
+        .def_readonly(
+            "generation_date",
+            &OPM::Header::generationDate,
+            R"doc(
+                Get the date at which the OPM message was generated.
+
+                Returns:
+                    instant (Instant): The date at which the OPM message was generated.
+
+            )doc"
+        )
+        .def_readonly(
+            "launch_date",
+            &OPM::Header::launchDate,
+            R"doc(
+                Get the date at which the spacecraft was launched.
+
+                Returns:
+                    instant (Instant): The date at which the spacecraft was launched.
+
+            )doc"
+        )
 
         ;
 
-    class_<OPM::Deployment>(opm, "Deployment")
+    class_<OPM::Deployment>(
+        opm,
+        "Deployment",
+        R"doc(
+            The deployment of the SpaceX OPM message.
+
+            Group:
+                SpaceX
+        )doc"
+    )
 
         .def(
             init<
@@ -78,24 +276,170 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Messages_SpaceX_OPM
             arg("mean_argument_of_perigee"),
             arg("mean_longitude_ascending_node"),
             arg("mean_mean_anomaly"),
-            arg("ballistic_coefficient")
+            arg("ballistic_coefficient"),
+            R"doc(
+                Constructor.
+
+                Args:
+                    name (str): The name of the deployment.
+                    sequence_number (int): The sequence number of the deployment.
+                    mission_time (Duration): The mission time of the deployment.
+                    date (Instant): The date of the deployment.
+                    position (Position): The position of the deployment.
+                    velocity (Velocity): The velocity of the deployment.
+                    mean_perigee_altitude (Length): The mean perigee altitude of the deployment.
+                    mean_apogee_altitude (Length): The mean apogee altitude of the deployment.
+                    mean_inclination (Angle): The mean inclination of the deployment.
+                    mean_argument_of_perigee (Angle): The mean argument of perigee of the deployment.
+                    mean_longitude_ascending_node (Angle): The mean longitude of the ascending node of the deployment.
+                    mean_mean_anomaly (Angle): The mean mean anomaly of the deployment.
+                    ballistic_coefficient (float): The ballistic coefficient of the deployment.
+
+            )doc"
         )
 
-        .def_readonly("name", &OPM::Deployment::name)
-        .def_readonly("sequence_number", &OPM::Deployment::sequenceNumber)
-        .def_readonly("mission_time", &OPM::Deployment::missionTime)
-        .def_readonly("date", &OPM::Deployment::date)
-        .def_readonly("position", &OPM::Deployment::position)
-        .def_readonly("velocity", &OPM::Deployment::velocity)
-        .def_readonly("mean_perigee_altitude", &OPM::Deployment::meanPerigeeAltitude)
-        .def_readonly("mean_apogee_altitude", &OPM::Deployment::meanApogeeAltitude)
-        .def_readonly("mean_inclination", &OPM::Deployment::meanInclination)
-        .def_readonly("mean_argument_of_perigee", &OPM::Deployment::meanArgumentOfPerigee)
-        .def_readonly("mean_longitude_ascending_node", &OPM::Deployment::meanLongitudeAscendingNode)
-        .def_readonly("mean_mean_anomaly", &OPM::Deployment::meanMeanAnomaly)
-        .def_readonly("ballistic_coefficient", &OPM::Deployment::ballisticCoefficient)
+        .def_readonly(
+            "name",
+            &OPM::Deployment::name,
+            R"doc(
+                Get the name of the deployment.
 
-        .def("to_state", &OPM::Deployment::toState)
+                :type: str
+
+        )doc"
+        )
+        .def_readonly(
+            "sequence_number",
+            &OPM::Deployment::sequenceNumber,
+            R"doc(
+                Get the sequence number of the deployment.
+
+                :type: int
+
+        )doc"
+        )
+        .def_readonly(
+            "mission_time",
+            &OPM::Deployment::missionTime,
+            R"doc(
+                Get the mission time of the deployment.
+
+                :type: Duration
+
+        )doc"
+        )
+        .def_readonly(
+            "date",
+            &OPM::Deployment::date,
+            R"doc(
+                Get the date of the deployment.
+
+                :type: Instant
+
+        )doc"
+        )
+        .def_readonly(
+            "position",
+            &OPM::Deployment::position,
+            R"doc(
+                Get the position of the deployment.
+
+                :type: Position
+
+        )doc"
+        )
+        .def_readonly(
+            "velocity",
+            &OPM::Deployment::velocity,
+            R"doc(
+                Get the velocity of the deployment.
+
+                :type: Velocity
+
+        )doc"
+        )
+        .def_readonly(
+            "mean_perigee_altitude",
+            &OPM::Deployment::meanPerigeeAltitude,
+            R"doc(
+                Get the mean perigee altitude of the deployment.
+
+                :type: Length
+
+        )doc"
+        )
+        .def_readonly(
+            "mean_apogee_altitude",
+            &OPM::Deployment::meanApogeeAltitude,
+            R"doc(
+                Get the mean apogee altitude of the deployment.
+
+                :type: Length
+
+        )doc"
+        )
+        .def_readonly(
+            "mean_inclination",
+            &OPM::Deployment::meanInclination,
+            R"doc(
+                Get the mean inclination of the deployment.
+
+                :type: Angle
+
+        )doc"
+        )
+        .def_readonly(
+            "mean_argument_of_perigee",
+            &OPM::Deployment::meanArgumentOfPerigee,
+            R"doc(
+                Get the mean argument of perigee of the deployment.
+
+                :type: Angle
+
+        )doc"
+        )
+        .def_readonly(
+            "mean_longitude_ascending_node",
+            &OPM::Deployment::meanLongitudeAscendingNode,
+            R"doc(
+                Get the mean longitude of the ascending node of the deployment.
+
+                :type: Angle
+
+        )doc"
+        )
+        .def_readonly(
+            "mean_mean_anomaly",
+            &OPM::Deployment::meanMeanAnomaly,
+            R"doc(
+                Get the mean mean anomaly of the deployment.
+
+                :type: Angle
+
+        )doc"
+        )
+        .def_readonly(
+            "ballistic_coefficient",
+            &OPM::Deployment::ballisticCoefficient,
+            R"doc(
+                Get the ballistic coefficient of the deployment.
+
+                :type: float
+
+        )doc"
+        )
+
+        .def(
+            "to_state",
+            &OPM::Deployment::toState,
+            R"doc(
+                Convert the deployment to a state.
+
+                Returns:
+                    state (State): The state of the deployment.
+
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model.cpp
@@ -14,7 +14,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
     using ostk::astro::trajectory::orbit::models::Propagated;
     using ostk::astro::trajectory::orbit::models::SGP4;
 
-    class_<Model>(aModule, "OrbitModel")
+    class_<Model>(
+        aModule,
+        "OrbitModel",
+        R"doc(
+            Base class for orbit models.
+
+            Provides the interface for orbit models.
+
+            Group:
+                Orbit
+        )doc"
+    )
 
         .def(
             "__eq__",
@@ -33,28 +44,57 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
 
         .def("__str__", &(shiftToString<Model>))
 
-        .def("is_defined", &Model::isDefined)
+        .def(
+            "is_defined",
+            &Model::isDefined,
+            R"doc(
+                Check if the orbit model is defined.
+
+                Returns:
+                    is_defined (bool): True if the orbit model is defined, False otherwise.
+            )doc"
+        )
 
         .def(
             "is_kepler",
             +[](const Model& aModel) -> bool
             {
                 return aModel.is<Kepler>();
-            }
+            },
+            R"doc(
+                Check if the orbit model is a Kepler model.
+
+                Returns:
+                    is_kepler (bool): True if the orbit model is a Kepler model, False otherwise.
+
+            )doc"
         )
         .def(
             "is_sgp4",
             +[](const Model& aModel) -> bool
             {
                 return aModel.is<SGP4>();
-            }
+            },
+            R"doc(
+                Check if the orbit model is an SGP4 model.
+
+                Returns:
+                    is_sgp4 (bool): True if the orbit model is an SGP4 model, False otherwise.
+            )doc"
         )
         .def(
             "is_propagated",
             +[](const Model& aModel) -> bool
             {
                 return aModel.is<Propagated>();
-            }
+            },
+            R"doc(
+                Check if the orbit model is a propagated model.
+
+                Returns:
+                    is_propagated (bool): True if the orbit model is a propagated model, False otherwise.
+
+            )doc"
         )
 
         .def(
@@ -63,7 +103,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
             {
                 return aModel.as<Kepler>();
             },
-            return_value_policy::reference
+            return_value_policy::reference,
+            R"doc(
+                Cast the orbit model to a Kepler model.
+
+                Returns:
+                    kepler (Kepler): The Kepler model.
+
+            )doc"
         )
         .def(
             "as_sgp4",
@@ -71,7 +118,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
             {
                 return aModel.as<SGP4>();
             },
-            return_value_policy::reference
+            return_value_policy::reference,
+            R"doc(
+                Cast the orbit model to an SGP4 model.
+
+                Returns:
+                    sgp4 (SGP4): The SGP4 model.
+
+            )doc"
         )
         .def(
             "as_propagated",
@@ -79,13 +133,68 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
             {
                 return aModel.as<Propagated>();
             },
-            return_value_policy::reference
+            return_value_policy::reference,
+            R"doc(
+                Cast the orbit model to a propagated model.
+
+                Returns:
+                    propagated (Propagated): The propagated model.
+
+            )doc"
         )
 
-        .def("get_epoch", &Model::getEpoch)
-        .def("get_revolution_number_at_epoch", &Model::getRevolutionNumberAtEpoch)
-        .def("calculate_state_at", &Model::calculateStateAt, arg("instant"))
-        .def("calculate_revolution_number_at", &Model::calculateRevolutionNumberAt, arg("instant"))
+        .def(
+            "get_epoch",
+            &Model::getEpoch,
+            R"doc(
+                Get the epoch of the orbit model.
+
+                Returns:
+                    epoc (Instant): The epoch of the orbit model.
+
+            )doc"
+        )
+        .def(
+            "get_revolution_number_at_epoch",
+            &Model::getRevolutionNumberAtEpoch,
+            R"doc(
+                Get the revolution number at the epoch of the orbit model.
+
+                Returns:
+                    revolution_number (int): The revolution number at the epoch of the orbit model.
+
+            )doc"
+        )
+        .def(
+            "calculate_state_at",
+            &Model::calculateStateAt,
+            R"doc(
+                Calculate the state of the orbit model at a given instant.
+
+                Args:
+                    instant (Instant): The instant at which to calculate the state.
+
+                Returns:
+                    state (State): The state of the orbit model at the given instant.
+
+            )doc",
+            arg("instant")
+        )
+        .def(
+            "calculate_revolution_number_at",
+            &Model::calculateRevolutionNumberAt,
+            R"doc(
+                Calculate the revolution number of the orbit model at a given instant.
+
+                Args:
+                    instant (Instant): The instant at which to calculate the revolution number.
+
+                Returns:
+                    revolution_number (int): The revolution number of the orbit model at the given instant.
+
+            )doc",
+            arg("instant")
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
             Provides the interface for orbit models.
 
             Group:
-                Orbit
+                orbit
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model.cpp
@@ -51,7 +51,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Check if the orbit model is defined.
 
                 Returns:
-                    is_defined (bool): True if the orbit model is defined, False otherwise.
+                    bool: True if the orbit model is defined, False otherwise.
             )doc"
         )
 
@@ -65,7 +65,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Check if the orbit model is a Kepler model.
 
                 Returns:
-                    is_kepler (bool): True if the orbit model is a Kepler model, False otherwise.
+                    bool: True if the orbit model is a Kepler model, False otherwise.
 
             )doc"
         )
@@ -79,7 +79,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Check if the orbit model is an SGP4 model.
 
                 Returns:
-                    is_sgp4 (bool): True if the orbit model is an SGP4 model, False otherwise.
+                    bool: True if the orbit model is an SGP4 model, False otherwise.
             )doc"
         )
         .def(
@@ -92,7 +92,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Check if the orbit model is a propagated model.
 
                 Returns:
-                    is_propagated (bool): True if the orbit model is a propagated model, False otherwise.
+                    bool: True if the orbit model is a propagated model, False otherwise.
 
             )doc"
         )
@@ -108,7 +108,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Cast the orbit model to a Kepler model.
 
                 Returns:
-                    kepler (Kepler): The Kepler model.
+                    Kepler: The Kepler model.
 
             )doc"
         )
@@ -123,7 +123,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Cast the orbit model to an SGP4 model.
 
                 Returns:
-                    sgp4 (SGP4): The SGP4 model.
+                    SGP4: The SGP4 model.
 
             )doc"
         )
@@ -138,7 +138,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Cast the orbit model to a propagated model.
 
                 Returns:
-                    propagated (Propagated): The propagated model.
+                    Propagated: The propagated model.
 
             )doc"
         )
@@ -150,7 +150,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Get the epoch of the orbit model.
 
                 Returns:
-                    epoc (Instant): The epoch of the orbit model.
+                    Instant: The epoch of the orbit model.
 
             )doc"
         )
@@ -161,7 +161,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                 Get the revolution number at the epoch of the orbit model.
 
                 Returns:
-                    revolution_number (int): The revolution number at the epoch of the orbit model.
+                    int: The revolution number at the epoch of the orbit model.
 
             )doc"
         )
@@ -175,7 +175,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                     instant (Instant): The instant at which to calculate the state.
 
                 Returns:
-                    state (State): The state of the orbit model at the given instant.
+                    State: The state of the orbit model at the given instant.
 
             )doc",
             arg("instant")
@@ -190,7 +190,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model(pybind11::mod
                     instant (Instant): The instant at which to calculate the revolution number.
 
                 Returns:
-                    revolution_number (int): The revolution number of the orbit model at the given instant.
+                    int: The revolution number of the orbit model at the given instant.
 
             )doc",
             arg("instant")

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models.cpp
@@ -1,6 +1,7 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler.cpp>
+#include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMean.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Propagated.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp>

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler.cpp
@@ -28,7 +28,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                 Provides the interface for orbit models.
 
                 Group:
-                    Models
+                    orbit
             )doc"
         );
 
@@ -68,8 +68,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                         epoch (Instant): The epoch.
                         gravitational_parameter (Derived): The gravitational parameter.
                         equatorial_radius (Length): The equatorial radius.
-                        j2 (Real): The J2 coefficient.
-                        j4 (Real): The J4 coefficient.
+                        j2 (float): The J2 coefficient.
+                        j4 (float): The J4 coefficient.
                         perturbation_type (PerturbationType): The perturbation type.
 
                 )doc",
@@ -116,9 +116,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         bool: True if the `Kepler` model is defined, False otherwise.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -130,9 +127,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         COE: The classical orbital elements.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -144,9 +138,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         Instant: The epoch.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -158,9 +149,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         int: The revolution number.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -172,9 +160,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         Derived: The gravitational parameter.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -186,9 +171,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         Length: The equatorial radius.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -199,10 +181,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                     Get the J2 coefficient of the `Kepler` model.
 
                     Returns:
-                        Real: The J2 coefficient.
-
-                    Group:
-                        Methods
+                        float: The J2 coefficient.
                 )doc"
             )
 
@@ -213,10 +192,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                     Get the J4 coefficient of the `Kepler` model.
 
                     Returns:
-                        Real: The J4 coefficient.
-
-                    Group:
-                        Methods
+                        float: The J4 coefficient.
                 )doc"
             )
 
@@ -228,9 +204,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         PerturbationType: The perturbation type.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -246,9 +219,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         State: The state.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -264,9 +234,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         int: The revolution number.
-
-                    Group:
-                        Methods
                 )doc"
             )
 
@@ -282,9 +249,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
                     Returns:
                         str: The string representation.
-
-                    Group:
-                        Methods
                 )doc"
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler.cpp
@@ -2,7 +2,6 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler.hpp>
 
-#include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMean.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp>
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybind11::module& aModule)
@@ -20,7 +19,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
     using ostk::astro::trajectory::orbit::models::kepler::COE;
 
     {
-        class_<Kepler, ostk::astro::trajectory::orbit::Model> kepler_class(aModule, "Kepler");
+        class_<Kepler, ostk::astro::trajectory::orbit::Model> kepler_class(
+            aModule,
+            "Kepler",
+            R"doc(
+                A Kepler orbit model.
+
+                Provides the interface for orbit models.
+
+                Group:
+                    Models
+            )doc"
+        );
 
         kepler_class
 
@@ -33,6 +43,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                     const Real&,
                     const Real&,
                     const Kepler::PerturbationType&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        coe (COE): The classical orbital elements.
+                        epoch (Instant): The epoch.
+                        gravitational_parameter (Derived): The gravitational parameter.
+                        equatorial_radius (Length): The equatorial radius.
+                        j2 (Real): The J2 coefficient.
+                        j4 (Real): The J4 coefficient.
+                        perturbation_type (Kepler.PerturbationType): The perturbation type.
+
+                )doc",
                 arg("coe"),
                 arg("epoch"),
                 arg("gravitational_parameter"),
@@ -44,6 +67,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
 
             .def(
                 init<const COE&, const Instant&, const Celestial&, const Kepler::PerturbationType&, const bool>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        coe (COE): The classical orbital elements.
+                        epoch (Instant): The epoch.
+                        celestial_object (Celestial): The celestial object.
+                        perturbation_type (Kepler.PerturbationType): The perturbation type.
+                        in_fixed_frame (bool): If True, the state is expressed in the fixed frame, otherwise it is expressed in the inertial frame. Default is False.
+
+                )doc",
                 arg("coe"),
                 arg("epoch"),
                 arg("celestial_object"),
@@ -57,28 +91,202 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
             .def("__str__", &(shiftToString<Kepler>))
             .def("__repr__", &(shiftToString<Kepler>))
 
-            .def("is_defined", &Kepler::isDefined)
+            .def(
+                "is_defined",
+                &Kepler::isDefined,
+                R"doc(
+                    Check if the `Kepler` model is defined.
 
-            .def("get_classical_orbital_elements", &Kepler::getClassicalOrbitalElements)
-            .def("get_epoch", &Kepler::getEpoch)
-            .def("get_revolution_number_at_epoch", &Kepler::getRevolutionNumberAtEpoch)
-            .def("get_gravitational_parameter", &Kepler::getGravitationalParameter)
-            .def("get_equatorial_radius", &Kepler::getEquatorialRadius)
-            .def("get_j2", &Kepler::getJ2)
-            .def("get_j4", &Kepler::getJ4)
-            .def("get_perturbation_type", &Kepler::getPerturbationType)
-            .def("calculate_state_at", &Kepler::calculateStateAt, arg("instant"))
-            .def("calculate_revolution_number_at", &Kepler::calculateRevolutionNumberAt, arg("instant"))
+                    Returns:
+                        bool: True if the `Kepler` model is defined, False otherwise.
 
-            .def_static("string_from_perturbation_type", &Kepler::StringFromPerturbationType, arg("perturbation_type"))
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "get_classical_orbital_elements",
+                &Kepler::getClassicalOrbitalElements,
+                R"doc(
+                    Get the classical orbital elements of the `Kepler` model.
+
+                    Returns:
+                        COE: The classical orbital elements.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "get_epoch",
+                &Kepler::getEpoch,
+                R"doc(
+                    Get the epoch of the `Kepler` model.
+
+                    Returns:
+                        Instant: The epoch.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "get_revolution_number_at_epoch",
+                &Kepler::getRevolutionNumberAtEpoch,
+                R"doc(
+                    Get the revolution number at the epoch of the `Kepler` model.
+
+                    Returns:
+                        int: The revolution number.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "get_gravitational_parameter",
+                &Kepler::getGravitationalParameter,
+                R"doc(
+                    Get the gravitational parameter of the `Kepler` model.
+
+                    Returns:
+                        Derived: The gravitational parameter.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "get_equatorial_radius",
+                &Kepler::getEquatorialRadius,
+                R"doc(
+                    Get the equatorial radius of the `Kepler` model.
+
+                    Returns:
+                        Length: The equatorial radius.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "get_j2",
+                &Kepler::getJ2,
+                R"doc(
+                    Get the J2 coefficient of the `Kepler` model.
+
+                    Returns:
+                        Real: The J2 coefficient.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "get_j4",
+                &Kepler::getJ4,
+                R"doc(
+                    Get the J4 coefficient of the `Kepler` model.
+
+                    Returns:
+                        Real: The J4 coefficient.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "get_perturbation_type",
+                &Kepler::getPerturbationType,
+                R"doc(
+                    Get the perturbation type of the `Kepler` model.
+
+                    Returns:
+                        Kepler.PerturbationType: The perturbation type.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "calculate_state_at",
+                &Kepler::calculateStateAt,
+                arg("instant"),
+                R"doc(
+                    Calculate the state of the `Kepler` model at a given instant.
+
+                    Args:
+                        instant (Instant): The instant.
+
+                    Returns:
+                        State: The state.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def(
+                "calculate_revolution_number_at",
+                &Kepler::calculateRevolutionNumberAt,
+                arg("instant"),
+                R"doc(
+                    Calculate the revolution number of the `Kepler` model at a given instant.
+
+                    Args:
+                        instant (Instant): The instant.
+
+                    Returns:
+                        int: The revolution number.
+
+                    Group:
+                        Methods
+                )doc"
+            )
+
+            .def_static(
+                "string_from_perturbation_type",
+                &Kepler::StringFromPerturbationType,
+                arg("perturbation_type"),
+                R"doc(
+                    Get the string representation of a `Kepler.PerturbationType`.
+
+                    Args:
+                        perturbation_type (Kepler.PerturbationType): The perturbation type.
+
+                    Returns:
+                        str: The string representation.
+
+                    Group:
+                        Methods
+                )doc"
+            )
 
             ;
 
-        enum_<Kepler::PerturbationType>(kepler_class, "PerturbationType")
+        enum_<Kepler::PerturbationType>(
+            kepler_class,
+            "PerturbationType",
+            R"doc(
+                The Perturbation Type due to Oblateness
+            
+            )doc"
+        )
 
-            .value("No", Kepler::PerturbationType::None)
-            .value("J2", Kepler::PerturbationType::J2)
-            .value("J4", Kepler::PerturbationType::J4)
+            .value("No", Kepler::PerturbationType::None, "No perturbation")
+
+            .value("J2", Kepler::PerturbationType::J2, "J2 perturbation")
+
+            .value("J4", Kepler::PerturbationType::J4, "J4 perturbation")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler.cpp
@@ -32,6 +32,23 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
             )doc"
         );
 
+        enum_<Kepler::PerturbationType>(
+            kepler_class,
+            "PerturbationType",
+            R"doc(
+                The Perturbation Type due to Oblateness
+            
+            )doc"
+        )
+
+            .value("No", Kepler::PerturbationType::None, "No perturbation")
+
+            .value("J2", Kepler::PerturbationType::J2, "J2 perturbation")
+
+            .value("J4", Kepler::PerturbationType::J4, "J4 perturbation")
+
+            ;
+
         kepler_class
 
             .def(
@@ -53,7 +70,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                         equatorial_radius (Length): The equatorial radius.
                         j2 (Real): The J2 coefficient.
                         j4 (Real): The J4 coefficient.
-                        perturbation_type (Kepler.PerturbationType): The perturbation type.
+                        perturbation_type (PerturbationType): The perturbation type.
 
                 )doc",
                 arg("coe"),
@@ -74,7 +91,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                         coe (COE): The classical orbital elements.
                         epoch (Instant): The epoch.
                         celestial_object (Celestial): The celestial object.
-                        perturbation_type (Kepler.PerturbationType): The perturbation type.
+                        perturbation_type (PerturbationType): The perturbation type.
                         in_fixed_frame (bool): If True, the state is expressed in the fixed frame, otherwise it is expressed in the inertial frame. Default is False.
 
                 )doc",
@@ -210,7 +227,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                     Get the perturbation type of the `Kepler` model.
 
                     Returns:
-                        Kepler.PerturbationType: The perturbation type.
+                        PerturbationType: The perturbation type.
 
                     Group:
                         Methods
@@ -258,10 +275,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                 &Kepler::StringFromPerturbationType,
                 arg("perturbation_type"),
                 R"doc(
-                    Get the string representation of a `Kepler.PerturbationType`.
+                    Get the string representation of a `PerturbationType`.
 
                     Args:
-                        perturbation_type (Kepler.PerturbationType): The perturbation type.
+                        perturbation_type (PerturbationType): The perturbation type.
 
                     Returns:
                         str: The string representation.
@@ -270,23 +287,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler(pybin
                         Methods
                 )doc"
             )
-
-            ;
-
-        enum_<Kepler::PerturbationType>(
-            kepler_class,
-            "PerturbationType",
-            R"doc(
-                The Perturbation Type due to Oblateness
-            
-            )doc"
-        )
-
-            .value("No", Kepler::PerturbationType::None, "No perturbation")
-
-            .value("J2", Kepler::PerturbationType::J2, "J2 perturbation")
-
-            .value("J4", Kepler::PerturbationType::J4, "J4 perturbation")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMean.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMean.cpp
@@ -55,7 +55,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
                 Brouwer-Lyddane mean orbit elements. This is a parent class, please use the Short or Long child classes as appropriate.
 
                 Group:
-                    kepler
+                    orbital-elements
             )doc"
         );
 
@@ -68,7 +68,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                     Args:
                         semi_major_axis (Length): The semi-major axis.
-                        eccentricity (Real): The eccentricity.
+                        eccentricity (float): The eccentricity.
                         inclination (Angle): The inclination.
                         raan (Angle): The right ascension of the ascending node.
                         aop (Angle): The argument of periapsis.
@@ -142,7 +142,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
                     Get the Cartesian state of the `BrouwerLyddaneMean` model.
 
                     Args:
-                        gravitational_parameter (Real): The gravitational parameter of the central body.
+                        gravitational_parameter (float): The gravitational parameter of the central body.
                         frame (str): The reference frame in which the state is expressed.
 
                     Returns:

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMean.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMean.cpp
@@ -48,12 +48,35 @@ class PyBrouwerLyddaneMean : public BrouwerLyddaneMean
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLyddaneMean(pybind11::module& aModule)
 {
     {
-        class_<BrouwerLyddaneMean, PyBrouwerLyddaneMean, COE> brouwerLyddaneMean(aModule, "BrouwerLyddaneMean");
+        class_<BrouwerLyddaneMean, PyBrouwerLyddaneMean, COE> brouwerLyddaneMean(
+            aModule,
+            "BrouwerLyddaneMean",
+            R"doc(
+                Brouwer-Lyddane mean orbit elements. This is a parent class, please use the Short or Long child classes as appropriate.
+
+                Group:
+                    Kepler
+            )doc"
+        );
 
         brouwerLyddaneMean
 
             .def(
                 init<const Length&, const Real&, const Angle&, const Angle&, const Angle&, const Angle&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        semi_major_axis (Length): The semi-major axis.
+                        eccentricity (Real): The eccentricity.
+                        inclination (Angle): The inclination.
+                        raan (Angle): The right ascension of the ascending node.
+                        aop (Angle): The argument of periapsis.
+                        mean_anomaly (Angle): The mean anomaly.
+
+                    Group:
+                        Constructors
+                )doc",
                 arg("semi_major_axis"),
                 arg("eccentricity"),
                 arg("inclination"),
@@ -62,14 +85,70 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
                 arg("mean_anomaly")
             )
 
-            .def("get_mean_anomaly", &BrouwerLyddaneMean::getMeanAnomaly)
-            .def("get_true_anomaly", &BrouwerLyddaneMean::getTrueAnomaly)
-            .def("get_eccentric_anomaly", &BrouwerLyddaneMean::getEccentricAnomaly)
+            .def(
+                "get_mean_anomaly",
+                &BrouwerLyddaneMean::getMeanAnomaly,
+                R"doc(
+                    Get the mean anomaly of the `BrouwerLyddaneMean` model.
+
+                    Returns:
+                        Angle: The mean anomaly.
+
+                )doc"
+            )
+
+            .def(
+                "get_true_anomaly",
+                &BrouwerLyddaneMean::getTrueAnomaly,
+                R"doc(
+                    Get the true anomaly of the `BrouwerLyddaneMean` model.
+
+                    Returns:
+                        Angle: The true anomaly.
+
+                )doc"
+            )
+
+            .def(
+                "get_eccentric_anomaly",
+                &BrouwerLyddaneMean::getEccentricAnomaly,
+                R"doc(
+                    Get the eccentric anomaly of the `BrouwerLyddaneMean` model.
+
+                    Returns:
+                        Angle: The eccentric anomaly.
+
+                )doc"
+            )
+
+            .def(
+                "to_coe",
+                &BrouwerLyddaneMean::toCOE,
+                R"doc(
+                    Convert the `BrouwerLyddaneMean` model to classical orbital elements.
+
+                    Returns:
+                        COE: The classical orbital elements.
+
+                )doc"
+            )
+
             .def(
                 "get_cartesian_state",
                 &BrouwerLyddaneMean::getCartesianState,
                 arg("gravitational_parameter"),
-                arg("frame")
+                arg("frame"),
+                R"doc(
+                    Get the Cartesian state of the `BrouwerLyddaneMean` model.
+
+                    Args:
+                        gravitational_parameter (Real): The gravitational parameter of the central body.
+                        frame (str): The reference frame in which the state is expressed.
+
+                    Returns:
+                        CartesianState: The Cartesian state.
+
+                )doc"
             )
 
             ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMean.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMean.cpp
@@ -55,7 +55,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
                 Brouwer-Lyddane mean orbit elements. This is a parent class, please use the Short or Long child classes as appropriate.
 
                 Group:
-                    Kepler
+                    kepler
             )doc"
         );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanLong.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanLong.cpp
@@ -16,12 +16,33 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
     using ostk::astro::trajectory::orbit::models::blm::BrouwerLyddaneMean;
     using ostk::astro::trajectory::orbit::models::blm::BrouwerLyddaneMeanLong;
 
-    class_<BrouwerLyddaneMeanLong, BrouwerLyddaneMean> brouwerLyddaneMeanLong(aModule, "BrouwerLyddaneMeanLong");
+    class_<BrouwerLyddaneMeanLong, BrouwerLyddaneMean> brouwerLyddaneMeanLong(
+        aModule,
+        "BrouwerLyddaneMeanLong",
+        R"doc(
+            Brouwer-Lyddane Mean (Long) orbit elements. Short periodic variations and secular variations are averaged.
+
+            Group:
+                Kepler
+        )doc"
+    );
 
     brouwerLyddaneMeanLong
 
         .def(
             init<const Length&, const Real&, const Angle&, const Angle&, const Angle&, const Angle&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    semi_major_axis (Length): The semi-major axis.
+                    eccentricity (Real): The eccentricity.
+                    inclination (Angle): The inclination.
+                    raan (Angle): The right ascension of the ascending node.
+                    aop (Angle): The argument of periapsis.
+                    mean_anomaly (Angle): The mean anomaly.
+
+            )doc",
             arg("semi_major_axis"),
             arg("eccentricity"),
             arg("inclination"),
@@ -30,15 +51,69 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
             arg("mean_anomaly")
         )
 
-        .def("to_coe", &BrouwerLyddaneMeanLong::toCOE)
+        .def(
+            "to_coe",
+            &BrouwerLyddaneMeanLong::toCOE,
+            R"doc(
+                Convert the `BrouwerLyddaneMeanLong` model to classical orbital elements.
 
-        .def_static("COE", &BrouwerLyddaneMeanLong::COE, arg("coe"))
+                Returns:
+                    COE: The classical orbital elements.
 
-        .def_static(
-            "cartesian", &BrouwerLyddaneMeanLong::Cartesian, arg("cartersian_state"), arg("gravitational_parameter")
+            )doc"
         )
 
-        .def_static("undefined", &BrouwerLyddaneMeanLong::Undefined)
+        .def_static(
+            "COE",
+            &BrouwerLyddaneMeanLong::COE,
+            R"doc(
+                Create a `BrouwerLyddaneMeanLong` model from classical orbital elements.
+
+                Args:
+                    coe (COE): The classical orbital elements.
+
+                Returns:
+                    BrouwerLyddaneMeanLong: The `BrouwerLyddaneMeanLong` model.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("coe")
+        )
+
+        .def_static(
+            "cartesian",
+            &BrouwerLyddaneMeanLong::Cartesian,
+            R"doc(
+                Create a `BrouwerLyddaneMeanLong` model from Cartesian state.
+
+                Args:
+                    cartesian_state (CartesianState): The Cartesian state.
+                    gravitational_parameter (Real): The gravitational parameter of the central body.
+
+                Returns:
+                    BrouwerLyddaneMeanLong: The `BrouwerLyddaneMeanLong` model.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("cartesian_state"),
+            arg("gravitational_parameter")
+        )
+
+        .def_static(
+            "undefined",
+            &BrouwerLyddaneMeanLong::Undefined,
+            R"doc(
+                Create an undefined `BrouwerLyddaneMeanLong` model.
+
+                Returns:
+                    BrouwerLyddaneMeanLong: The undefined `BrouwerLyddaneMeanLong` model.
+
+                Group:
+                    Static methods
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanLong.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanLong.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
             Brouwer-Lyddane Mean (Long) orbit elements. Short periodic variations and secular variations are averaged.
 
             Group:
-                Kepler
+                kepler
         )doc"
     );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanLong.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanLong.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
             Brouwer-Lyddane Mean (Long) orbit elements. Short periodic variations and secular variations are averaged.
 
             Group:
-                kepler
+                orbital-elements
         )doc"
     );
 
@@ -36,7 +36,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                 Args:
                     semi_major_axis (Length): The semi-major axis.
-                    eccentricity (Real): The eccentricity.
+                    eccentricity (float): The eccentricity.
                     inclination (Angle): The inclination.
                     raan (Angle): The right ascension of the ascending node.
                     aop (Angle): The argument of periapsis.
@@ -74,9 +74,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                 Returns:
                     BrouwerLyddaneMeanLong: The `BrouwerLyddaneMeanLong` model.
-
-                Group:
-                    Static methods
             )doc",
             arg("coe")
         )
@@ -89,13 +86,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                 Args:
                     cartesian_state (CartesianState): The Cartesian state.
-                    gravitational_parameter (Real): The gravitational parameter of the central body.
+                    gravitational_parameter (float): The gravitational parameter of the central body.
 
                 Returns:
                     BrouwerLyddaneMeanLong: The `BrouwerLyddaneMeanLong` model.
-
-                Group:
-                    Static methods
             )doc",
             arg("cartesian_state"),
             arg("gravitational_parameter")
@@ -109,9 +103,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                 Returns:
                     BrouwerLyddaneMeanLong: The undefined `BrouwerLyddaneMeanLong` model.
-
-                Group:
-                    Static methods
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanShort.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanShort.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
             Brouwer-Lyddane Mean (Short) orbit elements. Short periodic variations are averaged.
 
             Group:
-                kepler
+                orbital-elements
         )doc"
     );
 
@@ -36,7 +36,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                 Args:
                     semi_major_axis (Length): The semi-major axis.
-                    eccentricity (Real): The eccentricity.
+                    eccentricity (float): The eccentricity.
                     inclination (Angle): The inclination.
                     raan (Angle): The right ascension of the ascending node.
                     aop (Angle): The argument of periapsis.
@@ -73,9 +73,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                 Returns:
                     BrouwerLyddaneMeanShort: The `BrouwerLyddaneMeanShort` model.
-
-                Group:
-                    Static methods
             )doc",
             arg("coe")
         )
@@ -88,13 +85,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                 Args:
                     cartesian_state (CartesianState): The Cartesian state.
-                    gravitational_parameter (Real): The gravitational parameter of the central body.
+                    gravitational_parameter (float): The gravitational parameter of the central body.
 
                 Returns:
                     BrouwerLyddaneMeanShort: The `BrouwerLyddaneMeanShort` model.
-
-                Group:
-                    Static methods
             )doc",
             arg("cartesian_state"),
             arg("gravitational_parameter")
@@ -108,9 +102,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
 
                 Returns:
                     BrouwerLyddaneMeanShort: The undefined `BrouwerLyddaneMeanShort` model.
-
-                Group:
-                    Static methods
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanShort.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanShort.cpp
@@ -16,12 +16,33 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
     using ostk::astro::trajectory::orbit::models::blm::BrouwerLyddaneMean;
     using ostk::astro::trajectory::orbit::models::blm::BrouwerLyddaneMeanShort;
 
-    class_<BrouwerLyddaneMeanShort, BrouwerLyddaneMean> brouwerLyddaneMeanShort(aModule, "BrouwerLyddaneMeanShort");
+    class_<BrouwerLyddaneMeanShort, BrouwerLyddaneMean> brouwerLyddaneMeanShort(
+        aModule,
+        "BrouwerLyddaneMeanShort",
+        R"doc(
+            Brouwer-Lyddane Mean (Short) orbit elements. Short periodic variations are averaged.
+
+            Group:
+                Kepler
+        )doc"
+    );
 
     brouwerLyddaneMeanShort
 
         .def(
             init<const Length&, const Real&, const Angle&, const Angle&, const Angle&, const Angle&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    semi_major_axis (Length): The semi-major axis.
+                    eccentricity (Real): The eccentricity.
+                    inclination (Angle): The inclination.
+                    raan (Angle): The right ascension of the ascending node.
+                    aop (Angle): The argument of periapsis.
+                    mean_anomaly (Angle): The mean anomaly.
+
+            )doc",
             arg("semi_major_axis"),
             arg("eccentricity"),
             arg("inclination"),
@@ -30,13 +51,68 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
             arg("mean_anomaly")
         )
 
-        .def("to_coe", &BrouwerLyddaneMeanShort::toCOE)
+        .def(
+            "to_coe",
+            &BrouwerLyddaneMeanShort::toCOE,
+            R"doc(
+                Convert the `BrouwerLyddaneMeanShort` model to classical orbital elements.
 
-        .def_static("COE", &BrouwerLyddaneMeanShort::COE, arg("coe"))
-
-        .def_static(
-            "cartesian", &BrouwerLyddaneMeanShort::Cartesian, arg("cartersian_state"), arg("gravitational_parameter")
+                Returns:
+                    COE: The classical orbital elements.
+            )doc"
         )
 
-        .def_static("undefined", &BrouwerLyddaneMeanShort::Undefined);
+        .def_static(
+            "COE",
+            &BrouwerLyddaneMeanShort::COE,
+            R"doc(
+                Create a `BrouwerLyddaneMeanShort` model from classical orbital elements.
+
+                Args:
+                    coe (COE): The classical orbital elements.
+
+                Returns:
+                    BrouwerLyddaneMeanShort: The `BrouwerLyddaneMeanShort` model.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("coe")
+        )
+
+        .def_static(
+            "cartesian",
+            &BrouwerLyddaneMeanShort::Cartesian,
+            R"doc(
+                Create a `BrouwerLyddaneMeanShort` model from Cartesian state.
+
+                Args:
+                    cartesian_state (CartesianState): The Cartesian state.
+                    gravitational_parameter (Real): The gravitational parameter of the central body.
+
+                Returns:
+                    BrouwerLyddaneMeanShort: The `BrouwerLyddaneMeanShort` model.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("cartesian_state"),
+            arg("gravitational_parameter")
+        )
+
+        .def_static(
+            "undefined",
+            &BrouwerLyddaneMeanShort::Undefined,
+            R"doc(
+                Create an undefined `BrouwerLyddaneMeanShort` model.
+
+                Returns:
+                    BrouwerLyddaneMeanShort: The undefined `BrouwerLyddaneMeanShort` model.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+
+        ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanShort.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/BrouwerLyddaneMeanShort.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_BrouwerLydda
             Brouwer-Lyddane Mean (Short) orbit elements. Short periodic variations are averaged.
 
             Group:
-                Kepler
+                kepler
         )doc"
     );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -13,12 +13,52 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
     using ostk::astro::trajectory::orbit::models::kepler::COE;
 
-    class_<COE> coe(aModule, "COE");
+    class_<COE> coe(
+        aModule,
+        "COE",
+        R"doc(
+            Classical orbital elements.
+
+            Provides the classical orbital elements used to describe the orbit of a body around another.
+
+            .. math::
+
+                \begin{aligned}
+                    a & = \text{semi-major axis} \\
+                    e & = \text{eccentricity} \\
+                    i & = \text{inclination} \\
+                    \Omega & = \text{right ascension of the ascending node} \\
+                    \omega & = \text{argument of periapsis} \\
+                    \nu & = \text{true anomaly} \\
+                    M & = \text{mean anomaly} \\
+                    E & = \text{eccentric anomaly} \\
+                    r_p & = \text{periapsis radius} \\
+                    r_a & = \text{apoapsis radius}
+                \end{aligned}
+
+            Group:
+                Kepler
+        )doc"
+    );
 
     coe
 
         .def(
             init<const Length&, const Real&, const Angle&, const Angle&, const Angle&, const Angle&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    semi_major_axis (Length): The semi-major axis.
+                    eccentricity (Real): The eccentricity.
+                    inclination (Angle): The inclination.
+                    raan (Angle): The right ascension of the ascending node.
+                    aop (Angle): The argument of periapsis.
+                    true_anomaly (Angle): The true anomaly.
+
+                Group:
+                    Constructors
+            )doc",
             arg("semi_major_axis"),
             arg("eccentricity"),
             arg("inclination"),
@@ -55,13 +95,62 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
         .def_static("undefined", &COE::Undefined)
 
-        .def_static("cartesian", &COE::Cartesian, arg("cartesian_state"), arg("gravitational_parameter"))
+        .def_static(
+            "cartesian",
+            &COE::Cartesian,
+            R"doc(
+                Create a `COE` model from Cartesian state.
 
-        .def_static("from_SI_vector", &COE::FromSIVector, arg("vector"), arg("anomaly_type"))
+                Args:
+                    cartesian_state (CartesianState): The Cartesian state.
+                    gravitational_parameter (Real): The gravitational parameter of the central body.
+
+                Returns:
+                    COE: The `COE` model.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("cartesian_state"),
+            arg("gravitational_parameter")
+        )
+
+        .def_static(
+            "from_SI_vector",
+            &COE::FromSIVector,
+            R"doc(
+                Create a `COE` model from a state vector in SI units.
+
+                Args:
+                    vector (Vector6d): The state vector.
+                    anomaly_type (AnomalyType): The type of anomaly.
+
+                Returns:
+                    COE: The `COE` model.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("vector"),
+            arg("anomaly_type")
+        )
 
         .def_static(
             "eccentric_anomaly_from_true_anomaly",
             &COE::EccentricAnomalyFromTrueAnomaly,
+            R"doc(
+                Compute the eccentric anomaly from the true anomaly.
+
+                Args:
+                    true_anomaly (Angle): The true anomaly.
+                    eccentricity (Real): The eccentricity.
+
+                Returns:
+                    Angle: The eccentric anomaly.
+
+                Group:
+                    Static methods
+            )doc",
             arg("true_anomaly"),
             arg("eccentricity")
         )
@@ -69,6 +158,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
         .def_static(
             "true_anomaly_from_eccentric_anomaly",
             &COE::TrueAnomalyFromEccentricAnomaly,
+            R"doc(
+                Compute the true anomaly from the eccentric anomaly.
+
+                Args:
+                    eccentric_anomaly (Angle): The eccentric anomaly.
+                    eccentricity (Real): The eccentricity.
+
+                Returns:
+                    Angle: The true anomaly.
+
+                Group:
+                    Static methods
+            )doc",
             arg("eccentric_anomaly"),
             arg("eccentricity")
         )
@@ -76,6 +178,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
         .def_static(
             "mean_anomaly_from_eccentric_anomaly",
             &COE::MeanAnomalyFromEccentricAnomaly,
+            R"doc(
+                Compute the mean anomaly from the eccentric anomaly.
+
+                Args:
+                    eccentric_anomaly (Angle): The eccentric anomaly.
+                    eccentricity (Real): The eccentricity.
+
+                Returns:
+                    Angle: The mean anomaly.
+
+                Group:
+                    Static methods
+            )doc",
             arg("eccentric_anomaly"),
             arg("eccentricity")
         )
@@ -83,6 +198,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
         .def_static(
             "eccentric_anomaly_from_mean_anomaly",
             &COE::EccentricAnomalyFromMeanAnomaly,
+            R"doc(
+                Compute the eccentric anomaly from the mean anomaly.
+
+                Args:
+                    mean_anomaly (Angle): The mean anomaly.
+                    eccentricity (Real): The eccentricity.
+                    tolerance (float): The tolerance of the root solver.
+
+                Returns:
+                    Angle: The eccentric anomaly.
+
+                Group:
+                    Static methods
+            )doc",
             arg("mean_anomaly"),
             arg("eccentricity"),
             arg("tolerance")
@@ -91,33 +220,77 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
         .def_static(
             "true_anomaly_from_mean_anomaly",
             &COE::TrueAnomalyFromMeanAnomaly,
+            R"doc(
+                Compute the true anomaly from the mean anomaly.
+
+                Args:
+                    mean_anomaly (Angle): The mean anomaly.
+                    eccentricity (Real): The eccentricity.
+                    tolerance (float): The tolerance of the root solver.
+
+                Returns:
+                    Angle: The true anomaly.
+
+                Group:
+                    Static methods
+            )doc",
             arg("mean_anomaly"),
             arg("eccentricity"),
             arg("tolerance")
         )
 
-        .def_static("string_from_element", &COE::StringFromElement, arg("element"))
+        .def_static(
+            "string_from_element",
+            &COE::StringFromElement,
+            R"doc(
+                Get the string representation of an element.
+
+                Args:
+                    element (Element): The element.
+
+                Returns:
+                    str: The string representation.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("element")
+        )
 
         ;
 
-    enum_<COE::Element>(coe, "Element")
+    enum_<COE::Element>(
+        coe,
+        "Element",
+        R"doc(
+            Classical Orbital Element enumeration.
 
-        .value("SemiMajorAxis", COE::Element::SemiMajorAxis)
-        .value("Eccentricity", COE::Element::Eccentricity)
-        .value("Inclination", COE::Element::Inclination)
-        .value("Aop", COE::Element::Aop)
-        .value("Raan", COE::Element::Raan)
-        .value("TrueAnomaly", COE::Element::TrueAnomaly)
-        .value("MeanAnomaly", COE::Element::MeanAnomaly)
-        .value("EccentricAnomaly", COE::Element::EccentricAnomaly)
+        )doc"
+    )
+
+        .value("SemiMajorAxis", COE::Element::SemiMajorAxis, "Semi-Major Axis")
+        .value("Eccentricity", COE::Element::Eccentricity, "Eccentricity")
+        .value("Inclination", COE::Element::Inclination, "Inclination")
+        .value("Aop", COE::Element::Aop, "Argument of Perigee")
+        .value("Raan", COE::Element::Raan, "Right Angle of the Ascending Node")
+        .value("TrueAnomaly", COE::Element::TrueAnomaly, "True Anomaly")
+        .value("MeanAnomaly", COE::Element::MeanAnomaly, "Mean Anomaly")
+        .value("EccentricAnomaly", COE::Element::EccentricAnomaly, "Eccentric Anomaly")
 
         ;
 
-    enum_<COE::AnomalyType>(coe, "AnomalyType")
+    enum_<COE::AnomalyType>(
+        coe,
+        "AnomalyType",
+        R"doc(
+            The type of Anomaly.
+        )doc"
+    )
 
-        .value("TrueAnomaly", COE::AnomalyType::True)
-        .value("MeanAnomaly", COE::AnomalyType::Mean)
-        .value("EccentricAnomaly", COE::AnomalyType::Eccentric)
+        // Have to rename slightly as True is a keyword in Python
+        .value("TrueAnomaly", COE::AnomalyType::True, "True Anomaly")
+        .value("MeanAnomaly", COE::AnomalyType::Mean, "Mean Anomaly")
+        .value("EccentricAnomaly", COE::AnomalyType::Eccentric, "Eccentric Anomaly")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -41,6 +41,41 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
         )doc"
     );
 
+    enum_<COE::Element>(
+        coe,
+        "Element",
+        R"doc(
+            Classical Orbital Element enumeration.
+
+        )doc"
+    )
+
+        .value("SemiMajorAxis", COE::Element::SemiMajorAxis, "Semi-Major Axis")
+        .value("Eccentricity", COE::Element::Eccentricity, "Eccentricity")
+        .value("Inclination", COE::Element::Inclination, "Inclination")
+        .value("Aop", COE::Element::Aop, "Argument of Perigee")
+        .value("Raan", COE::Element::Raan, "Right Angle of the Ascending Node")
+        .value("TrueAnomaly", COE::Element::TrueAnomaly, "True Anomaly")
+        .value("MeanAnomaly", COE::Element::MeanAnomaly, "Mean Anomaly")
+        .value("EccentricAnomaly", COE::Element::EccentricAnomaly, "Eccentric Anomaly")
+
+        ;
+
+    enum_<COE::AnomalyType>(
+        coe,
+        "AnomalyType",
+        R"doc(
+            The type of Anomaly.
+        )doc"
+    )
+
+        // Have to rename slightly as True is a keyword in Python
+        .value("TrueAnomaly", COE::AnomalyType::True, "True Anomaly")
+        .value("MeanAnomaly", COE::AnomalyType::Mean, "Mean Anomaly")
+        .value("EccentricAnomaly", COE::AnomalyType::Eccentric, "Eccentric Anomaly")
+
+        ;
+
     coe
 
         .def(
@@ -256,41 +291,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
             )doc",
             arg("element")
         )
-
-        ;
-
-    enum_<COE::Element>(
-        coe,
-        "Element",
-        R"doc(
-            Classical Orbital Element enumeration.
-
-        )doc"
-    )
-
-        .value("SemiMajorAxis", COE::Element::SemiMajorAxis, "Semi-Major Axis")
-        .value("Eccentricity", COE::Element::Eccentricity, "Eccentricity")
-        .value("Inclination", COE::Element::Inclination, "Inclination")
-        .value("Aop", COE::Element::Aop, "Argument of Perigee")
-        .value("Raan", COE::Element::Raan, "Right Angle of the Ascending Node")
-        .value("TrueAnomaly", COE::Element::TrueAnomaly, "True Anomaly")
-        .value("MeanAnomaly", COE::Element::MeanAnomaly, "Mean Anomaly")
-        .value("EccentricAnomaly", COE::Element::EccentricAnomaly, "Eccentric Anomaly")
-
-        ;
-
-    enum_<COE::AnomalyType>(
-        coe,
-        "AnomalyType",
-        R"doc(
-            The type of Anomaly.
-        )doc"
-    )
-
-        // Have to rename slightly as True is a keyword in Python
-        .value("TrueAnomaly", COE::AnomalyType::True, "True Anomaly")
-        .value("MeanAnomaly", COE::AnomalyType::Mean, "Mean Anomaly")
-        .value("EccentricAnomaly", COE::AnomalyType::Eccentric, "Eccentric Anomaly")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -37,7 +37,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
                 \end{aligned}
 
             Group:
-                Kepler
+                kepler
         )doc"
     );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Kepler/COE.cpp
@@ -37,7 +37,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
                 \end{aligned}
 
             Group:
-                kepler
+                orbital-elements
         )doc"
     );
 
@@ -85,7 +85,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Args:
                     semi_major_axis (Length): The semi-major axis.
-                    eccentricity (Real): The eccentricity.
+                    eccentricity (float): The eccentricity.
                     inclination (Angle): The inclination.
                     raan (Angle): The right ascension of the ascending node.
                     aop (Angle): The argument of periapsis.
@@ -108,27 +108,199 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
         .def("__str__", &(shiftToString<COE>))
         .def("__repr__", &(shiftToString<COE>))
 
-        .def("is_defined", &COE::isDefined)
+        .def(
+            "is_defined",
+            &COE::isDefined,
+            R"doc(
+               Check if the COE is defined.
 
-        .def("get_semi_major_axis", &COE::getSemiMajorAxis)
-        .def("get_eccentricity", &COE::getEccentricity)
-        .def("get_inclination", &COE::getInclination)
-        .def("get_raan", &COE::getRaan)
-        .def("get_aop", &COE::getAop)
-        .def("get_true_anomaly", &COE::getTrueAnomaly)
-        .def("get_mean_anomaly", &COE::getMeanAnomaly)
-        .def("get_eccentric_anomaly", &COE::getEccentricAnomaly)
-        .def("get_periapsis_radius", &COE::getPeriapsisRadius)
-        .def("get_apoapsis_radius", &COE::getApoapsisRadius)
-        .def("get_SI_vector", &COE::getSIVector, arg("anomaly_type"))
+               Returns:
+                  bool: True if the COE is defined, False otherwise.
+            )doc"
+        )
 
-        .def("get_mean_motion", &COE::getMeanMotion, arg("gravitational_parameter"))
+        .def(
+            "get_semi_major_axis",
+            &COE::getSemiMajorAxis,
+            R"doc(
+               Get the semi-major axis of the COE.
 
-        .def("get_orbital_period", &COE::getOrbitalPeriod, arg("gravitational_parameter"))
+               Returns:
+                  Length: The semi-major axis of the COE.
+            )doc"
+        )
 
-        .def("get_cartesian_state", &COE::getCartesianState, arg("gravitational_parameter"), arg("frame"))
+        .def(
+            "get_eccentricity",
+            &COE::getEccentricity,
+            R"doc(
+               Get the eccentricity of the COE.
 
-        .def_static("undefined", &COE::Undefined)
+               Returns:
+                  float: The eccentricity of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_inclination",
+            &COE::getInclination,
+            R"doc(
+               Get the inclination of the COE.
+
+               Returns:
+                  Angle: The inclination of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_raan",
+            &COE::getRaan,
+            R"doc(
+               Get the right ascension of the ascending node of the COE.
+
+               Returns:
+                  Angle: The right ascension of the ascending node of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_aop",
+            &COE::getAop,
+            R"doc(
+               Get the argument of periapsis of the COE.
+
+               Returns:
+                  Angle: The argument of periapsis of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_true_anomaly",
+            &COE::getTrueAnomaly,
+            R"doc(
+               Get the true anomaly of the COE.
+
+               Returns:
+                  Angle: The true anomaly of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_mean_anomaly",
+            &COE::getMeanAnomaly,
+            R"doc(
+               Get the mean anomaly of the COE.
+
+               Returns:
+                  Angle: The mean anomaly of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_eccentric_anomaly",
+            &COE::getEccentricAnomaly,
+            R"doc(
+               Get the eccentric anomaly of the COE.
+
+               Returns:
+                  Angle: The eccentric anomaly of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_periapsis_radius",
+            &COE::getPeriapsisRadius,
+            R"doc(
+               Get the periapsis radius of the COE.
+
+               Returns:
+                  Length: The periapsis radius of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_apoapsis_radius",
+            &COE::getApoapsisRadius,
+            R"doc(
+               Get the apoapsis radius of the COE.
+
+               Returns:
+                  Length: The apoapsis radius of the COE.
+            )doc"
+        )
+
+        .def(
+            "get_SI_vector",
+            &COE::getSIVector,
+            R"doc(
+               Get the state vector of the COE in the specified anomaly type.
+
+               Args:
+                  anomaly_type (AnomalyType): The type of anomaly.
+
+               Returns:
+                  numpy.ndarray: The state vector of the COE in the specified anomaly type.
+            )doc",
+            arg("anomaly_type")
+        )
+
+        .def(
+            "get_mean_motion",
+            &COE::getMeanMotion,
+            R"doc(
+               Get the mean motion of the COE.
+
+               Args:
+                  gravitational_parameter (double): The gravitational parameter of the central body.
+
+               Returns:
+                  float: The mean motion of the COE.
+            )doc",
+            arg("gravitational_parameter")
+        )
+
+        .def(
+            "get_orbital_period",
+            &COE::getOrbitalPeriod,
+            R"doc(
+               Get the orbital period of the COE.
+
+               Args:
+                  gravitational_parameter (double): The gravitational parameter of the central body.
+
+               Returns:
+                  Duration: The orbital period of the COE.
+            )doc",
+            arg("gravitational_parameter")
+        )
+
+        .def(
+            "get_cartesian_state",
+            &COE::getCartesianState,
+            R"doc(
+               Get the Cartesian state of the COE.
+
+               Args:
+                  gravitational_parameter (double): The gravitational parameter of the central body.
+                  frame (Frame): The reference frame in which to express the Cartesian state.
+
+               Returns:
+                  CartesianState: The Cartesian state of the COE.
+            )doc",
+            arg("gravitational_parameter"),
+            arg("frame")
+        )
+
+        .def_static(
+            "undefined",
+            &COE::Undefined,
+            R"doc(
+                Create an undefined `COE` model.
+
+                Returns:
+                    COE: The undefined `COE` model.
+            )doc"
+        )
 
         .def_static(
             "cartesian",
@@ -138,13 +310,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Args:
                     cartesian_state (CartesianState): The Cartesian state.
-                    gravitational_parameter (Real): The gravitational parameter of the central body.
+                    gravitational_parameter (float): The gravitational parameter of the central body.
 
                 Returns:
                     COE: The `COE` model.
-
-                Group:
-                    Static methods
             )doc",
             arg("cartesian_state"),
             arg("gravitational_parameter")
@@ -162,9 +331,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Returns:
                     COE: The `COE` model.
-
-                Group:
-                    Static methods
             )doc",
             arg("vector"),
             arg("anomaly_type")
@@ -178,13 +344,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Args:
                     true_anomaly (Angle): The true anomaly.
-                    eccentricity (Real): The eccentricity.
+                    eccentricity (float): The eccentricity.
 
                 Returns:
                     Angle: The eccentric anomaly.
-
-                Group:
-                    Static methods
             )doc",
             arg("true_anomaly"),
             arg("eccentricity")
@@ -198,13 +361,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Args:
                     eccentric_anomaly (Angle): The eccentric anomaly.
-                    eccentricity (Real): The eccentricity.
+                    eccentricity (float): The eccentricity.
 
                 Returns:
                     Angle: The true anomaly.
-
-                Group:
-                    Static methods
             )doc",
             arg("eccentric_anomaly"),
             arg("eccentricity")
@@ -218,13 +378,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Args:
                     eccentric_anomaly (Angle): The eccentric anomaly.
-                    eccentricity (Real): The eccentricity.
+                    eccentricity (float): The eccentricity.
 
                 Returns:
                     Angle: The mean anomaly.
-
-                Group:
-                    Static methods
             )doc",
             arg("eccentric_anomaly"),
             arg("eccentricity")
@@ -238,14 +395,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Args:
                     mean_anomaly (Angle): The mean anomaly.
-                    eccentricity (Real): The eccentricity.
+                    eccentricity (float): The eccentricity.
                     tolerance (float): The tolerance of the root solver.
 
                 Returns:
                     Angle: The eccentric anomaly.
-
-                Group:
-                    Static methods
             )doc",
             arg("mean_anomaly"),
             arg("eccentricity"),
@@ -260,14 +414,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Args:
                     mean_anomaly (Angle): The mean anomaly.
-                    eccentricity (Real): The eccentricity.
+                    eccentricity (float): The eccentricity.
                     tolerance (float): The tolerance of the root solver.
 
                 Returns:
                     Angle: The true anomaly.
-
-                Group:
-                    Static methods
             )doc",
             arg("mean_anomaly"),
             arg("eccentricity"),
@@ -285,9 +436,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Kepler_COE(p
 
                 Returns:
                     str: The string representation.
-
-                Group:
-                    Static methods
             )doc",
             arg("element")
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Propagated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Propagated.cpp
@@ -54,7 +54,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Propagated(p
 
                     Args:
                         propagator (Propagator): The propagator.
-                        state_array (Array[State]): The initial state array.
+                        state_array (list[State]): The initial state array.
 
                 )doc",
                 arg("propagator"),
@@ -129,10 +129,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Propagated(p
                     Calculate the states of the `Propagated` model at given instants.
 
                     Args:
-                        instant_array (Array[Instant]): The instants.
+                        instant_array (list[Instant]): The instants.
 
                     Returns:
-                        Array[State]: The states.
+                        list[State]: The states.
 
                 )doc"
             )
@@ -160,7 +160,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Propagated(p
                     Access the cached state array of the `Propagated` model.
 
                     Returns:
-                        Array[State]: The cached state array.
+                        list[State]: The cached state array.
 
                 )doc"
             )
@@ -185,7 +185,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Propagated(p
                     Set the cached state array of the `Propagated` model.
 
                     Args:
-                        state_array (Array[State]): The state array.
+                        state_array (list[State]): The state array.
 
                 )doc"
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Propagated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Propagated.cpp
@@ -27,7 +27,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Propagated(p
                 Provides the interface for orbit models.
 
                 Group:
-                    Models
+                    orbit
             )doc"
         );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Propagated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Propagated.cpp
@@ -18,35 +18,177 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Propagated(p
     using ostk::astro::trajectory::orbit::models::Propagated;
 
     {
-        class_<Propagated, ostk::astro::trajectory::orbit::Model> propagated_class(aModule, "Propagated");
+        class_<Propagated, ostk::astro::trajectory::orbit::Model> propagated_class(
+            aModule,
+            "Propagated",
+            R"doc(
+                A Propagated orbit model.
+
+                Provides the interface for orbit models.
+
+                Group:
+                    Models
+            )doc"
+        );
 
         propagated_class
 
-            .def(init<const Propagator&, const State&>(), arg("propagator"), arg("state"))
+            .def(
+                init<const Propagator&, const State&>(),
+                R"doc(
+                    Constructor.
 
-            .def(init<const Propagator&, const Array<State>&>(), arg("propagator"), arg("state_array"))
+                    Args:
+                        propagator (Propagator): The propagator.
+                        state (State): The initial state.
+
+                )doc",
+                arg("propagator"),
+                arg("state")
+            )
+
+            .def(
+                init<const Propagator&, const Array<State>&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        propagator (Propagator): The propagator.
+                        state_array (Array[State]): The initial state array.
+
+                )doc",
+                arg("propagator"),
+                arg("state_array")
+            )
 
             .def(self == self)
+
             .def(self != self)
 
             .def("__str__", &(shiftToString<Propagated>))
+
             .def("__repr__", &(shiftToString<Propagated>))
 
-            .def("is_defined", &Propagated::isDefined)
+            .def(
+                "is_defined",
+                &Propagated::isDefined,
+                R"doc(
+                    Check if the `Propagated` model is defined.
 
-            .def("get_epoch", &Propagated::getEpoch)
-            .def("get_revolution_number_at_epoch", &Propagated::getRevolutionNumberAtEpoch)
+                    Returns:
+                        bool: True if the `Propagated` model is defined, False otherwise.
 
-            .def("calculate_state_at", &Propagated::calculateStateAt, arg("instant"))
+                )doc"
+            )
 
-            .def("calculate_states_at", &Propagated::calculateStatesAt, arg("instant_array"))
+            .def(
+                "get_epoch",
+                &Propagated::getEpoch,
+                R"doc(
+                    Get the epoch of the `Propagated` model.
 
-            .def("calculate_revolution_number_at", &Propagated::calculateRevolutionNumberAt, arg("instant"))
+                    Returns:
+                        Instant: The epoch.
 
-            .def("access_cached_state_array", &Propagated::accessCachedStateArray)
-            .def("access_propagator", &Propagated::accessPropagator)
+                )doc"
+            )
 
-            .def("set_cached_state_array", &Propagated::setCachedStateArray, arg("state_array"))
+            .def(
+                "get_revolution_number_at_epoch",
+                &Propagated::getRevolutionNumberAtEpoch,
+                R"doc(
+                    Get the revolution number at the epoch of the `Propagated` model.
+
+                    Returns:
+                        int: The revolution number.
+
+                )doc"
+            )
+
+            .def(
+                "calculate_state_at",
+                &Propagated::calculateStateAt,
+                arg("instant"),
+                R"doc(
+                    Calculate the state of the `Propagated` model at a given instant.
+
+                    Args:
+                        instant (Instant): The instant.
+
+                    Returns:
+                        State: The state.
+
+                )doc"
+            )
+
+            .def(
+                "calculate_states_at",
+                &Propagated::calculateStatesAt,
+                arg("instant_array"),
+                R"doc(
+                    Calculate the states of the `Propagated` model at given instants.
+
+                    Args:
+                        instant_array (Array[Instant]): The instants.
+
+                    Returns:
+                        Array[State]: The states.
+
+                )doc"
+            )
+
+            .def(
+                "calculate_revolution_number_at",
+                &Propagated::calculateRevolutionNumberAt,
+                arg("instant"),
+                R"doc(
+                    Calculate the revolution number of the `Propagated` model at a given instant.
+
+                    Args:
+                        instant (Instant): The instant.
+
+                    Returns:
+                        int: The revolution number.
+
+                )doc"
+            )
+
+            .def(
+                "access_cached_state_array",
+                &Propagated::accessCachedStateArray,
+                R"doc(
+                    Access the cached state array of the `Propagated` model.
+
+                    Returns:
+                        Array[State]: The cached state array.
+
+                )doc"
+            )
+
+            .def(
+                "access_propagator",
+                &Propagated::accessPropagator,
+                R"doc(
+                    Access the propagator of the `Propagated` model.
+
+                    Returns:
+                        Propagator: The propagator.
+
+                )doc"
+            )
+
+            .def(
+                "set_cached_state_array",
+                &Propagated::setCachedStateArray,
+                arg("state_array"),
+                R"doc(
+                    Set the cached state array of the `Propagated` model.
+
+                    Args:
+                        state_array (Array[State]): The state array.
+
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4.cpp
@@ -12,25 +12,110 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4(pybind1
     using ostk::astro::trajectory::orbit::models::sgp4::TLE;
 
     {
-        class_<SGP4, ostk::astro::trajectory::orbit::Model>(aModule, "SGP4")
+        class_<SGP4, ostk::astro::trajectory::orbit::Model>(
+            aModule,
+            "SGP4",
+            R"doc(
+                A SGP4 model.
 
-            .def(init<TLE>(), arg("tle"))
+                Provides the interface for orbit models.
 
-            .def(self == self)
-            .def(self != self)
+                Group:
+                    Models
+            )doc"
+        )
 
-            .def("__str__", &(shiftToString<SGP4>))
-            .def("__repr__", &(shiftToString<SGP4>))
+            .def(
+                init<TLE>(),
+                R"doc(
+                    Constructor.
 
-            .def("is_defined", &SGP4::isDefined)
+                    Args:
+                        tle (TLE): The TLE.
 
-            .def("get_tle", &SGP4::getTle)
-            .def("get_epoch", &SGP4::getEpoch)
-            .def("get_revolution_number_at_epoch", &SGP4::getRevolutionNumberAtEpoch)
+                )doc",
+                arg("tle")
+            )
 
-            .def("calculate_state_at", &SGP4::calculateStateAt, arg("instant"))
+            .def(
+                "is_defined",
+                &SGP4::isDefined,
+                R"doc(
+                    Check if the `SGP4` model is defined.
 
-            .def("calculate_revolution_number_at", &SGP4::calculateRevolutionNumberAt, arg("instant"))
+                    Returns:
+                        bool: True if the `SGP4` model is defined, False otherwise.
+
+                )doc"
+            )
+
+            .def(
+                "get_tle",
+                &SGP4::getTle,
+                R"doc(
+                    Get the TLE of the `SGP4` model.
+
+                    Returns:
+                        TLE: The TLE.
+
+                )doc"
+            )
+
+            .def(
+                "get_epoch",
+                &SGP4::getEpoch,
+                R"doc(
+                    Get the epoch of the `SGP4` model.
+
+                    Returns:
+                        Instant: The epoch.
+
+                )doc"
+            )
+
+            .def(
+                "get_revolution_number_at_epoch",
+                &SGP4::getRevolutionNumberAtEpoch,
+                R"doc(
+                    Get the revolution number at the epoch of the `SGP4` model.
+
+                    Returns:
+                        int: The revolution number.
+
+                )doc"
+            )
+
+            .def(
+                "calculate_state_at",
+                &SGP4::calculateStateAt,
+                arg("instant"),
+                R"doc(
+                    Calculate the state of the `SGP4` model at a given instant.
+
+                    Args:
+                        instant (Instant): The instant.
+
+                    Returns:
+                        State: The state.
+
+                )doc"
+            )
+
+            .def(
+                "calculate_revolution_number_at",
+                &SGP4::calculateRevolutionNumberAt,
+                arg("instant"),
+                R"doc(
+                    Calculate the revolution number of the `SGP4` model at a given instant.
+
+                    Args:
+                        instant (Instant): The instant.
+
+                    Returns:
+                        int: The revolution number.
+
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4.cpp
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4(pybind1
                 Provides the interface for orbit models.
 
                 Group:
-                    Models
+                    orbit
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4/TLE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4/TLE.cpp
@@ -28,7 +28,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
                 https://en.wikipedia.org/wiki/Two-line_element_set
 
             Group:
-                SGP4
+                orbit
         )doc"
     )
 
@@ -359,10 +359,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
 
                 Returns:
                     TLE: The undefined `TLE` object.
-                
-                Group:
-                    Static methods
-
             )doc"
         )
 
@@ -383,10 +379,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
 
                 Returns:
                     bool: True if the TLE can be parsed, False otherwise.
-                
-                Group:
-                    Static methods
-
             )doc"
         )
 
@@ -402,10 +394,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
 
                 Returns:
                     TLE: The parsed TLE.
-
-                Group:
-                    Static methods
-
             )doc"
         )
 
@@ -421,10 +409,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
 
                 Returns:
                     TLE: The loaded TLE.
-
-                Group:
-                    Static methods
-
             )doc"
         )
 
@@ -489,10 +473,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
 
                 Returns:
                     TLE: The constructed TLE.
-
-                Group:
-                    Static methods
-
             )doc"
         )
 
@@ -554,10 +534,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
 
                 Returns:
                     TLE: The constructed TLE.
-
-                Group:
-                    Static methods
-
             )doc"
         )
 
@@ -573,10 +549,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
 
                 Returns:
                     int: The checksum.
-
-                Group:
-                    Static methods
-
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4/TLE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4/TLE.cpp
@@ -16,11 +16,48 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
 
     using ostk::astro::trajectory::orbit::models::sgp4::TLE;
 
-    class_<TLE>(aModule, "TLE")
+    class_<TLE>(
+        aModule,
+        "TLE",
+        R"doc(
+            A TLE.
 
-        .def(init<String, String>(), arg("first_line"), arg("second_line"))
+            Provides the interface for TLEs.
 
-        .def(init<String, String, String>(), arg("satellite_name"), arg("first_line"), arg("second_line"))
+            Group:
+                SGP4
+        )doc"
+    )
+
+        .def(
+            init<String, String>(),
+            arg("first_line"),
+            arg("second_line"),
+            R"doc(
+                Constructor.
+
+                Args:
+                    first_line (str): The first line of the TLE.
+                    second_line (str): The second line of the TLE.
+
+            )doc"
+        )
+
+        .def(
+            init<String, String, String>(),
+            arg("satellite_name"),
+            arg("first_line"),
+            arg("second_line"),
+            R"doc(
+                Constructor.
+
+                Args:
+                    satellite_name (str): The name of the satellite.
+                    first_line (str): The first line of the TLE.
+                    second_line (str): The second line of the TLE.
+
+            )doc"
+        )
 
         .def(self == self)
         .def(self != self)
@@ -28,39 +65,303 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
         .def("__str__", &(shiftToString<TLE>))
         .def("__repr__", &(shiftToString<TLE>))
 
-        .def("is_defined", &TLE::isDefined)
-
-        .def("get_satellite_name", &TLE::getSatelliteName)
-        .def("get_first_line", &TLE::getFirstLine)
-        .def("get_second_line", &TLE::getSecondLine)
-        .def("get_satellite_number", &TLE::getSatelliteNumber)
-        .def("get_classification", &TLE::getClassification)
-        .def("get_international_designator", &TLE::getInternationalDesignator)
-        .def("get_epoch", &TLE::getEpoch)
-        .def("get_mean_motion_first_time_derivative_divided_by_two", &TLE::getMeanMotionFirstTimeDerivativeDividedByTwo)
         .def(
-            "get_mean_motion_second_time_derivative_divided_by_six", &TLE::getMeanMotionSecondTimeDerivativeDividedBySix
+            "is_defined",
+            &TLE::isDefined,
+            R"doc(
+                Check if the `TLE` object is defined.
+
+                Returns:
+                    bool: True if the `TLE` object is defined, False otherwise.
+
+            )doc"
         )
-        .def("get_b_star_drag_term", &TLE::getBStarDragTerm)
-        .def("get_ephemeris_type", &TLE::getEphemerisType)
-        .def("get_element_set_number", &TLE::getElementSetNumber)
-        .def("get_first_line_checksum", &TLE::getFirstLineChecksum)
-        .def("get_inclination", &TLE::getInclination)
-        .def("get_raan", &TLE::getRaan)
-        .def("get_eccentricity", &TLE::getEccentricity)
-        .def("get_aop", &TLE::getAop)
-        .def("get_mean_anomaly", &TLE::getMeanAnomaly)
-        .def("get_mean_motion", &TLE::getMeanMotion)
-        .def("get_revolution_number_at_epoch", &TLE::getRevolutionNumberAtEpoch)
-        .def("get_second_line_checksum", &TLE::getSecondLineChecksum)
 
-        .def("set_satellite_number", &TLE::setSatelliteNumber, arg("satellite_number"))
+        .def(
+            "get_satellite_name",
+            &TLE::getSatelliteName,
+            R"doc(
+                Get the name of the satellite.
 
-        .def("set_epoch", &TLE::setEpoch, arg("epoch"))
+                Returns:
+                    str: The name of the satellite.
 
-        .def("set_revolution_number_at_epoch", &TLE::setRevolutionNumberAtEpoch, arg("revolution_number"))
+            )doc"
+        )
+        .def(
+            "get_first_line",
+            &TLE::getFirstLine,
+            R"doc(
+                Get the first line of the TLE.
 
-        .def_static("undefined", &TLE::Undefined)
+                Returns:
+                    str: The first line of the TLE.
+
+            )doc"
+        )
+        .def(
+            "get_second_line",
+            &TLE::getSecondLine,
+            R"doc(
+                Get the second line of the TLE.
+
+                Returns:
+                    str: The second line of the TLE.
+
+            )doc"
+        )
+        .def(
+            "get_satellite_number",
+            &TLE::getSatelliteNumber,
+            R"doc(
+                Get the satellite number.
+
+                Returns:
+                    int: The satellite number.
+
+            )doc"
+        )
+        .def(
+            "get_classification",
+            &TLE::getClassification,
+            R"doc(
+                Get the classification.
+
+                Returns:
+                    str: The classification.
+
+            )doc"
+        )
+        .def(
+            "get_international_designator",
+            &TLE::getInternationalDesignator,
+            R"doc(
+                Get the international designator.
+
+                Returns:
+                    str: The international designator.
+
+            )doc"
+        )
+        .def(
+            "get_epoch",
+            &TLE::getEpoch,
+            R"doc(
+                Get the epoch.
+
+                Returns:
+                    Instant: The epoch.
+
+            )doc"
+        )
+        .def(
+            "get_mean_motion_first_time_derivative_divided_by_two",
+            &TLE::getMeanMotionFirstTimeDerivativeDividedByTwo,
+            R"doc(
+                Get the mean motion first time derivative divided by two.
+
+                Returns:
+                    float: The mean motion first time derivative divided by two.
+
+            )doc"
+        )
+        .def(
+            "get_mean_motion_second_time_derivative_divided_by_six",
+            &TLE::getMeanMotionSecondTimeDerivativeDividedBySix,
+            R"doc(
+                Get the mean motion second time derivative divided by six.
+
+                Returns:
+                    float: The mean motion second time derivative divided by six.
+
+            )doc"
+        )
+        .def(
+            "get_b_star_drag_term",
+            &TLE::getBStarDragTerm,
+            R"doc(
+                Get the B* drag term.
+
+                Returns:
+                    float: The B* drag term.
+
+            )doc"
+        )
+        .def(
+            "get_ephemeris_type",
+            &TLE::getEphemerisType,
+            R"doc(
+                Get the ephemeris type.
+
+                Returns:
+                    int: The ephemeris type.
+
+            )doc"
+        )
+        .def(
+            "get_element_set_number",
+            &TLE::getElementSetNumber,
+            R"doc(
+                Get the element set number.
+
+                Returns:
+                    int: The element set number.
+
+            )doc"
+        )
+        .def(
+            "get_first_line_checksum",
+            &TLE::getFirstLineChecksum,
+            R"doc(
+                Get the checksum of the first line.
+
+                Returns:
+                    int: The checksum of the first line.
+
+            )doc"
+        )
+        .def(
+            "get_inclination",
+            &TLE::getInclination,
+            R"doc(
+                Get the inclination.
+
+                Returns:
+                    Angle: The inclination.
+
+            )doc"
+        )
+        .def(
+            "get_raan",
+            &TLE::getRaan,
+            R"doc(
+                Get the right ascension of the ascending node.
+
+                Returns:
+                    Angle: The right ascension of the ascending node.
+
+            )doc"
+        )
+        .def(
+            "get_eccentricity",
+            &TLE::getEccentricity,
+            R"doc(
+                Get the eccentricity.
+
+                Returns:
+                    float: The eccentricity.
+
+            )doc"
+        )
+        .def(
+            "get_aop",
+            &TLE::getAop,
+            R"doc(
+                Get the argument of perigee.
+
+                Returns:
+                    Angle: The argument of perigee.
+
+            )doc"
+        )
+        .def(
+            "get_mean_anomaly",
+            &TLE::getMeanAnomaly,
+            R"doc(
+                Get the mean anomaly.
+
+                Returns:
+                    Angle: The mean anomaly.
+
+            )doc"
+        )
+        .def(
+            "get_mean_motion",
+            &TLE::getMeanMotion,
+            R"doc(
+                Get the mean motion.
+
+                Returns:
+                    float: The mean motion.
+
+            )doc"
+        )
+        .def(
+            "get_revolution_number_at_epoch",
+            &TLE::getRevolutionNumberAtEpoch,
+            R"doc(
+                Get the revolution number at epoch.
+
+                Returns:
+                    int: The revolution number at epoch.
+
+            )doc"
+        )
+        .def(
+            "get_second_line_checksum",
+            &TLE::getSecondLineChecksum,
+            R"doc(
+                Get the checksum of the second line.
+
+                Returns:
+                    int: The checksum of the second line.
+
+            )doc"
+        )
+
+        .def(
+            "set_satellite_number",
+            &TLE::setSatelliteNumber,
+            arg("satellite_number"),
+            R"doc(
+                Set the satellite number.
+
+                Args:
+                    satellite_number (int): The satellite number.
+
+            )doc"
+        )
+
+        .def(
+            "set_epoch",
+            &TLE::setEpoch,
+            arg("epoch"),
+            R"doc(
+                Set the epoch.
+
+                Args:
+                    epoch (Instant): The epoch.
+
+            )doc"
+        )
+
+        .def(
+            "set_revolution_number_at_epoch",
+            &TLE::setRevolutionNumberAtEpoch,
+            arg("revolution_number"),
+            R"doc(
+                Set the revolution number at epoch.
+
+                Args:
+                    revolution_number (int): The revolution number at epoch.
+
+            )doc"
+        )
+
+        .def_static(
+            "undefined",
+            &TLE::Undefined,
+            R"doc(
+                Create an undefined `TLE` object.
+
+                Returns:
+                    TLE: The undefined `TLE` object.
+                
+                Group:
+                    Static methods
+
+            )doc"
+        )
 
         .def_static(
             "can_parse",
@@ -69,12 +370,60 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
                 return TLE::CanParse(aFirstLine, aSecondLine);
             },
             arg("first_line"),
-            arg("second_line")
+            arg("second_line"),
+            R"doc(
+                Check if a TLE can be parsed from two strings.
+
+                Args:
+                    first_line (str): The first line of the TLE.
+                    second_line (str): The second line of the TLE.
+
+                Returns:
+                    bool: True if the TLE can be parsed, False otherwise.
+                
+                Group:
+                    Static methods
+
+            )doc"
         )
 
-        .def_static("parse", &TLE::Parse, arg("string"))
+        .def_static(
+            "parse",
+            &TLE::Parse,
+            arg("string"),
+            R"doc(
+                Parse a TLE from a string.
 
-        .def_static("load", &TLE::Load, arg("file"))
+                Args:
+                    string (str): The string to parse.
+
+                Returns:
+                    TLE: The parsed TLE.
+
+                Group:
+                    Static methods
+
+            )doc"
+        )
+
+        .def_static(
+            "load",
+            &TLE::Load,
+            arg("file"),
+            R"doc(
+                Load a TLE from a file.
+
+                Args:
+                    file (str): The path to the file.
+
+                Returns:
+                    TLE: The loaded TLE.
+
+                Group:
+                    Static methods
+
+            )doc"
+        )
 
         .def_static(
             "construct",
@@ -112,7 +461,36 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
             arg("aop"),
             arg("mean_anomaly"),
             arg("mean_motion"),
-            arg("revolution_number_at_epoch")
+            arg("revolution_number_at_epoch"),
+            R"doc(
+                Construct a TLE.
+
+                Args:
+                    satellite_name (str): The name of the satellite.
+                    satellite_number (int): The satellite number.
+                    classification (str): The classification.
+                    international_designator (str): The international designator.
+                    epoch (Instant): The epoch.
+                    mean_motion_first_time_derivative_divided_by_two (float): The mean motion first time derivative divided by two.
+                    mean_motion_second_time_derivative_divided_by_six (float): The mean motion second time derivative divided by six.
+                    b_star_drag_term (float): The B* drag term.
+                    ephemeris_type (int): The ephemeris type.
+                    element_set_number (int): The element set number.
+                    inclination (Angle): The inclination.
+                    raan (Angle): The right ascension of the ascending node.
+                    eccentricity (float): The eccentricity.
+                    aop (Angle): The argument of perigee.
+                    mean_anomaly (Angle): The mean anomaly.
+                    mean_motion (float): The mean motion.
+                    revolution_number_at_epoch (int): The revolution number at epoch.
+
+                Returns:
+                    TLE: The constructed TLE.
+
+                Group:
+                    Static methods
+
+            )doc"
         )
 
         .def_static(
@@ -149,10 +527,55 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
             arg("aop"),
             arg("mean_anomaly"),
             arg("mean_motion"),
-            arg("revolution_number_at_epoch")
+            arg("revolution_number_at_epoch"),
+            R"doc(
+                Construct a TLE.
+
+                Args:
+                    satellite_number (int): The satellite number.
+                    classification (str): The classification.
+                    international_designator (str): The international designator.
+                    epoch (Instant): The epoch.
+                    mean_motion_first_time_derivative_divided_by_two (float): The mean motion first time derivative divided by two.
+                    mean_motion_second_time_derivative_divided_by_six (float): The mean motion second time derivative divided by six.
+                    b_star_drag_term (float): The B* drag term.
+                    ephemeris_type (int): The ephemeris type.
+                    element_set_number (int): The element set number.
+                    inclination (Angle): The inclination.
+                    raan (Angle): The right ascension of the ascending node.
+                    eccentricity (float): The eccentricity.
+                    aop (Angle): The argument of perigee.
+                    mean_anomaly (Angle): The mean anomaly.
+                    mean_motion (float): The mean motion.
+                    revolution_number_at_epoch (int): The revolution number at epoch.
+
+                Returns:
+                    TLE: The constructed TLE.
+
+                Group:
+                    Static methods
+
+            )doc"
         )
 
-        .def_static("generate_checksum", &TLE::GenerateChecksum, arg("string"))
+        .def_static(
+            "generate_checksum",
+            &TLE::GenerateChecksum,
+            arg("string"),
+            R"doc(
+                Generate the checksum of a string.
+
+                Args:
+                    string (str): The string.
+
+                Returns:
+                    int: The checksum.
+
+                Group:
+                    Static methods
+
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4/TLE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/SGP4/TLE.cpp
@@ -20,9 +20,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_SGP4_TLE(pyb
         aModule,
         "TLE",
         R"doc(
-            A TLE.
+            A Two-Line Element set (TLE).
 
-            Provides the interface for TLEs.
+            A TLE is a data format encoding a list of orbital elements of an Earth-orbiting object for a given point in time
+
+            Reference:
+                https://en.wikipedia.org/wiki/Two-line_element_set
 
             Group:
                 SGP4

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp
@@ -44,7 +44,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
                 Constructor.
 
                 Args:
-                    states (Array[State]): The states.
+                    states (list[State]): The states.
                     initial_revolution_number (int): The initial revolution number.
                     interpolation_type (Tabulated.InterpolationType, optional): The interpolation type.
 
@@ -145,10 +145,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
                 Calculate the states of the `Tabulated` model at given instants.
 
                 Args:
-                    instants (Array[Instant]): The instants.
+                    instants (list[Instant]): The instants.
 
                 Returns:
-                    Array[State]: The states.
+                    list[State]: The states.
 
             )doc",
             arg("instants")

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp
@@ -23,13 +23,23 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
         )doc"
     );
 
+    enum_<Tabulated::InterpolationType>(
+        tabulated_class,
+        "InterpolationType",
+        R"doc(
+            The Interpolation Type.
+        )doc"
+    )
+        .value("Linear", Tabulated::InterpolationType::Linear, "Linear")
+        .value("CubicSpline", Tabulated::InterpolationType::CubicSpline, "Cubic Spline")
+        .value("BarycentricRational", Tabulated::InterpolationType::BarycentricRational, "Barycentric Rational")
+
+        ;
+
     tabulated_class
 
         .def(
             init<Array<State>, Integer, Tabulated::InterpolationType>(),
-            arg("states"),
-            arg("initial_revolution_number"),
-            arg("interpolation_type") = DEFAULT_TABULATED_INTERPOLATION_TYPE,
             R"doc(
                 Constructor.
 
@@ -38,7 +48,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
                     initial_revolution_number (int): The initial revolution number.
                     interpolation_type (Tabulated.InterpolationType, optional): The interpolation type.
 
-            )doc"
+            )doc",
+            arg("states"),
+            arg("initial_revolution_number"),
+            arg("interpolation_type") = DEFAULT_TABULATED_INTERPOLATION_TYPE
         )
 
         .def(self == self)
@@ -112,7 +125,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
         .def(
             "calculate_state_at",
             &Tabulated::calculateStateAt,
-            arg("instant"),
             R"doc(
                 Calculate the state of the `Tabulated` model at a given instant.
 
@@ -122,13 +134,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
                 Returns:
                     State: The state.
 
-            )doc"
+            )doc",
+            arg("instant")
         )
 
         .def(
             "calculate_states_at",
             &Tabulated::calculateStatesAt,
-            arg("instants"),
             R"doc(
                 Calculate the states of the `Tabulated` model at given instants.
 
@@ -138,13 +150,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
                 Returns:
                     Array[State]: The states.
 
-            )doc"
+            )doc",
+            arg("instants")
         )
 
         .def(
             "calculate_revolution_number_at",
             &Tabulated::calculateRevolutionNumberAt,
-            arg("instant"),
             R"doc(
                 Calculate the revolution number of the `Tabulated` model at a given instant.
 
@@ -154,21 +166,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
                 Returns:
                     int: The revolution number.
 
-            )doc"
+            )doc",
+            arg("instant")
         )
-
-        ;
-
-    enum_<Tabulated::InterpolationType>(
-        tabulated_class,
-        "InterpolationType",
-        R"doc(
-            The Interpolation Type.
-        )doc"
-    )
-        .value("Linear", Tabulated::InterpolationType::Linear, "Linear")
-        .value("CubicSpline", Tabulated::InterpolationType::CubicSpline, "Cubic Spline")
-        .value("BarycentricRational", Tabulated::InterpolationType::BarycentricRational, "Barycentric Rational")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp
@@ -2,49 +2,173 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Tabulated.hpp>
 
+using namespace pybind11;
+
+using ostk::core::ctnr::Array;
+using ostk::core::types::Integer;
+
+using ostk::astro::trajectory::State;
+using ostk::astro::trajectory::orbit::models::Tabulated;
+
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(pybind11::module& aModule)
 {
-    using namespace pybind11;
+    class_<Tabulated, ostk::astro::trajectory::orbit::Model> tabulated_class(
+        aModule,
+        "Tabulated",
+        R"doc(
+            Tabulated orbit model.
 
-    using ostk::core::ctnr::Array;
-    using ostk::core::types::Integer;
-
-    using ostk::astro::trajectory::State;
-    using ostk::astro::trajectory::orbit::models::Tabulated;
-
-    class_<Tabulated, ostk::astro::trajectory::orbit::Model> tabulated_class(aModule, "Tabulated");
-
-    enum_<Tabulated::InterpolationType>(tabulated_class, "InterpolationType")
-
-        .value("Linear", Tabulated::InterpolationType::Linear)
-        .value("CubicSpline", Tabulated::InterpolationType::CubicSpline)
-        .value("BarycentricRational", Tabulated::InterpolationType::BarycentricRational)
-
-        ;
+            Group:
+                Models
+        )doc"
+    );
 
     tabulated_class
+
         .def(
             init<Array<State>, Integer, Tabulated::InterpolationType>(),
             arg("states"),
             arg("initial_revolution_number"),
-            arg("interpolation_type") = DEFAULT_TABULATED_INTERPOLATION_TYPE
+            arg("interpolation_type") = DEFAULT_TABULATED_INTERPOLATION_TYPE,
+            R"doc(
+                Constructor.
+
+                Args:
+                    states (Array[State]): The states.
+                    initial_revolution_number (int): The initial revolution number.
+                    interpolation_type (Tabulated.InterpolationType, optional): The interpolation type.
+
+            )doc"
         )
 
         .def(self == self)
+
         .def(self != self)
 
         .def("__str__", &(shiftToString<Tabulated>))
+
         .def("__repr__", &(shiftToString<Tabulated>))
 
-        .def("is_defined", &Tabulated::isDefined)
+        .def(
+            "is_defined",
+            &Tabulated::isDefined,
+            R"doc(
+                Check if the `Tabulated` model is defined.
 
-        .def("get_epoch", &Tabulated::getEpoch)
-        .def("get_revolution_number_at_epoch", &Tabulated::getRevolutionNumberAtEpoch)
-        .def("get_interval", &Tabulated::getInterval)
-        .def("get_interpolation_type", &Tabulated::getInterpolationType)
-        .def("calculate_state_at", &Tabulated::calculateStateAt, arg("instant"))
-        .def("calculate_states_at", &Tabulated::calculateStatesAt, arg("instants"))
-        .def("calculate_revolution_number_at", &Tabulated::calculateRevolutionNumberAt, arg("instant"))
+                Returns:
+                    bool: True if the `Tabulated` model is defined, False otherwise.
+
+            )doc"
+        )
+
+        .def(
+            "get_epoch",
+            &Tabulated::getEpoch,
+            R"doc(
+                Get the epoch of the `Tabulated` model.
+
+                Returns:
+                    Instant: The epoch.
+
+            )doc"
+        )
+
+        .def(
+            "get_revolution_number_at_epoch",
+            &Tabulated::getRevolutionNumberAtEpoch,
+            R"doc(
+                Get the revolution number at the epoch of the `Tabulated` model.
+
+                Returns:
+                    int: The revolution number.
+
+            )doc"
+        )
+
+        .def(
+            "get_interval",
+            &Tabulated::getInterval,
+            R"doc(
+                Get the interval of the `Tabulated` model.
+
+                Returns:
+                    Interval: The interval.
+
+            )doc"
+        )
+
+        .def(
+            "get_interpolation_type",
+            &Tabulated::getInterpolationType,
+            R"doc(
+                Get the interpolation type of the `Tabulated` model.
+
+                Returns:
+                    Tabulated.InterpolationType: The interpolation type.
+
+            )doc"
+        )
+
+        .def(
+            "calculate_state_at",
+            &Tabulated::calculateStateAt,
+            arg("instant"),
+            R"doc(
+                Calculate the state of the `Tabulated` model at a given instant.
+
+                Args:
+                    instant (Instant): The instant.
+
+                Returns:
+                    State: The state.
+
+            )doc"
+        )
+
+        .def(
+            "calculate_states_at",
+            &Tabulated::calculateStatesAt,
+            arg("instants"),
+            R"doc(
+                Calculate the states of the `Tabulated` model at given instants.
+
+                Args:
+                    instants (Array[Instant]): The instants.
+
+                Returns:
+                    Array[State]: The states.
+
+            )doc"
+        )
+
+        .def(
+            "calculate_revolution_number_at",
+            &Tabulated::calculateRevolutionNumberAt,
+            arg("instant"),
+            R"doc(
+                Calculate the revolution number of the `Tabulated` model at a given instant.
+
+                Args:
+                    instant (Instant): The instant.
+
+                Returns:
+                    int: The revolution number.
+
+            )doc"
+        )
+
+        ;
+
+    enum_<Tabulated::InterpolationType>(
+        tabulated_class,
+        "InterpolationType",
+        R"doc(
+            The Interpolation Type.
+        )doc"
+    )
+        .value("Linear", Tabulated::InterpolationType::Linear, "Linear")
+        .value("CubicSpline", Tabulated::InterpolationType::CubicSpline, "Cubic Spline")
+        .value("BarycentricRational", Tabulated::InterpolationType::BarycentricRational, "Barycentric Rational")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Models/Tabulated.cpp
@@ -19,7 +19,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Models_Tabulated(py
             Tabulated orbit model.
 
             Group:
-                Models
+                orbit
         )doc"
     );
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
@@ -12,7 +12,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
 
     using ostk::astro::trajectory::orbit::Pass;
 
-    class_<Pass> pass_class(aModule, "Pass");
+    class_<Pass> pass_class(
+        aModule,
+        "Pass",
+        R"doc(
+            A revolution of an orbiting object.
+
+            Group:
+                Orbit
+        )doc"
+    );
 
     pass_class
 
@@ -20,7 +29,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             init<const Pass::Type&, const Integer&, const Interval&>(),
             arg("type"),
             arg("revolution_number"),
-            arg("interval")
+            arg("interval"),
+            R"doc(
+                Constructor.
+
+                Args:
+                    type (Pass.Type): The type of the pass.
+                    revolution_number (int): The revolution number of the pass.
+                    interval (Interval): The interval of the pass.
+
+            )doc"
         )
 
         .def(self == self)
@@ -29,43 +47,167 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
         .def("__str__", &(shiftToString<Pass>))
         .def("__repr__", &(shiftToString<Pass>))
 
-        .def("is_defined", &Pass::isDefined)
-        .def("is_complete", &Pass::isComplete)
+        .def("is_defined", &Pass::isDefined, R"doc(
+            Check if the pass is defined.
 
-        .def("get_type", &Pass::getType)
-        .def("get_revolution_number", &Pass::getRevolutionNumber)
-        .def("get_interval", &Pass::getInterval)
+            Returns:
+                bool: True if the pass is defined, False otherwise.
 
-        .def_static("undefined", &Pass::Undefined)
-        .def_static("string_from_type", &Pass::StringFromType, arg("type"))
-        .def_static("string_from_phase", &Pass::StringFromPhase, arg("phase"))
-        .def_static("string_from_quarter", &Pass::StringFromQuarter, arg("quarter"))
+        )doc")
+        .def(
+            "is_complete",
+            &Pass::isComplete,
+            R"doc(
+                Check if the pass is complete.
+
+                Returns:
+                    bool: True if the pass is complete, False otherwise.
+
+            )doc"
+        )
+
+        .def(
+            "get_type",
+            &Pass::getType,
+            R"doc(
+                Get the type of the pass.
+
+                Returns:
+                    Pass.Type: The type of the pass.
+
+            )doc"
+        )
+        .def(
+            "get_revolution_number",
+            &Pass::getRevolutionNumber,
+            R"doc(
+                Get the revolution number of the pass.
+
+                Returns:
+                    int: The revolution number of the pass.
+
+            )doc"
+        )
+        .def(
+            "get_interval",
+            &Pass::getInterval,
+            R"doc(
+                Get the interval of the pass.
+
+                Returns:
+                    Interval: The interval of the pass.
+
+            )doc"
+        )
+
+        .def_static(
+            "undefined",
+            &Pass::Undefined,
+            R"doc(
+                Get an undefined pass.
+
+                Returns:
+                    Pass: The undefined pass.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "string_from_type",
+            &Pass::StringFromType,
+            R"doc(
+                Get the string representation of a pass type.
+
+                Args:
+                    type (Pass.Type): The pass type.
+
+                Returns:
+                    str: The string representation of the pass type.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("type")
+        )
+        .def_static(
+            "string_from_phase",
+            &Pass::StringFromPhase,
+            R"doc(
+                Get the string representation of a pass phase.
+
+                Args:
+                    phase (Pass.Phase): The pass phase.
+
+                Returns:
+                    str: The string representation of the pass phase.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("phase")
+        )
+        .def_static(
+            "string_from_quarter",
+            &Pass::StringFromQuarter,
+            R"doc(
+                Get the string representation of a pass quarter.
+
+                Args:
+                    quarter (Pass.Quarter): The pass quarter.
+
+                Returns:
+                    str: The string representation of the pass quarter.
+
+                Group:
+                    Static methods
+            )doc",
+            arg("quarter")
+        )
 
         ;
 
-    enum_<Pass::Type>(pass_class, "Type")
+    enum_<Pass::Type>(
+        pass_class,
+        "Type",
+        R"doc(
+            The type of `Pass`.
+        )doc"
+    )
 
-        .value("Undefined", Pass::Type::Undefined)
-        .value("Complete", Pass::Type::Complete)
-        .value("Partial", Pass::Type::Partial)
-
-        ;
-
-    enum_<Pass::Phase>(pass_class, "Phase")
-
-        .value("Undefined", Pass::Phase::Undefined)
-        .value("Ascending", Pass::Phase::Ascending)
-        .value("Descending", Pass::Phase::Descending)
+        .value("Undefined", Pass::Type::Undefined, "Undefined")
+        .value("Complete", Pass::Type::Complete, "Complete")
+        .value("Partial", Pass::Type::Partial, "Partial")
 
         ;
 
-    enum_<Pass::Quarter>(pass_class, "Quarter")
+    enum_<Pass::Phase>(
+        pass_class,
+        "Phase",
+        R"doc(
+            The phase of the `Pass`.
+        )doc"
+    )
 
-        .value("Undefined", Pass::Quarter::Undefined)
-        .value("First", Pass::Quarter::First)
-        .value("Second", Pass::Quarter::Second)
-        .value("Third", Pass::Quarter::Third)
-        .value("Fourth", Pass::Quarter::Fourth)
+        .value("Undefined", Pass::Phase::Undefined, "Undefined")
+        .value("Ascending", Pass::Phase::Ascending, "Ascending")
+        .value("Descending", Pass::Phase::Descending, "Descending")
+
+        ;
+
+    enum_<Pass::Quarter>(
+        pass_class,
+        "Quarter",
+        R"doc(
+            The quarter of the `Pass`.
+        )doc"
+    )
+
+        .value("Undefined", Pass::Quarter::Undefined, "Undefined")
+        .value("First", Pass::Quarter::First, "First")
+        .value("Second", Pass::Quarter::Second, "Second")
+        .value("Third", Pass::Quarter::Third, "Third")
+        .value("Fourth", Pass::Quarter::Fourth, "Fourth")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
@@ -23,6 +23,50 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
         )doc"
     );
 
+    enum_<Pass::Type>(
+        pass_class,
+        "Type",
+        R"doc(
+            The type of `Pass`.
+        )doc"
+    )
+
+        .value("Undefined", Pass::Type::Undefined, "Undefined")
+        .value("Complete", Pass::Type::Complete, "Complete")
+        .value("Partial", Pass::Type::Partial, "Partial")
+
+        ;
+
+    enum_<Pass::Phase>(
+        pass_class,
+        "Phase",
+        R"doc(
+            The phase of the `Pass`.
+        )doc"
+    )
+
+        .value("Undefined", Pass::Phase::Undefined, "Undefined")
+        .value("Ascending", Pass::Phase::Ascending, "Ascending")
+        .value("Descending", Pass::Phase::Descending, "Descending")
+
+        ;
+
+    enum_<Pass::Quarter>(
+        pass_class,
+        "Quarter",
+        R"doc(
+            The quarter of the `Pass`.
+        )doc"
+    )
+
+        .value("Undefined", Pass::Quarter::Undefined, "Undefined")
+        .value("First", Pass::Quarter::First, "First")
+        .value("Second", Pass::Quarter::Second, "Second")
+        .value("Third", Pass::Quarter::Third, "Third")
+        .value("Fourth", Pass::Quarter::Fourth, "Fourth")
+
+        ;
+
     pass_class
 
         .def(
@@ -168,50 +212,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             )doc",
             arg("quarter")
         )
-
-        ;
-
-    enum_<Pass::Type>(
-        pass_class,
-        "Type",
-        R"doc(
-            The type of `Pass`.
-        )doc"
-    )
-
-        .value("Undefined", Pass::Type::Undefined, "Undefined")
-        .value("Complete", Pass::Type::Complete, "Complete")
-        .value("Partial", Pass::Type::Partial, "Partial")
-
-        ;
-
-    enum_<Pass::Phase>(
-        pass_class,
-        "Phase",
-        R"doc(
-            The phase of the `Pass`.
-        )doc"
-    )
-
-        .value("Undefined", Pass::Phase::Undefined, "Undefined")
-        .value("Ascending", Pass::Phase::Ascending, "Ascending")
-        .value("Descending", Pass::Phase::Descending, "Descending")
-
-        ;
-
-    enum_<Pass::Quarter>(
-        pass_class,
-        "Quarter",
-        R"doc(
-            The quarter of the `Pass`.
-        )doc"
-    )
-
-        .value("Undefined", Pass::Quarter::Undefined, "Undefined")
-        .value("First", Pass::Quarter::First, "First")
-        .value("Second", Pass::Quarter::Second, "Second")
-        .value("Third", Pass::Quarter::Third, "Third")
-        .value("Fourth", Pass::Quarter::Fourth, "Fourth")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
@@ -156,9 +156,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
 
                 Returns:
                     Pass: The undefined pass.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -172,9 +169,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
 
                 Returns:
                     str: The string representation of the pass type.
-
-                Group:
-                    Static methods
             )doc",
             arg("type")
         )
@@ -189,9 +183,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
 
                 Returns:
                     str: The string representation of the pass phase.
-
-                Group:
-                    Static methods
             )doc",
             arg("phase")
         )
@@ -206,9 +197,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
 
                 Returns:
                     str: The string representation of the pass quarter.
-
-                Group:
-                    Static methods
             )doc",
             arg("quarter")
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
@@ -47,13 +47,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
         .def("__str__", &(shiftToString<Pass>))
         .def("__repr__", &(shiftToString<Pass>))
 
-        .def("is_defined", &Pass::isDefined, R"doc(
-            Check if the pass is defined.
+        .def(
+            "is_defined",
+            &Pass::isDefined,
+            R"doc(
+                Check if the pass is defined.
 
-            Returns:
-                bool: True if the pass is defined, False otherwise.
+                Returns:
+                    bool: True if the pass is defined, False otherwise.
 
-        )doc")
+            )doc"
+        )
         .def(
             "is_complete",
             &Pass::isComplete,

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
@@ -19,39 +19,181 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
     using ostk::astro::trajectory::Propagator;
     using ostk::astro::trajectory::State;
 
-    class_<Propagator>(aModule, "Propagator")
+    class_<Propagator>(
+        aModule,
+        "Propagator",
+        R"mydelimiter(
+            A `Propagator` that proapgates the provided `State` using it's `NumericalSolver` under the set `Dynamics`.
+
+            Group:
+                trajectory
+        )mydelimiter"
+    )
 
         .def(
             init<const NumericalSolver&, const Array<Shared<Dynamics>>&>(),
             arg("numerical_solver"),
-            arg("dynamics") = Array<Shared<Dynamics>>::Empty()
+            arg("dynamics") = Array<Shared<Dynamics>>::Empty(),
+            R"mydelimiter(
+                Construct a new `Propagator` object.
+
+                Args:
+                    numerical_solver (NumericalSolver) The numerical solver.
+                    dynamics (Array[Shared[Dynamics]], optional) The dynamics.
+
+                Returns:
+                    Propagator: The new `Propagator` object.
+
+            )mydelimiter"
         )
 
         .def("__str__", &(shiftToString<Propagator>))
         .def("__repr__", &(shiftToString<Propagator>))
 
-        .def("is_defined", &Propagator::isDefined)
+        .def("is_defined", &Propagator::isDefined,
+            R"mydelimiter(
+                Check if the propagator is defined.
 
-        .def("access_numerical_solver", &Propagator::accessNumericalSolver)
+                Returns:
+                    bool: True if the propagator is defined, False otherwise.
 
-        .def("get_number_of_coordinates", &Propagator::getNumberOfCoordinates)
-        .def("get_dynamics", &Propagator::getDynamics)
-        .def("set_dynamics", &Propagator::setDynamics, arg("dynamics"))
-        .def("add_dynamics", &Propagator::addDynamics, arg("dynamics"))
-        .def("clear_dynamics", &Propagator::clearDynamics)
+            )mydelimiter"
+        )
 
-        .def("calculate_state_at", &Propagator::calculateStateAt, arg("state"), arg("instant"))
+        .def("access_numerical_solver", &Propagator::accessNumericalSolver,
+            R"mydelimiter(
+                Access the numerical solver.
+
+                Returns:
+                    NumericalSolver&: The numerical solver.
+
+            )mydelimiter"
+        )
+
+        .def("get_number_of_coordinates", &Propagator::getNumberOfCoordinates,
+            R"mydelimiter(
+                Get the number of coordinates.
+
+                Returns:
+                    int: The number of coordinates.
+                
+            )mydelimiter"
+        )
+        .def("get_dynamics", &Propagator::getDynamics,
+            R"mydelimiter(
+                Get the dynamics.
+
+                Returns:
+                    Array[Shared[Dynamics]]: The dynamics.
+                
+            )mydelimiter"
+        )
+        .def("set_dynamics", &Propagator::setDynamics, arg("dynamics"),
+            R"mydelimiter(
+                Set the dynamics.
+
+                Args:
+                    dynamics (Array[Shared[Dynamics]]) The dynamics.
+                
+            )mydelimiter"
+        )
+        .def("add_dynamics", &Propagator::addDynamics, arg("dynamics"),
+            R"mydelimiter(
+                Add dynamics.
+
+                Args:
+                    dynamics (Shared[Dynamics]) The dynamics.
+                
+            )mydelimiter"
+        )
+        .def("clear_dynamics", &Propagator::clearDynamics,
+            R"mydelimiter(
+                Clear the dynamics.
+            
+            )mydelimiter"
+        )
+
+        .def("calculate_state_at", &Propagator::calculateStateAt, arg("state"), arg("instant"),
+            R"mydelimiter(
+                Calculate the state at a given instant.
+
+                Args:
+                    state (State) The state.
+                    instant (Instant) The instant.
+
+                Returns:
+                    State: The state at the given instant.
+                
+            )mydelimiter"
+        )
         .def(
             "calculate_state_to_condition",
             &Propagator::calculateStateToCondition,
             arg("state"),
             arg("instant"),
-            arg("event_condition")
+            arg("event_condition"),
+            R"mydelimiter(
+                Calculate the state up to a given event condition.
+
+                Args:
+                    state (State) The state.
+                    instant (Instant) The instant.
+                    event_condition (EventCondition) The event condition.
+
+                Returns:
+                    State: The state up to the given event condition.
+                
+            )mydelimiter"
         )
 
-        .def("calculate_states_at", &Propagator::calculateStatesAt, arg("state"), arg("instant_array"))
+        .def("calculate_states_at", &Propagator::calculateStatesAt, arg("state"), arg("instant_array"),
+            R"mydelimiter(
+                Calculate the states at given instants.
 
-        .def_static("default", overload_cast<>(&Propagator::Default))
-        .def_static("default", overload_cast<const Environment&>(&Propagator::Default), arg("environment"))
-        .def_static("from_environment", &Propagator::FromEnvironment, arg("numerical_solver"), arg("environment"));
+                Args:
+                    state (State) The state.
+                    instant_array (Array[Instant]) The instants.
+
+                Returns:
+                    Array[State]: The states at the given instants.
+                
+            )mydelimiter"
+        )
+
+        .def_static("default", overload_cast<>(&Propagator::Default),
+            R"mydelimiter(
+                Get the default propagator.
+
+                Returns:
+                    Propagator: The default propagator.
+                
+            )mydelimiter"
+        )
+        .def_static("default", overload_cast<const Environment&>(&Propagator::Default), arg("environment"),
+            R"mydelimiter(
+                Get the default propagator for a given environment.
+
+                Args:
+                    environment (Environment) The environment.
+
+                Returns:
+                    Propagator: The default propagator for the given environment.
+                
+            )mydelimiter"
+        )
+        .def_static("from_environment", &Propagator::FromEnvironment, arg("numerical_solver"), arg("environment"),
+            R"mydelimiter(
+                Create a propagator from an environment.
+
+                Args:
+                    numerical_solver (NumericalSolver) The numerical solver.
+                    environment (Environment) The environment.
+
+                Returns:
+                    Propagator: The propagator.
+
+                Group:
+                    Static methods
+            )mydelimiter"
+        );
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
@@ -192,7 +192,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
 
                 Returns:
                     Propagator: The default propagator.
-                
             )doc"
         )
         .def_static(
@@ -207,7 +206,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
 
                 Returns:
                     Propagator: The default propagator for the given environment.
-                
             )doc"
         )
         .def_static(
@@ -224,9 +222,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
 
                 Returns:
                     Propagator: The propagator.
-
-                Group:
-                    Static methods
             )doc"
         );
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
@@ -22,99 +22,119 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
     class_<Propagator>(
         aModule,
         "Propagator",
-        R"mydelimiter(
+        R"doc(
             A `Propagator` that proapgates the provided `State` using it's `NumericalSolver` under the set `Dynamics`.
 
             Group:
                 trajectory
-        )mydelimiter"
+        )doc"
     )
 
         .def(
             init<const NumericalSolver&, const Array<Shared<Dynamics>>&>(),
             arg("numerical_solver"),
             arg("dynamics") = Array<Shared<Dynamics>>::Empty(),
-            R"mydelimiter(
+            R"doc(
                 Construct a new `Propagator` object.
 
                 Args:
                     numerical_solver (NumericalSolver) The numerical solver.
-                    dynamics (Array[Shared[Dynamics]], optional) The dynamics.
+                    dynamics (list[Dynamics], optional) The dynamics.
 
                 Returns:
                     Propagator: The new `Propagator` object.
 
-            )mydelimiter"
+            )doc"
         )
 
         .def("__str__", &(shiftToString<Propagator>))
         .def("__repr__", &(shiftToString<Propagator>))
 
-        .def("is_defined", &Propagator::isDefined,
-            R"mydelimiter(
+        .def(
+            "is_defined",
+            &Propagator::isDefined,
+            R"doc(
                 Check if the propagator is defined.
 
                 Returns:
                     bool: True if the propagator is defined, False otherwise.
 
-            )mydelimiter"
+            )doc"
         )
 
-        .def("access_numerical_solver", &Propagator::accessNumericalSolver,
-            R"mydelimiter(
+        .def(
+            "access_numerical_solver",
+            &Propagator::accessNumericalSolver,
+            R"doc(
                 Access the numerical solver.
 
                 Returns:
                     NumericalSolver&: The numerical solver.
 
-            )mydelimiter"
+            )doc"
         )
 
-        .def("get_number_of_coordinates", &Propagator::getNumberOfCoordinates,
-            R"mydelimiter(
+        .def(
+            "get_number_of_coordinates",
+            &Propagator::getNumberOfCoordinates,
+            R"doc(
                 Get the number of coordinates.
 
                 Returns:
                     int: The number of coordinates.
                 
-            )mydelimiter"
+            )doc"
         )
-        .def("get_dynamics", &Propagator::getDynamics,
-            R"mydelimiter(
+        .def(
+            "get_dynamics",
+            &Propagator::getDynamics,
+            R"doc(
                 Get the dynamics.
 
                 Returns:
-                    Array[Shared[Dynamics]]: The dynamics.
+                    list[Dynamics]: The dynamics.
                 
-            )mydelimiter"
+            )doc"
         )
-        .def("set_dynamics", &Propagator::setDynamics, arg("dynamics"),
-            R"mydelimiter(
+        .def(
+            "set_dynamics",
+            &Propagator::setDynamics,
+            arg("dynamics"),
+            R"doc(
                 Set the dynamics.
 
                 Args:
-                    dynamics (Array[Shared[Dynamics]]) The dynamics.
+                    dynamics (list[Dynamics]) The dynamics.
                 
-            )mydelimiter"
+            )doc"
         )
-        .def("add_dynamics", &Propagator::addDynamics, arg("dynamics"),
-            R"mydelimiter(
+        .def(
+            "add_dynamics",
+            &Propagator::addDynamics,
+            arg("dynamics"),
+            R"doc(
                 Add dynamics.
 
                 Args:
-                    dynamics (Shared[Dynamics]) The dynamics.
+                    dynamics (Dynamics) The dynamics.
                 
-            )mydelimiter"
+            )doc"
         )
-        .def("clear_dynamics", &Propagator::clearDynamics,
-            R"mydelimiter(
+        .def(
+            "clear_dynamics",
+            &Propagator::clearDynamics,
+            R"doc(
                 Clear the dynamics.
             
-            )mydelimiter"
+            )doc"
         )
 
-        .def("calculate_state_at", &Propagator::calculateStateAt, arg("state"), arg("instant"),
-            R"mydelimiter(
+        .def(
+            "calculate_state_at",
+            &Propagator::calculateStateAt,
+            arg("state"),
+            arg("instant"),
+            R"doc(
                 Calculate the state at a given instant.
 
                 Args:
@@ -124,7 +144,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
                 Returns:
                     State: The state at the given instant.
                 
-            )mydelimiter"
+            )doc"
         )
         .def(
             "calculate_state_to_condition",
@@ -132,7 +152,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
             arg("state"),
             arg("instant"),
             arg("event_condition"),
-            R"mydelimiter(
+            R"doc(
                 Calculate the state up to a given event condition.
 
                 Args:
@@ -143,34 +163,43 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
                 Returns:
                     State: The state up to the given event condition.
                 
-            )mydelimiter"
+            )doc"
         )
 
-        .def("calculate_states_at", &Propagator::calculateStatesAt, arg("state"), arg("instant_array"),
-            R"mydelimiter(
+        .def(
+            "calculate_states_at",
+            &Propagator::calculateStatesAt,
+            arg("state"),
+            arg("instant_array"),
+            R"doc(
                 Calculate the states at given instants.
 
                 Args:
                     state (State) The state.
-                    instant_array (Array[Instant]) The instants.
+                    instant_array (list[Instant]) The instants.
 
                 Returns:
-                    Array[State]: The states at the given instants.
+                    list[State]: The states at the given instants.
                 
-            )mydelimiter"
+            )doc"
         )
 
-        .def_static("default", overload_cast<>(&Propagator::Default),
-            R"mydelimiter(
+        .def_static(
+            "default",
+            overload_cast<>(&Propagator::Default),
+            R"doc(
                 Get the default propagator.
 
                 Returns:
                     Propagator: The default propagator.
                 
-            )mydelimiter"
+            )doc"
         )
-        .def_static("default", overload_cast<const Environment&>(&Propagator::Default), arg("environment"),
-            R"mydelimiter(
+        .def_static(
+            "default",
+            overload_cast<const Environment&>(&Propagator::Default),
+            arg("environment"),
+            R"doc(
                 Get the default propagator for a given environment.
 
                 Args:
@@ -179,10 +208,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
                 Returns:
                     Propagator: The default propagator for the given environment.
                 
-            )mydelimiter"
+            )doc"
         )
-        .def_static("from_environment", &Propagator::FromEnvironment, arg("numerical_solver"), arg("environment"),
-            R"mydelimiter(
+        .def_static(
+            "from_environment",
+            &Propagator::FromEnvironment,
+            arg("numerical_solver"),
+            arg("environment"),
+            R"doc(
                 Create a propagator from an environment.
 
                 Args:
@@ -194,6 +227,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
 
                 Group:
                     Static methods
-            )mydelimiter"
+            )doc"
         );
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -16,47 +16,203 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
     using ostk::astro::trajectory::Segment;
     using ostk::astro::Dynamics;
 
-    class_<Segment::Solution>(aModule, "SegmentSolution")
+    class_<Segment::Solution>(
+        aModule,
+        "SegmentSolution",
+        R"doc(
+            The Solution object returned when a `Segment` is solved.
+
+            Group:
+                trajectory
+        )doc"
+    )
 
         .def("__str__", &(shiftToString<Segment::Solution>))
         .def("__repr__", &(shiftToString<Segment::Solution>))
 
-        .def_readonly("name", &Segment::Solution::name)
-        .def_readonly("dynamics", &Segment::Solution::dynamics)
-        .def_readonly("states", &Segment::Solution::states)
-        .def_readonly("condition_is_satisfied", &Segment::Solution::conditionIsSatisfied)
-        .def_readonly("segment_type", &Segment::Solution::segmentType)
+        .def_readonly("name", &Segment::Solution::name,
+            R"doc(
+                The name of the segment.
 
-        .def("access_start_instant", &Segment::Solution::accessStartInstant)
-        .def("access_end_instant", &Segment::Solution::accessEndInstant)
+                :type: str
+            )doc")
+        .def_readonly("dynamics", &Segment::Solution::dynamics,
+            R"doc(
+                The dynamics.
 
-        .def("get_initial_mass", &Segment::Solution::getInitialMass)
-        .def("get_final_mass", &Segment::Solution::getFinalMass)
-        .def("get_propagation_duration", &Segment::Solution::getPropagationDuration)
+                :type: Dynamics
+            )doc")
+        .def_readonly("states", &Segment::Solution::states,
+            R"doc(
+                The states.
 
-        .def("compute_delta_mass", &Segment::Solution::computeDeltaMass)
-        .def("compute_delta_v", &Segment::Solution::computeDeltaV, arg("specific_impulse"))
+                :type: List[State]
+            )doc")
+        .def_readonly("condition_is_satisfied", &Segment::Solution::conditionIsSatisfied,
+            R"doc(
+                Whether the event condition is satisfied.
+
+                :type: bool
+            )doc")
+        .def_readonly("segment_type", &Segment::Solution::segmentType,
+            R"doc(
+                The type of the segment.
+
+                :type: Type
+            )doc")
+
+        .def("access_start_instant", &Segment::Solution::accessStartInstant,
+            R"doc(
+                Get the instant at which the segment starts.
+
+                Returns:
+                    Instant: The instant at which the segment starts.
+
+            )doc")
+        .def("access_end_instant", &Segment::Solution::accessEndInstant,
+            R"doc(
+                Get the instant at which the segment ends.
+
+                Returns:
+                    Instant: The instant at which the segment ends.
+
+            )doc")
+
+        .def("get_initial_mass", &Segment::Solution::getInitialMass,
+            R"doc(
+                Get the initial mass.
+
+                Returns:
+                    Mass: The initial mass.
+
+            )doc")
+        .def("get_final_mass", &Segment::Solution::getFinalMass,
+            R"doc(
+                Get the final mass.
+
+                Returns:
+                    Mass: The final mass.
+
+            )doc")
+        .def("get_propagation_duration", &Segment::Solution::getPropagationDuration,
+            R"doc(
+                Get the propagation duration.
+
+                Returns:
+                    Duration: The propagation duration.
+
+            )doc")
+
+        .def("compute_delta_mass", &Segment::Solution::computeDeltaMass,
+            R"doc(
+                Compute the delta mass.
+
+                Returns:
+                    Mass: The delta mass.
+
+            )doc")
+        .def("compute_delta_v", &Segment::Solution::computeDeltaV, arg("specific_impulse"),
+            R"doc(
+                Compute the delta V.
+
+                Args:
+                    specific_impulse (float): The specific impulse.
+
+                Returns:
+                    float: The delta V.
+
+            )doc")
 
         ;
 
     {
-        class_<Segment> segment(aModule, "Segment");
+        class_<Segment> segment(
+            aModule,
+            "Segment",
+            R"doc(
+                A `Segment` that can be solved provided an initial `State` and termination `Event Condition`.
+
+                Group:
+                    trajectory
+            )doc"
+        );
 
         segment
 
             .def("__str__", &(shiftToString<Segment>))
             .def("__repr__", &(shiftToString<Segment>))
 
-            .def("get_name", &Segment::getName)
-            .def("get_event_condition", &Segment::getEventCondition)
-            .def("get_dynamics", &Segment::getDynamics)
-            .def("get_numerical_solver", &Segment::getNumericalSolver)
-            .def("get_type", &Segment::getType)
+            .def("get_name", &Segment::getName,
+                R"doc(
+                    Get the name of the segment.
 
-            .def("solve", &Segment::solve, arg("state"), arg("maximum_propagation_duration") = Duration::Days(30.0))
+                    Returns:
+                        str: The name of the segment.
+
+                )doc")
+            .def("get_event_condition", &Segment::getEventCondition,
+                R"doc(
+                    Get the event condition.
+
+                    Returns:
+                        EventCondition: The event condition.
+
+                )doc")
+            .def("get_dynamics", &Segment::getDynamics,
+                R"doc(
+                    Get the dynamics.
+
+                    Returns:
+                        Dynamics: The dynamics.
+
+                )doc")
+            .def("get_numerical_solver", &Segment::getNumericalSolver,
+                R"doc(
+                    Get the numerical solver.
+
+                    Returns:
+                        NumericalSolver: The numerical solver.
+
+                )doc")
+            .def("get_type", &Segment::getType,
+                R"doc(
+                    Get the type of the segment.
+
+                    Returns:
+                        Type: The type of the segment.
+
+                )doc")
+
+            .def("solve", &Segment::solve, arg("state"), arg("maximum_propagation_duration") = Duration::Days(30.0),
+                R"doc(
+                    Solve the segment.
+
+                    Args:
+                        state (State): The state.
+                        maximum_propagation_duration (Duration, optional): The maximum propagation duration.
+
+                    Returns:
+                        SegmentSolution: The segment solution.
+
+                )doc")
 
             .def_static(
-                "coast", &Segment::Coast, arg("name"), arg("event_condition"), arg("dynamics"), arg("numerical_solver")
+                "coast", &Segment::Coast, arg("name"), arg("event_condition"), arg("dynamics"), arg("numerical_solver"),
+                R"doc(
+                    Create a coast segment.
+
+                    Args:
+                        name (str): The name of the segment.
+                        event_condition (EventCondition): The event condition.
+                        dynamics (Dynamics): The dynamics.
+                        numerical_solver (NumericalSolver): The numerical solver.
+
+                    Returns:
+                        Segment: The coast segment.
+
+                    Group:
+                        Static methods
+                )doc"
             )
 
             .def_static(
@@ -66,15 +222,43 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
                 arg("event_condition"),
                 arg("thruster_dynamics"),
                 arg("dynamics"),
-                arg("numerical_solver")
+                arg("numerical_solver"),
+                R"doc(
+                    Create a maneuver segment.
+
+                    Args:
+                        name (str): The name of the segment.
+                        event_condition (EventCondition): The event condition.
+                        thruster_dynamics (ThrusterDynamics): The thruster dynamics.
+                        dynamics (Dynamics): The dynamics.
+                        numerical_solver (NumericalSolver): The numerical solver.
+
+                    Returns:
+                        Segment: The maneuver segment.
+
+                    Group:
+                        Static methods
+                )doc"
             )
 
             ;
 
         enum_<Segment::Type>(segment, "Type")
 
-            .value("Coast", Segment::Type::Coast)
-            .value("Maneuver", Segment::Type::Maneuver)
+            .value(
+                "Coast",
+                Segment::Type::Coast,
+                R"doc(
+                    The coast segment type.
+                )doc"
+            )
+            .value(
+                "Maneuver",
+                Segment::Type::Maneuver,
+                R"doc(
+                    The maneuver segment type.
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -284,9 +284,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
 
                     Returns:
                         Segment: The coast segment.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 
@@ -310,9 +307,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
 
                     Returns:
                         Segment: The maneuver segment.
-
-                    Group:
-                        Static methods
                 )doc"
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -174,6 +174,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
             )doc"
         );
 
+        enum_<Segment::Type>(
+            segment,
+            "Type",
+            R"doc(
+                Segment type.
+            )doc"
+        )
+
+            .value("Coast", Segment::Type::Coast, "Coast")
+            .value("Maneuver", Segment::Type::Maneuver, "Maneuver")
+
+            ;
+
         segment
 
             .def("__str__", &(shiftToString<Segment>))
@@ -302,19 +315,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
                         Static methods
                 )doc"
             )
-
-            ;
-
-        enum_<Segment::Type>(
-            segment,
-            "Type",
-            R"doc(
-                Segment type.
-            )doc"
-        )
-
-            .value("Coast", Segment::Type::Coast, "Coast")
-            .value("Maneuver", Segment::Type::Maneuver, "Maneuver")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -54,7 +54,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
             R"doc(
                 The states.
 
-                :type: List[State]
+                :type: list[State]
             )doc"
         )
         .def_readonly(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -30,88 +30,124 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
         .def("__str__", &(shiftToString<Segment::Solution>))
         .def("__repr__", &(shiftToString<Segment::Solution>))
 
-        .def_readonly("name", &Segment::Solution::name,
+        .def_readonly(
+            "name",
+            &Segment::Solution::name,
             R"doc(
                 The name of the segment.
 
                 :type: str
-            )doc")
-        .def_readonly("dynamics", &Segment::Solution::dynamics,
+            )doc"
+        )
+        .def_readonly(
+            "dynamics",
+            &Segment::Solution::dynamics,
             R"doc(
                 The dynamics.
 
                 :type: Dynamics
-            )doc")
-        .def_readonly("states", &Segment::Solution::states,
+            )doc"
+        )
+        .def_readonly(
+            "states",
+            &Segment::Solution::states,
             R"doc(
                 The states.
 
                 :type: List[State]
-            )doc")
-        .def_readonly("condition_is_satisfied", &Segment::Solution::conditionIsSatisfied,
+            )doc"
+        )
+        .def_readonly(
+            "condition_is_satisfied",
+            &Segment::Solution::conditionIsSatisfied,
             R"doc(
                 Whether the event condition is satisfied.
 
                 :type: bool
-            )doc")
-        .def_readonly("segment_type", &Segment::Solution::segmentType,
+            )doc"
+        )
+        .def_readonly(
+            "segment_type",
+            &Segment::Solution::segmentType,
             R"doc(
                 The type of the segment.
 
                 :type: Type
-            )doc")
+            )doc"
+        )
 
-        .def("access_start_instant", &Segment::Solution::accessStartInstant,
+        .def(
+            "access_start_instant",
+            &Segment::Solution::accessStartInstant,
             R"doc(
                 Get the instant at which the segment starts.
 
                 Returns:
                     Instant: The instant at which the segment starts.
 
-            )doc")
-        .def("access_end_instant", &Segment::Solution::accessEndInstant,
+            )doc"
+        )
+        .def(
+            "access_end_instant",
+            &Segment::Solution::accessEndInstant,
             R"doc(
                 Get the instant at which the segment ends.
 
                 Returns:
                     Instant: The instant at which the segment ends.
 
-            )doc")
+            )doc"
+        )
 
-        .def("get_initial_mass", &Segment::Solution::getInitialMass,
+        .def(
+            "get_initial_mass",
+            &Segment::Solution::getInitialMass,
             R"doc(
                 Get the initial mass.
 
                 Returns:
                     Mass: The initial mass.
 
-            )doc")
-        .def("get_final_mass", &Segment::Solution::getFinalMass,
+            )doc"
+        )
+        .def(
+            "get_final_mass",
+            &Segment::Solution::getFinalMass,
             R"doc(
                 Get the final mass.
 
                 Returns:
                     Mass: The final mass.
 
-            )doc")
-        .def("get_propagation_duration", &Segment::Solution::getPropagationDuration,
+            )doc"
+        )
+        .def(
+            "get_propagation_duration",
+            &Segment::Solution::getPropagationDuration,
             R"doc(
                 Get the propagation duration.
 
                 Returns:
                     Duration: The propagation duration.
 
-            )doc")
+            )doc"
+        )
 
-        .def("compute_delta_mass", &Segment::Solution::computeDeltaMass,
+        .def(
+            "compute_delta_mass",
+            &Segment::Solution::computeDeltaMass,
             R"doc(
                 Compute the delta mass.
 
                 Returns:
                     Mass: The delta mass.
 
-            )doc")
-        .def("compute_delta_v", &Segment::Solution::computeDeltaV, arg("specific_impulse"),
+            )doc"
+        )
+        .def(
+            "compute_delta_v",
+            &Segment::Solution::computeDeltaV,
+            arg("specific_impulse"),
             R"doc(
                 Compute the delta V.
 
@@ -121,7 +157,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
                 Returns:
                     float: The delta V.
 
-            )doc")
+            )doc"
+        )
 
         ;
 
@@ -142,48 +179,67 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
             .def("__str__", &(shiftToString<Segment>))
             .def("__repr__", &(shiftToString<Segment>))
 
-            .def("get_name", &Segment::getName,
+            .def(
+                "get_name",
+                &Segment::getName,
                 R"doc(
                     Get the name of the segment.
 
                     Returns:
                         str: The name of the segment.
 
-                )doc")
-            .def("get_event_condition", &Segment::getEventCondition,
+                )doc"
+            )
+            .def(
+                "get_event_condition",
+                &Segment::getEventCondition,
                 R"doc(
                     Get the event condition.
 
                     Returns:
                         EventCondition: The event condition.
 
-                )doc")
-            .def("get_dynamics", &Segment::getDynamics,
+                )doc"
+            )
+            .def(
+                "get_dynamics",
+                &Segment::getDynamics,
                 R"doc(
                     Get the dynamics.
 
                     Returns:
                         Dynamics: The dynamics.
 
-                )doc")
-            .def("get_numerical_solver", &Segment::getNumericalSolver,
+                )doc"
+            )
+            .def(
+                "get_numerical_solver",
+                &Segment::getNumericalSolver,
                 R"doc(
                     Get the numerical solver.
 
                     Returns:
                         NumericalSolver: The numerical solver.
 
-                )doc")
-            .def("get_type", &Segment::getType,
+                )doc"
+            )
+            .def(
+                "get_type",
+                &Segment::getType,
                 R"doc(
                     Get the type of the segment.
 
                     Returns:
                         Type: The type of the segment.
 
-                )doc")
+                )doc"
+            )
 
-            .def("solve", &Segment::solve, arg("state"), arg("maximum_propagation_duration") = Duration::Days(30.0),
+            .def(
+                "solve",
+                &Segment::solve,
+                arg("state"),
+                arg("maximum_propagation_duration") = Duration::Days(30.0),
                 R"doc(
                     Solve the segment.
 
@@ -194,10 +250,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
                     Returns:
                         SegmentSolution: The segment solution.
 
-                )doc")
+                )doc"
+            )
 
             .def_static(
-                "coast", &Segment::Coast, arg("name"), arg("event_condition"), arg("dynamics"), arg("numerical_solver"),
+                "coast",
+                &Segment::Coast,
+                arg("name"),
+                arg("event_condition"),
+                arg("dynamics"),
+                arg("numerical_solver"),
                 R"doc(
                     Create a coast segment.
 
@@ -243,22 +305,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
 
             ;
 
-        enum_<Segment::Type>(segment, "Type")
+        enum_<Segment::Type>(
+            segment,
+            "Type",
+            R"doc(
+                Segment type.
+            )doc"
+        )
 
-            .value(
-                "Coast",
-                Segment::Type::Coast,
-                R"doc(
-                    The coast segment type.
-                )doc"
-            )
-            .value(
-                "Maneuver",
-                Segment::Type::Maneuver,
-                R"doc(
-                    The maneuver segment type.
-                )doc"
-            )
+            .value("Coast", Segment::Type::Coast, "Coast")
+            .value("Maneuver", Segment::Type::Maneuver, "Maneuver")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -19,29 +19,114 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
     using ostk::astro::Dynamics;
     using ostk::astro::flight::system::SatelliteSystem;
 
-    class_<Sequence::Solution>(aModule, "SequenceSolution")
+    class_<Sequence::Solution>(
+        aModule,
+        "SequenceSolution",
+        R"doc(
+            The Solution object that is returned when a `Sequence` is solved.
+
+            Group:
+                trajectory
+        )doc"
+    )
 
         .def("__str__", &(shiftToString<Sequence::Solution>))
         .def("__repr__", &(shiftToString<Sequence::Solution>))
 
-        .def_readonly("segment_solutions", &Sequence::Solution::segmentSolutions)
-        .def_readonly("execution_is_complete", &Sequence::Solution::executionIsComplete)
+        .def_readonly("segment_solutions", &Sequence::Solution::segmentSolutions,
+            R"doc(
+                The solutions for each segment.
 
-        .def("access_start_instant", &Sequence::Solution::accessStartInstant)
-        .def("access_end_instant", &Sequence::Solution::accessEndInstant)
+                :type: List[SegmentSolution]
+            )doc")
+        .def_readonly("execution_is_complete", &Sequence::Solution::executionIsComplete,
+            R"doc(
+                Whether the execution is complete.
 
-        .def("get_states", &Sequence::Solution::getStates)
-        .def("get_initial_mass", &Sequence::Solution::getInitialMass)
-        .def("get_final_mass", &Sequence::Solution::getFinalMass)
-        .def("get_propagation_duration", &Sequence::Solution::getPropagationDuration)
+                :type: bool
+            )doc")
 
-        .def("compute_delta_mass", &Sequence::Solution::computeDeltaMass)
-        .def("compute_delta_v", &Sequence::Solution::computeDeltaV, arg("specific_impulse"))
+        .def("access_start_instant", &Sequence::Solution::accessStartInstant,
+            R"doc(
+                Get the instant at which the access starts.
+
+                Returns:
+                    Instant: The instant at which the access starts.
+                
+            )doc")
+        .def("access_end_instant", &Sequence::Solution::accessEndInstant,
+            R"doc(
+                Get the instant at which the access ends.
+
+                Returns:
+                    Instant: The instant at which the access ends.
+
+            )doc")
+
+        .def("get_states", &Sequence::Solution::getStates,
+            R"doc(
+                Get the states.
+
+                Returns:
+                    List[State]: The states.
+
+            )doc")
+        .def("get_initial_mass", &Sequence::Solution::getInitialMass,
+            R"doc(
+                Get the initial mass.
+
+                Returns:
+                    float: The initial mass.
+            
+            )doc")
+        .def("get_final_mass", &Sequence::Solution::getFinalMass,
+            R"doc(
+                Get the final mass.
+
+                Returns:
+                    float: The final mass.
+
+            )doc")
+        .def("get_propagation_duration", &Sequence::Solution::getPropagationDuration,
+            R"doc(
+                Get the propagation duration.
+
+                Returns:
+                    Duration: The propagation duration.
+                
+            )doc")
+
+        .def("compute_delta_mass", &Sequence::Solution::computeDeltaMass,
+            R"doc(
+                Compute the delta mass.
+
+                Returns:
+                    float: The delta mass.
+                
+            )doc")
+        .def("compute_delta_v", &Sequence::Solution::computeDeltaV, arg("specific_impulse"),
+            R"doc(
+                Compute the delta V.
+
+                Args:
+                    specific_impulse (float): The specific impulse.
+
+                Returns:
+                    float: The delta V.
+                
+            )doc")
 
         ;
 
     {
-        class_<Sequence>(aModule, "Sequence")
+        class_<Sequence>(
+            aModule,
+            "Sequence",
+            R"doc(
+                A mission `Sequence`. Consists of a list of `Segment` objects and various configuration parameters.
+
+            )doc"
+        )
 
             .def(
                 init<
@@ -56,25 +141,107 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                 arg("numerical_solver") = NumericalSolver::DefaultConditional(),
                 arg("dynamics") = Array<Shared<Dynamics>>::Empty(),
                 arg("maximum_propagation_duration") = Duration::Days(30.0),
-                arg("verbosity") = 1
+                arg("verbosity") = 1,
+                R"doc(
+                    Construct a new `Sequence` object.
+
+                    Args:
+                    segments (List[Segment], optional): The segments.
+                    repetition_count (int, optional): The repetition count.
+                    numerical_solver (NumericalSolver, optional): The numerical solver.
+                    dynamics (List[Dynamics], optional): The dynamics.
+                    maximum_propagation_duration (Duration, optional): The maximum propagation duration.
+                    verbosity (int, optional): The verbosity level.
+
+                    Returns:
+                        Sequence: The new `Sequence` object.
+
+                )doc"
             )
 
             .def("__str__", &(shiftToString<Sequence>))
             .def("__repr__", &(shiftToString<Sequence>))
 
-            .def("get_segments", &Sequence::getSegments)
-            .def("get_numerical_solver", &Sequence::getNumericalSolver)
-            .def("get_dynamics", &Sequence::getDynamics)
-            .def("get_maximum_propagation_duration", &Sequence::getMaximumPropagationDuration)
+            .def("get_segments", &Sequence::getSegments,
+                R"doc(
+                    Get the segments.
 
-            .def("add_segment", overload_cast<const Segment&>(&Sequence::addSegment), arg("segment"))
-            .def("add_segment", overload_cast<const Array<Segment>&>(&Sequence::addSegment), arg("segments"))
-            .def("add_coast_segment", &Sequence::addCoastSegment, arg("event_condition"))
+                    Returns:
+                        List[Segment]: The segments.
+                    
+                )doc")
+            .def("get_numerical_solver", &Sequence::getNumericalSolver,
+                R"doc(
+                    Get the numerical solver.
+
+                    Returns:
+                        NumericalSolver: The numerical solver.
+
+                )doc")
+            .def("get_dynamics", &Sequence::getDynamics,
+                R"doc(
+                    Get the dynamics.
+
+                    Returns:
+                        List[Dynamics]: The dynamics.
+
+                )doc")
+            .def("get_maximum_propagation_duration", &Sequence::getMaximumPropagationDuration,
+                R"doc(
+                    Get the maximum propagation duration.
+
+                    Returns:
+                        Duration: The maximum propagation duration.
+                    
+                )doc")
+
+            .def("add_segment", overload_cast<const Segment&>(&Sequence::addSegment), arg("segment"),
+                R"doc(
+                    Add a segment.
+
+                    Args:
+                        segment (Segment): The segment.
+
+                )doc")
+            .def("add_segment", overload_cast<const Array<Segment>&>(&Sequence::addSegment), arg("segments"),
+                R"doc(
+                    Add segments.
+
+                    Args:
+                        segments (List[Segment]): The segments.
+
+                )doc")
+            .def("add_coast_segment", &Sequence::addCoastSegment, arg("event_condition"),
+                R"doc(
+                    Add a coast segment.
+
+                    Args:
+                        event_condition (EventCondition): The event condition.
+
+                )doc")
             .def(
-                "add_maneuver_segment", &Sequence::addManeuverSegment, arg("event_condition"), arg("thruster_dynamics")
+                "add_maneuver_segment", &Sequence::addManeuverSegment, arg("event_condition"), arg("thruster_dynamics"),
+                R"doc(
+                    Add a maneuver segment.
+
+                    Args:
+                        event_condition (EventCondition): The event condition.
+                        thruster_dynamics (ThrusterDynamics): The thruster dynamics.
+
+                )doc"
             )
 
-            .def("solve", &Sequence::solve, arg("state"))
+            .def("solve", &Sequence::solve, arg("state"),
+                R"doc(
+                    Solve the sequence.
+
+                    Args:
+                    state (State): The state.
+
+                    Returns:
+                    SequenceSolution: The sequence solution.
+
+                )doc")
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -286,7 +286,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
 
                     Args:
                         event_condition (EventCondition): The event condition.
-                        thruster_dynamics (ThrusterDynamics): The thruster dynamics.
+                        thruster_dynamics (Thruster): The thruster dynamics.
 
                 )doc"
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -33,78 +33,108 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
         .def("__str__", &(shiftToString<Sequence::Solution>))
         .def("__repr__", &(shiftToString<Sequence::Solution>))
 
-        .def_readonly("segment_solutions", &Sequence::Solution::segmentSolutions,
+        .def_readonly(
+            "segment_solutions",
+            &Sequence::Solution::segmentSolutions,
             R"doc(
                 The solutions for each segment.
 
                 :type: List[SegmentSolution]
-            )doc")
-        .def_readonly("execution_is_complete", &Sequence::Solution::executionIsComplete,
+            )doc"
+        )
+        .def_readonly(
+            "execution_is_complete",
+            &Sequence::Solution::executionIsComplete,
             R"doc(
                 Whether the execution is complete.
 
                 :type: bool
-            )doc")
+            )doc"
+        )
 
-        .def("access_start_instant", &Sequence::Solution::accessStartInstant,
+        .def(
+            "access_start_instant",
+            &Sequence::Solution::accessStartInstant,
             R"doc(
                 Get the instant at which the access starts.
 
                 Returns:
                     Instant: The instant at which the access starts.
                 
-            )doc")
-        .def("access_end_instant", &Sequence::Solution::accessEndInstant,
+            )doc"
+        )
+        .def(
+            "access_end_instant",
+            &Sequence::Solution::accessEndInstant,
             R"doc(
                 Get the instant at which the access ends.
 
                 Returns:
                     Instant: The instant at which the access ends.
 
-            )doc")
+            )doc"
+        )
 
-        .def("get_states", &Sequence::Solution::getStates,
+        .def(
+            "get_states",
+            &Sequence::Solution::getStates,
             R"doc(
                 Get the states.
 
                 Returns:
                     List[State]: The states.
 
-            )doc")
-        .def("get_initial_mass", &Sequence::Solution::getInitialMass,
+            )doc"
+        )
+        .def(
+            "get_initial_mass",
+            &Sequence::Solution::getInitialMass,
             R"doc(
                 Get the initial mass.
 
                 Returns:
                     float: The initial mass.
             
-            )doc")
-        .def("get_final_mass", &Sequence::Solution::getFinalMass,
+            )doc"
+        )
+        .def(
+            "get_final_mass",
+            &Sequence::Solution::getFinalMass,
             R"doc(
                 Get the final mass.
 
                 Returns:
                     float: The final mass.
 
-            )doc")
-        .def("get_propagation_duration", &Sequence::Solution::getPropagationDuration,
+            )doc"
+        )
+        .def(
+            "get_propagation_duration",
+            &Sequence::Solution::getPropagationDuration,
             R"doc(
                 Get the propagation duration.
 
                 Returns:
                     Duration: The propagation duration.
                 
-            )doc")
+            )doc"
+        )
 
-        .def("compute_delta_mass", &Sequence::Solution::computeDeltaMass,
+        .def(
+            "compute_delta_mass",
+            &Sequence::Solution::computeDeltaMass,
             R"doc(
                 Compute the delta mass.
 
                 Returns:
                     float: The delta mass.
                 
-            )doc")
-        .def("compute_delta_v", &Sequence::Solution::computeDeltaV, arg("specific_impulse"),
+            )doc"
+        )
+        .def(
+            "compute_delta_v",
+            &Sequence::Solution::computeDeltaV,
+            arg("specific_impulse"),
             R"doc(
                 Compute the delta V.
 
@@ -114,7 +144,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                 Returns:
                     float: The delta V.
                 
-            )doc")
+            )doc"
+        )
 
         ;
 
@@ -125,6 +156,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
             R"doc(
                 A mission `Sequence`. Consists of a list of `Segment` objects and various configuration parameters.
 
+                Group:
+                    trajectory
             )doc"
         )
 
@@ -162,65 +195,92 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
             .def("__str__", &(shiftToString<Sequence>))
             .def("__repr__", &(shiftToString<Sequence>))
 
-            .def("get_segments", &Sequence::getSegments,
+            .def(
+                "get_segments",
+                &Sequence::getSegments,
                 R"doc(
                     Get the segments.
 
                     Returns:
                         List[Segment]: The segments.
                     
-                )doc")
-            .def("get_numerical_solver", &Sequence::getNumericalSolver,
+                )doc"
+            )
+            .def(
+                "get_numerical_solver",
+                &Sequence::getNumericalSolver,
                 R"doc(
                     Get the numerical solver.
 
                     Returns:
                         NumericalSolver: The numerical solver.
 
-                )doc")
-            .def("get_dynamics", &Sequence::getDynamics,
+                )doc"
+            )
+            .def(
+                "get_dynamics",
+                &Sequence::getDynamics,
                 R"doc(
                     Get the dynamics.
 
                     Returns:
                         List[Dynamics]: The dynamics.
 
-                )doc")
-            .def("get_maximum_propagation_duration", &Sequence::getMaximumPropagationDuration,
+                )doc"
+            )
+            .def(
+                "get_maximum_propagation_duration",
+                &Sequence::getMaximumPropagationDuration,
                 R"doc(
                     Get the maximum propagation duration.
 
                     Returns:
                         Duration: The maximum propagation duration.
                     
-                )doc")
+                )doc"
+            )
 
-            .def("add_segment", overload_cast<const Segment&>(&Sequence::addSegment), arg("segment"),
+            .def(
+                "add_segment",
+                overload_cast<const Segment&>(&Sequence::addSegment),
+                arg("segment"),
                 R"doc(
                     Add a segment.
 
                     Args:
                         segment (Segment): The segment.
 
-                )doc")
-            .def("add_segment", overload_cast<const Array<Segment>&>(&Sequence::addSegment), arg("segments"),
+                )doc"
+            )
+            .def(
+                "add_segment",
+                overload_cast<const Array<Segment>&>(&Sequence::addSegment),
+                arg("segments"),
                 R"doc(
                     Add segments.
 
                     Args:
                         segments (List[Segment]): The segments.
 
-                )doc")
-            .def("add_coast_segment", &Sequence::addCoastSegment, arg("event_condition"),
+                )doc"
+            )
+            .def(
+                "add_coast_segment",
+                &Sequence::addCoastSegment,
+                arg("event_condition"),
                 R"doc(
                     Add a coast segment.
 
                     Args:
                         event_condition (EventCondition): The event condition.
 
-                )doc")
+                )doc"
+            )
             .def(
-                "add_maneuver_segment", &Sequence::addManeuverSegment, arg("event_condition"), arg("thruster_dynamics"),
+                "add_maneuver_segment",
+                &Sequence::addManeuverSegment,
+                arg("event_condition"),
+                arg("thruster_dynamics"),
                 R"doc(
                     Add a maneuver segment.
 
@@ -231,7 +291,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                 )doc"
             )
 
-            .def("solve", &Sequence::solve, arg("state"),
+            .def(
+                "solve",
+                &Sequence::solve,
+                arg("state"),
                 R"doc(
                     Solve the sequence.
 
@@ -241,7 +304,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                     Returns:
                     SequenceSolution: The sequence solution.
 
-                )doc")
+                )doc"
+            )
 
             ;
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -39,7 +39,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
             R"doc(
                 The solutions for each segment.
 
-                :type: List[SegmentSolution]
+                :type: list[SegmentSolution]
             )doc"
         )
         .def_readonly(
@@ -82,7 +82,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                 Get the states.
 
                 Returns:
-                    List[State]: The states.
+                    list[State]: The states.
 
             )doc"
         )
@@ -179,10 +179,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                     Construct a new `Sequence` object.
 
                     Args:
-                    segments (List[Segment], optional): The segments.
+                    segments (list[Segment], optional): The segments.
                     repetition_count (int, optional): The repetition count.
                     numerical_solver (NumericalSolver, optional): The numerical solver.
-                    dynamics (List[Dynamics], optional): The dynamics.
+                    dynamics (list[Dynamics], optional): The dynamics.
                     maximum_propagation_duration (Duration, optional): The maximum propagation duration.
                     verbosity (int, optional): The verbosity level.
 
@@ -202,7 +202,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                     Get the segments.
 
                     Returns:
-                        List[Segment]: The segments.
+                        list[Segment]: The segments.
                     
                 )doc"
             )
@@ -224,7 +224,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                     Get the dynamics.
 
                     Returns:
-                        List[Dynamics]: The dynamics.
+                        list[Dynamics]: The dynamics.
 
                 )doc"
             )
@@ -260,7 +260,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                     Add segments.
 
                     Args:
-                        segments (List[Segment]): The segments.
+                        segments (list[Segment]): The segments.
 
                 )doc"
             )
@@ -299,10 +299,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                     Solve the sequence.
 
                     Args:
-                    state (State): The state.
+                        state (State): The state.
 
                     Returns:
-                    SequenceSolution: The sequence solution.
+                        SequenceSolution: The sequence solution.
 
                 )doc"
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -27,7 +27,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
             This class represents the physical state of an object.
 
             Group:
-                trajectory
+                state
         )doc"
     )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -20,11 +20,42 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
     using ostk::astro::trajectory::State;
     using ostk::astro::trajectory::state::CoordinatesBroker;
 
-    class_<State>(aModule, "State")
+    class_<State>(
+        aModule,
+        "State",
+        R"doc(
+            This class represents the physical state of an object.
 
-        .def(init<const Instant&, const Position&, const Velocity&>(), arg("instant"), arg("position"), arg("velocity"))
+            Group:
+                trajectory
+        )doc"
+    )
+
+        .def(
+            init<const Instant&, const Position&, const Velocity&>(),
+            R"doc(
+                 Utility constructor for Position/Velocity only.
+                 
+                 Args:
+                     instant (Instant): An instant
+                     position (Position): The cartesian position at the instant in International System of Units
+                     velocity (Velocity): The cartesian velocity at the instant in International System of Units
+             )doc",
+            arg("instant"),
+            arg("position"),
+            arg("velocity")
+        )
         .def(
             init<const Instant&, const VectorXd&, const Shared<const Frame>&, const Shared<const CoordinatesBroker>&>(),
+            R"doc(
+                 Constructor with a pre-defined Coordinates Broker.
+                 
+                 Args:
+                     instant (Instant): An instant
+                     coordinates (numpy.ndarray): The coordinates at the instant in International System of Units
+                     frame (Frame): The reference frame in which the coordinates are referenced to and resolved in
+                     coordinates_broker (CoordinatesBroker): The coordinates broker associated to the coordinates
+             )doc",
             arg("instant"),
             arg("coordinates"),
             arg("frame"),
@@ -36,6 +67,15 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
                 const VectorXd&,
                 const Shared<const Frame>&,
                 const Array<Shared<const CoordinatesSubset>>&>(),
+            R"doc(
+                 Constructor with coordinate subsets.
+                 
+                 Args:
+                     instant (Instant): An instant
+                     coordinates (numpy.ndarray): The coordinates at the instant in International System of Units
+                     frame (Frame): The reference frame in which the coordinates are referenced to and resolved in
+                     coordinates_subsets (CoordinatesBroker): The coordinates subsets associated to the coordinates
+             )doc",
             arg("instant"),
             arg("coordinates"),
             arg("frame"),
@@ -51,31 +91,155 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
         .def("__str__", &(shiftToString<State>))
         .def("__repr__", &(shiftToString<State>))
 
-        .def("is_defined", &State::isDefined)
+        .def(
+            "is_defined",
+            &State::isDefined,
+            R"doc(
+                Check if the state is defined.
 
-        .def("get_size", &State::getSize)
-        .def("get_instant", &State::getInstant)
-        .def("get_position", &State::getPosition)
-        .def("get_velocity", &State::getVelocity)
-        .def("get_coordinates", &State::getCoordinates)
-        .def("get_coordinates_subsets", &State::getCoordinatesSubsets)
-        .def("has_subset", &State::hasSubset, arg("subset"))
-        .def("get_frame", &State::getFrame)
+                Returns:
+                    bool: True if the state is defined, False otherwise.
+            )doc"
+        )
+        .def(
+            "get_size",
+            &State::getSize,
+            R"doc(
+                Get the size of the state.
 
+                Returns:
+                    int: The size of the state.
+            )doc"
+        )
+        .def(
+            "get_instant",
+            &State::getInstant,
+            R"doc(
+                Get the instant of the state.
+
+                Returns:
+                    Instant: The instant of the state.
+            )doc"
+        )
+        .def(
+            "get_position",
+            &State::getPosition,
+            R"doc(
+                Get the position of the state.
+
+                Returns:
+                    Position: The position of the state.
+            )doc"
+        )
+        .def(
+            "get_velocity",
+            &State::getVelocity,
+            R"doc(
+                Get the velocity of the state.
+
+                Returns:
+                    Velocity: The velocity of the state.
+            )doc"
+        )
+        .def(
+            "get_coordinates",
+            &State::getCoordinates,
+            R"doc(
+                Get the coordinates of the state.
+
+                Returns:
+                    np.array: The coordinates of the state.
+            )doc"
+        )
+        .def(
+            "get_coordinates_subsets",
+            &State::getCoordinatesSubsets,
+            R"doc(
+                Get the coordinates subsets associated to the state.
+
+                Returns:
+                    list[CoordinatesSubset]: The coordinates subsets associated to the state.
+            )doc"
+        )
+        .def(
+            "get_frame",
+            &State::getFrame,
+            R"doc(
+                Get the reference frame of the state.
+
+                Returns:
+                    Frame: The reference frame of the state.
+            )doc"
+        )
+
+        .def(
+            "has_subset",
+            &State::hasSubset,
+            R"doc(
+                Check if the state has a given subset.
+
+                Args:
+                    subset (CoordinatesSubset): The subset to check.
+
+                Returns:
+                    bool: True if the state has the subset, False otherwise.
+            )doc",
+            arg("subset")
+        )
         .def(
             "extract_coordinates",
             overload_cast<const Shared<const CoordinatesSubset>&>(&State::extractCoordinates, const_),
+            R"doc(
+                Extract the coordinates associated to a subset of the state.
+
+                Args:
+                    coordinates_subset (CoordinatesSubset): The coordinates subset to extract.
+
+                Returns:
+                    np.array: The coordinates associated to the subset.
+            )doc",
             arg("coordinates_subset")
         )
         .def(
             "extract_coordinates",
             overload_cast<const Array<Shared<const CoordinatesSubset>>&>(&State::extractCoordinates, const_),
+            R"doc(
+                Extract the coordinates associated to a set of subsets of the state.
+
+                Args:
+                    coordinates_subsets (list[CoordinatesSubset]): The coordinates subsets to extract.
+
+                Returns:
+                    np.array: The coordinates associated to the subsets.
+            )doc",
             arg("coordinates_subsets")
         )
 
-        .def("in_frame", &State::inFrame, arg("frame"))
+        .def(
+            "in_frame",
+            &State::inFrame,
+            R"doc(
+                Check if the state is in a given reference frame.
 
-        .def_static("undefined", &State::Undefined)
+                Args:
+                    frame (Frame): The reference frame to check.
+
+                Returns:
+                    bool: True if the state is in the reference frame, False otherwise.
+            )doc",
+            arg("frame")
+        )
+
+        .def_static(
+            "undefined",
+            &State::Undefined,
+            R"doc(
+                Get an undefined state.
+
+                Returns:
+                    State: An undefined state.
+            )doc"
+        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State.cpp
@@ -38,8 +38,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State(pybind11::module& a
                  
                  Args:
                      instant (Instant): An instant
-                     position (Position): The cartesian position at the instant in International System of Units
-                     velocity (Velocity): The cartesian velocity at the instant in International System of Units
+                     position (Position): The cartesian position at the instant
+                     velocity (Velocity): The cartesian velocity at the instant
              )doc",
             arg("instant"),
             arg("position"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesBroker.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesBroker.cpp
@@ -28,7 +28,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 Create a broker for ther provided coordinate subsets.
 
                 Args:
-                    coordinates_subsets (List[CoordinatesSubset]): The list of coordinates subsets.
+                    List[CoordinatesSubset]: The list of coordinates subsets.
 
             )doc"
         )
@@ -43,7 +43,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 Access the list of coordinates subsets.
 
                 Returns:
-                    coordinate_subsets (List[CoordinatesSubset]): The list of coordinates subsets.
+                    List[CoordinatesSubset]: The list of coordinates subsets.
 
             )doc"
         )
@@ -54,7 +54,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 Get the total number of coordinates.
 
                 Returns:
-                    number_of_coordinates (int): The total number of coordinates.
+                    int: The total number of coordinates.
 
             )doc"
         )
@@ -65,7 +65,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 Get the number of coordinates subsets.
 
                 Returns:
-                    number_of_subsets (int): The number of coordinates subsets.
+                    int: The number of coordinates subsets.
 
             )doc"
         )
@@ -76,7 +76,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 Get the list of coordinates subsets.
 
                 Returns:
-                    coordinates_subsets (List[CoordinatesSubset]): The list of coordinates subsets.
+                    List[CoordinatesSubset]: The list of coordinates subsets.
 
             )doc"
         )
@@ -103,7 +103,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                     coordinates_subset (CoordinatesSubset): The coordinates subset to check.
 
                 Returns:
-                    has_subset (bool): True if the coordinates broker has the coordinates subset, False otherwise.
+                    bool: True if the coordinates broker has the coordinates subset, False otherwise.
 
             )doc"
         )
@@ -120,7 +120,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                     coordinates_subset (CoordinatesSubset): The coordinates subset.
 
                 Returns:
-                    coordinates (numpy.ndarray): The coordinates of the subset.
+                    numpy.ndarray: The coordinates of the subset.
 
             )doc"
         )
@@ -139,7 +139,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                     coordinates_subset (CoordinatesSubset): The coordinates subset.
 
                 Returns:
-                    coordinates (numpy.ndarray): The coordinates of the subset.
+                    numpy.ndarray: The coordinates of the subset.
 
             )doc"
         )
@@ -158,7 +158,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                     coordinates_subsets (List[CoordinatesSubset]): The coordinates subsets.
 
                 Returns:
-                    coordinates (numpy.ndarray): The coordinates of the subsets.
+                    numpy.ndarray: The coordinates of the subsets.
 
             )doc"
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesBroker.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesBroker.cpp
@@ -13,7 +13,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
     using ostk::astro::trajectory::state::CoordinatesBroker;
     using ostk::astro::trajectory::state::CoordinatesSubset;
 
-    class_<CoordinatesBroker, Shared<CoordinatesBroker>>(aModule, "CoordinatesBroker")
+    class_<CoordinatesBroker, Shared<CoordinatesBroker>>(
+        aModule,
+        "CoordinatesBroker",
+        R"doc(
+            Class to manage the coordinates subsets of a state.
+        
+            Group:
+                state
+        )doc"
+    )
 
         .def(
             init<>(),
@@ -28,7 +37,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 Create a broker for ther provided coordinate subsets.
 
                 Args:
-                    List[CoordinatesSubset]: The list of coordinates subsets.
+                    list[CoordinatesSubset]: The list of coordinates subsets.
 
             )doc"
         )
@@ -43,7 +52,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 Access the list of coordinates subsets.
 
                 Returns:
-                    List[CoordinatesSubset]: The list of coordinates subsets.
+                    list[CoordinatesSubset]: The list of coordinates subsets.
 
             )doc"
         )
@@ -76,7 +85,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 Get the list of coordinates subsets.
 
                 Returns:
-                    List[CoordinatesSubset]: The list of coordinates subsets.
+                    list[CoordinatesSubset]: The list of coordinates subsets.
 
             )doc"
         )
@@ -155,7 +164,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
 
                 Args:
                     coordinates (numpy.ndarray): The full coordinates vector.
-                    coordinates_subsets (List[CoordinatesSubset]): The coordinates subsets.
+                    coordinates_subsets (list[CoordinatesSubset]): The coordinates subsets.
 
                 Returns:
                     numpy.ndarray: The coordinates of the subsets.

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesBroker.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesBroker.cpp
@@ -15,27 +15,114 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
 
     class_<CoordinatesBroker, Shared<CoordinatesBroker>>(aModule, "CoordinatesBroker")
 
-        .def(init<>())
-        .def(init<const Array<Shared<const CoordinatesSubset>>&>(), arg("coordinates_subsets"))
+        .def(
+            init<>(),
+            R"doc(
+                Default constructor.
+            )doc"
+        )
+        .def(
+            init<const Array<Shared<const CoordinatesSubset>>&>(),
+            arg("coordinates_subsets"),
+            R"doc(
+                Create a broker for ther provided coordinate subsets.
+
+                Args:
+                    coordinates_subsets (List[CoordinatesSubset]): The list of coordinates subsets.
+
+            )doc"
+        )
 
         .def(self == self)
         .def(self != self)
 
-        .def("access_subsets", &CoordinatesBroker::accessSubsets)
-        .def("get_number_of_coordinates", &CoordinatesBroker::getNumberOfCoordinates)
-        .def("get_number_of_subsets", &CoordinatesBroker::getNumberOfSubsets)
-        .def("get_subsets", &CoordinatesBroker::getSubsets)
-        .def("add_subset", &CoordinatesBroker::addSubset, arg("coordinates_subset"))
+        .def(
+            "access_subsets",
+            &CoordinatesBroker::accessSubsets,
+            R"doc(
+                Access the list of coordinates subsets.
+
+                Returns:
+                    coordinate_subsets (List[CoordinatesSubset]): The list of coordinates subsets.
+
+            )doc"
+        )
+        .def(
+            "get_number_of_coordinates",
+            &CoordinatesBroker::getNumberOfCoordinates,
+            R"doc(
+                Get the total number of coordinates.
+
+                Returns:
+                    number_of_coordinates (int): The total number of coordinates.
+
+            )doc"
+        )
+        .def(
+            "get_number_of_subsets",
+            &CoordinatesBroker::getNumberOfSubsets,
+            R"doc(
+                Get the number of coordinates subsets.
+
+                Returns:
+                    number_of_subsets (int): The number of coordinates subsets.
+
+            )doc"
+        )
+        .def(
+            "get_subsets",
+            &CoordinatesBroker::getSubsets,
+            R"doc(
+                Get the list of coordinates subsets.
+
+                Returns:
+                    coordinates_subsets (List[CoordinatesSubset]): The list of coordinates subsets.
+
+            )doc"
+        )
+        .def(
+            "add_subset",
+            &CoordinatesBroker::addSubset,
+            R"doc(
+                Add a coordinates subset.
+
+                Args:
+                    coordinates_subset (CoordinatesSubset): The coordinates subset to add.
+
+            )doc",
+            arg("coordinates_subset")
+        )
         .def(
             "has_subset",
             overload_cast<const Shared<const CoordinatesSubset>&>(&CoordinatesBroker::hasSubset, const_),
-            arg("coordinates_subset")
+            arg("coordinates_subset"),
+            R"doc(
+                Check if the coordinates broker has a given coordinates subset.
+
+                Args:
+                    coordinates_subset (CoordinatesSubset): The coordinates subset to check.
+
+                Returns:
+                    has_subset (bool): True if the coordinates broker has the coordinates subset, False otherwise.
+
+            )doc"
         )
         .def(
             "extract_coordinates",
             overload_cast<const VectorXd&, const CoordinatesSubset&>(&CoordinatesBroker::extractCoordinates, const_),
             arg("coordinates"),
-            arg("coordinates_subset")
+            arg("coordinates_subset"),
+            R"doc(
+                Extract the coordinates of a subset from a full coordinates vector.
+
+                Args:
+                    coordinates (numpy.ndarray): The full coordinates vector.
+                    coordinates_subset (CoordinatesSubset): The coordinates subset.
+
+                Returns:
+                    coordinates (numpy.ndarray): The coordinates of the subset.
+
+            )doc"
         )
         .def(
             "extract_coordinates",
@@ -43,7 +130,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 &CoordinatesBroker::extractCoordinates, const_
             ),
             arg("coordinates"),
-            arg("coordinates_subset")
+            arg("coordinates_subset"),
+            R"doc(
+                Extract the coordinates of a subset from a full coordinates vector.
+
+                Args:
+                    coordinates (numpy.ndarray): The full coordinates vector.
+                    coordinates_subset (CoordinatesSubset): The coordinates subset.
+
+                Returns:
+                    coordinates (numpy.ndarray): The coordinates of the subset.
+
+            )doc"
         )
         .def(
             "extract_coordinates",
@@ -51,7 +149,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesBroker(p
                 &CoordinatesBroker::extractCoordinates, const_
             ),
             arg("coordinates"),
-            arg("coordinates_subsets")
+            arg("coordinates_subsets"),
+            R"doc(
+                Extract the coordinates of multiple subsets from a full coordinates vector.
+
+                Args:
+                    coordinates (numpy.ndarray): The full coordinates vector.
+                    coordinates_subsets (List[CoordinatesSubset]): The coordinates subsets.
+
+                Returns:
+                    coordinates (numpy.ndarray): The coordinates of the subsets.
+
+            )doc"
         )
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubset.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubset.cpp
@@ -85,20 +85,85 @@ class PyCoordinatesSubset : public CoordinatesSubset
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(pybind11::module& aModule)
 {
-    class_<CoordinatesSubset, PyCoordinatesSubset, Shared<CoordinatesSubset>>(aModule, "CoordinatesSubset")
+    class_<CoordinatesSubset, PyCoordinatesSubset, Shared<CoordinatesSubset>>(
+        aModule,
+        "CoordinatesSubset",
+        R"doc(
+            State coordinates subset. It contains information related to a particular group of coordinates. It does not
+            contain the coordinate values.
 
-        .def(init<const String&, const Size&>(), arg("name"), arg("size"))
+
+
+            Group:
+                State
+        )doc"
+    )
+
+        .def(
+            init<const String&, const Size&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    name (str): The name of the coordinates subset.
+                    size (int): The size of the coordinates subset.
+
+            )doc",
+            arg("name"),
+            arg("size")
+        )
 
         .def("__eq__", &CoordinatesSubset::operator==)
         .def("__ne__", &CoordinatesSubset::operator!=)
 
-        .def("get_id", &CoordinatesSubset::getId)
-        .def("get_name", &CoordinatesSubset::getName)
-        .def("get_size", &CoordinatesSubset::getSize)
+        .def(
+            "get_id",
+            &CoordinatesSubset::getId,
+            R"doc(
+                Get the identifier of the coordinates subset.
+
+                Returns:
+                    id (str): The identifier of the coordinates subset.
+            )doc"
+        )
+        .def(
+            "get_name",
+            &CoordinatesSubset::getName,
+            R"doc(
+                Get the name of the coordinates subset.
+
+                Returns:
+                    name (str): The name of the coordinates subset.
+            )doc"
+        )
+        .def(
+            "get_size",
+            &CoordinatesSubset::getSize,
+            R"doc(
+                Get the size of the coordinates subset.
+
+                Returns:
+                    size (int): The size of the coordinates subset.
+            )doc"
+        )
 
         .def(
             "add",
             &CoordinatesSubset::add,
+            R"doc(
+                Add the coordinates of another state to the coordinates of this state.
+
+                Args:
+                    instant (Instant): The instant of the state.
+                    coordinates (numpy.ndarray): The coordinates of this state.
+                    another_coordinates (numpy.ndarray): The coordinates of the other state.
+                    frame (Frame): The reference frame of the coordinates.
+                    coordinate_broker (CoordinatesBroker): The coordinates broker.
+
+                Returns:
+                    coordinates (numpy.ndarray): The sum of the coordinates.
+
+            )doc",
             arg("instant"),
             arg("coordinates"),
             arg("another_coordinates"),
@@ -108,6 +173,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
         .def(
             "subtract",
             &CoordinatesSubset::subtract,
+            R"doc(
+                Subtract the coordinates of another state from the coordinates of this state.
+
+                Args:
+                    instant (Instant): The instant of the state.
+                    coordinates (numpy.ndarray): The coordinates of this state.
+                    another_coordinates (numpy.ndarray): The coordinates of the other state.
+                    frame (Frame): The reference frame of the coordinates.
+                    coordinate_broker (CoordinatesBroker): The coordinates broker.
+
+                Returns:
+                    coordinates (numpy.ndarray): The difference of the coordinates.
+
+            )doc",
             arg("instant"),
             arg("coordinates"),
             arg("another_coordinates"),
@@ -117,6 +196,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
         .def(
             "in_frame",
             &CoordinatesSubset::inFrame,
+            R"doc(
+                Convert the coordinates of this state from one frame to another.
+
+                Args:
+                    instant (Instant): The instant of the state.
+                    coordinates (numpy.ndarray): The coordinates of this state.
+                    from_frame (Frame): The reference frame of the input coordinates.
+                    to_frame (Frame): The reference frame of the output coordinates.
+                    coordinate_broker (CoordinatesBroker): The coordinates broker.
+
+                Returns:
+                    coordinates (numpy.ndarray): The coordinates in the output frame.
+
+            )doc",
             arg("instant"),
             arg("coordinates"),
             arg("from_frame"),
@@ -124,9 +217,45 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
             arg("coordinate_broker")
         )
 
-        .def_static("mass", &CoordinatesSubset::Mass)
-        .def_static("surface_area", &CoordinatesSubset::SurfaceArea)
-        .def_static("drag_coefficient", &CoordinatesSubset::DragCoefficient)
+        .def_static(
+            "mass",
+            &CoordinatesSubset::Mass,
+            R"doc(
+                Get the mass coordinates subset.
+
+                Returns:
+                    CoordinatesSubset: The mass coordinates subset.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "surface_area",
+            &CoordinatesSubset::SurfaceArea,
+            R"doc(
+                Get the surface area coordinates subset.
+
+                Returns:
+                    CoordinatesSubset: The surface area coordinates subset.
+
+                Group:
+                    Static methods
+            )doc"
+        )
+        .def_static(
+            "drag_coefficient",
+            &CoordinatesSubset::DragCoefficient,
+            R"doc(
+                Get the drag coefficient coordinates subset.
+
+                Returns:
+                    CoordinatesSubset: The drag coefficient coordinates subset.
+
+                Group:
+                    Static methods
+            )doc"
+        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubset.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubset.cpp
@@ -123,7 +123,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
                 Get the identifier of the coordinates subset.
 
                 Returns:
-                    id (str): The identifier of the coordinates subset.
+                    str: The identifier of the coordinates subset.
             )doc"
         )
         .def(
@@ -133,7 +133,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
                 Get the name of the coordinates subset.
 
                 Returns:
-                    name (str): The name of the coordinates subset.
+                    str: The name of the coordinates subset.
             )doc"
         )
         .def(
@@ -143,7 +143,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
                 Get the size of the coordinates subset.
 
                 Returns:
-                    size (int): The size of the coordinates subset.
+                    int: The size of the coordinates subset.
             )doc"
         )
 
@@ -161,7 +161,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
                     coordinate_broker (CoordinatesBroker): The coordinates broker.
 
                 Returns:
-                    coordinates (numpy.ndarray): The sum of the coordinates.
+                    numpy.ndarray: The sum of the coordinates.
 
             )doc",
             arg("instant"),
@@ -184,7 +184,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
                     coordinate_broker (CoordinatesBroker): The coordinates broker.
 
                 Returns:
-                    coordinates (numpy.ndarray): The difference of the coordinates.
+                    numpy.ndarray: The difference of the coordinates.
 
             )doc",
             arg("instant"),
@@ -207,7 +207,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
                     coordinate_broker (CoordinatesBroker): The coordinates broker.
 
                 Returns:
-                    coordinates (numpy.ndarray): The coordinates in the output frame.
+                    numpy.ndarray: The coordinates in the output frame.
 
             )doc",
             arg("instant"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubset.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubset.cpp
@@ -225,9 +225,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
 
                 Returns:
                     CoordinatesSubset: The mass coordinates subset.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -238,9 +235,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
 
                 Returns:
                     CoordinatesSubset: The surface area coordinates subset.
-
-                Group:
-                    Static methods
             )doc"
         )
         .def_static(
@@ -251,9 +245,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubset(p
 
                 Returns:
                     CoordinatesSubset: The drag coefficient coordinates subset.
-
-                Group:
-                    Static methods
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianPosition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianPosition.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
             Defined with respect to a reference frame.
 
             Group:
-                CoordinatesSubsets
+                state
         )doc"
     )
 
@@ -71,9 +71,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
 
                 Returns:
                     CartesianPosition: The default Cartesian position subset.
-
-                Group:
-                    Static methods
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianPosition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianPosition.cpp
@@ -14,28 +14,31 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
     pybind11::module& aModule
 )
 {
-    class_<CartesianPosition, Shared<CartesianPosition>, CoordinatesSubset>(aModule, "CartesianPosition")
+    class_<CartesianPosition, Shared<CartesianPosition>, CoordinatesSubset>(
+        aModule,
+        "CartesianPosition",
+        R"doc(
+            Cartesian position coordinates subset.
 
-        .def(init<const String&>(), arg("name"))
+            Defined with respect to a reference frame.
+
+            Group:
+                CoordinatesSubsets
+        )doc"
+    )
 
         .def(
-            "add",
-            &CartesianPosition::add,
-            arg("instant"),
-            arg("coordinates"),
-            arg("another_coordinates"),
-            arg("frame"),
-            arg("coordinates_broker")
+            init<const String&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    name (str): The name of the subset.
+
+            )doc",
+            arg("name")
         )
-        .def(
-            "subtract",
-            &CartesianPosition::subtract,
-            arg("instant"),
-            arg("coordinates"),
-            arg("another_coordinates"),
-            arg("frame"),
-            arg("coordinates_broker")
-        )
+
         .def(
             "in_frame",
             &CartesianPosition::inFrame,
@@ -43,10 +46,32 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
             arg("coordinates"),
             arg("from_frame"),
             arg("to_frame"),
-            arg("coordinates_broker")
+            arg("coordinates_broker"),
+            R"doc(
+                Convert a Cartesian position from one reference frame to another.
+
+                Args:
+                    instant (Instant): The instant of the conversion.
+                    coordinates (numpy.ndarray): The Cartesian position to convert.
+                    from_frame (str): The reference frame of the input Cartesian position.
+                    to_frame (str): The reference frame of the output Cartesian position.
+                    coordinates_broker (CoordinatesBroker): The coordinates broker.
+
+                Returns:
+                    coordinates (numpy.ndarray): The Cartesian position in the output reference frame.
+
+            )doc"
         )
 
-        .def_static("default", &CartesianPosition::Default)
+        .def_static("default", &CartesianPosition::Default, R"doc(
+            Get the default Cartesian position subset.
+
+            Returns:
+                cartesian_position (CartesianPosition): The default Cartesian position subset.
+
+            Group:
+                Static methods
+        )doc")
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianPosition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianPosition.cpp
@@ -63,15 +63,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
             )doc"
         )
 
-        .def_static("default", &CartesianPosition::Default, R"doc(
-            Get the default Cartesian position subset.
+        .def_static(
+            "default",
+            &CartesianPosition::Default,
+            R"doc(
+                Get the default Cartesian position subset.
 
-            Returns:
-                CartesianPosition: The default Cartesian position subset.
+                Returns:
+                    CartesianPosition: The default Cartesian position subset.
 
-            Group:
-                Static methods
-        )doc")
+                Group:
+                    Static methods
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianPosition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianPosition.cpp
@@ -58,7 +58,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
                     coordinates_broker (CoordinatesBroker): The coordinates broker.
 
                 Returns:
-                    coordinates (numpy.ndarray): The Cartesian position in the output reference frame.
+                    numpy.ndarray: The Cartesian position in the output reference frame.
 
             )doc"
         )
@@ -67,7 +67,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
             Get the default Cartesian position subset.
 
             Returns:
-                cartesian_position (CartesianPosition): The default Cartesian position subset.
+                CartesianPosition: The default Cartesian position subset.
 
             Group:
                 Static methods

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianVelocity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianVelocity.cpp
@@ -14,31 +14,50 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
     pybind11::module& aModule
 )
 {
-    class_<CartesianVelocity, Shared<CartesianVelocity>, CoordinatesSubset>(aModule, "CartesianVelocity")
+    class_<CartesianVelocity, Shared<CartesianVelocity>, CoordinatesSubset>(
+        aModule,
+        "CartesianVelocity",
+        R"doc(
+            Cartesian velocity coordinates subset.
 
-        .def(init<const Shared<const CartesianPosition>&, const String&>(), arg("cartesian_position"), arg("name"))
+            Defined with respect to a reference frame and a Cartesian position.
+
+            Group:
+                CoordinatesSubsets
+        )doc"
+    )
 
         .def(
-            "add",
-            &CartesianVelocity::add,
-            arg("instant"),
-            arg("coordinates"),
-            arg("another_coordinates"),
-            arg("frame"),
-            arg("coordinates_broker")
+            init<const Shared<const CartesianPosition>&, const String&>(),
+            R"doc(
+                Constructor.
+
+                Args:
+                    cartesian_position (CartesianPosition): The Cartesian position.
+                    name (str): The name of the subset.
+
+            )doc",
+            arg("cartesian_position"),
+            arg("name")
         )
-        .def(
-            "subtract",
-            &CartesianVelocity::subtract,
-            arg("instant"),
-            arg("coordinates"),
-            arg("another_coordinates"),
-            arg("frame"),
-            arg("coordinates_broker")
-        )
+
         .def(
             "in_frame",
             &CartesianVelocity::inFrame,
+            R"doc(
+                Convert a Cartesian velocity from one reference frame to another.
+
+                Args:
+                    instant (Instant): The instant of the conversion.
+                    coordinates (numpy.ndarray): The Cartesian velocity to convert.
+                    from_frame (str): The reference frame of the input Cartesian velocity.
+                    to_frame (str): The reference frame of the output Cartesian velocity.
+                    coordinates_broker (CoordinatesBroker): The coordinates broker.
+
+                Returns:
+                    coordinates (numpy.ndarray): The Cartesian velocity in the output reference frame.
+
+            )doc",
             arg("instant"),
             arg("coordinates"),
             arg("from_frame"),
@@ -46,7 +65,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
             arg("coordinates_broker")
         )
 
-        .def_static("default", &CartesianVelocity::Default)
+        .def_static(
+            "default",
+            &CartesianVelocity::Default,
+            R"doc(
+                Get the default Cartesian velocity subset.
+
+                Returns:
+                    cartesian_velocity (CartesianVelocity): The default Cartesian velocity subset.
+
+                Group:
+                    Static methods
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianVelocity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianVelocity.cpp
@@ -55,7 +55,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
                     coordinates_broker (CoordinatesBroker): The coordinates broker.
 
                 Returns:
-                    coordinates (numpy.ndarray): The Cartesian velocity in the output reference frame.
+                    numpy.ndarray: The Cartesian velocity in the output reference frame.
 
             )doc",
             arg("instant"),
@@ -72,7 +72,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
                 Get the default Cartesian velocity subset.
 
                 Returns:
-                    cartesian_velocity (CartesianVelocity): The default Cartesian velocity subset.
+                    CartesianVelocity: The default Cartesian velocity subset.
 
                 Group:
                     Static methods

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianVelocity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinatesSubsets/CartesianVelocity.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
             Defined with respect to a reference frame and a Cartesian position.
 
             Group:
-                CoordinatesSubsets
+                state
         )doc"
     )
 
@@ -73,9 +73,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinatesSubsets_
 
                 Returns:
                     CartesianVelocity: The default Cartesian velocity subset.
-
-                Group:
-                    Static methods
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -21,14 +21,52 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
     )>
         pythonSystemOfEquationsSignature;
 
-    class_<NumericalSolver::ConditionSolution>(aModule, "ConditionSolution")
+    class_<NumericalSolver::ConditionSolution>(
+        aModule,
+        "ConditionSolution",
+        R"doc(
+            The solution to an event condition.
 
-        .def_readonly("state", &NumericalSolver::ConditionSolution::state)
-        .def_readonly("condition_is_satisfied", &NumericalSolver::ConditionSolution::conditionIsSatisfied)
-        .def_readonly("iteration_count", &NumericalSolver::ConditionSolution::iterationCount)
-        .def_readonly("root_solver_has_converged", &NumericalSolver::ConditionSolution::rootSolverHasConverged)
+            Group:
+                astrodynamics
+        )doc"
+    )
+        .def_readonly(
+            "state",
+            &NumericalSolver::ConditionSolution::state,
+            R"doc(
+                The state of the trajectory.
 
-        ;
+                :rtype: State
+            )doc"
+        )
+        .def_readonly(
+            "condition_is_satisfied",
+            &NumericalSolver::ConditionSolution::conditionIsSatisfied,
+            R"doc(
+                Whether the event condition is satisfied.
+
+                :rtype: bool
+            )doc"
+        )
+        .def_readonly(
+            "iteration_count",
+            &NumericalSolver::ConditionSolution::iterationCount,
+            R"doc(
+                The number of iterations required to find the solution.
+
+                :rtype: int
+            )doc"
+        )
+        .def_readonly(
+            "root_solver_has_converged",
+            &NumericalSolver::ConditionSolution::rootSolverHasConverged,
+            R"doc(
+                Whether the root solver has converged.
+
+                :rtype: bool
+            )doc"
+        );
 
     {
         class_<NumericalSolver, MathNumericalSolver> numericalSolver(aModule, "NumericalSolver");
@@ -43,6 +81,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     const Real&,
                     const Real&,
                     const RootSolver&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        log_type (NumericalSolver.LogType): The type of logging.
+                        stepper_type (NumericalSolver.StepperType): The type of stepper.
+                        time_step (float): The time step.
+                        relative_tolerance (float): The relative tolerance.
+                        absolute_tolerance (float): The absolute tolerance.
+                        root_solver (RootSolver, optional): The root solver. Defaults to RootSolver.Default().
+
+                )doc",
                 arg("log_type"),
                 arg("stepper_type"),
                 arg("time_step"),
@@ -57,17 +107,44 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             .def("__str__", &(shiftToString<NumericalSolver>))
             .def("__repr__", &(shiftToString<NumericalSolver>))
 
-            .def("is_defined", &NumericalSolver::isDefined)
+            .def(
+                "is_defined",
+                &NumericalSolver::isDefined,
+                R"doc(
+                    Check if the numerical solver is defined.
 
-            .def("get_observed_states", &NumericalSolver::getObservedStates)
-            .def("get_root_solver", &NumericalSolver::getRootSolver)
+                    Returns:
+                        is_defined (bool): True if the numerical solver is defined, False otherwise.
+                )doc"
+            )
+
+            .def(
+                "get_observed_states",
+                &NumericalSolver::getObservedStates,
+                R"doc(
+                    Get the observed states.
+
+                    Returns:
+                        observed_states (List)[State]: The observed states.
+                )doc"
+            )
+            .def(
+                "get_root_solver",
+                &NumericalSolver::getRootSolver,
+                R"doc(
+                    Get the root solver.
+
+                    Returns:
+                        root_solver (RootSolver): The root solver.
+                )doc"
+            )
 
             .def(
                 "integrate_time",
                 +[](NumericalSolver& aNumericalSolver,
                     const State& aState,
                     const Instant& anInstant,
-                    const object& aSystemOfEquationsObject)
+                    const object& aSystemOfEquationsObject) -> State
                 {
                     const auto pythonDynamicsEquation =
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
@@ -81,6 +158,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     return aNumericalSolver.integrateTime(aState, anInstant, systemOfEquations);
                 },
+                R"doc(
+                    Integrate the trajectory to a given instant.
+
+                    Args:
+                        state (State): The initial state of the trajectory.
+                        instant (Instant): The instant to integrate to.
+                        system_of_equations (callable): The system of equations.
+
+                    Returns:
+                       state (State): The state at the requested time.
+
+                )doc",
                 arg("state"),
                 arg("instant"),
                 arg("system_of_equations")
@@ -91,7 +180,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 +[](NumericalSolver& aNumericalSolver,
                     const State& aState,
                     const Array<Instant>& instants,
-                    const object& aSystemOfEquationsObject)
+                    const object& aSystemOfEquationsObject) -> Array<State>
                 {
                     const auto pythonDynamicsEquation =
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
@@ -105,6 +194,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     return aNumericalSolver.integrateTime(aState, instants, systemOfEquations);
                 },
+                R"doc(
+                    Integrate the trajectory to a set of instants.
+
+                    Args:
+                        state (State): The initial state of the trajectory.
+                        instants (List[Instant]): The instants to integrate to.
+                        system_of_equations (callable): The system of equations.
+
+                    Returns:
+                        states (List[State]): The states at the requested times.
+
+                )doc",
                 arg("state"),
                 arg("instants"),
                 arg("system_of_equations")
@@ -116,7 +217,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     const State& aState,
                     const Instant& anInstant,
                     const object& aSystemOfEquationsObject,
-                    const EventCondition& anEventCondition)
+                    const EventCondition& anEventCondition) -> NumericalSolver::ConditionSolution
                 {
                     const auto pythonDynamicsEquation =
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
@@ -130,17 +231,65 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     return aNumericalSolver.integrateTime(aState, anInstant, systemOfEquations, anEventCondition);
                 },
+                R"doc(
+                    Integrate the trajectory to a given instant, with an event condition.
+
+                    Args:
+                        state (State): The initial state of the trajectory.
+                        instant (Instant): The instant to integrate to.
+                        system_of_equations (callable): The system of equations.
+                        event_condition (EventCondition): The event condition.
+
+                    Returns:
+                        solution (ConditionSolution): The solution to the event condition.
+
+                )doc",
                 arg("state"),
                 arg("instant"),
                 arg("system_of_equations"),
                 arg("event_condition")
             )
 
-            .def_static("default", &NumericalSolver::Default)
-            .def_static("undefined", &NumericalSolver::Undefined)
-            .def_static("default_conditional", &NumericalSolver::DefaultConditional, arg("state_logger") = nullptr)
-            .def_static("conditional", &NumericalSolver::Conditional)
+            .def_static("default", &NumericalSolver::Default, R"doc(
+                Return the default numerical solver.
 
-            ;
+                Returns:
+                    NumericalSolver: The default numerical solver.
+
+                Group:
+                    Static methods
+            )doc")
+            .def_static("undefined", &NumericalSolver::Undefined, R"doc(
+                Return an undefined numerical solver.
+
+                Returns:
+                    numerical_solver (NumericalSolver): The undefined numerical solver.
+
+                Group:
+                    Static methods
+            )doc")
+            .def_static(
+                "default_conditional", &NumericalSolver::DefaultConditional, arg("state_logger") = nullptr, R"doc(
+                Return the default conditional numerical solver.
+
+                Args:
+                    state_logger (StateLogger, optional): The state logger. Defaults to None.
+
+                Returns:
+                    numerical_solver (NumericalSolver): The default conditional numerical solver.
+
+                Group:
+                    Static methods
+            )doc"
+            )
+            .def_static("conditional", &NumericalSolver::Conditional, R"doc(
+                Return a conditional numerical solver.
+
+                Returns:
+                    numerical_solver (NumericalSolver): The conditional numerical solver.
+
+                Group:
+                    Static methods
+            )doc");
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -28,7 +28,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             The solution to an event condition.
 
             Group:
-                astrodynamics
+                state
         )doc"
     )
         .def_readonly(
@@ -83,7 +83,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 or to a set of instants, or until an `Event Condition` is met.
 
                 Group:
-                    State
+                    state
             )doc"
         );
 
@@ -274,9 +274,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Returns:
                         NumericalSolver: The default numerical solver.
-
-                    Group:
-                        Static methods
                 )doc"
             )
             .def_static(
@@ -287,9 +284,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Returns:
                         NumericalSolver: The undefined numerical solver.
-
-                    Group:
-                        Static methods
                 )doc"
             )
             .def_static(
@@ -303,9 +297,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Returns:
                         NumericalSolver: The default conditional numerical solver.
-
-                    Group:
-                        Static methods
                 )doc",
                 arg("state_logger") = nullptr
             )
@@ -317,9 +308,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Returns:
                         NumericalSolver: The conditional numerical solver.
-
-                    Group:
-                        Static methods
                 )doc"
             );
     }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -125,7 +125,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Get the observed states.
 
                     Returns:
-                        List[State]: The observed states.
+                        list[State]: The observed states.
                 )doc"
             )
             .def(
@@ -199,11 +199,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Args:
                         state (State): The initial state of the trajectory.
-                        instants (List[Instant]): The instants to integrate to.
+                        instants (list[Instant]): The instants to integrate to.
                         system_of_equations (callable): The system of equations.
 
                     Returns:
-                        List[State]: The states at the requested times.
+                        list[State]: The states at the requested times.
 
                 )doc",
                 arg("state"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -37,7 +37,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             R"doc(
                 The state of the trajectory.
 
-                :rtype: State
+                :type: State
             )doc"
         )
         .def_readonly(
@@ -46,7 +46,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             R"doc(
                 Whether the event condition is satisfied.
 
-                :rtype: bool
+                :type: bool
             )doc"
         )
         .def_readonly(
@@ -55,7 +55,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             R"doc(
                 The number of iterations required to find the solution.
 
-                :rtype: int
+                :type: int
             )doc"
         )
         .def_readonly(
@@ -64,7 +64,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             R"doc(
                 Whether the root solver has converged.
 
-                :rtype: bool
+                :type: bool
             )doc"
         );
 
@@ -114,7 +114,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Check if the numerical solver is defined.
 
                     Returns:
-                        is_defined (bool): True if the numerical solver is defined, False otherwise.
+                        bool: True if the numerical solver is defined, False otherwise.
                 )doc"
             )
 
@@ -125,7 +125,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Get the observed states.
 
                     Returns:
-                        observed_states (List)[State]: The observed states.
+                        List[State]: The observed states.
                 )doc"
             )
             .def(
@@ -135,7 +135,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Get the root solver.
 
                     Returns:
-                        root_solver (RootSolver): The root solver.
+                        RootSolver: The root solver.
                 )doc"
             )
 
@@ -167,7 +167,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         system_of_equations (callable): The system of equations.
 
                     Returns:
-                       state (State): The state at the requested time.
+                       State: The state at the requested time.
 
                 )doc",
                 arg("state"),
@@ -203,7 +203,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         system_of_equations (callable): The system of equations.
 
                     Returns:
-                        states (List[State]): The states at the requested times.
+                        List[State]: The states at the requested times.
 
                 )doc",
                 arg("state"),
@@ -241,7 +241,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         event_condition (EventCondition): The event condition.
 
                     Returns:
-                        solution (ConditionSolution): The solution to the event condition.
+                        ConditionSolution: The solution to the event condition.
 
                 )doc",
                 arg("state"),
@@ -263,7 +263,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 Return an undefined numerical solver.
 
                 Returns:
-                    numerical_solver (NumericalSolver): The undefined numerical solver.
+                    NumericalSolver: The undefined numerical solver.
 
                 Group:
                     Static methods
@@ -276,7 +276,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     state_logger (StateLogger, optional): The state logger. Defaults to None.
 
                 Returns:
-                    numerical_solver (NumericalSolver): The default conditional numerical solver.
+                    NumericalSolver: The default conditional numerical solver.
 
                 Group:
                     Static methods
@@ -286,7 +286,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 Return a conditional numerical solver.
 
                 Returns:
-                    numerical_solver (NumericalSolver): The conditional numerical solver.
+                    NumericalSolver: The conditional numerical solver.
 
                 Group:
                     Static methods

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -37,7 +37,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             R"doc(
                 The state of the trajectory.
 
-                :type: State
+                Type:
+                    State
             )doc"
         )
         .def_readonly(
@@ -46,7 +47,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             R"doc(
                 Whether the event condition is satisfied.
 
-                :type: bool
+                Type:
+                    bool
             )doc"
         )
         .def_readonly(
@@ -55,7 +57,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             R"doc(
                 The number of iterations required to find the solution.
 
-                :type: int
+                Type:
+                    int
             )doc"
         )
         .def_readonly(
@@ -64,12 +67,25 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             R"doc(
                 Whether the root solver has converged.
 
-                :type: bool
+                Type:
+                    bool
             )doc"
         );
 
     {
-        class_<NumericalSolver, MathNumericalSolver> numericalSolver(aModule, "NumericalSolver");
+        class_<NumericalSolver, MathNumericalSolver> numericalSolver(
+            aModule,
+            "NumericalSolver",
+            R"doc(
+                A numerical solver is used to integrate the trajectory of a dynamical system.
+
+                The numerical solver can be used to integrate the trajectory of a dynamical system to a given instant,
+                or to a set of instants, or until an `Event Condition` is met.
+
+                Group:
+                    State
+            )doc"
+        );
 
         numericalSolver
 
@@ -250,46 +266,61 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 arg("event_condition")
             )
 
-            .def_static("default", &NumericalSolver::Default, R"doc(
-                Return the default numerical solver.
-
-                Returns:
-                    NumericalSolver: The default numerical solver.
-
-                Group:
-                    Static methods
-            )doc")
-            .def_static("undefined", &NumericalSolver::Undefined, R"doc(
-                Return an undefined numerical solver.
-
-                Returns:
-                    NumericalSolver: The undefined numerical solver.
-
-                Group:
-                    Static methods
-            )doc")
             .def_static(
-                "default_conditional", &NumericalSolver::DefaultConditional, arg("state_logger") = nullptr, R"doc(
-                Return the default conditional numerical solver.
+                "default",
+                &NumericalSolver::Default,
+                R"doc(
+                    Return the default numerical solver.
 
-                Args:
-                    state_logger (StateLogger, optional): The state logger. Defaults to None.
+                    Returns:
+                        NumericalSolver: The default numerical solver.
 
-                Returns:
-                    NumericalSolver: The default conditional numerical solver.
-
-                Group:
-                    Static methods
-            )doc"
+                    Group:
+                        Static methods
+                )doc"
             )
-            .def_static("conditional", &NumericalSolver::Conditional, R"doc(
-                Return a conditional numerical solver.
+            .def_static(
+                "undefined",
+                &NumericalSolver::Undefined,
+                R"doc(
+                    Return an undefined numerical solver.
 
-                Returns:
-                    NumericalSolver: The conditional numerical solver.
+                    Returns:
+                        NumericalSolver: The undefined numerical solver.
 
-                Group:
-                    Static methods
-            )doc");
+                    Group:
+                        Static methods
+                )doc"
+            )
+            .def_static(
+                "default_conditional",
+                &NumericalSolver::DefaultConditional,
+                R"doc(
+                    Return the default conditional numerical solver.
+
+                    Args:
+                        state_logger (StateLogger, optional): The state logger. Defaults to None.
+
+                    Returns:
+                        NumericalSolver: The default conditional numerical solver.
+
+                    Group:
+                        Static methods
+                )doc",
+                arg("state_logger") = nullptr
+            )
+            .def_static(
+                "conditional",
+                &NumericalSolver::Conditional,
+                R"doc(
+                    Return a conditional numerical solver.
+
+                    Returns:
+                        NumericalSolver: The conditional numerical solver.
+
+                    Group:
+                        Static methods
+                )doc"
+            );
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -16,29 +16,97 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
     using ostk::astro::trajectory::state::CoordinatesBroker;
     using ostk::astro::trajectory::state::CoordinatesSubset;
 
-    class_<StateBuilder>(aModule, "StateBuilder")
+    class_<StateBuilder>(
+        aModule,
+        "StateBuilder",
+        R"doc(
+            This class makes it convenient to build a `State` object.
+        
+            Group:
+                trajectory
+        )doc"
+    )
 
         .def(
             init<const Shared<const Frame>&, const Array<Shared<const CoordinatesSubset>>&>(),
             arg("frame"),
-            arg("coordinates_subsets")
+            arg("coordinates_subsets"),
+            R"pydoc(
+                Construct a new `StateBuilder` object.
+
+                Arguments:
+                    frame (Shared<const Frame>): The reference frame.
+                    coordinates_subsets (Array<Shared<const CoordinatesSubset>>): The coordinates subsets.
+
+                Returns:
+                    StateBuilder 
+
+            )pydoc"
         )
         .def(
             init<const Shared<const Frame>&, const Shared<const CoordinatesBroker>&>(),
             arg("frame"),
-            arg("coordinates_broker")
-        )
-        .def(init<const State&>(), arg("state"))
+            arg("coordinates_broker"),
+            R"doc(
+                Construct a new `StateBuilder` object.
 
-        .def(self == self)
-        .def(self != self)
+                Arguments:
+                    frame (Shared<const Frame>): The reference frame.
+                    coordinates_broker (Shared<const CoordinatesBroker>): The coordinates broker.
+
+                Returns:
+                    StateBuilder: The new `StateBuilder` object.
+
+            )doc"
+        )
+        .def(init<const State&>(), arg("state"),
+            R"doc(
+                Construct a new `StateBuilder` object.
+
+                Arguments:
+                    state (State): The state.
+
+                Returns:
+                    StateBuilder: The new `StateBuilder` object.
+                
+            )doc"
+        )
+
+        .def(self == self,
+            R"doc(
+                Check if two `StateBuilder` objects are equal.
+
+                Returns:
+                    bool: True if the two `StateBuilder` objects are equal, False otherwise.
+            
+            )doc"
+        )
+        .def(self != self,
+            R"doc(
+                Check if two `StateBuilder` objects are not equal.
+
+                Returns:
+                    bool: True if the two `StateBuilder` objects are not equal, False otherwise.
+
+            )doc"
+        )
         .def(
             "__add__",
             [](const StateBuilder& aStateBuilder, const Shared<const CoordinatesSubset>& aCoordinatesSubsetSPtr)
             {
                 return aStateBuilder + aCoordinatesSubsetSPtr;
             },
-            is_operator()
+            is_operator(),
+            R"doc(
+                Add a coordinates subset to the `StateBuilder`.
+
+                Arguments:
+                    coordinates_subsets (Shared<const CoordinatesSubset>): The coordinates subset to add.
+
+                Returns:
+                    StateBuilder: The `StateBuilder` with the added coordinates subset.
+
+            )doc"
         )
         .def(
             "__sub__",
@@ -46,23 +114,108 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             {
                 return aStateBuilder - aCoordinatesSubsetSPtr;
             },
-            is_operator()
+            is_operator(),
+            R"doc(
+                Remove a coordinates subset from the `StateBuilder`.
+
+                Arguments:
+                    coordinates_subset (Shared<const CoordinatesSubset>): The coordinates subset to remove.
+
+                Returns:
+                    StateBuilder: The `StateBuilder` with the removed coordinates subset.
+
+            )doc"
         )
 
         .def("__str__", &(shiftToString<StateBuilder>))
         .def("__repr__", &(shiftToString<StateBuilder>))
 
-        .def("is_defined", &StateBuilder::isDefined)
+        .def("is_defined", &StateBuilder::isDefined,
+            R"doc(
+                Check if the `StateBuilder` is defined.
 
-        .def("build", &StateBuilder::build, arg("instant"), arg("coordinates"))
-        .def("reduce", &StateBuilder::reduce, arg("state"))
-        .def("expand", &StateBuilder::expand, arg("state"), arg("default_state"))
+                Returns:
+                    bool: True if the `StateBuilder` is defined, False otherwise.
 
-        .def("get_coordinates_subsets", &StateBuilder::getCoordinatesSubsets)
-        .def("access_coordinates_broker", &StateBuilder::accessCoordinatesBroker)
-        .def("get_frame", &StateBuilder::getFrame)
+            )doc"
+        )
 
-        .def_static("undefined", &StateBuilder::Undefined)
+        .def("build", &StateBuilder::build, arg("instant"), arg("coordinates"),
+            R"doc(
+                Build a `State` object from the `StateBuilder`.
+
+                Arguments:
+                    instant (Instant): The instant of the state.
+                    coordinates (VectorXd): The coordinates of the state.
+
+                Returns:
+                    State: The `State` object built from the `StateBuilder`.
+
+            )doc"
+        )
+        .def("reduce", &StateBuilder::reduce, arg("state"),
+            R"doc(
+                Reduce a `State` object to the `StateBuilder`.
+
+                Arguments:
+                    state (State): The `State` object to reduce.
+
+                Returns:
+                    StateBuilder: The `StateBuilder` object reduced from the `State`.
+
+            )doc"
+        )
+        .def("expand", &StateBuilder::expand, arg("state"), arg("default_state"),
+            R"doc(
+                Expand a `State` object to the `StateBuilder`.
+
+                Arguments:
+                    state (State): The `State` object to expand.
+                    default_state (State): The default `State` object.
+
+                Returns:
+                    StateBuilder: The `StateBuilder` object expanded from the `State`.
+
+            )doc"
+        )
+
+        .def("get_coordinates_subsets", &StateBuilder::getCoordinatesSubsets,
+            R"doc(
+                Get the coordinates subsets of the `StateBuilder`.
+
+                Returns:
+                    Array<Shared<const CoordinatesSubset>>: The coordinates subsets of the `StateBuilder`.
+
+            )doc"
+        )
+        .def("access_coordinates_broker", &StateBuilder::accessCoordinatesBroker,
+            R"doc(
+                Access the coordinates broker of the `StateBuilder`.
+
+                Returns:
+                    Shared<const CoordinatesBroker>: The coordinates broker of the `StateBuilder`.
+
+            )doc"
+        )
+        .def("get_frame", &StateBuilder::getFrame,
+            R"doc(
+                Get the reference frame of the `StateBuilder`.
+
+                Returns:
+                    Shared<const Frame>: The reference frame of the `StateBuilder`.
+
+            )doc"
+        )
+
+        .def_static("undefined", &StateBuilder::Undefined,
+            R"doc(
+                Get an undefined `StateBuilder`.
+
+                Returns:
+                    StateBuilder: The undefined `StateBuilder`.
+                
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -35,8 +35,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                 Construct a new `StateBuilder` object.
 
                 Arguments:
-                    frame (Shared<const Frame>): The reference frame.
-                    coordinates_subsets (Array<Shared<const CoordinatesSubset>>): The coordinates subsets.
+                    frame (Frame): The reference frame.
+                    coordinates_subsets list[CoordinatesSubset]: The coordinates subsets.
 
                 Returns:
                     StateBuilder 
@@ -51,15 +51,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                 Construct a new `StateBuilder` object.
 
                 Arguments:
-                    frame (Shared<const Frame>): The reference frame.
-                    coordinates_broker (Shared<const CoordinatesBroker>): The coordinates broker.
+                    frame (Frame): The reference frame.
+                    coordinates_broker (CoordinatesBroker): The coordinates broker.
 
                 Returns:
                     StateBuilder: The new `StateBuilder` object.
 
             )doc"
         )
-        .def(init<const State&>(), arg("state"),
+        .def(
+            init<const State&>(),
+            arg("state"),
             R"doc(
                 Construct a new `StateBuilder` object.
 
@@ -72,7 +74,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             )doc"
         )
 
-        .def(self == self,
+        .def(
+            self == self,
             R"doc(
                 Check if two `StateBuilder` objects are equal.
 
@@ -81,7 +84,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             
             )doc"
         )
-        .def(self != self,
+        .def(
+            self != self,
             R"doc(
                 Check if two `StateBuilder` objects are not equal.
 
@@ -101,7 +105,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                 Add a coordinates subset to the `StateBuilder`.
 
                 Arguments:
-                    coordinates_subsets (Shared<const CoordinatesSubset>): The coordinates subset to add.
+                    coordinates_subsets (CoordinatesSubset): The coordinates subset to add.
 
                 Returns:
                     StateBuilder: The `StateBuilder` with the added coordinates subset.
@@ -119,7 +123,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                 Remove a coordinates subset from the `StateBuilder`.
 
                 Arguments:
-                    coordinates_subset (Shared<const CoordinatesSubset>): The coordinates subset to remove.
+                    coordinates_subset (CoordinatesSubset): The coordinates subset to remove.
 
                 Returns:
                     StateBuilder: The `StateBuilder` with the removed coordinates subset.
@@ -130,7 +134,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
         .def("__str__", &(shiftToString<StateBuilder>))
         .def("__repr__", &(shiftToString<StateBuilder>))
 
-        .def("is_defined", &StateBuilder::isDefined,
+        .def(
+            "is_defined",
+            &StateBuilder::isDefined,
             R"doc(
                 Check if the `StateBuilder` is defined.
 
@@ -140,7 +146,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             )doc"
         )
 
-        .def("build", &StateBuilder::build, arg("instant"), arg("coordinates"),
+        .def(
+            "build",
+            &StateBuilder::build,
+            arg("instant"),
+            arg("coordinates"),
             R"doc(
                 Build a `State` object from the `StateBuilder`.
 
@@ -153,7 +163,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
             )doc"
         )
-        .def("reduce", &StateBuilder::reduce, arg("state"),
+        .def(
+            "reduce",
+            &StateBuilder::reduce,
+            arg("state"),
             R"doc(
                 Reduce a `State` object to the `StateBuilder`.
 
@@ -165,7 +178,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
             )doc"
         )
-        .def("expand", &StateBuilder::expand, arg("state"), arg("default_state"),
+        .def(
+            "expand",
+            &StateBuilder::expand,
+            arg("state"),
+            arg("default_state"),
             R"doc(
                 Expand a `State` object to the `StateBuilder`.
 
@@ -179,7 +196,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             )doc"
         )
 
-        .def("get_coordinates_subsets", &StateBuilder::getCoordinatesSubsets,
+        .def(
+            "get_coordinates_subsets",
+            &StateBuilder::getCoordinatesSubsets,
             R"doc(
                 Get the coordinates subsets of the `StateBuilder`.
 
@@ -188,26 +207,32 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
             )doc"
         )
-        .def("access_coordinates_broker", &StateBuilder::accessCoordinatesBroker,
+        .def(
+            "access_coordinates_broker",
+            &StateBuilder::accessCoordinatesBroker,
             R"doc(
                 Access the coordinates broker of the `StateBuilder`.
 
                 Returns:
-                    Shared<const CoordinatesBroker>: The coordinates broker of the `StateBuilder`.
+                    CoordinatesBroker: The coordinates broker of the `StateBuilder`.
 
             )doc"
         )
-        .def("get_frame", &StateBuilder::getFrame,
+        .def(
+            "get_frame",
+            &StateBuilder::getFrame,
             R"doc(
                 Get the reference frame of the `StateBuilder`.
 
                 Returns:
-                    Shared<const Frame>: The reference frame of the `StateBuilder`.
+                    Frame: The reference frame of the `StateBuilder`.
 
             )doc"
         )
 
-        .def_static("undefined", &StateBuilder::Undefined,
+        .def_static(
+            "undefined",
+            &StateBuilder::Undefined,
             R"doc(
                 Get an undefined `StateBuilder`.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -238,7 +238,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder: The undefined `StateBuilder`.
-                
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -31,7 +31,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             init<const Shared<const Frame>&, const Array<Shared<const CoordinatesSubset>>&>(),
             arg("frame"),
             arg("coordinates_subsets"),
-            R"pydoc(
+            R"doc(
                 Construct a new `StateBuilder` object.
 
                 Arguments:
@@ -41,7 +41,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                 Returns:
                     StateBuilder 
 
-            )pydoc"
+            )doc"
         )
         .def(
             init<const Shared<const Frame>&, const Shared<const CoordinatesBroker>&>(),


### PR DESCRIPTION
I had to move the enums from the bottom of the modules to the top. Other than that this should only have touched the docstrings in the bindings.
Also worth noting, there is a field called:
```
Group:
    blah
```
This is used for the auto-grouping of docstrings in the documentation. More to come on that in other MRs.