### PR TITLE
feat: use analytical derivatives for QLaw

### DIFF
--- a/bindings/python/docs/Demonstration/Orbit Propagation.ipynb
+++ b/bindings/python/docs/Demonstration/Orbit Propagation.ipynb
@@ -265,10 +265,12 @@
     "moon_third_body_gravity = ThirdBodyGravity(Moon.default())\n",
     "atmospheric_drag = AtmosphericDrag(earth)\n",
     "constant_thrust_thruster = Thruster(\n",
-    "        satellite_system=satellite_system,\n",
-    "        guidance_law=ConstantThrust.intrack(True), # Use a factory method of the ConstantThrust guidance law for this\n",
-    "        name=\"Constant Thrust Thruster Dynamics\",\n",
-    "    )"
+    "    satellite_system=satellite_system,\n",
+    "    guidance_law=ConstantThrust.intrack(\n",
+    "        True\n",
+    "    ),  # Use a factory method of the ConstantThrust guidance law for this\n",
+    "    name=\"Constant Thrust Thruster Dynamics\",\n",
+    ")"
    ]
   },
   {

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/GuidanceLaw/QLaw.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/GuidanceLaw/QLaw.cpp
@@ -19,7 +19,6 @@ using ostk::physics::units::Derived;
 using ostk::astro::GuidanceLaw;
 using ostk::astro::guidancelaw::QLaw;
 using ostk::astro::trajectory::orbit::models::kepler::COE;
-using ostk::astro::solvers::FiniteDifferenceSolver;
 
 void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
 {
@@ -176,7 +175,7 @@ void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
         .def("__repr__", &(shiftToString<QLaw>))
 
         .def(
-            init<const COE&, const Derived&, const QLaw::Parameters&, const FiniteDifferenceSolver&>(),
+            init<const COE&, const Derived&, const QLaw::Parameters&>(),
             R"doc(
                 Constructor.
 
@@ -184,13 +183,11 @@ void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
                     coe (COE): The target orbit described by Classical Orbital Elements.
                     gravitational_parameter (float): The gravitational parameter of the central body.
                     parameters (QLaw.Parameters): A set of parameters for the QLaw.
-                    finite_difference_solver (FiniteDifferenceSolver): The finite difference solver.
 
             )doc",
             arg("target_coe"),
             arg("gravitational_parameter"),
-            arg("parameters"),
-            arg("finite_difference_solver")
+            arg("parameters")
         )
 
         .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/GuidanceLaw/QLaw.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/GuidanceLaw/QLaw.cpp
@@ -22,9 +22,30 @@ using ostk::astro::trajectory::orbit::models::kepler::COE;
 
 void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
 {
-    class_<QLaw::Parameters>(
+    class_<QLaw, GuidanceLaw, Shared<QLaw>> qLaw(
         aModule,
-        "QLawParameters",
+        "QLaw",
+        R"doc(
+            This class implements the Q-law guidance law.
+
+            Ref: https://dataverse.jpl.nasa.gov/api/access/datafile/10307?gbrecs=true
+            Ref: https://www.researchgate.net/publication/370849580_Analytic_Calculation_and_Application_of_the_Q-Law_Guidance_Algorithm_Partial_Derivatives
+            Ref for derivations: https://dataverse.jpl.nasa.gov/api/access/datafile/13727?gbrecs=true
+
+            The Q-law is a Lyapunov feedback control law developed by Petropoulos,
+            based on analytic expressions for maximum rates of change of the orbit elements and
+            the desired changes in the elements. Q, the proximity quotient, serves as a candidate Lyapunov
+            function. As the spacecraft approaches the target orbit, Q decreases monotonically (becoming zero at the target orbit).
+
+            Group:
+                guidance-law
+        )doc"
+    )
+
+        ;
+    class_<QLaw::Parameters>(
+        qLaw,
+        "Parameters",
         R"doc(
             Q-law parameters.
 
@@ -151,31 +172,26 @@ void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
 
         ;
 
-    class_<QLaw, GuidanceLaw, Shared<QLaw>>(
-        aModule,
-        "QLaw",
+    enum_<QLaw::GradientStrategy>(
+        qLaw,
+        "GradientStrategy",
         R"doc(
-            This class implements the Q-law guidance law.
-
-            Ref: https://dataverse.jpl.nasa.gov/api/access/datafile/10307?gbrecs=true
-            Ref: https://www.researchgate.net/publication/370849580_Analytic_Calculation_and_Application_of_the_Q-Law_Guidance_Algorithm_Partial_Derivatives
-            Ref for derivations: https://dataverse.jpl.nasa.gov/api/access/datafile/13727?gbrecs=true
-
-            The Q-law is a Lyapunov feedback control law developed by Petropoulos,
-            based on analytic expressions for maximum rates of change of the orbit elements and
-            the desired changes in the elements. Q, the proximity quotient, serves as a candidate Lyapunov
-            function. As the spacecraft approaches the target orbit, Q decreases monotonically (becoming zero at the target orbit).
-
-            Group:
-                guidance-law
+            Gradient strategy.
         )doc"
     )
+
+        .value("Analytical", QLaw::GradientStrategy::Analytical, "Analytical")
+        .value("FiniteDifference", QLaw::GradientStrategy::FiniteDifference, "Finite Differenced")
+
+        ;
+
+    qLaw
 
         .def("__str__", &(shiftToString<QLaw>))
         .def("__repr__", &(shiftToString<QLaw>))
 
         .def(
-            init<const COE&, const Derived&, const QLaw::Parameters&>(),
+            init<const COE&, const Derived&, const QLaw::Parameters&, const QLaw::GradientStrategy&>(),
             R"doc(
                 Constructor.
 
@@ -183,11 +199,13 @@ void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
                     coe (COE): The target orbit described by Classical Orbital Elements.
                     gravitational_parameter (float): The gravitational parameter of the central body.
                     parameters (QLaw.Parameters): A set of parameters for the QLaw.
+                    gradient_strategy (QLaw.GradientStrategy): The strategy used to compute the gradient dQ_dOE. Defaults to FiniteDifference.
 
             )doc",
             arg("target_coe"),
             arg("gravitational_parameter"),
-            arg("parameters")
+            arg("parameters"),
+            arg("gradient_strategy") = QLaw::GradientStrategy::FiniteDifference
         )
 
         .def(
@@ -208,6 +226,16 @@ void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
 
                 Returns:
                     COE: The target COE.
+            )doc"
+        )
+        .def(
+            "get_gradient_strategy",
+            &QLaw::getGradientStrategy,
+            R"doc(
+                Get the gradient strategy.
+
+                Returns:
+                    QLaw.GradientStrategy: The gradient strategy.
             )doc"
         )
 

