### PR TITLE
feat: add dynamics contribution getters to segment solution

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -203,13 +203,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
                     frame (Frame): The frame.
 
                 Returns:
-                    MatrixXd: The matrix of dynamics contributions to acceleration.
+                    np.ndarray: The matrix of dynamics contributions to acceleration.
 
             )doc"
         )
         .def(
-            "get_dynamics_contributions",
-            &Segment::Solution::getDynamicsContributions,
+            "get_all_dynamics_contributions",
+            &Segment::Solution::getAllDynamicsContributions,
             arg("frame"),
             R"doc(
                 Compute the contributions of all segment's dynamics in the provided frame for all states assocated with the segment.
@@ -218,7 +218,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
                     frame (Frame): The frame.
 
                 Returns:
-                    list[MatrixXd]: The list of matrices with individual dynamics contributions.
+                    dict[Dynamics, np.ndarray]: The list of matrices with individual dynamics contributions.
 
             )doc"
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -171,13 +171,34 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
             )doc"
         )
         .def(
-            "compute_accelerations",
-            &Segment::Solution::computeAccelerations,
+            "get_dynamics_contribution",
+            &Segment::Solution::getDynamicsContribution,
+            arg("dynamics"),
+            arg("frame"),
             R"doc(
-                Compute the accelerations contributions of the involved dynamics.
+                Compute the contribution of the provided dynamics in the provided frame for all states associated with the segment.
+
+                Args:
+                    dynamics (Dynamics): The dynamics.
+                    frame (Frame): The frame.
 
                 Returns:
-                    list[MatrixXd]: The list of acceleration matrices.
+                    MatrixXd: The matrix of dynamics contributions.
+
+            )doc"
+        )
+        .def(
+            "get_dynamics_contributions",
+            &Segment::Solution::getDynamicsContributions,
+            arg("frame"),
+            R"doc(
+                Compute the contributions of all segment's dynamics in the provided frame for all states assocated with the segment.
+
+                Args:
+                    frame (Frame): The frame.
+
+                Returns:
+                    list[MatrixXd]: The list of matrices with individual dynamics contributions.
 
             )doc"
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -170,6 +170,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
 
             )doc"
         )
+        .def(
+            "compute_accelerations",
+            &Segment::Solution::computeAccelerations,
+            R"doc(
+                Compute the accelerations contributions of the involved dynamics.
+
+                Returns:
+                    list[MatrixXd]: The list of acceleration matrices.
+
+            )doc"
+        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -13,6 +13,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
     using ostk::physics::time::Duration;
 
     using ostk::astro::trajectory::state::NumericalSolver;
+    using ostk::astro::trajectory::state::CoordinatesSubset;
     using ostk::astro::trajectory::Segment;
     using ostk::astro::Dynamics;
 
@@ -175,15 +176,34 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
             &Segment::Solution::getDynamicsContribution,
             arg("dynamics"),
             arg("frame"),
+            arg("coordinates_subsets") = Array<Shared<const CoordinatesSubset>>::Empty(),
             R"doc(
                 Compute the contribution of the provided dynamics in the provided frame for all states associated with the segment.
 
                 Args:
                     dynamics (Dynamics): The dynamics.
                     frame (Frame): The frame.
+                    coordinates_subsets (list[CoordinatesSubset], optional): A subset of the dynamics writing coordinates subsets to consider.
 
                 Returns:
-                    MatrixXd: The matrix of dynamics contributions.
+                    MatrixXd: The matrix of dynamics contributions for the selected coordinates subsets of the dynamics.
+
+            )doc"
+        )
+        .def(
+            "get_dynamics_acceleration_contribution",
+            &Segment::Solution::getDynamicsAccelerationContribution,
+            arg("dynamics"),
+            arg("frame"),
+            R"doc(
+                Compute the contribution of the provided dynamics to the acceleration in the provided frame for all states associated with the segment.
+
+                Args:
+                    dynamics (Dynamics): The dynamics.
+                    frame (Frame): The frame.
+
+                Returns:
+                    MatrixXd: The matrix of dynamics contributions to acceleration.
 
             )doc"
         )

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -243,7 +243,7 @@ class TestSegment:
         assert second_dynamics_contribution.shape == (len(solution.states), 3)
         assert third_dynamics_contribution.shape == (len(solution.states), 4)
 
