### PR TITLE
feat: update finite difference solver callable interface

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/FiniteDifferenceSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/FiniteDifferenceSolver.cpp
@@ -45,33 +45,65 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
     finiteDifferenceSolver
 
         .def(
-            init<const ostk::astro::solvers::FiniteDifferenceSolver::Type&>(),
+            init<const ostk::astro::solvers::FiniteDifferenceSolver::Type&, const Real&, const Duration&>(),
             R"doc(
                 Construct a FiniteDifferenceSolver.
 
                 Args:
                     type (FiniteDifferenceSolver.Type): Type of finite difference scheme.
+                    step_percentage (float): The step percentage to use for computing the STM.
+                    step_duration (Duration): The step duration to use for computing the gradient.
 
                 Returns:
                     FiniteDifferenceSolver: The FiniteDifferenceSolver.
             )doc",
-            arg("type")
+            arg("type"),
+            arg("step_percentage"),
+            arg("step_duration")
         )
 
         .def("__str__", &(shiftToString<FiniteDifferenceSolver>))
         .def("__repr__", &(shiftToString<FiniteDifferenceSolver>))
 
         .def(
+            "get_type",
+            &FiniteDifferenceSolver::getType,
+            R"doc(
+                Get the type.
+
+                Returns:
+                    FiniteDifferenceSolver.Type: The type.
+            )doc"
+        )
+        .def(
+            "get_step_percentage",
+            &FiniteDifferenceSolver::getStepPercentage,
+            R"doc(
+                Get the step percentage used for computing the STM.
+
+                Returns:
+                    float: The step percentage.
+            )doc"
+        )
+        .def(
+            "get_step_duration",
+            &FiniteDifferenceSolver::getStepDuration,
+            R"doc(
+                Get the step duration used for computing the gradient.
+
+                Returns:
+                    Duration: The step duration.
+            )doc"
+        )
+
+        .def(
             "compute_state_transition_matrix",
-            [](const ostk::astro::solvers::FiniteDifferenceSolver& solver,
-               const State& aState,
-               const Array<Instant>& anInstantArray,
-               std::function<MatrixXd(const State&, const Array<Instant>&)> generateStateCoordinates,
-               const Real& aStepPercentage = 1e-3) -> Eigen::MatrixXd
+            +[](const ostk::astro::solvers::FiniteDifferenceSolver& solver,
+                const State& aState,
+                const Array<Instant>& anInstantArray,
+                std::function<MatrixXd(const State&, const Array<Instant>&)> generateStateCoordinates) -> MatrixXd
             {
-                return solver.computeStateTransitionMatrix(
-                    aState, anInstantArray, generateStateCoordinates, aStepPercentage
-                );
+                return solver.computeStateTransitionMatrix(aState, anInstantArray, generateStateCoordinates);
             },
             R"doc(
                 Compute the state transition matrix.
@@ -79,28 +111,23 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
                 Args:
                     state (State): The state.
                     instants (Array(Instant)): The instants at which to calculate the STM.
-                    generate_states_coordinatess (function): The function to get the states.
-                    step_percentage (float): The step percentage. Defaults to 1e-3.
+                    generate_states_coordinates (function): The function to get the states.
 
                 Returns:
                     np.array: The state transition matrix.
             )doc",
             arg("state"),
             arg("instants"),
-            arg("generate_states_coordinatess"),
-            arg("step_percentage")
+            arg("generate_states_coordinates")
         )
         .def(
             "compute_state_transition_matrix",
-            [](const ostk::astro::solvers::FiniteDifferenceSolver& solver,
-               const State& aState,
-               const Instant& anInstant,
-               std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates,
-               const Real& aStepPercentage = 1e-3) -> MatrixXd
+            +[](const ostk::astro::solvers::FiniteDifferenceSolver& solver,
+                const State& aState,
+                const Instant& anInstant,
+                std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates) -> MatrixXd
             {
-                return solver.computeStateTransitionMatrix(
-                    aState, anInstant, generateStateCoordinates, aStepPercentage
-                );
+                return solver.computeStateTransitionMatrix(aState, anInstant, generateStateCoordinates);
             },
             R"doc(
                 Compute the state transition matrix.
@@ -109,24 +136,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
                     state (State): The state.
                     instant (Instant): The instant at which to calculate the STM.
                     generate_state_coordinates (function): The function to get the state.
-                    step_percentage (float): The step percentage. Defaults to 1e-3.
 
                 Returns:
                     np.array: The state transition matrix.
             )doc",
             arg("state"),
             arg("instant"),
