### PR TITLE
feat: relative/absolute effectivity thresholds for QLaw

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/GuidanceLaw/QLaw.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/GuidanceLaw/QLaw.cpp
@@ -113,6 +113,26 @@ void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
                     float
             )doc"
         )
+        .def_readonly(
+            "absolute_effectivity_threshold",
+            &QLaw::Parameters::absoluteEffectivityThreshold,
+            R"doc(
+                Absolute effectivity threshold.
+
+                Type:
+                    Real
+            )doc"
+        )
+        .def_readonly(
+            "relative_effectivity_threshold",
+            &QLaw::Parameters::relativeEffectivityThreshold,
+            R"doc(
+                Relative effectivity threshold.
+
+                Type:
+                    Real
+            )doc"
+        )
 
         .def(
             init<
@@ -123,21 +143,25 @@ void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
                 const double&,
                 const Size&,
                 const double&,
-                const Length&>(),
+                const Length&,
+                const Real&,
+                const Real&>(),
             R"doc(
-            Constructor.
+                Constructor.
 
-            Args:
-                element_weights (dict): Key-value pair of COE elements and the (weights, tolerances) for the targeter.
-                m (int): Scaling parameter for Semi-Major Axis delta. Default to 3.
-                n (int): Scaling parameter for Semi-Major Axis delta. Default to 4.
-                r (int): Scaling parameter for Semi-Major Axis delta. Default to 2.
-                b (float): Scaling parameter for Argument of Periapsis maximal change. Default to 0.01.
-                k (int): Penalty parameter for periapsis. Default to 100.
-                periapsis_weight (float): Periapsis weight. Default to 0.0.
-                minimum_periapsis_radius (Length): Minimum periapsis radius. Default to 6578.0 km.
+                Args:
+                    element_weights (dict): Key-value pair of COE elements and the (weights, tolerances) for the targeter.
+                    m (int): Scaling parameter for Semi-Major Axis delta. Default to 3.
+                    n (int): Scaling parameter for Semi-Major Axis delta. Default to 4.
+                    r (int): Scaling parameter for Semi-Major Axis delta. Default to 2.
+                    b (float): Scaling parameter for Argument of Periapsis maximal change. Default to 0.01.
+                    k (int): Penalty parameter for periapsis. Default to 100.
+                    periapsis_weight (float): Periapsis weight. Default to 0.0.
+                    minimum_periapsis_radius (Length): Minimum periapsis radius. Default to 6578.0 km.
+                    absolute_effectivity_threshold (Real): Absolute effectivity threshold. Default to undefined (not used).
+                    relative_effectivity_threshold (Real): Relative effectivity threshold. Default to undefined (not used).
 
-        )doc",
+            )doc",
             arg("element_weights"),
             arg("m") = 3,
             arg("n") = 4,
@@ -145,7 +169,9 @@ void OpenSpaceToolkitAstrodynamicsPy_GuidanceLaw_QLaw(pybind11::module& aModule)
             arg("b") = 0.01,
             arg("k") = 100,
             arg("periapsis_weight") = 0.0,