-        all_contributions = solution.get_dynamics_contributions(state_frame)
+        all_contributions = solution.get_all_dynamics_contributions(state_frame)
         assert len(all_contributions) == len(solution.dynamics)
 
         assert all_contributions is not None

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -221,9 +221,4 @@ class TestSegment:
         assert solution.compute_delta_mass() is not None
         assert solution.compute_delta_v(1500.0) is not None
 
-        accelerations = solution.compute_accelerations()
-
-        print(accelerations[0])
-        print(accelerations[1])
-        print(accelerations[2])
-        # assert solution.compute_accelerations() is not None
+        assert solution.compute_accelerations() is not None

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -220,3 +220,10 @@ class TestSegment:
 
         assert solution.compute_delta_mass() is not None
         assert solution.compute_delta_v(1500.0) is not None
+
+        accelerations = solution.compute_accelerations()
+
+        print(accelerations[0])
+        print(accelerations[1])
+        print(accelerations[2])
+        # assert solution.compute_accelerations() is not None

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -7,6 +7,8 @@
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
 
+#include <OpenSpaceToolkit/Mathematics/Objects/Matrix.hpp>
+
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
@@ -26,6 +28,8 @@ namespace trajectory
 using ostk::core::ctnr::Array;
 using ostk::core::types::Shared;
 using ostk::core::types::String;
+
+using ostk::math::object::MatrixXd;
 
 using ostk::physics::time::Instant;
 using ostk::physics::time::Duration;
@@ -74,6 +78,8 @@ class Segment
 
         Real computeDeltaV(const Real& aSpecificImpulse) const;
         Mass computeDeltaMass() const;
+
+        Array<MatrixXd> computeAccelerations() const;
 
         void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -41,7 +41,7 @@ using ostk::astro::Dynamics;
 using ostk::astro::dynamics::Thruster;
 using ostk::astro::EventCondition;
 