-            arg("generate_state_coordinates"),
-            arg("step_percentage")
+            arg("generate_state_coordinates")
         )
         .def(
             "compute_gradient",
             [](const ostk::astro::solvers::FiniteDifferenceSolver& solver,
                const State& aState,
-               std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates,
-               const Duration& aStepSize = Duration::Seconds(1e-6)) -> VectorXd
+               std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates) -> VectorXd
             {
-                return solver.computeGradient(aState, generateStateCoordinates, aStepSize);
+                return solver.computeGradient(aState, generateStateCoordinates);
             },
             R"doc(
                 Compute the gradient.
@@ -134,14 +158,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
                 Args:
                     state (State): The state.
                     generate_state_coordinates (function): The function to generate the state.
-                    step_size (duration): The step size as a duration. Defaults to 1e-6 seconds.
 
                 Returns:
                     np.array: The state transition matrix.
             )doc",
             arg("state"),
-            arg("generate_state_coordinates"),
-            arg("step_size")
+            arg("generate_state_coordinates")
         )
 
         .def_static(
@@ -167,7 +189,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
 
                 Returns:
                     FiniteDifferenceSolver: The default Finite Difference Solver.
-            )doc",
+            )doc"
         )
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/FiniteDifferenceSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/FiniteDifferenceSolver.cpp
@@ -157,7 +157,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
 
                 Args:
                     state (State): The state.
-                    generate_state_coordinates (function): The function to generate the state.
+                    generate_state_coordinates (function): The function to generate the state coordinates.
 
                 Returns:
                     np.array: The state transition matrix.

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/FiniteDifferenceSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/FiniteDifferenceSolver.cpp
@@ -159,5 +159,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
             arg("type")
         )
 
+        .def_static(
+            "default",
+            &FiniteDifferenceSolver::Default,
+            R"doc(
+                Get the default Finite Difference Solver.
+
+                Returns:
+                    FiniteDifferenceSolver: The default Finite Difference Solver.
+            )doc",
+        )
+
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/FiniteDifferenceSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solvers/FiniteDifferenceSolver.cpp
@@ -66,10 +66,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
             [](const ostk::astro::solvers::FiniteDifferenceSolver& solver,
                const State& aState,
                const Array<Instant>& anInstantArray,
-               std::function<Array<State>(const State&, const Array<Instant>&)> getStates,
+               std::function<MatrixXd(const State&, const Array<Instant>&)> generateStateCoordinates,
                const Real& aStepPercentage = 1e-3) -> Eigen::MatrixXd
             {
-                return solver.computeStateTransitionMatrix(aState, anInstantArray, getStates, aStepPercentage);
+                return solver.computeStateTransitionMatrix(
+                    aState, anInstantArray, generateStateCoordinates, aStepPercentage
+                );
             },
             R"doc(
                 Compute the state transition matrix.
@@ -77,7 +79,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
                 Args:
                     state (State): The state.
                     instants (Array(Instant)): The instants at which to calculate the STM.
-                    get_states (function): The function to get the states.
+                    generate_states_coordinatess (function): The function to get the states.
                     step_percentage (float): The step percentage. Defaults to 1e-3.
 
                 Returns:
@@ -85,7 +87,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
             )doc",
             arg("state"),
             arg("instants"),
-            arg("get_states"),
+            arg("generate_states_coordinatess"),
             arg("step_percentage")
         )
         .def(
@@ -93,10 +95,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
             [](const ostk::astro::solvers::FiniteDifferenceSolver& solver,
                const State& aState,
                const Instant& anInstant,
-               std::function<State(const State&, const Instant&)> generateState,
+               std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates,
                const Real& aStepPercentage = 1e-3) -> MatrixXd
             {
-                return solver.computeStateTransitionMatrix(aState, anInstant, generateState, aStepPercentage);
+                return solver.computeStateTransitionMatrix(
+                    aState, anInstant, generateStateCoordinates, aStepPercentage
+                );
             },
             R"doc(
                 Compute the state transition matrix.
@@ -104,7 +108,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
                 Args:
                     state (State): The state.
                     instant (Instant): The instant at which to calculate the STM.
-                    get_state (function): The function to get the state.
+                    generate_state_coordinates (function): The function to get the state.
                     step_percentage (float): The step percentage. Defaults to 1e-3.
 
                 Returns:
@@ -112,31 +116,31 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(pybin
             )doc",
             arg("state"),
             arg("instant"),
-            arg("get_state"),
+            arg("generate_state_coordinates"),
             arg("step_percentage")
         )
         .def(
             "compute_gradient",
             [](const ostk::astro::solvers::FiniteDifferenceSolver& solver,
                const State& aState,
-               std::function<State(const State&, const Instant&)> generateState,
+               std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates,
                const Duration& aStepSize = Duration::Seconds(1e-6)) -> VectorXd
             {
-                return solver.computeGradient(aState, generateState, aStepSize);
+                return solver.computeGradient(aState, generateStateCoordinates, aStepSize);
             },
             R"doc(
                 Compute the gradient.
 
                 Args:
                     state (State): The state.
-                    get_state (function): The function to get the state.
+                    generate_state_coordinates (function): The function to generate the state.
                     step_size (duration): The step size as a duration. Defaults to 1e-6 seconds.
 
                 Returns:
                     np.array: The state transition matrix.
             )doc",
             arg("state"),
