### PR TITLE
chore: improve-makefile-and-dev-experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ debug-jupyter: build-development-image ## Debug jupyter notebook using the ostk-
 
 .PHONY: debug-jupyter
 
-debug-jupyter-standalone: build-release-image-jupyter ## Debug jupyter notebook using the ostk-astro package built from current source code
+debug-jupyter-rebuild: build-release-image-jupyter ## Debug jupyter notebook using the ostk-astro package built from current source code
 
 	@ echo "Debugging Jupyter Notebook environment..."
 

--- a/Makefile
+++ b/Makefile
@@ -289,13 +289,14 @@ start-jupyter-notebook: build-release-image-jupyter ## Start Jupyter Notebook en
 
 .PHONY: start-jupyter-notebook
 
-debug-jupyter-notebook: build-release-image-jupyter ## Debug jupyter notebook using the ostk-astro package built from current source code
+debug-jupyter-notebook: build-development-image build-release-image-jupyter ## Debug jupyter notebook using the ostk-astro package built from current source code
 
 	@ echo "Building Python$(jupyter_python_version) packages..."
 	@ mkdir -p $(CURDIR)/build
 	@ mkdir -p $(CURDIR)/packages/python
 
 	docker run \
+		-it \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--workdir=/app/build \

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ debug-jupyter-rebuild: build-release-image-jupyter ## Debug jupyter notebook usi
 
 	@ sudo chown -R $(shell id -u):$(shell id -g) $(CURDIR)
 
-.PHONY: debug-jupyter-standalone
+.PHONY: debug-jupyter-rebuild
 
 debug-development: build-development-image ## Debug development environment
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 project_name := astrodynamics
 project_version := $(shell git describe --tags --always)
-project_major_version := $(shell git describe --tags --always | cut -c 1)
 
 docker_registry_path := openspacecollective
 docker_image_repository := $(docker_registry_path)/open-space-toolkit-$(project_name)
@@ -16,8 +15,6 @@ docker_release_image_jupyter_repository := $(docker_image_repository)-jupyter
 jupyter_notebook_port := 9005
 jupyter_notebook_image_repository := jupyter/scipy-notebook:x86_64-python-3.11.3
 jupyter_python_version := 3.11
-
-project_name_camel_case := $(shell echo $(project_name) | sed -r 's/(^|-)([a-z])/\U\2/g')
 
 pull: ## Pull all images
 


### PR DESCRIPTION
This MR aims to make the ostk dev experience better by streamlining the build/make process by improving the makefile:
- allow the `make debug-jupyter-notebook` target to build and cache the binaries for the locally modified source code everytime you run that command, instead of needing to spin up a development container and build/re-build before re-launching jupyter
- make clean now removes all build/lib/package/etc folders to actually clean things properly

The part that hasn't been done yet is to fix container users so that we aren't root inside the container, which causes issues when working inside and outside the container since the hosts' files are now changed owners. This might become a little difficult because CMake doesn't seem to like being run from a non-root user.