--- a/bindings/python/test/guidance_law/test_qlaw.py
+++ b/bindings/python/test/guidance_law/test_qlaw.py
@@ -18,7 +18,6 @@ from ostk.physics.units import Derived
 from ostk.astrodynamics.trajectory.orbit.models.kepler import COE
 from ostk.astrodynamics import GuidanceLaw
 from ostk.astrodynamics.guidance_law import QLaw
-from ostk.astrodynamics.guidance_law import QLawParameters
 
 
 @pytest.fixture
@@ -41,8 +40,8 @@ def gravitational_parameter() -> Derived:
 
 
 @pytest.fixture
-def parameters() -> QLawParameters:
-    return QLawParameters(
+def parameters() -> QLaw.Parameters:
+    return QLaw.Parameters(
         element_weights={
             COE.Element.SemiMajorAxis: (1.0, 100.0),
             COE.Element.Eccentricity: (1.0, 1e-3),
@@ -51,15 +50,22 @@ def parameters() -> QLawParameters:
 
 
 @pytest.fixture
+def gradient_strategy() -> QLaw.GradientStrategy:
+    return QLaw.GradientStrategy.FiniteDifference
+
+
+@pytest.fixture
 def q_law(
     target_COE: COE,
     gravitational_parameter: Derived,
-    parameters: QLawParameters,
+    parameters: QLaw.Parameters,
+    gradient_strategy: QLaw.GradientStrategy,
 ) -> QLaw:
     return QLaw(
         target_coe=target_COE,
         gravitational_parameter=gravitational_parameter,
         parameters=parameters,
+        gradient_strategy=gradient_strategy,
     )
 
 
@@ -89,11 +95,11 @@ def instant() -> Instant:
 
 
 class TestQLawParameters:
-    def test_constructors(self, parameters: QLawParameters):
+    def test_constructors(self, parameters: QLaw.Parameters):
         assert parameters is not None
-        assert isinstance(parameters, QLawParameters)
+        assert isinstance(parameters, QLaw.Parameters)
 
-    def test_getters(self, parameters: QLawParameters):
+    def test_getters(self, parameters: QLaw.Parameters):
         assert parameters.get_control_weights() is not None
         assert parameters.m is not None
         assert parameters.n is not None
@@ -110,6 +116,7 @@ class TestQLaw:
     def test_getters(self, q_law: QLaw):
         assert q_law.get_parameters() is not None
         assert q_law.get_target_coe() is not None
+        assert q_law.get_gradient_strategy() is not None
 
     def test_calculate_thrust_acceleration_at(
         self,

--- a/bindings/python/test/guidance_law/test_qlaw.py
+++ b/bindings/python/test/guidance_law/test_qlaw.py
@@ -15,7 +15,6 @@ from ostk.physics.units import Angle
 from ostk.physics.units import Derived
 
 
-from ostk.astrodynamics.solvers import FiniteDifferenceSolver
 from ostk.astrodynamics.trajectory.orbit.models.kepler import COE
 from ostk.astrodynamics import GuidanceLaw
 from ostk.astrodynamics.guidance_law import QLaw
@@ -52,22 +51,15 @@ def parameters() -> QLawParameters:
 
 
 @pytest.fixture
-def finite_difference_solver() -> FiniteDifferenceSolver:
-    return FiniteDifferenceSolver.default()
-
-
-@pytest.fixture
 def q_law(
     target_COE: COE,
     gravitational_parameter: Derived,
     parameters: QLawParameters,
-    finite_difference_solver: FiniteDifferenceSolver,
 ) -> QLaw:
     return QLaw(
         target_coe=target_COE,
         gravitational_parameter=gravitational_parameter,
         parameters=parameters,
-        finite_difference_solver=finite_difference_solver,
     )
 
 

--- a/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp
@@ -11,9 +11,7 @@
 #include <OpenSpaceToolkit/Physics/Units/Derived.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/GuidanceLaw.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 namespace ostk
 {
@@ -44,8 +42,6 @@ using ostk::physics::units::Length;
 
 using ostk::astro::trajectory::orbit::models::kepler::COE;
 using ostk::astro::GuidanceLaw;
-using ostk::astro::solvers::FiniteDifferenceSolver;
-using ostk::astro::trajectory::StateBuilder;
 
 /// @brief                     The Q-law is a Lyapunov feedback control law developed by Petropoulos,
 ///    based on analytic expressions for maximum rates of change of the orbit elements and
@@ -76,9 +72,9 @@ class QLaw : public GuidanceLaw
         Vector5d getControlWeights() const;
         Length getMinimumPeriapsisRadius() const;
 
-        const Size m;
-        const Size n;
-        const Size r;
+        const double m;
+        const double n;
+        const double r;
         const double b;
         const double k;
         const double periapsisWeight;
@@ -103,14 +99,8 @@ class QLaw : public GuidanceLaw
     /// @param                  [in] aCOE A target orbit described by Classical Orbital Elements.
     /// @param                  [in] aGravitationalParameter The gravitational parameter of the central body.
     /// @param                  [in] aParameterSet A set of parameters for the QLaw.
-    /// @param                  [in] aFiniteDifferenceSolver The finite difference solver.
 
-    QLaw(
-        const COE& aCOE,
-        const Derived& aGravitationalParameter,
-        const Parameters& aParameterSet,
-        const FiniteDifferenceSolver& aFiniteDifferenceSolver
-    );
+    QLaw(const COE& aCOE, const Derived& aGravitationalParameter, const Parameters& aParameterSet);
 
     /// @brief                  Destructor
 
@@ -225,8 +215,6 @@ class QLaw : public GuidanceLaw
     const double mu_;
     const Vector6d targetCOEVector_;
     const Derived gravitationalParameter_;
-    const FiniteDifferenceSolver finiteDifferenceSolver_;
-    const StateBuilder stateBuilder_;
 
     Vector5d computeDeltaCOE(const Vector5d& aCOEVector) const;
 };

--- a/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp
@@ -235,13 +235,11 @@ class QLaw : public GuidanceLaw
     static Matrix3d ThetaRHToGCRF(const Vector3d& aPositionCoordinates, const Vector3d& aVelocityCoordinates);
 
    private:
-    Parameters parameters_;
+    const Parameters parameters_;
     const double mu_;
     const Vector6d targetCOEVector_;
     const Derived gravitationalParameter_;
-
     const GradientStrategy gradientStrategy_;
-
     const FiniteDifferenceSolver finiteDifferenceSolver_;
     const StateBuilder stateBuilder_;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp
@@ -13,6 +13,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/GuidanceLaw.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Kepler/COE.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 namespace ostk
 {
@@ -45,6 +46,7 @@ using ostk::physics::units::Length;
 using ostk::astro::GuidanceLaw;
 using ostk::astro::trajectory::orbit::models::kepler::COE;
 using ostk::astro::solvers::FiniteDifferenceSolver;
+using ostk::astro::trajectory::StateBuilder;
 
 /// @brief                     The Q-law is a Lyapunov feedback control law developed by Petropoulos,
 ///    based on analytic expressions for maximum rates of change of the orbit elements and
@@ -146,6 +148,12 @@ class QLaw : public GuidanceLaw
 
     COE getTargetCOE() const;
 
+    /// @brief                  Get Gradient Strategy
+    ///
+    /// @return                 Gradient Strategy
+
+    GradientStrategy getGradientStrategy() const;
+
     /// @brief                  Print guidance law
     ///
     /// @param                  [in] anOutputStream An output stream
@@ -233,6 +241,7 @@ class QLaw : public GuidanceLaw
     const Derived gravitationalParameter_;
 
     const GradientStrategy gradientStrategy_;
+
     const FiniteDifferenceSolver finiteDifferenceSolver_;
     const StateBuilder stateBuilder_;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
@@ -5,7 +5,6 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
 
 namespace ostk
 {
@@ -23,7 +22,6 @@ using ostk::physics::coord::Position;
 using ostk::physics::coord::Velocity;
 
 using ostk::astro::trajectory::State;
-using ostk::astro::trajectory::state::CoordinatesSubset;
 
 QLaw::Parameters::Parameters(
     const Map<COE::Element, Tuple<double, double>>& anElementWeightsMap,
@@ -80,19 +78,12 @@ Length QLaw::Parameters::getMinimumPeriapsisRadius() const
     return Length::Meters(minimumPeriapsisRadius_);
 }
 
-QLaw::QLaw(
-    const COE& aCOE,
-    const Derived& aGravitationalParameter,
-    const QLaw::Parameters& aParameterSet,
-    const FiniteDifferenceSolver& aFiniteDifferenceSolver
-)
+QLaw::QLaw(const COE& aCOE, const Derived& aGravitationalParameter, const QLaw::Parameters& aParameterSet)
     : GuidanceLaw("Q-Law"),
       parameters_(aParameterSet),
       mu_(aGravitationalParameter.in(aGravitationalParameter.getUnit())),
       targetCOEVector_(aCOE.getSIVector(COE::AnomalyType::True)),
-      gravitationalParameter_(aGravitationalParameter),
-      finiteDifferenceSolver_(aFiniteDifferenceSolver),
-      stateBuilder_(Frame::GCRF(), {std::make_shared<CoordinatesSubset>("QLaw Element Vector", 5)})
+      gravitationalParameter_(aGravitationalParameter)
 {
 }
 
@@ -149,25 +140,227 @@ Vector3d QLaw::calculateThrustAccelerationAt(
 
 Vector5d QLaw::compute_dQ_dOE(const Vector5d& aCOEVector, const double& aThrustAcceleration) const
 {
-    const auto getQ = [this,
-                       &aThrustAcceleration](const State& aState, [[maybe_unused]] const Instant& anInstant) -> VectorXd
+    const double& semiMajorAxis = aCOEVector(0);
+    const double& eccentricity = aCOEVector(1);
+    const double& inclination = aCOEVector(2);
+    const double& rightAscensionOfAscendingNode = aCOEVector(3);
+    const double& argumentOfPeriapsis = aCOEVector(4);
+
+    const double& semiMajorAxisTarget = targetCOEVector_(0);
+    const double& eccentricityTarget = targetCOEVector_(1);
+    const double& inclinationTarget = targetCOEVector_(2);
+    const double& rightAscensionOfAscendingNodeTarget = targetCOEVector_(3);
+    const double& argumentOfPeriapsisTarget = targetCOEVector_(4);
+
+    const double& semiMajorAxisWeight = parameters_.controlWeights_(0);
+    const double& eccentricityWeight = parameters_.controlWeights_(1);
+    const double& inclinationWeight = parameters_.controlWeights_(2);
+    const double& rightAscensionOfAscendingNodeWeight = parameters_.controlWeights_(3);
+    const double& argumentOfPeriapsisWeight = parameters_.controlWeights_(4);
+
+    const double& periapsisWeight = parameters_.periapsisWeight;
+    const double& minimumPeriapsisRadius = parameters_.minimumPeriapsisRadius_;
+
+    // common grouped expressions
+    const double x0 = 1.0 / minimumPeriapsisRadius;
+    const double x1 = eccentricity - 1.0;
+    const double x2 = x0 * x1;
+    const double x3 = eccentricity - eccentricityTarget;
+    const double x4 = eccentricityWeight * std::pow(x3, 2.0);
+    const double x5 = 1.0 / semiMajorAxis;
+    const double x6 = std::pow(eccentricity, 2.0);
+    const double x7 = x6 - 1.0;
+    const double x8 = 1.0 / x7;
+    const double x9 = x5 * x8;
+    const double x10 = semiMajorAxis - semiMajorAxisTarget;
+    const double x11 = std::pow(x10, 2.0);
+    const double x12 = std::pow(semiMajorAxis, -3.0);
+    const double x13 = eccentricity + 1.0;
+    const double x14 = 1.0 / x13;
+    const double x15 = std::pow(x10 / (parameters_.m * semiMajorAxisTarget), parameters_.n);
+    const double x16 = x15 + 1.0;
+    const double x17 = 1.0 / parameters_.r;
+    const double x18 = std::pow(x16, x17);
+    const double x19 = semiMajorAxisWeight * x12 * x14 * x18;
+    const double x20 = x11 * x19;
+    const double x21 = 4.0 * x9;
+    const double x22 = inclination - inclinationTarget;
+    const double x23 = std::pow(x22, 2.0);
+    const double x24 = std::cos(argumentOfPeriapsis);
+    const double x25 = std::fabs(x24);
+    const double x26 = std::sin(argumentOfPeriapsis);
+    const double x27 = std::pow(x26, 2.0);
+    const double x28 = std::sqrt(-x27 * x6 + 1.0);
+    const double x29 = eccentricity * x25 - x28;
+    const double x30 = inclinationWeight * std::pow(x29, 2.0);
+    const double x31 = x23 * x30;
+    const double x32 = std::fabs(x26);
+    const double x33 = std::pow(x24, 2.0);
+    const double x34 = std::sqrt(-x33 * x6 + 1.0);
+    const double x35 = eccentricity * x32 - x34;
+    const double x36 = std::pow(x35, 2.0);
+    const double x37 = rightAscensionOfAscendingNode - rightAscensionOfAscendingNodeTarget;
+    const double x38 = std::cos(x37);
+    const double x39 = std::acos(x38);
+    const double x40 = std::pow(x39, 2.0);
+    const double x41 = std::sin(inclination);
+    const double x42 = std::pow(x41, 2.0);
+    const double x43 = rightAscensionOfAscendingNodeWeight * x40 * x42;
+    const double x44 = x36 * x43;
+    const double x45 = semiMajorAxis * x7;
+    const double x46 = std::pow(parameters_.b + 1.0, 2.0);
+    const double x47 = 1.0 / x35;
+    const double x48 = std::cos(inclination);
+    const double x49 = std::fabs(x48);
+    const double x50 = parameters_.b * x49 / x41;
+    const double x51 = 1.0 / eccentricity;
+    const double x52 = -x7;
+    const double x53 = x52 / std::pow(eccentricity, 3.0);
+    const double x54 = std::sqrt(0.14814814814814814 + std::pow(x52, 2.0) / std::pow(eccentricity, 6.0));
+    const double x55 = x53 + x54;
+    const double x56 = -x53 + x54;
+    const double x57 =
+        x51 - 0.79370052598409979 * std::pow(x55, (1.0 / 3.0)) + 0.79370052598409979 * std::pow(x56, (1.0 / 3.0));
+    const double x58 = -x57;
+    const double x59 = std::pow(x58, 2.0);
+    const double x60 = x59 - 1.0;
+    const double x61 = std::fabs(semiMajorAxis);
+    const double x62 = std::fabs(x7);
+    const double x63 = x51 * x61 * x62;
+    const double x64 =
+        x45 * x47 * x50 +
+        x63 * std::sqrt(std::pow(x57, 2.0) - x60 * std::pow(1.0 + 1.0 / (-eccentricity * x57 + 1.0), 2.0));
+    const double x65 = std::pow(x64, -2.0);
+    const double x66 = argumentOfPeriapsis - argumentOfPeriapsisTarget;
+    const double x67 = std::cos(x66);
+    const double x68 = std::acos(x67);
+    const double x69 = std::pow(x68, 2.0);
+    const double x70 = 4.0 * x69;
+    const double x71 = periapsisWeight * std::exp(parameters_.k * (semiMajorAxis * x2 + 1.0));
+    const double x72 = parameters_.k * x71 *
+                       (argumentOfPeriapsisWeight * x45 * x46 * x65 * x70 + x1 * x20 + x21 * x31 + x21 * x44 + x4 * x9);
+    const double x73 = x71 + 1.0;
+    const double x74 = mu_ * x4;
+    const double x75 = std::pow(semiMajorAxis, 2.0);
+    const double x76 = 1.0 / x52;
+    const double x77 = x76 / x75;
+    const double x78 = -x1;
+    const double x79 = mu_ * x10 * x19 * x78;
+    const double x80 = inclinationWeight * x23;
+    const double x81 = 4.0 * mu_ * x77;
+    const double x82 = mu_ * semiMajorAxisWeight * x11 * x18;
+    const double x83 = -x35;
+    const double x84 = std::pow(x83, 2.0);
+    const double x85 = x50 / x83;
+    const double x86 = x52 * x85;
+    const double x87 = -x60;
+    const double x88 = eccentricity * x58 + 1.0;
+    const double x89 = 1.0 / x88;
+    const double x90 = x89 + 1.0;
+    const double x91 = std::pow(x90, 2.0);
+    const double x92 = std::sqrt(x59 + x87 * x91);
+    const double x93 = x51 * x52 / (x61 * x62 * x92);
+    const double x94 = 2.0 * semiMajorAxis;
+    const double x95 = mu_ * semiMajorAxis;
+    const double x96 = x52 * x95;
+    const double x97 = argumentOfPeriapsisWeight * x46 * x70;
+    const double x98 = std::pow(aThrustAcceleration, -2.0);
+    const double x99 = (1.0 / 4.0) * x98;
+    const double x100 = mu_ * x9;
+    const double x101 = 2.0 * eccentricity;
+    const double x102 = std::pow(x7, 2.0);
+    const double x103 = x5 / x102;
+    const double x104 = eccentricity * mu_;
+    const double x105 = 8.0 * x103 * x104;
+    const double x106 = eccentricity / x28;
+    const double x107 = 8.0 * x100;
+    const double x108 = eccentricity / x34;
+    const double x109 = x108 * x33 + x32;
+    const double x110 = x35 * x43;
+    const double x111 = std::pow(x64, -3.0);
+    const double x112 = 1.0 / x6;
+    const double x113 = 2.0 * x61 * x62 * x92;
+    const double x114 = x112 * x52;
+    const double x115 = (1.0 / 3.0) * x53 * (3.0 * x114 + 2.0) / x54;
+    const double x116 = x112 * (1.0 - 1.0 * x6) + (2.0 / 3.0);
+    const double x117 = std::pow(x55, -(2.0 / 3.0)) * (x115 + x116);
+    const double x118 = std::pow(x56, -(2.0 / 3.0)) * (-x115 + x116);
+    const double x119 = -1.5874010519681996 * x117 - 1.5874010519681996 * x118 + 2.0;
+    const double x120 = rightAscensionOfAscendingNodeWeight * x100 * x36;
+    const double x121 = argumentOfPeriapsisWeight * x102 * x111 * x46 * x69 * x75;
+    const double x122 = 2.0 * x73 * x98;
+    const double x123 = x24 * (x108 * x26 - (((x26) > 0) - ((x26) < 0)));
+
+    double dQ_dSemiMajorAxis =
+        -x99 * (mu_ * x2 * x72 + x73 * (-parameters_.n * x15 * x17 * x79 / x16 + std::pow(x29, 2.0) * x80 * x81 +
+                                        x43 * x81 * x84 + x74 * x77 - 2.0 * x79 -
+                                        x96 * x97 *
+                                            (x5 * x51 * x61 * x62 * x92 - x86 -
+                                             x93 * x94 * (x52 * x59 + x87 * x90 * (x52 * x89 - x6 + 1.0))) /
+                                            std::pow(semiMajorAxis * x86 + x63 * x92, 3.0) +
+                                        3.0 * x14 * x78 * x82 / std::pow(semiMajorAxis, 4.0)));
+
+    double dQ_dEccentricity =
+        -x99 *
+        (x0 * x72 * x95 +
+         x73 *
+             (2.0 * eccentricityWeight * x100 * x3 + mu_ * x20 - x1 * x12 * x82 / std::pow(x13, 2.0) -
+              x101 * x103 * x74 - x105 * x31 - x105 * x44 + x107 * x109 * x110 + x107 * x29 * x80 * (x106 * x27 + x25) +
+              x111 * x97 * std::pow(-x7 * x95, 3.0 / 2.0) *
+                  (-semiMajorAxis * x101 * x85 + x109 * x50 * x52 * x94 / x84 - x112 * x113 + x113 * x76 +
+                   x75 * x93 *
+                       (-4.0 * eccentricity * x59 + x112 * x119 * x52 * x58 - x114 * x119 * x58 * x91 +
+                        2.0 * x87 * x90 *
+                            (-x101 * x89 - x101 +
+                             x52 * (-x51 * (-0.79370052598409979 * x117 - 0.79370052598409979 * x118 + 1.0) + x57) /
+                                 std::pow(x88, 2.0)))) /
+                  std::sqrt(x96)));
+
+    double dQ_dInclination =
+        -x122 * (mu_ * parameters_.b * x121 * x47 * ((((x48) > 0) - ((x48) < 0)) + x48 * x49 / x42) + x100 * x22 * x30 +
+                 x120 * x40 * x41 * x48);
+
+    double dQ_dRightAscensionOfAscendingNode =
+        -x120 * x122 * x39 * x42 * std::sin(x37) / std::sqrt(1.0 - std::pow(x38, 2.0));
+
+    double dQ_dArgumentOfPeriapsis = -x122 * (argumentOfPeriapsisWeight * mu_ * semiMajorAxis * x46 * x65 * x68 * x7 *
+                                                  std::sin(x66) / std::sqrt(1.0 - std::pow(x67, 2.0)) +
+                                              eccentricity * inclinationWeight * mu_ * x23 * x26 * x29 * x5 * x8 *
+                                                  (x106 * x24 - (((x24) > 0) - ((x24) < 0))) -
+                                              eccentricity * x100 * x110 * x123 - x104 * x121 * x123 * x50 / x36);
+
+    if (!std::isfinite(dQ_dSemiMajorAxis))
     {
-        const Vector5d& coeVector = aState.accessCoordinates();
+        dQ_dSemiMajorAxis = 0.0;
+    }
 
-        VectorXd coordinates(1);
-        coordinates << this->computeQ(coeVector, aThrustAcceleration);
+    if (!std::isfinite(dQ_dEccentricity))
+    {
+        dQ_dEccentricity = 0.0;
+    }
 
-        return coordinates;
+    if (!std::isfinite(dQ_dInclination))
+    {
+        dQ_dInclination = 0.0;
+    }
+
+    if (!std::isfinite(dQ_dArgumentOfPeriapsis))
+    {
+        dQ_dArgumentOfPeriapsis = 0.0;
+    }
+
+    if (!std::isfinite(dQ_dRightAscensionOfAscendingNode))
+    {
+        dQ_dRightAscensionOfAscendingNode = 0.0;
+    }
+
+    return {
+        dQ_dSemiMajorAxis,
+        dQ_dEccentricity,
+        dQ_dInclination,
+        dQ_dRightAscensionOfAscendingNode,
+        dQ_dArgumentOfPeriapsis,
     };
-
-    const Vector5d jacobian = Eigen::Map<Vector5d>(
-        finiteDifferenceSolver_
-            .computeJacobian(stateBuilder_.build(Instant::J2000(), aCOEVector), Instant::J2000(), getQ, 1)
-            .data(),
-        5
-    );
-
-    return jacobian;
 }
 
 Vector3d QLaw::computeThrustDirection(const Vector6d& aCOEVector, const double& aThrustAcceleration) const

--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
@@ -170,8 +170,6 @@ Vector5d QLaw::compute_dQ_dOE(const Vector5d& aCOEVector, const double& aThrustA
 
 Vector3d QLaw::computeThrustDirection(const Vector6d& aCOEVector, const double& aThrustAcceleration) const
 {
-    const Vector3d D = -(jacobian.transpose() * derivativeMatrix).normalized();
-
     const Vector5d coeVectorSegment = aCOEVector.segment(0, 5);
 
     const Vector5d deltaCOE = computeDeltaCOE(coeVectorSegment);
@@ -193,8 +191,6 @@ Vector3d QLaw::computeThrustDirection(const Vector6d& aCOEVector, const double& 
     }
 
     const Vector3d D = -(jacobian.transpose() * derivativeMatrix).normalized();
-
-    return D;
 
     return D;
 }
@@ -318,6 +314,10 @@ Vector5d QLaw::computeOrbitalElementsMaximalChange(const Vector5d& aCOEVector, c
                                                semiLatusRectum * semiLatusRectum * cosTheta_xxSquared +
                                                std::pow((semiLatusRectum + r_xx), 2) * (1.0 - cosTheta_xxSquared)
                                            );
+
+    const double argumentOfPeriapsisO_xx = rightAscensionOfAscendingNode_xx * std::abs(std::cos(inclination));
+    const double argumentOfPeriapsis_xx =
+        (argumentOfPeriapsisI_xx + parameters_.b * argumentOfPeriapsisO_xx) / (1.0 + parameters_.b);
 
     return {
         semiMajorAxis_xx,

--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
@@ -5,6 +5,7 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinatesSubset.hpp>
 
 namespace ostk
 {
@@ -20,8 +21,10 @@ using ostk::math::object::VectorXd;
 
 using ostk::physics::coord::Position;
 using ostk::physics::coord::Velocity;
+using ostk::physics::coord::Frame;
 
 using ostk::astro::trajectory::State;
+using ostk::astro::trajectory::state::CoordinatesSubset;
 
 QLaw::Parameters::Parameters(
     const Map<COE::Element, Tuple<double, double>>& anElementWeightsMap,
@@ -91,9 +94,9 @@ QLaw::QLaw(
       gravitationalParameter_(aGravitationalParameter),
       gradientStrategy_(aGradientStrategy),
       finiteDifferenceSolver_(
-          FiniteDifferenceSolver(FiniteDifferenceSolver::Type::Central, 1e-6, Duration::Seconds(1e-6))
+          FiniteDifferenceSolver(FiniteDifferenceSolver::Type::Central, 1e-3, Duration::Seconds(1e-6))
       ),
-      stateBuilder_()
+      stateBuilder_(Frame::GCRF(), {std::make_shared<CoordinatesSubset>("QLaw Element Vector", 5)})
 {
 }
 
@@ -120,6 +123,11 @@ QLaw::Parameters QLaw::getParameters() const
 COE QLaw::getTargetCOE() const
 {
     return COE::FromSIVector(targetCOEVector_, COE::AnomalyType::True);
+}
+
+QLaw::GradientStrategy QLaw::getGradientStrategy() const
+{
+    return gradientStrategy_;
 }
 
 Vector3d QLaw::calculateThrustAccelerationAt(

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -747,7 +747,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access_Generator, AerRanges)
         const Environment environment = Environment::Default();
 
         const ostk::math::object::Interval<Real> azimuthRange = ostk::math::object::Interval<Real>::Closed(0.0, 360.0);
-        const ostk::math::object::Interval<Real> elevationRange = ostk::math::object::Interval<Real>::Closed(60.0, 90.0);
+        const ostk::math::object::Interval<Real> elevationRange =
+            ostk::math::object::Interval<Real>::Closed(60.0, 90.0);
         const ostk::math::object::Interval<Real> rangeRange = ostk::math::object::Interval<Real>::Closed(0.0, 10000e3);
 
         const Generator generator = Generator::AerRanges(azimuthRange, elevationRange, rangeRange, environment);

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
@@ -336,7 +336,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Comput
 
         const Vector5d dQ_dOE = qlaw.compute_dQ_dOE(currentCOEVector.segment(0, 5), thrustAcceleration);
 
-        // finite differences manually by using sympy
+        // calculated analtyically by using sympy
         const Vector5d expected_dQ_dOE = {
             -4451831.72900846,
             304679993012117.0,

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
@@ -58,7 +58,6 @@ using ostk::astro::trajectory::state::CoordinatesSubset;
 using ostk::astro::trajectory::state::CoordinatesBroker;
 using ostk::astro::trajectory::state::coordinatessubsets::CartesianPosition;
 using ostk::astro::trajectory::state::coordinatessubsets::CartesianVelocity;
-using ostk::astro::solvers::FiniteDifferenceSolver;
 using ostk::astro::flight::system::SatelliteSystem;
 using ostk::astro::flight::system::PropulsionSystem;
 using ostk::astro::Dynamics;
@@ -131,7 +130,6 @@ class OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw : public
             targetCOE,
             gravitationalParameter_,
             parameters,
-            finiteDifferenceSolver_,
         };
 
         return std::make_tuple(qlaw, currentCOEVector, thrustAcceleration);
@@ -165,13 +163,10 @@ class OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw : public
 
     const Real thrustAcceleration_ = 1.0 / 300.0;
 
-    const FiniteDifferenceSolver finiteDifferenceSolver_ = FiniteDifferenceSolver::Default();
-
     const QLaw qlaw_ = {
         targetCOE_,
         gravitationalParameter_,
         parameters_,
-        finiteDifferenceSolver_,
     };
 
     State initialState_ = State::Undefined();
@@ -179,11 +174,9 @@ class OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw : public
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Constructor)
 {
-    EXPECT_NO_THROW(QLaw qlaw(targetCOE_, gravitationalParameter_, parameters_, finiteDifferenceSolver_));
+    EXPECT_NO_THROW(QLaw qlaw(targetCOE_, gravitationalParameter_, parameters_));
 
-    EXPECT_THROW(
-        QLaw qlaw(targetCOE_, gravitationalParameter_, {{}}, finiteDifferenceSolver_), ostk::core::error::RuntimeError
-    );
+    EXPECT_THROW(QLaw qlaw(targetCOE_, gravitationalParameter_, {{}}), ostk::core::error::RuntimeError);
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, GetParameters)
@@ -275,7 +268,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Comput
 
         const Vector3d thrustDirection = qlaw.computeThrustDirection(currentCOEVector, thrustAcceleration);
 
-        const Vector3d expectedThrustDirection = {0.63856458, 0.00650164, -0.76954078};
+        const Vector3d expectedThrustDirection = {0.65328616, 0.00639639, -0.75708406};
 
         for (Size i = 0; i < 3; ++i)
         {
@@ -296,11 +289,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Comput
 
         // finite differences manually by using sympy
         const Vector5d expected_dQ_dOE = {
-            -4458973.44508479,
-            308846550517104.0,
-            478538133471352.0,
-            -99677385.5546418,
-            1306605428444.13,
+            -4451831.72900846,
+            304679993012117.0,
+            478538188797579.0,
+            -99677391.4654718,
+            1306605416901.52,
         };
 
         for (Size i = 0; i < 5; ++i)
@@ -360,7 +353,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Calcul
             targetCOE,
             gravitationalParameter_,
             parameters,
-            finiteDifferenceSolver_,
         };
 
         const COE currentCOE = {
@@ -400,7 +392,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Calcul
 
         for (Size i = 0; i < 3; ++i)
         {
-            EXPECT_NEAR(acceleration(i), accelerationExpected(i), 1e-12);
+            EXPECT_NEAR(acceleration(i), accelerationExpected(i), 1e-4);
         }
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -2535,7 +2535,7 @@ INSTANTIATE_TEST_SUITE_P(
     QLaw_GradientStrategy,
     OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw,
     testing::Values(
-        std::make_tuple(QLaw::GradientStrategy::Analytical), std::make_tuple(QLaw::GradientStrategy::FiniteDifference)
+        std::make_tuple(QLaw::GradientStrategy::FiniteDifference), std::make_tuple(QLaw::GradientStrategy::Analytical)
     )
 );
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -2525,8 +2525,25 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_Thruster
     Propagator defaultPropagator_ = Propagator::Undefined();
 };
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, QLaw_Paper_Case_A)
+class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw
+    : public OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator,
+      public ::testing::WithParamInterface<Tuple<QLaw::GradientStrategy>>
 {
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    QLaw_GradientStrategy,
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw,
+    testing::Values(
+        std::make_tuple(QLaw::GradientStrategy::Analytical), std::make_tuple(QLaw::GradientStrategy::FiniteDifference)
+    )
+);
+
+TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw, QLaw_Paper_Case_A)
+{
+    const auto testParameters = GetParam();
+    const QLaw::GradientStrategy gradientStrategy = std::get<0>(testParameters);
+
     const COE targetCOE = {
         Length::Meters(42000.0e3),
         0.01,
@@ -2553,7 +2570,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, QLaw_P
     const Derived gravitationalParameter =
         Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit());
 
-    const Shared<QLaw> qlaw = std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters));
+    const Shared<QLaw> qlaw =
+        std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
     const Mass mass = Mass::Kilograms(50.0);
     const Composite satelliteGeometry(Cuboid(
@@ -2623,9 +2641,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, QLaw_P
     EXPECT_TRUE(std::abs(endCOE.getSemiMajorAxis().inMeters() - targetCOE.getSemiMajorAxis().inMeters()) < 60000.0);
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, QLaw_Paper_Case_E)
+TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw, QLaw_Paper_Case_E)
 {
     GTEST_SKIP() << "Skipping test as it does not produce comparable results between Release + Debug.";
+
+    const auto testParameters = GetParam();
+    const QLaw::GradientStrategy gradientStrategy = std::get<0>(testParameters);
 
     const COE targetCOE = {
         Length::Meters(26500.0e3),
@@ -2649,7 +2670,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, QLaw_P
     const Derived gravitationalParameter =
         Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit());
 
-    const Shared<QLaw> qlaw = std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters));
+    const Shared<QLaw> qlaw =
+        std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
     const Mass mass = Mass::Kilograms(50.0);
     const Composite satelliteGeometry(Cuboid(
@@ -2725,8 +2747,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, QLaw_P
     // EXPECT_TRUE(std::abs(endCOE.getAop().inDegrees() - targetCOE.getAop().inDegrees()) < 1.0);
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_targeting)
+TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw, SSO_targeting)
 {
+    const auto testParameters = GetParam();
+    const QLaw::GradientStrategy gradientStrategy = std::get<0>(testParameters);
+
     const Orbit orbit = Orbit::SunSynchronous(
         Instant::J2000(), Length::Meters(585.0e3), Time(10, 0, 0), std::make_shared<Earth>(Earth::Default())
     );
@@ -2796,7 +2821,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_ta
             },
         };
 
-        const Shared<QLaw> qlaw = std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters));
+        const Shared<QLaw> qlaw =
+            std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
         const Shared<Thruster> thruster = std::make_shared<Thruster>(Thruster(satelliteSystem, qlaw));
         const Array<Shared<Dynamics>> dynamics = {
@@ -2832,9 +2858,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_ta
             },
         };
 
-        const Shared<QLaw> qlaw = std::make_shared<QLaw>(
-            QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default())
-        );
+        const Shared<QLaw> qlaw =
+            std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
         const Shared<Thruster> thruster = std::make_shared<Thruster>(Thruster(satelliteSystem, qlaw));
         const Array<Shared<Dynamics>> dynamics = {
@@ -2870,9 +2895,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_ta
             },
         };
 
-        const Shared<QLaw> qlaw = std::make_shared<QLaw>(
-            QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default())
-        );
+        const Shared<QLaw> qlaw =
+            std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
         const Shared<Thruster> thruster = std::make_shared<Thruster>(Thruster(satelliteSystem, qlaw));
         const Array<Shared<Dynamics>> dynamics = {
@@ -2908,9 +2932,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_ta
             },
         };
 