-            arg("get_state"),
+            arg("generate_state_coordinates"),
             arg("step_size")
         )
 

--- a/bindings/python/test/solvers/test_finite_difference_solver.py
+++ b/bindings/python/test/solvers/test_finite_difference_solver.py
@@ -152,3 +152,6 @@ class TestFiniteDifferenceSolver:
         )
         assert isinstance(gradient, np.ndarray)
         assert all(gradient - np.array([0.0, -1.0]) < 1e-6)
+
+    def test_default(self):
+        assert isinstance(FiniteDifferenceSolver.default(), FiniteDifferenceSolver)

--- a/include/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.hpp
@@ -68,7 +68,8 @@ class FiniteDifferenceSolver
     ///
     /// @param                  [in] aState A state.
     /// @param                  [in] anInstantArray An array of instants.
-    /// @param                  [in] getStates Callable to generate States at the requested Instants.
+    /// @param                  [in] generateStateCoordinates Callable to generate coordinates of States at the
+    /// requested Instants.
     /// @param                  [in] aStepPercentage The step percentage to use for the perturbation. Defaults to 1e-3.
     ///
     /// @return                 The State Transition Matrix
@@ -76,7 +77,7 @@ class FiniteDifferenceSolver
     MatrixXd computeStateTransitionMatrix(
         const State& aState,
         const Array<Instant>& anInstantArray,
-        std::function<Array<State>(const State&, const Array<Instant>&)> getStates,
+        std::function<MatrixXd(const State&, const Array<Instant>&)> generateStateCoordinates,
         const Real& aStepPercentage = 1e-3
     ) const;
 
@@ -84,7 +85,8 @@ class FiniteDifferenceSolver
     ///
     /// @param                  [in] aState A state.
     /// @param                  [in] anInstant An instant.
-    /// @param                  [in] generateState Callable to generate a State at the requested Instant.
+    /// @param                  [in] generateStateCoordinates Callable to generate coordinates of a state at the
+    /// requested Instant.
     /// @param                  [in] aStepPercentage The step percentage to use for the perturbation. Defaults to 1e-3.
     ///
     /// @return                 The State Transition Matrix
@@ -92,22 +94,22 @@ class FiniteDifferenceSolver
     MatrixXd computeStateTransitionMatrix(
         const State& aState,
         const Instant& anInstant,
-        std::function<State(const State&, const Instant&)> generateState,
+        std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates,
         const Real& aStepPercentage = 1e-3
     ) const;
 
     /// @brief                  Compute the gradient
     ///
     /// @param                  [in] aState The state to compute the gradient of.
-    /// @param                  [in] generateState Callable that generates the state given an initial state and target.
-    /// instant.
+    /// @param                  [in] generateStateCoordinates Callable to generate coordinates of a state at the
+    /// requested Instant.
     /// @param                  [in] aStepSize The step size to use for the time perturbation step.
     ///
     /// @return                 The gradient
 
     VectorXd computeGradient(
         const State& aState,
-        std::function<State(const State&, const Instant&)> generateState,
+        std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates,
         const Duration& aStepSize = Duration::Milliseconds(1e-3)
     ) const;
 
@@ -125,6 +127,12 @@ class FiniteDifferenceSolver
     /// @return                 The string name of the type.
 
     static String StringFromType(const Type& aType);
+
+    /// @brief                  Default Finite Difference Solver
+    ///
+    /// @return                 The default Finite Difference Solver.
+
+    static FiniteDifferenceSolver Default();
 
    private:
     const Type type_;

--- a/include/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.hpp
@@ -106,7 +106,7 @@ class FiniteDifferenceSolver
     ///
     /// @param                  [in] aState A state.
     /// @param                  [in] anInstant An instant.
-    /// @param                  [in] generateStateCoordinates Callable to generate coordinates of a state at the
+    /// @param                  [in] generateStateCoordinates Callable to generate coordinates of a State at the
     /// requested Instant.
     /// @param                  [in] aStepPercentage The step percentage to use for the perturbation. Defaults to 1e-3.
     ///
