### PR TITLE
feat: scale mass flow rate by thrust percentage

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.cpp
@@ -95,11 +95,13 @@ VectorXd Thruster::computeContribution(
         anInstant, positionCoordinates, velocityCoordinates, maximumThrustAccelerationMagnitude, aFrameSPtr
     );
 
+    const Real effectiveThrustPercent = acceleration.norm() / maximumThrustAccelerationMagnitude;
+
     // Compute contribution
     VectorXd contribution(4);
     // TBI: Can be optimized to cache the SI value of mass flow rate as a Real
     contribution << acceleration[0], acceleration[1], acceleration[2],
-        -satelliteSystem_.accessPropulsionSystem().getMassFlowRate().getValue();
+        -effectiveThrustPercent * satelliteSystem_.accessPropulsionSystem().getMassFlowRate().getValue();
 
     return contribution;
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.test.cpp
@@ -157,7 +157,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster, ComputeContribution)
             defaultThruster_.computeContribution(Instant::J2000(), coordinates, Frame::GCRF());
 
         VectorXd expectedAcceleration(4);
-        expectedAcceleration << 0.0, 0.0, 0.0, -0.0001019716212977928;
+        expectedAcceleration << 0.0, 0.0, 0.0, 0.0;
 
         EXPECT_TRUE(acceleration.isNear(expectedAcceleration, 1e-12));
     }


### PR DESCRIPTION
In the scenario that we return an acceleration that is < the thrust magnitude maximum we should scale the mass flow rate based on the effective thrust.