-/// @brief                                  Represent a propagation segment for astrodynamics purposes
+/// @brief                      Represent a propagation segment for astrodynamics purposes
 
 class Segment
 {
@@ -79,7 +79,10 @@ class Segment
         Real computeDeltaV(const Real& aSpecificImpulse) const;
         Mass computeDeltaMass() const;
 
-        Array<MatrixXd> computeAccelerations() const;
+        MatrixXd getDynamicsContribution(
+            const Shared<const Dynamics>& aDynamicsSPtr, const Shared<const Frame>& aFrameSPtr
+        ) const;
+        Array<MatrixXd> getDynamicsContributions(const Shared<const Frame>& aFrameSPtr) const;
 
         void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -57,6 +57,15 @@ class Segment
     struct Solution
     {
        public:
+        /// @brief              Constructor
+        ///
+        /// @param              [in] aName Name of the segment
+        /// @param              [in] aDynamicsArray Array of dynamics
+        /// @param              [in] aStates Array of states for the segment
+        /// @param              [in] aConditionIsSatisfied True if the event condition is satisfied
+        /// @param              [in] aSegmentType Type of segment
+        /// @return             An instance of Solution
+
         Solution(
             const String& aName,
             const Array<Shared<Dynamics>>& aDynamicsArray,
@@ -65,36 +74,94 @@ class Segment
             const Segment::Type& aSegmentType
         );
 
-        String name;                       /// Name of the segment.
-        Array<Shared<Dynamics>> dynamics;  /// List of dynamics used.
-        Array<State> states;               /// Array of states for the segment.
-        bool conditionIsSatisfied;         /// True if the event condition is satisfied.
-        Segment::Type segmentType;         /// Type of segment.
+        /// @brief              Access Start Instant
+        /// @return             Start Instant
 
         const Instant& accessStartInstant() const;
+
+        /// @brief              Access end instant
+        /// @return             End Instant
+
         const Instant& accessEndInstant() const;
 
+        /// @brief              Get initial mass
+        /// @return             Initial mass
+
         Mass getInitialMass() const;
+
+        /// @brief              Get final mass
+        /// @return             Final mass
+
         Mass getFinalMass() const;
+
+        /// @brief              Get propagation duration
+        /// @return             Propagation duration
+
         Duration getPropagationDuration() const;
 
+        /// @brief              Compute delta V
+        ///
+        /// @param              [in] aSpecificImpulse Specific impulse
+        /// @return             Delta V
+
         Real computeDeltaV(const Real& aSpecificImpulse) const;
+
+        /// @brief              Compute delta mass
+        /// @return             Delta mass
+
         Mass computeDeltaMass() const;
 
-        Map<Shared<Dynamics>, MatrixXd> getDynamicsContributions(const Shared<const Frame>& aFrameSPtr) const;
+        /// @brief              Get dynamics contribution
+        ///
+        /// @param              [in] aDynamicsSPtr Dynamics
+        /// @param              [in] aFrameSPtr Frame
+        /// @param              [in] aCoordinatesSubsetSPtrArray Array of coordinates subsets
+        /// @return             Dynamics contribution
+
         MatrixXd getDynamicsContribution(
             const Shared<Dynamics>& aDynamicsSPtr,
             const Shared<const Frame>& aFrameSPtr,
             const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetSPtrArray =
                 Array<Shared<const CoordinatesSubset>>::Empty()
         ) const;
+
+        /// @brief              Get dynamics acceleration contribution
+        ///
+        /// @param              [in] aDynamicsSPtr Dynamics
+        /// @param              [in] aFrameSPtr Frame
+        /// @return             Dynamics acceleration contribution
+
         MatrixXd getDynamicsAccelerationContribution(
             const Shared<Dynamics>& aDynamicsSPtr, const Shared<const Frame>& aFrameSPtr
         ) const;
 
+        /// @brief              Get all segment dynamics contributions
+        ///
+        /// @param              [in] aFrameSPtr Frame
+        /// @return             All segment dynamics contributions
+
+        Map<Shared<Dynamics>, MatrixXd> getAllDynamicsContributions(const Shared<const Frame>& aFrameSPtr) const;
+
+        /// @brief              Print the segment solution
+        ///
+        /// @param              [in] anOutputStream An output stream
+        /// @param              [in] (optional) displayDecorators If true, display decorators
+
         void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
+        /// @brief              Output stream operator
+        ///
+        /// @param              [in] anOutputStream An output stream
+        /// @param              [in] aSolution A Solution
+        /// @return             An output stream
+
         friend std::ostream& operator<<(std::ostream& anOutputStream, const Solution& aSolution);
+
+        String name;                       /// Name of the segment.
+        Array<Shared<Dynamics>> dynamics;  /// List of dynamics used.
+        Array<State> states;               /// Array of states for the segment.
+        bool conditionIsSatisfied;         /// True if the event condition is satisfied.
+        Segment::Type segmentType;         /// Type of segment.
     };
 
     /// @brief                  Output stream operator

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -4,6 +4,7 @@
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_Segment__
 
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
+#include <OpenSpaceToolkit/Core/Containers/Map.hpp>
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
 
@@ -26,6 +27,7 @@ namespace trajectory
 {
 
 using ostk::core::ctnr::Array;
+using ostk::core::ctnr::Map;
 using ostk::core::types::Shared;
 using ostk::core::types::String;
 
@@ -79,10 +81,16 @@ class Segment
         Real computeDeltaV(const Real& aSpecificImpulse) const;
         Mass computeDeltaMass() const;
 
+        Map<Shared<Dynamics>, MatrixXd> getDynamicsContributions(const Shared<const Frame>& aFrameSPtr) const;
         MatrixXd getDynamicsContribution(
-            const Shared<const Dynamics>& aDynamicsSPtr, const Shared<const Frame>& aFrameSPtr
+            const Shared<Dynamics>& aDynamicsSPtr,
+            const Shared<const Frame>& aFrameSPtr,
+            const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetSPtrArray =
+                Array<Shared<const CoordinatesSubset>>::Empty()
         ) const;
-        Array<MatrixXd> getDynamicsContributions(const Shared<const Frame>& aFrameSPtr) const;
+        MatrixXd getDynamicsAccelerationContribution(
+            const Shared<Dynamics>& aDynamicsSPtr, const Shared<const Frame>& aFrameSPtr
+        ) const;
 
         void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -148,6 +148,9 @@ MatrixXd Segment::Solution::getDynamicsContribution(
     // Extract dynamics context and behavior relative to state
     Array<Shared<const CoordinatesSubset>> dynamicsReadCoordinatesSubsets = aDynamicsSPtr->getReadCoordinatesSubsets();
 
+    // Construct state builder
+    const StateBuilder builder = StateBuilder(aFrameSPtr, dynamicsReadCoordinatesSubsets);
+
     // Compute the size of dynamicsContributionMatrix
     Size dynamicsWriteSize = std::accumulate(
         definitiveCoordinateSubsetArray.begin(),
@@ -166,8 +169,6 @@ MatrixXd Segment::Solution::getDynamicsContribution(
     for (Index stateIndex = 0; stateIndex < numberOfstates; ++stateIndex)
     {
         const State& state = states[stateIndex];
-
-        const StateBuilder builder = StateBuilder(aFrameSPtr, dynamicsReadCoordinatesSubsets);
 
         VectorXd dynamicsContributionAtState = aDynamicsSPtr->computeContribution(
             state.getInstant(), builder.reduce(state.inFrame(aFrameSPtr)).getCoordinates(), aFrameSPtr

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -416,20 +416,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetAll
                 contributions.at(dynamics).cols(), dynamics->getWriteCoordinatesSubsets().getSize()
             );  // Check the number of columns corresponds to the number of coordinates subsets to which the dynamics
                 // writes
-
-            // Check the contribution is correct
-            Shared<const CoordinatesBroker> coordinatesBrokerSPtr = initialStateWithMass_.accessCoordinatesBroker();
-            VectorXd readStateCoordinates = coordinatesBrokerSPtr->extractCoordinates(
-                initialStateWithMass_.getCoordinates(), dynamics->getReadCoordinatesSubsets()
-            );
-            EXPECT_EQ(
-                contributions.at(dynamics).row(0),
-                dynamics->computeContribution(initialStateWithMass_.getInstant(), readStateCoordinates, stateFrame)
-            );
-            EXPECT_EQ(
-                contributions.at(dynamics).row(1),
-                dynamics->computeContribution(finalStateWithMass_.getInstant(), readStateCoordinates, stateFrame)
-            );
         }
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -327,7 +327,44 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDyn
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDynamicsContributions)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDynamicsAccelerationContribution)
+{
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
+
+        // Check error for PositionDerivative
+        const String expectedString =
+            "Provided coordinates subset is not part of the dynamics write coordinates subsets.";
+
+        // Test the throw and the message that is thrown
+        EXPECT_THROW(
+            {
+                try
+                {
+                    MatrixXd accelerationContribution =
+                        segmentSolution.getDynamicsAccelerationContribution(defaultDynamics_[0], stateFrame);
+                }
+                catch (const ostk::core::error::runtime::Undefined& e)
+                {
+                    EXPECT_EQ(expectedString, e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+
+        // Check output for Gravity
+        MatrixXd accelerationContribution =
+            segmentSolution.getDynamicsAccelerationContribution(defaultDynamics_[1], stateFrame);
+        EXPECT_EQ(accelerationContribution.cols(), 3);
+        EXPECT_EQ(accelerationContribution.rows(), segmentSolution.states.getSize());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetAllDynamicsContributions)
 {
     {
         const Segment::Solution segmentSolution =
@@ -394,43 +431,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDyn
                 dynamics->computeContribution(finalStateWithMass_.getInstant(), readStateCoordinates, stateFrame)
             );
         }
-    }
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDynamicsAccelerationContribution)
-{
-    {
-        const Segment::Solution segmentSolution =
-            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
-
-        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
-
-        // Check error for PositionDerivative
-        const String expectedString =
-            "Provided coordinates subset is not part of the dynamics write coordinates subsets.";
-
-        // Test the throw and the message that is thrown
-        EXPECT_THROW(
-            {
-                try
-                {
-                    MatrixXd accelerationContribution =
-                        segmentSolution.getDynamicsAccelerationContribution(defaultDynamics_[0], stateFrame);
-                }
-                catch (const ostk::core::error::runtime::Undefined& e)
-                {
-                    EXPECT_EQ(expectedString, e.getMessage());
-                    throw;
-                }
-            },
-            ostk::core::error::RuntimeError
-        );
-
-        // Check output for Gravity
-        MatrixXd accelerationContribution =
-            segmentSolution.getDynamicsAccelerationContribution(defaultDynamics_[1], stateFrame);
-        EXPECT_EQ(accelerationContribution.cols(), 3);
-        EXPECT_EQ(accelerationContribution.rows(), segmentSolution.states.getSize());
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -26,6 +26,7 @@ using ostk::core::types::Shared;
 using ostk::core::types::Real;
 
 using ostk::math::object::VectorXd;
+using ostk::math::object::MatrixXd;
 
 using ostk::physics::environment::object::Celestial;
 using ostk::physics::time::Instant;
@@ -199,6 +200,27 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Comput
 
         // 1500 * 9.80665 * ln(200 / 180) -> Rocket equation
         EXPECT_DOUBLE_EQ(1549.850551313734, segmentSolution.computeDeltaV(1500.0));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_ComputeAccelerations)
+{
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        Array<MatrixXd> accelerations = segmentSolution.computeAccelerations();
+
+        std::cout << accelerations << std::endl;
+    }
+
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        Array<MatrixXd> accelerations = segmentSolution.computeAccelerations();
+
+        std::cout << accelerations << std::endl;
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -203,24 +203,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Comput
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_ComputeAccelerations)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDynamicsContributions)
 {
     {
         const Segment::Solution segmentSolution =
             Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
 
-        Array<MatrixXd> accelerations = segmentSolution.computeAccelerations();
-
-        std::cout << accelerations << std::endl;
-    }
-
-    {
-        const Segment::Solution segmentSolution =
-            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
-
-        Array<MatrixXd> accelerations = segmentSolution.computeAccelerations();
-
-        std::cout << accelerations << std::endl;
+        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
+        Array<MatrixXd> contributions = segmentSolution.getDynamicsContributions(stateFrame);
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -334,7 +334,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDyn
             Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
 
         const Shared<const Frame> stateFrame = defaultState_.accessFrame();
-        Map<Shared<Dynamics>, MatrixXd> contributions = segmentSolution.getDynamicsContributions(stateFrame);
+        Map<Shared<Dynamics>, MatrixXd> contributions = segmentSolution.getAllDynamicsContributions(stateFrame);
 
         EXPECT_EQ(defaultDynamics_.getSize(), contributions.size());
         for (const Shared<Dynamics>& dynamics : defaultDynamics_)
@@ -366,7 +366,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDyn
         );
 
         const Shared<const Frame> stateFrame = initialStateWithMass_.accessFrame();
-        Map<Shared<Dynamics>, MatrixXd> contributions = segmentSolution.getDynamicsContributions(stateFrame);
+        Map<Shared<Dynamics>, MatrixXd> contributions = segmentSolution.getAllDynamicsContributions(stateFrame);
 
         EXPECT_EQ(defaultDynamics_.getSize(), contributions.size());
         for (const Shared<Dynamics>& dynamics : defaultDynamics_)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -8,6 +8,7 @@
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
 
+#include <OpenSpaceToolkit/Astrodynamics/Dynamics/AtmosphericDrag.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/CentralBodyGravity.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/PositionDerivative.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp>
@@ -20,6 +21,7 @@
 
 #include <Global.test.hpp>
 
+using ostk::core::ctnr::Map;
 using ostk::core::ctnr::Array;
 using ostk::core::types::String;
 using ostk::core::types::Shared;
@@ -33,6 +35,7 @@ using ostk::physics::time::Instant;
 using ostk::physics::time::Duration;
 using ostk::physics::time::DateTime;
 using ostk::physics::time::Scale;
+using ostk::physics::environment::object::Celestial;
 using ostk::physics::environment::object::celestial::Earth;
 using ostk::physics::coord::Frame;
 using ostk::physics::coord::Position;
@@ -47,6 +50,8 @@ using ostk::astro::guidancelaw::ConstantThrust;
 using ostk::astro::trajectory::Segment;
 using ostk::astro::trajectory::LocalOrbitalFrameDirection;
 using ostk::astro::trajectory::LocalOrbitalFrameFactory;
+using ostk::astro::Dynamics;
+using ostk::astro::dynamics::AtmosphericDrag;
 using ostk::astro::dynamics::CentralBodyGravity;
 using ostk::astro::dynamics::PositionDerivative;
 using ostk::astro::eventcondition::InstantCondition;
@@ -57,6 +62,9 @@ using ostk::astro::trajectory::state::CoordinatesBroker;
 using ostk::astro::trajectory::state::CoordinatesSubset;
 using ostk::astro::trajectory::state::coordinatessubsets::CartesianPosition;
 using ostk::astro::trajectory::state::coordinatessubsets::CartesianVelocity;
+using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
+using EarthMagneticModel = ostk::physics::environment::magnetic::Earth;
+using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 
 class OpenSpaceToolkit_Astrodynamics_Trajectory_Segment : public ::testing::Test
 {
@@ -203,6 +211,122 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Comput
     }
 }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDynamicsContribution)
+{
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
+        for (const Shared<Dynamics>& dynamics : defaultDynamics_)
+        {
+            EXPECT_NO_THROW(segmentSolution.getDynamicsContribution(dynamics, stateFrame));
+        }
+    }
+
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
+        for (const Shared<Dynamics>& dynamics : defaultDynamics_)
+        {
+            const MatrixXd contributionDefault = segmentSolution.getDynamicsContribution(dynamics, stateFrame);
+            const Array<Shared<const CoordinatesSubset>> dynamicsWriteCoordinatesSubsets =
+                dynamics->getWriteCoordinatesSubsets();
+            const MatrixXd contributionExplicit =
+                segmentSolution.getDynamicsContribution(dynamics, stateFrame, dynamicsWriteCoordinatesSubsets);
+            EXPECT_EQ(contributionDefault, contributionExplicit);
+        }
+    }
+
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
+
+        for (const Shared<Dynamics>& dynamics : defaultDynamics_)
+        {
+            const Array<Shared<const CoordinatesSubset>> dynamicsWriteCoordinatesSubsets =
+                dynamics->getWriteCoordinatesSubsets();
+            const Shared<const CoordinatesSubset> dynamicsWriteCoordinatesSubset = dynamicsWriteCoordinatesSubsets[0];
+            const MatrixXd contribution =
+                segmentSolution.getDynamicsContribution(dynamics, stateFrame, {dynamicsWriteCoordinatesSubset});
+            EXPECT_EQ(contribution.cols(), dynamicsWriteCoordinatesSubset->getSize());
+            EXPECT_EQ(contribution.rows(), segmentSolution.states.getSize());
+        }
+    }
+
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
+
+        // Construct a coordinatesSubset not part of the dynamics for which the contribution is requested
+        const Shared<Dynamics> dynamics = defaultDynamics_[0];
+        const Shared<const CoordinatesSubset> coordinatesSubset = CoordinatesSubset::DragCoefficient();
+
+        EXPECT_FALSE(dynamics->getWriteCoordinatesSubsets().contains(coordinatesSubset));
+
+        const String expectedString =
+            "Provided coordinates subset is not part of the dynamics write coordinates subsets.";
+
+        // Test the throw and the message that is thrown
+        EXPECT_THROW(
+            {
+                try
+                {
+                    MatrixXd contribution =
+                        segmentSolution.getDynamicsContribution(dynamics, stateFrame, {coordinatesSubset});
+                }
+                catch (const ostk::core::error::runtime::Undefined& e)
+                {
+                    EXPECT_EQ(expectedString, e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        // Construct a dynamics not part of the segment
+        const Earth earth = Earth::FromModels(
+            std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::Spherical),
+            std::make_shared<EarthMagneticModel>(EarthMagneticModel::Type::Undefined),
+            std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
+        );
+        const Shared<Celestial> earthSPtr = std::make_shared<Celestial>(earth);
+        const Shared<Dynamics> atmosphericDragDynamics = std::make_shared<AtmosphericDrag>(earthSPtr);
+
+        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
+
+        const String expectedString = "Provided dynamics is not part of the segment dynamics.";
+
+        // Test the throw and the message that is thrown
+        EXPECT_THROW(
+            {
+                try
+                {
+                    MatrixXd contribution =
+                        segmentSolution.getDynamicsContribution(atmosphericDragDynamics, stateFrame);
+                }
+                catch (const ostk::core::error::runtime::Undefined& e)
+                {
+                    EXPECT_EQ(expectedString, e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDynamicsContributions)
 {
     {
@@ -210,7 +334,103 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDyn
             Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
 
         const Shared<const Frame> stateFrame = defaultState_.accessFrame();
-        Array<MatrixXd> contributions = segmentSolution.getDynamicsContributions(stateFrame);
+        Map<Shared<Dynamics>, MatrixXd> contributions = segmentSolution.getDynamicsContributions(stateFrame);
+
+        EXPECT_EQ(defaultDynamics_.getSize(), contributions.size());
+        for (const Shared<Dynamics>& dynamics : defaultDynamics_)
+        {
+            EXPECT_EQ(1, contributions.count(dynamics));  // Check all dynamics are present
+            EXPECT_EQ(
+                segmentSolution.states.getSize(), contributions.at(dynamics).rows()
+            );  // Check the number of rows corresponds to the number of states
+            EXPECT_GT(
+                contributions.at(dynamics).cols(), dynamics->getWriteCoordinatesSubsets().getSize()
+            );  // Check the number of columns corresponds to the number of coordinates subsets to which the dynamics
+                // writes
+
+            // Check the contribution is correct
+            Shared<const CoordinatesBroker> coordinatesBrokerSPtr = defaultState_.accessCoordinatesBroker();
+            VectorXd readStateCoordinates = coordinatesBrokerSPtr->extractCoordinates(
+                defaultState_.getCoordinates(), dynamics->getReadCoordinatesSubsets()
+            );
+            EXPECT_EQ(
+                contributions.at(dynamics).row(0),
+                dynamics->computeContribution(defaultState_.getInstant(), readStateCoordinates, stateFrame)
+            );
+        }
+    }
+
+    {
+        const Segment::Solution segmentSolution = Segment::Solution(
+            defaultName_, defaultDynamics_, {initialStateWithMass_, finalStateWithMass_}, true, Segment::Type::Maneuver
+        );
+
+        const Shared<const Frame> stateFrame = initialStateWithMass_.accessFrame();
+        Map<Shared<Dynamics>, MatrixXd> contributions = segmentSolution.getDynamicsContributions(stateFrame);
+
+        EXPECT_EQ(defaultDynamics_.getSize(), contributions.size());
+        for (const Shared<Dynamics>& dynamics : defaultDynamics_)
+        {
+            EXPECT_EQ(1, contributions.count(dynamics));  // Check all dynamics are present
+            EXPECT_EQ(
+                segmentSolution.states.getSize(), contributions.at(dynamics).rows()
+            );  // Check the number of rows corresponds to the number of states
+            EXPECT_GT(
+                contributions.at(dynamics).cols(), dynamics->getWriteCoordinatesSubsets().getSize()
+            );  // Check the number of columns corresponds to the number of coordinates subsets to which the dynamics
+                // writes
+
+            // Check the contribution is correct
+            Shared<const CoordinatesBroker> coordinatesBrokerSPtr = initialStateWithMass_.accessCoordinatesBroker();
+            VectorXd readStateCoordinates = coordinatesBrokerSPtr->extractCoordinates(
+                initialStateWithMass_.getCoordinates(), dynamics->getReadCoordinatesSubsets()
+            );
+            EXPECT_EQ(
+                contributions.at(dynamics).row(0),
+                dynamics->computeContribution(initialStateWithMass_.getInstant(), readStateCoordinates, stateFrame)
+            );
+            EXPECT_EQ(
+                contributions.at(dynamics).row(1),
+                dynamics->computeContribution(finalStateWithMass_.getInstant(), readStateCoordinates, stateFrame)
+            );
+        }
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetDynamicsAccelerationContribution)
+{
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        const Shared<const Frame> stateFrame = defaultState_.accessFrame();
+
+        // Check error for PositionDerivative
+        const String expectedString =
+            "Provided coordinates subset is not part of the dynamics write coordinates subsets.";
+
+        // Test the throw and the message that is thrown
+        EXPECT_THROW(
+            {
+                try
+                {
+                    MatrixXd accelerationContribution =
+                        segmentSolution.getDynamicsAccelerationContribution(defaultDynamics_[0], stateFrame);
+                }
+                catch (const ostk::core::error::runtime::Undefined& e)
+                {
+                    EXPECT_EQ(expectedString, e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+
+        // Check output for Gravity
+        MatrixXd accelerationContribution =
+            segmentSolution.getDynamicsAccelerationContribution(defaultDynamics_[1], stateFrame);
+        EXPECT_EQ(accelerationContribution.cols(), 3);
+        EXPECT_EQ(accelerationContribution.rows(), segmentSolution.states.getSize());
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -384,16 +384,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_GetAll
                 contributions.at(dynamics).cols(), dynamics->getWriteCoordinatesSubsets().getSize()
             );  // Check the number of columns corresponds to the number of coordinates subsets to which the dynamics
                 // writes
-
-            // Check the contribution is correct
-            Shared<const CoordinatesBroker> coordinatesBrokerSPtr = defaultState_.accessCoordinatesBroker();
-            VectorXd readStateCoordinates = coordinatesBrokerSPtr->extractCoordinates(
-                defaultState_.getCoordinates(), dynamics->getReadCoordinatesSubsets()
-            );
-            EXPECT_EQ(
-                contributions.at(dynamics).row(0),
-                dynamics->computeContribution(defaultState_.getInstant(), readStateCoordinates, stateFrame)
-            );
         }
     }
 


### PR DESCRIPTION
- `getDynamicsContribution` method allowing to compute the contribution of a `Dynamics` attached to the Segment Solution for a `Frame`, `Dynamics` and optional subset of `CoordinatesSubset` attached to Dynamics write coordinates Subset. 
- `getAllDynamicsContributions` method leveraging the first method and returning on Map of contributions Matrices for all dynamics of the Segment Solution. 
- `getAccelerationDynamicsContribution` method leveraging the first method and returning the acceleration contribution only of a Dynamics. 