@@ -121,7 +121,7 @@ class FiniteDifferenceSolver
     /// @brief                  Compute the gradient
     ///
     /// @param                  [in] aState The state to compute the gradient of.
-    /// @param                  [in] generateStateCoordinates Callable to generate coordinates of a state at the
+    /// @param                  [in] generateStateCoordinates Callable to generate coordinates of a State at the
     /// requested Instant.
     ///
     /// @return                 The gradient

--- a/include/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.hpp
@@ -47,14 +47,18 @@ class FiniteDifferenceSolver
     ///
     /// @code
     ///                         const Type aType = FiniteDifferenceSolver::Type::Forward;
+    ///                         const Real aStepPercentage = 1e-3;
+    ///                         const Duration aStepDuration = Duration::Milliseconds(1e-3);
     ///
     ///                         FiniteDifferenceSolver finiteDifferenceSolver = {aType};
     ///
     /// @endcode
     ///
     /// @param                  [in] aType A Finite Difference type.
+    /// @param                  [in] aStepPercentage The step percentage to use for computing the STM.
+    /// @param                  [in] aStepDuration The step duration to use for computing the gradient.
 
-    FiniteDifferenceSolver(const Type& aType);
+    FiniteDifferenceSolver(const Type& aType, const Real& aStepPercentage, const Duration& aStepDuration);
 
     /// @brief                  Output stream operator.
     ///
@@ -63,6 +67,24 @@ class FiniteDifferenceSolver
     /// @return                 An output stream.
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const FiniteDifferenceSolver& aFiniteDifference);
+
+    /// @brief                  Get the Type.
+    ///
+    /// @return                 The Type.
+
+    Type getType() const;
+
+    /// @brief                  Get the step percentage.
+    ///
+    /// @return                 The step percentage.
+
+    Real getStepPercentage() const;
+
+    /// @brief                  Get the step duration.
+    ///
+    /// @return                 The step duration.
+
+    Duration getStepDuration() const;
 
     /// @brief                  Compute the State Transition Matrix by perturbing the coordinates
     ///
@@ -77,8 +99,7 @@ class FiniteDifferenceSolver
     MatrixXd computeStateTransitionMatrix(
         const State& aState,
         const Array<Instant>& anInstantArray,
-        std::function<MatrixXd(const State&, const Array<Instant>&)> generateStateCoordinates,
-        const Real& aStepPercentage = 1e-3
+        std::function<MatrixXd(const State&, const Array<Instant>&)> generateStateCoordinates
     ) const;
 
     /// @brief                  Compute the State Transition Matrix by perturbing the coordinates
@@ -94,8 +115,7 @@ class FiniteDifferenceSolver
     MatrixXd computeStateTransitionMatrix(
         const State& aState,
         const Instant& anInstant,
-        std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates,
-        const Real& aStepPercentage = 1e-3
+        std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates
     ) const;
 
     /// @brief                  Compute the gradient
@@ -103,14 +123,11 @@ class FiniteDifferenceSolver
     /// @param                  [in] aState The state to compute the gradient of.
     /// @param                  [in] generateStateCoordinates Callable to generate coordinates of a state at the
     /// requested Instant.
-    /// @param                  [in] aStepSize The step size to use for the time perturbation step.
     ///
     /// @return                 The gradient
 
     VectorXd computeGradient(
-        const State& aState,
-        std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates,
-        const Duration& aStepSize = Duration::Milliseconds(1e-3)
+        const State& aState, std::function<VectorXd(const State&, const Instant&)> generateStateCoordinates
     ) const;
 
     /// @brief                  Print the solver.
@@ -136,6 +153,8 @@ class FiniteDifferenceSolver
 
    private:
     const Type type_;
+    const Real stepPercentage_;
+    const Duration stepDuration_;
 };
 
 }  // namespace solvers

--- a/test/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.test.cpp
@@ -221,3 +221,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, StringFrom
     EXPECT_EQ("Forward", FiniteDifferenceSolver::StringFromType(FiniteDifferenceSolver::Type::Forward));
     EXPECT_EQ("Backward", FiniteDifferenceSolver::StringFromType(FiniteDifferenceSolver::Type::Backward));
 }
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, Default)
+{
+    EXPECT_NO_THROW(FiniteDifferenceSolver::Default());
+}


### PR DESCRIPTION
Updating the callable interface to return coordinates so that it's easier to generate the STM/Gradient. It's a bit annoying to create a state when we're only using the coordinates. Also, in cases like QLaw, we're finite differencing abstract concepts like the Q value where it doesn't make sense to create a fake state for it.