-        const Shared<QLaw> qlaw = std::make_shared<QLaw>(
-            QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default())
-        );
+        const Shared<QLaw> qlaw =
+            std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
         const Shared<Thruster> thruster = std::make_shared<Thruster>(Thruster(satelliteSystem, qlaw));
         const Array<Shared<Dynamics>> dynamics = {
@@ -2947,9 +2970,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_ta
             },
         };
 
-        const Shared<QLaw> qlaw = std::make_shared<QLaw>(
-            QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default())
-        );
+        const Shared<QLaw> qlaw =
+            std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
         const Shared<Thruster> thruster = std::make_shared<Thruster>(Thruster(satelliteSystem, qlaw));
         const Array<Shared<Dynamics>> dynamics = {
@@ -2988,9 +3010,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_ta
             },
         };
 
-        const Shared<QLaw> qlaw = std::make_shared<QLaw>(
-            QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default())
-        );
+        const Shared<QLaw> qlaw =
+            std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
         const Shared<Thruster> thruster = std::make_shared<Thruster>(Thruster(satelliteSystem, qlaw));
         const Array<Shared<Dynamics>> dynamics = {
@@ -3031,9 +3052,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_ta
             },
         };
 
-        const Shared<QLaw> qlaw = std::make_shared<QLaw>(
-            QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default())
-        );
+        const Shared<QLaw> qlaw =
+            std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
 
         const Shared<Thruster> thruster = std::make_shared<Thruster>(Thruster(satelliteSystem, qlaw));
         const Array<Shared<Dynamics>> dynamics = {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -2796,9 +2796,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, SSO_ta
             },
         };
 
