### PR TITLE
feat: add fixed step size factory method for numerical solver

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -292,10 +292,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 "fixed_step_size",
                 &NumericalSolver::FixedStepSize,
                 R"doc(
-                    Return an undefined numerical solver.
+                    Return a Numerical Solver using a fixed stepper.
 
                     Returns:
-                        NumericalSolver: The undefined numerical solver.
+                        NumericalSolver: The numerical solver.
                 )doc",
                 arg("stepper_type"),
                 arg("time_step")

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -289,6 +289,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 )doc"
             )
             .def_static(
+                "fixed_step_size",
+                &NumericalSolver::FixedStepSize,
+                R"doc(
+                    Return an undefined numerical solver.
+
+                    Returns:
+                        NumericalSolver: The undefined numerical solver.
+                )doc",
+                arg("stepper_type"),
+                arg("time_step")
+            )
+            .def_static(
                 "default_conditional",
                 &NumericalSolver::DefaultConditional,
                 R"doc(

--- a/bindings/python/test/trajectory/state/test_numerical_solver.py
+++ b/bindings/python/test/trajectory/state/test_numerical_solver.py
@@ -282,7 +282,7 @@ class TestNumericalSolver:
         assert NumericalSolver.undefined() is not None
         assert NumericalSolver.undefined().is_defined() is False
 
-    def test_fixed_step_size_factory(
+    def test_fixed_step_size(
         self,
         fixed_size_stepper_type: NumericalSolver.StepperType,
         variable_size_stepper_type: NumericalSolver.StepperType,

--- a/bindings/python/test/trajectory/state/test_numerical_solver.py
+++ b/bindings/python/test/trajectory/state/test_numerical_solver.py
@@ -116,7 +116,7 @@ def numerical_solver(
 ) -> NumericalSolver:
     return NumericalSolver(
         log_type=log_type,
-        variable_size_stepper_type=variable_size_stepper_type,
+        stepper_type=variable_size_stepper_type,
         time_step=initial_time_step,
         relative_tolerance=relative_tolerance,
         absolute_tolerance=absolute_tolerance,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -153,6 +153,15 @@ class NumericalSolver : public MathNumericalSolver
 
     static NumericalSolver Default();
 
+    /// @brief Create a fixed step size numerical solver.
+    ///
+    /// @param                  [in] aTimeStep The time step to use for integration.
+    /// @param                  [in] aSystemOfEquations System of equations to integrate.
+    ///
+    /// @return                 A fixed step size numerical solver.
+
+    static NumericalSolver FixedStepSize(const NumericalSolver::StepperType& aStepperType, const Real& aTimeStep);
+
     /// @brief                  Default conditional
     ///
     /// @param                  [in] stateLogger A function that takes a `State` object and logs. Defaults to `nullptr`.

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -153,7 +153,7 @@ class NumericalSolver : public MathNumericalSolver
 
     static NumericalSolver Default();
 
-    /// @brief Create a fixed step size numerical solver.
+    /// @brief                  Create a fixed step size numerical solver.
     ///
     /// @param                  [in] aTimeStep The time step to use for integration.
     /// @param                  [in] aSystemOfEquations System of equations to integrate.

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -296,7 +296,7 @@ NumericalSolver NumericalSolver::FixedStepSize(const NumericalSolver::StepperTyp
 {
     if (aStepperType != NumericalSolver::StepperType::RungeKutta4)
     {
-        throw ostk::core::error::runtime::Wrong("Fixed step size is only supported with RungeKutta4 stepper type.");
+        throw ostk::core::error::RuntimeError("Fixed step size is only supported with RungeKutta4 stepper type.");
     }
 
     return {

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -292,6 +292,24 @@ NumericalSolver NumericalSolver::Default()
     };
 }
 
+NumericalSolver NumericalSolver::FixedStepSize(const NumericalSolver::StepperType& aStepperType, const Real& aTimeStep)
+{
+    if (aStepperType != NumericalSolver::StepperType::RungeKutta4)
+    {
+        throw ostk::core::error::runtime::Wrong("Fixed step size is only supported with RungeKutta4 stepper type.");
+    }
+
+    return {
+        NumericalSolver::LogType::NoLog,
+        aStepperType,
+        aTimeStep,
+        1.0,
+        1.0,
+        RootSolver::Default(),
+        nullptr,
+    };
+}
+
 NumericalSolver NumericalSolver::DefaultConditional(const std::function<void(const State&)>& stateLogger)
 {
     return NumericalSolver::Conditional(5.0, 1.0e-12, 1.0e-12, stateLogger);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -370,6 +370,34 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
     }
 }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Undefined)
+{
+    {
+        EXPECT_NO_THROW(NumericalSolver::Undefined());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Default)
+{
+    {
+        EXPECT_NO_THROW(NumericalSolver::Default());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, FixedStepSize)
+{
+    {
+        EXPECT_NO_THROW(NumericalSolver::FixedStepSize(NumericalSolver::StepperType::RungeKutta4, 30.0));
+    }
+
+    {
+        EXPECT_THROW(
+            NumericalSolver::FixedStepSize(NumericalSolver::StepperType::RungeKuttaDopri5, 30.0),
+            ostk::core::error::runtime::Wrong
+        );
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, DefaultConditional)
 {
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -393,7 +393,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, FixedSte
     {
         EXPECT_THROW(
             NumericalSolver::FixedStepSize(NumericalSolver::StepperType::RungeKuttaDopri5, 30.0),
-            ostk::core::error::runtime::Wrong
+            ostk::core::error::RuntimeError
         );
     }
 }


### PR DESCRIPTION
This adds a static constructor to enable the creation of a fixed step size numerical solver with the RK4 stepper type like so:
```
solver = NumericalSolver.fixed_step_size(RK4, 30.0)
```