-            arg("minimum_periapsis_radius") = Length::Kilometers(6578.0)
+            arg("minimum_periapsis_radius") = Length::Kilometers(6578.0),
+            arg("absolute_effectivity_threshold") = Real::Undefined(),
+            arg("relative_effectivity_threshold") = Real::Undefined()
         )
 
         .def(

--- a/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp
@@ -254,6 +254,11 @@ class QLaw : public GuidanceLaw
     Vector5d computeAnalytical_dQ_dOE(const Vector5d& aCOEVector, const double& aThrustAcceleration) const;
     Vector5d computeNumerical_dQ_dOE(const Vector5d& aCOEVector, const double& aThrustAcceleration) const;
 
+    /// @brief                Compute the effectivity of the guidance law
+    ///
+    /// @ref
+    /// https://www.researchgate.net/publication/341296727_Q-Law_Aided_Direct_Trajectory_Optimization_of_Many-Revolution_Low-Thrust_Transfers
+
     Tuple<double, double> computeEffectivity(
         const Vector6d& aCOEVector, const Vector3d& aThrustDirection, const Vector5d& dQ_dOE
     ) const;

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
@@ -69,16 +69,8 @@ class OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw : public
 {
     void SetUp() override
     {
-        const COE currentCOE = {
-            Length::Meters(7000.0e3),
-            0.01,
-            Angle::Degrees(0.05),
-            Angle::Degrees(0.0),
-            Angle::Degrees(0.0),
-            Angle::Degrees(0.0),
-        };
-
-        const COE::CartesianState cartesianState = currentCOE.getCartesianState(gravitationalParameter_, Frame::GCRF());
+        const COE::CartesianState cartesianState =
+            currentCOE_.getCartesianState(gravitationalParameter_, Frame::GCRF());
 
         initialState_ = {
             Instant::J2000(),
@@ -148,6 +140,15 @@ class OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw : public
         100,
         1.0,
         Length::Kilometers(6578.0),
+    };
+
+    const COE currentCOE_ = {
+        Length::Meters(7000.0e3),
+        0.01,
+        Angle::Degrees(0.05),
+        Angle::Degrees(0.0),
+        Angle::Degrees(0.0),
+        Angle::Degrees(0.0),
     };
 
     const COE targetCOE_ = {
@@ -298,6 +299,123 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Comput
         for (Size i = 0; i < 3; ++i)
         {
             EXPECT_NEAR(thrustDirection(i), expectedThrustDirection(i), 1e-8);
+        }
+    }
+
+    // expect no thrust when within tolerance of targeted orbital elements
+    {
+        const COE coe = {
+            Length::Meters(26500.0e3),
+            0.7,
+            Angle::Degrees(116.0),
+            Angle::Degrees(180.0),
+            Angle::Degrees(270.0),
+            Angle::Degrees(0.0),
+        };
+        const Vector6d currentCOEVector = coe.getSIVector(COE::AnomalyType::True);
+        const Real thrustAcceleration = 0.1;
+        const QLaw qlaw = {
+            coe,
+            gravitationalParameter_,
+            {
+                {
+                    {COE::Element::SemiMajorAxis, {1.0, 100.0}},
+                    {COE::Element::Eccentricity, {1.0, 1e-4}},
+                    {COE::Element::Inclination, {1.0, 1e-4}},
+                    {COE::Element::Raan, {1.0, 1e-4}},
+                    {COE::Element::Aop, {1.0, 1e-4}},
+                },
+                3,
+                4,
+                2,
+                0.01,
+                100,
+                1.0,
+                Length::Kilometers(6578.0),
+            },
+            gradientStrategy_,
+        };
+
+        const Vector3d thrustDirection = qlaw.computeThrustDirection(currentCOEVector, thrustAcceleration);
+
+        const Vector3d expectedThrustDirection = {0.0, 0.0, 0.0};
+
+        for (Size i = 0; i < 3; ++i)
+        {
+            EXPECT_NEAR(thrustDirection(i), expectedThrustDirection(i), 1e-14);
+        }
+    }
+
+    {
+        const Vector6d currentCOEVector = currentCOE_.getSIVector(COE::AnomalyType::True);
+        const Real thrustAcceleration = 0.1;
+        const QLaw qlaw = {
+            currentCOE_,
+            gravitationalParameter_,
+            {
+                {
+                    {COE::Element::SemiMajorAxis, {1.0, 100.0}},
+                    {COE::Element::Eccentricity, {1.0, 1e-4}},
+                    {COE::Element::Inclination, {1.0, 1e-4}},
+                    {COE::Element::Raan, {1.0, 1e-4}},
+                    {COE::Element::Aop, {1.0, 1e-4}},
+                },
+                3,
+                4,
+                2,
+                0.01,
+                100,
+                1.0,
+                Length::Kilometers(6578.0),
+                0.8,
+            },
+            gradientStrategy_,
+        };
+
+        const Vector3d thrustDirection = qlaw.computeThrustDirection(currentCOEVector, thrustAcceleration);
+
+        const Vector3d expectedThrustDirection = {0.0, 0.0, 0.0};
+
+        for (Size i = 0; i < 3; ++i)
+        {
+            EXPECT_NEAR(thrustDirection(i), expectedThrustDirection(i), 1e-14);
+        }
+    }
+
+    {
+        const Vector6d currentCOEVector = currentCOE_.getSIVector(COE::AnomalyType::True);
+        const Real thrustAcceleration = 0.1;
+        const QLaw qlaw = {
+            currentCOE_,
+            gravitationalParameter_,
+            {
+                {
+                    {COE::Element::SemiMajorAxis, {1.0, 100.0}},
+                    {COE::Element::Eccentricity, {1.0, 1e-4}},
+                    {COE::Element::Inclination, {1.0, 1e-4}},
+                    {COE::Element::Raan, {1.0, 1e-4}},
+                    {COE::Element::Aop, {1.0, 1e-4}},
+                },
+                3,
+                4,
+                2,
+                0.01,
+                100,
+                1.0,
+                Length::Kilometers(6578.0),
+                Real::Undefined(),
+                0.8,
+            },
+            gradientStrategy_,
+        };
+
+        const Vector3d thrustDirection = qlaw.computeThrustDirection(currentCOEVector, thrustAcceleration);
+
+        const Vector3d expectedThrustDirection = {0.0, 0.0, 0.0};
+
+        for (Size i = 0; i < 3; ++i)
+        {
+            EXPECT_NEAR(thrustDirection(i), expectedThrustDirection(i), 1e-14);
         }
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
@@ -69,8 +69,16 @@ class OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw : public
 {
     void SetUp() override
     {
-        const COE::CartesianState cartesianState =
-            currentCOE_.getCartesianState(gravitationalParameter_, Frame::GCRF());
+        const COE currentCOE = {
+            Length::Meters(7000.0e3),
+            0.01,
+            Angle::Degrees(0.05),
+            Angle::Degrees(0.0),
+            Angle::Degrees(0.0),
+            Angle::Degrees(0.0),
+        };
+
+        const COE::CartesianState cartesianState = currentCOE.getCartesianState(gravitationalParameter_, Frame::GCRF());
 
         initialState_ = {
             Instant::J2000(),
@@ -140,15 +148,6 @@ class OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw : public
         100,
         1.0,
         Length::Kilometers(6578.0),
-    };
-
-    const COE currentCOE_ = {
-        Length::Meters(7000.0e3),
-        0.01,
-        Angle::Degrees(0.05),
-        Angle::Degrees(0.0),
-        Angle::Degrees(0.0),
-        Angle::Degrees(0.0),
     };
 
     const COE targetCOE_ = {
@@ -346,11 +345,21 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Comput
         }
     }
 
+    /// Absolute effectivity threshold
     {
-        const Vector6d currentCOEVector = currentCOE_.getSIVector(COE::AnomalyType::True);
+        const COE currentCOE = {
+            Length::Meters(7000.0e3),
+            0.01,
+            Angle::Degrees(0.05),
+            Angle::Degrees(0.0),
+            Angle::Degrees(0.0),
+            Angle::Degrees(90.0),
+        };
+
+        const Vector6d currentCOEVector = currentCOE.getSIVector(COE::AnomalyType::True);
         const Real thrustAcceleration = 0.1;
         const QLaw qlaw = {
-            currentCOE_,
+            targetCOE_,
             gravitationalParameter_,
             {
                 {
@@ -382,11 +391,21 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Comput
         }
     }
 
+    /// Relative effectivity threshold
     {
-        const Vector6d currentCOEVector = currentCOE_.getSIVector(COE::AnomalyType::True);
+        const COE currentCOE = {
+            Length::Meters(7000.0e3),
+            0.01,
+            Angle::Degrees(0.05),
+            Angle::Degrees(0.0),
+            Angle::Degrees(0.0),
+            Angle::Degrees(90.0),
+        };
+
+        const Vector6d currentCOEVector = currentCOE.getSIVector(COE::AnomalyType::True);
         const Real thrustAcceleration = 0.1;
         const QLaw qlaw = {
-            currentCOE_,
+            targetCOE_,
             gravitationalParameter_,
             {
                 {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -2738,8 +2738,6 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw, Q
 
     const COE endCOE = COE::Cartesian({state.getPosition(), state.getVelocity()}, gravitationalParameter);
 
-    std::cout << endCOE << std::endl;
-
     EXPECT_TRUE(std::abs(endCOE.getSemiMajorAxis().inMeters() - targetCOE.getSemiMajorAxis().inMeters()) < 50000.0);
 
     // TBI: These don't close yes, have to investigate why

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -2705,7 +2705,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw, Q
     const NumericalSolver numericalSolver = {
         NumericalSolver::LogType::NoLog,
         NumericalSolver::StepperType::RungeKutta4,
-        120.0,
+        5.0,
         1e-12,
         1e-12,
     };
@@ -2737,6 +2737,8 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Models_Propagator_QLaw, Q
         propagator.calculateStateAt(initialState, initialState.accessInstant() + Duration::Days(72.49716435185185187));
 
     const COE endCOE = COE::Cartesian({state.getPosition(), state.getVelocity()}, gravitationalParameter);
+
+    std::cout << endCOE << std::endl;
 
     EXPECT_TRUE(std::abs(endCOE.getSemiMajorAxis().inMeters() - targetCOE.getSemiMajorAxis().inMeters()) < 50000.0);
 


### PR DESCRIPTION
This allows us to trade time of flight with fuel mass. It will force some coast arcs so that we burn at "optimal" points in the orbit.

<img width="1040" alt="Screen Shot 2023-12-01 at 9 22 38 AM" src="https://github.com/open-space-collective/open-space-toolkit-astrodynamics/assets/4754322/addfeeeb-9767-4e26-8b36-a124eb1c9daa">