-        const Shared<QLaw> qlaw = std::make_shared<QLaw>(
-            QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default())
-        );
+        const Shared<QLaw> qlaw = std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters));
 
         const Shared<Thruster> thruster = std::make_shared<Thruster>(Thruster(satelliteSystem, qlaw));
         const Array<Shared<Dynamics>> dynamics = {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -2553,8 +2553,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, QLaw_P
     const Derived gravitationalParameter =
         Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit());
 
-    const Shared<QLaw> qlaw =
-        std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default()));
+    const Shared<QLaw> qlaw = std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters));
 
     const Mass mass = Mass::Kilograms(50.0);
     const Composite satelliteGeometry(Cuboid(
@@ -2650,8 +2649,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator, QLaw_P
     const Derived gravitationalParameter =
         Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit());
 
-    const Shared<QLaw> qlaw =
-        std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, FiniteDifferenceSolver::Default()));
+    const Shared<QLaw> qlaw = std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters));
 
     const Mass mass = Mass::Kilograms(50.0);
     const Composite satelliteGeometry(Cuboid(


### PR DESCRIPTION
We should absolutely not review the functions that are calculating the analytical derivatives, it's a lot of code.
Instead if someone can use sympy to calculate the analytical derivatives and confirm that they are producing similar numbers for the same inputs, that would be great. Or you can double check my math in this script:

```
from sympy import symbols, diff, sin, cos, sqrt, exp, Abs, acos, cse
import numpy as np
from sympy.printing.cxx import CXX17CodePrinter


# Define the symbols for the orbital elements and other parameters
(
    a,
    e,
    i,
    raan,
    aop,
    v,
    aT,
    eT,
    iT,
    raanT,
    aopT,
    thrust_acceleration,
    WP,
    rpmin,
    m_scale,
    n_scale,
    r_scale,
    k_scale,
    b_scale,
    mu,
    W_a,
    W_e,
    W_i,
    W_raan,
    W_aop,
) = symbols(
    "semiMajorAxis eccentricity inclination rightAscensionOfAscendingNode argumentOfPeriapsis trueAnomaly semiMajorAxisTarget eccentricityTarget inclinationTarget rightAscensionOfAscendingNodeTarget argumentOfPeriapsisTarget aThrustAcceleration periapsisWeight minimumPeriapsisRadius parameters_.m parameters_.n parameters_.r parameters_.k parameters_.b  mu_ semiMajorAxisWeight eccentricityWeight inclinationWeight rightAscensionOfAscendingNodeWeight argumentOfPeriapsisWeight",
    real=True,
)

# commonly used terms
p = a * (1 - e**2)
r = p / (1 + (e * cos(v)))
h = sqrt(mu * p)
rp = a * (1 - e)

params = {
    a: 24505900.0,
    aT: 26500000.0,
    e: 0.725,
    eT: 0.7,
    i: 0.001047197551196598,
    iT: 2.024581932313422,
    raan: 0.05235987755982989,
    raanT: 3.141592653589793,
    aop: 0.08726646259971647,
    aopT: 4.71238898038469,
    thrust_acceleration: 2.0 / 2000.0,
    k_scale: 100,
    m_scale: 3,
    n_scale: 4,
    r_scale: 2,
    mu: 398600.49e9,
    WP: 1.0,
    rpmin: 6578000.0,
    b_scale: 0.01,
    W_a: 1.0,
    W_e: 1.0,
    W_i: 1.0,
    W_raan: 1.0,
    W_aop: 1.0,
    v: 0.0,
}
params[rp] = params[a] * (1 - params[e])

# Define the specific rate of change equations for the orbital elements
adot_xx = 2 * thrust_acceleration * sqrt(a**3 * (1 + e) / (mu * (1 - e)))
edot_xx = 2 * p * thrust_acceleration / h
idot_xx = (
    p
    * thrust_acceleration
    / (h * (sqrt(1 - (e**2 * sin(aop) ** 2)) - e * Abs(cos(aop))))
)
raandot_xx = (
    p
    * thrust_acceleration
    / (h * sin(i) * (sqrt(1 - (e**2 * cos(aop) ** 2)) - e * Abs(sin(aop))))
)
alpha = (1 - e**2) / (e**3)
beta = sqrt(0.25 * alpha**2 + (1 / 27.0))
theta_xx = acos(
    ((0.5 * alpha) + beta) ** (1 / 3.0) - (beta - (0.5 * alpha)) ** (1 / 3.0) - 1 / e
)
r_xx = p / (1 + e * cos(theta_xx))
aopdot_xx_i = (thrust_acceleration / (e * h)) * sqrt(
    p**2 * cos(theta_xx) ** 2 + (p + r_xx) ** 2 * sin(theta_xx) ** 2
)
aopdot_xx_o = raandot_xx * Abs(cos(i))
aopdot_xx = (aopdot_xx_i + (b_scale * aopdot_xx_o)) / (1 + b_scale)

# Define S_sigma and P as per the specific problem
S_a = (1 + ((a - aT) / (m_scale * aT)) ** n_scale) ** (1.0 / r_scale)  # for sigma = a
P_expr = exp(k_scale * (1 - rp / rpmin))

# Define delta OE
d_a = a - aT
d_e = e - eT
d_i = i - iT
d_raan = acos(cos(raan - raanT))
d_aop = acos(cos(aop - aopT))

# Define Q for each orbital element
Q_a = W_a * S_a * (d_a / adot_xx) ** 2
Q_e = W_e * (d_e / edot_xx) ** 2
Q_i = W_i * (d_i / idot_xx) ** 2
Q_raan = W_raan * (d_raan / raandot_xx) ** 2
Q_aop = W_aop * (d_aop / aopdot_xx) ** 2
Q = (1 + WP * P_expr) * (Q_a + Q_e + Q_i + Q_raan + Q_aop)

# Calculate the partial derivatives of Q with respect to each orbital element
Qdot_a = diff(Q, a)
Qdot_e = diff(Q, e)
Qdot_i = diff(Q, i)
Qdot_raan = diff(Q, raan)
Qdot_aop = diff(Q, aop)

# intermediate terms to calculate Q
print(
    f"delta COE: {d_a.subs(params)}, {d_e.subs(params)}, {d_i.subs(params)}, {d_raan.subs(params)}, {d_aop.subs(params)}"
)
print(f"Scaling COE: {S_a.subs(params)}")
print(f"adot_xx: {adot_xx.subs(params)}")
print(f"edot_xx: {edot_xx.subs(params)}")
print(f"idot_xx: {idot_xx.subs(params)}")
print(f"raandot_xx: {raandot_xx.subs(params)}")
print(f"aopdot_xx: {aopdot_xx.subs(params)}")
print(f"Q: {Q.subs(params)}")

# analytical derivatives
print(f"Qdot_a: {Qdot_a.subs(params)}")
print(f"Qdot_e: {Qdot_e.subs(params)}")
print(f"Qdot_i: {Qdot_i.subs(params)}")
print(f"Qdot_raan: {Qdot_raan.subs(params)}")
print(f"Qdot_aop: {Qdot_aop.subs(params)}")

# finite difference
step_pct = 1e-6
Qdot_fd = []
for elem in [a, e, i, raan, aop]:
    tmp_val = params[elem]
    step_size = tmp_val * step_pct
    print("\n\n")
    print(
        f"Differencing {elem} with step size: [{step_size}], coe: {params[a]}, {params[e]}, {params[i]}, {params[raan]}, {params[aop]}"
    )
    params[elem] += step_size
    params[rp] = params[a] * (1 - params[e])
    Q_fwd = Q.subs(params)
    print(f"{Q_fwd}: {params[elem]}")

    params[elem] -= 2.0 * step_size
    params[rp] = params[a] * (1 - params[e])
    Q_bck = Q.subs(params)
    print(f"{Q_bck}: {params[elem]}")

    Qdot_fd_val = (Q_fwd - Q_bck) / (2.0 * step_size)
    print(f"Qdot_{elem}: {Qdot_fd_val}")
    params[elem] = tmp_val
    params[rp] = params[a] * (1 - params[e])

    Qdot_fd.append(Qdot_fd_val)

Qdot_fd = np.array(Qdot_fd)

Qdot_analytical = np.array(
    [
        Qdot_a.subs(params),
        Qdot_e.subs(params),
        Qdot_i.subs(params),
        Qdot_raan.subs(params),
        Qdot_aop.subs(params),
    ]
)


# Define the symbols for the orbital elements and other parameters
(f_theta, f_r, f_h) = symbols("f_t f_r f_h", real=True)

da_dt = ((2.0 * a**2) / h) * ((e * sin(v) * f_r) + (p * f_theta / r))
de_dt = ((p * sin(v) * f_r) + (((p + r) * cos(v)) + (r * e)) * f_theta) / h
di_dt = (r * cos(v + aop) * f_h) / h
draan_dt = (r * sin(v + aop) * f_h) / (h * sin(i))
daop_dt = ((-p * cos(v) * f_r) + ((p + r) * sin(v) * f_theta)) / (e * h) - (
    r * sin(v + aop) * cos(i) * f_h
) / (h * sin(i))

matrix = []
# da_dt
matrix.append(diff(da_dt, f_theta).subs(params))
matrix.append(diff(da_dt, f_r).subs(params))
matrix.append(diff(da_dt, f_h).subs(params))

# de_dt
matrix.append(diff(de_dt, f_theta).subs(params))
matrix.append(diff(de_dt, f_r).subs(params))
matrix.append(diff(de_dt, f_h).subs(params))

# di_dt
matrix.append(diff(di_dt, f_theta).subs(params))
matrix.append(diff(di_dt, f_r).subs(params))
matrix.append(diff(di_dt, f_h).subs(params))

# draan_dt
matrix.append(diff(draan_dt, f_theta).subs(params))
matrix.append(diff(draan_dt, f_r).subs(params))
matrix.append(diff(draan_dt, f_h).subs(params))

# daop_dt
matrix.append(diff(daop_dt, f_theta).subs(params))
matrix.append(diff(daop_dt, f_r).subs(params))
matrix.append(diff(daop_dt, f_h).subs(params))

matrix = np.array(matrix).reshape(5, 3)

# finite differenced U
u = np.dot(Qdot_fd, matrix).astype(float)
u = -u / np.linalg.norm(u)
print(u)

# Analytical U
u = np.dot(Qdot_analytical, matrix).astype(float)
u = -u / np.linalg.norm(u)
print(u)


# reduce expressions and log
reduced_exprs, reduced_Qdots = cse(
    [Qdot_a, Qdot_e, Qdot_i, Qdot_raan, Qdot_aop], optimizations="basic"
)


class CustomCXXCodePrinter(CXX17CodePrinter):
    def _print_Integer(self, expr):
        return f"{expr.evalf():.1f}"


printer = CustomCXXCodePrinter()

for reduced_expr in reduced_exprs:
    print(f"const double {reduced_expr[0]} = {printer.doprint(reduced_expr[1])};")

for reduced_Qdot in reduced_Qdots:
    print(printer.doprint(reduced_Qdot), "\n")
```