### PR TITLE
chore: improve dev container with non-root access 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,44 +1,45 @@
 {
     "name": "Open Space Toolkit Astrodynamics",
-    "mounts": [
-        "source=ostk_astrodynamics_vscode_extensions,target=/home/vscode/.vscode-server/extensions,type=volume"
-    ],
+    "image": "openspacecollective/open-space-toolkit-astrodynamics-development:latest",
+    "initializeCommand": "make build-development-image",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
+    "workspaceFolder": "/app",
+    "containerUser": "vscode",
+    "updateRemoteUserUID": true,
     "runArgs": [
         "--name",
         "open-space-toolkit-astrodynamics-dev",
         "--privileged"
     ],
-    "containerEnv": {
-        "PACKAGE_DEPLOY_TOKEN": "${localEnv:PACKAGE_DEPLOY_TOKEN}"
-    },
-    "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
-    "workspaceFolder": "/app",
-    "updateRemoteUserUID": true,
-    "image": "openspacecollective/open-space-toolkit-astrodynamics-development:latest",
-    "initializeCommand": "make build-development-image",
+    "mounts": [
+        "source=ostk_astrodynamics_vscode_extensions,target=/home/vscode/.vscode-server/extensions,type=volume",
+        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly"
+    ],
     "shutdownAction": "stopContainer",
     "customizations": {
         "vscode": {
-            "settings": {
-                "C_Cpp.clang_format_style": "file:/app/thirdparty/clang/.clang-format",
-                "terminal.integrated.cwd": "/app/build",
-                "terminal.integrated.profiles.linux": {
-                    "bash": {
-                        "path": "/bin/bash",
-                        "icon": "terminal-bash"
-                    }
-                },
-                "python.analysis.diagnosticSeverityOverrides": {
-                    "reportMissingModuleSource": "none"
-                }
-            },
             "extensions": [
                 "ms-vscode.cpptools",
                 "ms-python.python",
                 "ms-python.black-formatter",
                 "mhutchie.git-graph",
-                "ms-vscode.cpptools-extension-pack"
-            ]
+                "ms-vscode.cpptools-extension-pack",
+                "mechatroner.rainbow-csv"
+            ],
+            "settings": {
+                "C_Cpp.clang_format_style": "file:/app/thirdparty/clang/.clang-format",
+                "terminal.integrated.cwd": "/app/build",
+                "terminal.integrated.profile.linux": {
+                    "zsh": {
+                        "path": "/bin/zsh"
+                    }
+                },
+                "terminal.integrated.defaultProfile.linux": "zsh",
+                "python.defaultInterpreterPath": "/usr/local/bin/python3.11",
+                "python.analysis.diagnosticSeverityOverrides": {
+                    "reportMissingModuleSource": "none"
+                }
+            }
         }
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
                 "ms-python.black-formatter",
                 "mhutchie.git-graph",
                 "ms-vscode.cpptools-extension-pack",
-                "mechatroner.rainbow-csv"
+                "mechatroner.rainbow-csv",
+                "twxs.cmake"
             ],
             "settings": {
                 "C_Cpp.clang_format_style": "file:/app/thirdparty/clang/.clang-format",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "initializeCommand": "make build-development-image-non-root && mkdir -p ${localWorkspaceFolder}/build",
     "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
     "workspaceFolder": "/app",
-    "containerUser": "vscode",
+    "containerUser": "developer",
     "updateRemoteUserUID": true,
     "runArgs": [
         "--name",
@@ -12,9 +12,9 @@
 
     ],
     "mounts": [
-        "source=ostk_astrodynamics_vscode_extensions,target=/home/vscode/.vscode-server/extensions,type=volume",
-        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly",
-        "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly"
+        "source=ostk_astrodynamics_vscode_extensions,target=/home/developer/.vscode-server/extensions,type=volume",
+        "source=${localEnv:HOME}/.ssh,target=/home/developer/.ssh,type=bind,readonly",
+        "source=${localEnv:HOME}/.gitconfig,target=/home/developer/.gitconfig,type=bind,readonly"
     ],
     "shutdownAction": "stopContainer",
     "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,20 @@
 {
     "name": "Open Space Toolkit Astrodynamics",
-    "image": "openspacecollective/open-space-toolkit-astrodynamics-development:latest",
-    "initializeCommand": "make build-development-image",
+    "image": "openspacecollective/open-space-toolkit-astrodynamics-development-non-root:latest",
+    "initializeCommand": "make build-development-image-non-root && mkdir -p ${localWorkspaceFolder}/build",
     "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
     "workspaceFolder": "/app",
     "containerUser": "vscode",
     "updateRemoteUserUID": true,
     "runArgs": [
         "--name",
-        "open-space-toolkit-astrodynamics-dev",
-        "--privileged"
+        "open-space-toolkit-astrodynamics-dev-non-root"
+
     ],
     "mounts": [
         "source=ostk_astrodynamics_vscode_extensions,target=/home/vscode/.vscode-server/extensions,type=volume",
-        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly"
+        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly",
+        "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly"
     ],
     "shutdownAction": "stopContainer",
     "customizations": {

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,7 +44,7 @@ jobs:
     name: Build & Test
     needs:
       - prepare-environment
-    uses: open-space-collective/open-space-toolkit/.github/workflows/build-test.yml@chore/improve-dev-container
+    uses: open-space-collective/open-space-toolkit/.github/workflows/build-test.yml@main
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-# Apache License 2.0 
+# Apache License 2.0
 
 name: Build and Test
 
@@ -44,7 +44,7 @@ jobs:
     name: Build & Test
     needs:
       - prepare-environment
-    uses: open-space-collective/open-space-toolkit/.github/workflows/build-test.yml@main
+    uses: open-space-collective/open-space-toolkit/.github/workflows/build-test.yml@chore/improve-dev-container
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}
@@ -84,4 +84,3 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/main' }}
           alert-threshold: "200%"
           comment-on-alert: true
-      

--- a/Makefile
+++ b/Makefile
@@ -236,12 +236,13 @@ build-packages-python-standalone: ## Build Python packages (standalone)
 start-development-no-link: build-development-image ## Start development environment
 
 	@ echo "Starting development environment..."
+	@ mkdir -p $(CURDIR)/build
 
 	docker run \
 		--name=open-space-toolkit-$(project_name)-dev \
 		-it \
 		--rm \
-		--volume="$(CURDIR):/app" \
+		--volume="$(CURDIR):/app:delegated" \
 		--volume="$(HOME)/.ssh:/home/$(dev_username)/.ssh:ro" \
 		--volume="$(HOME)/.gitconfig:/home/$(dev_username)/.gitconfig:ro" \
 		--workdir=/app/build \

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ build-images: ## Build development and release images
 
 .PHONY: build-images
 
-build-development-image: ## Build development image
+build-development-image: pull-development-image ## Build development image
 
 	@ echo "Building development image with root user..."
 
@@ -103,7 +103,7 @@ build-development-image: ## Build development image
 
 .PHONY: build-development-image
 
-build-development-image-non-root: ## Build development image for humans
+build-development-image-non-root: pull-development-image ## Build development image for humans
 
 	@ echo "Building development image for humans with non-root user..."
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ jupyter_python_version_without_dot := $(shell echo $(jupyter_python_version) | s
 jupyter_notebook_image_repository := jupyter/scipy-notebook:x86_64-python-$(jupyter_python_version).3
 extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./' | sed 's/-.*//')
 
+dev_username := vscode
+
 pull: ## Pull all images
 
 	@ echo "Pulling images..."
@@ -96,6 +98,8 @@ build-development-image: pull-development-image ## Build development image
 		--tag=$(docker_development_image_repository):$(docker_image_version) \
 		--tag=$(docker_development_image_repository):latest \
 		--build-arg="VERSION=$(docker_image_version)" \
+		--build-arg="USER_UID=$(shell id -u)" \
+		--build-arg="USER_GID=$(shell id -g)" \
 		"$(CURDIR)"
 
 .PHONY: build-development-image
@@ -234,13 +238,15 @@ start-development-no-link: build-development-image ## Start development environm
 	@ echo "Starting development environment..."
 
 	docker run \
+		--name=open-space-toolkit-$(project_name)-dev \
 		-it \
 		--rm \
-		--privileged \
-		--volume="$(CURDIR):/app:delegated" \
+		--volume="$(CURDIR):/app" \
+		--volume="$(HOME)/.ssh:/home/$(dev_username)/.ssh:ro" \
+		--volume="$(HOME)/.gitconfig:/home/$(dev_username)/.gitconfig:ro" \
 		--workdir=/app/build \
 		$(docker_development_image_repository):$(docker_image_version) \
-		/bin/bash
+		/bin/zsh
 
 .PHONY: start-development-no-link
 

--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,6 @@ format-cpp: build-development-image ## Format all of the source code with the ru
 
 	docker run \
 		--rm \
-		--user="$(shell id -u):$(shell id -g)" \
 		--volume="$(CURDIR):/app" \
 		--workdir=/app \
 		$(docker_development_image_repository):$(docker_image_version) \
@@ -439,7 +438,6 @@ format-check-cpp-standalone:
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--workdir=/app \
-		--user="$(shell id -u):$(shell id -g)" \
 		$(docker_development_image_repository):$(docker_image_version) \
 		ostk-check-format-cpp
 
@@ -517,7 +515,6 @@ test-unit-python-standalone: ## Run Python unit tests (standalone)
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \
 		--workdir=/app/build \
-		--entrypoint="" \
 		$(docker_development_image_repository):$(docker_image_version) \
 		/bin/bash -c "cmake -DBUILD_PYTHON_BINDINGS=ON -DBUILD_UNIT_TESTS=OFF .. \
 		&& $(MAKE) -j 4 && python3.11 -m pip install --root-user-action=ignore bindings/python/dist/*311*.whl \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ jupyter_python_version_without_dot := $(shell echo $(jupyter_python_version) | s
 jupyter_notebook_image_repository := jupyter/scipy-notebook:x86_64-python-$(jupyter_python_version).3
 extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./' | sed 's/-.*//')
 
-dev_username := vscode
+dev_username := developer
 
 pull: ## Pull all images
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -172,6 +172,30 @@ ARG VERSION
 ENV VERSION="${VERSION}"
 LABEL VERSION="${VERSION}"
 
-# Execution
+# Install dev utilities
 
-CMD [ "/bin/bash" ]
+RUN apt-get update \
+ && apt-get install -y zsh sudo \
+ && rm -rf /var/lib/apt/lists/*
+
+## Create non-root user and group
+
+ARG USERNAME="vscode"
+ARG USER_UID="1000"
+ARG USER_GID=${USER_UID}
+RUN groupadd --gid ${USER_GID} ${USERNAME} || true \
+ && adduser --uid ${USER_UID} --gid ${USER_GID} ${USERNAME}
+
+## Use non-root user
+
+USER ${USERNAME}
+
+## Install shell utilities
+
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \
+ && git clone https://github.com/bhilburn/powerlevel9k.git /home/${USERNAME}/.oh-my-zsh/custom/themes/powerlevel9k \
+ && git clone https://github.com/zsh-users/zsh-autosuggestions /home/${USERNAME}/.oh-my-zsh/custom/plugins/zsh-autosuggestions \
+ && git clone https://github.com/zsh-users/zsh-syntax-highlighting.git /home/${USERNAME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting \
+ && mkdir -p /home/${USERNAME}/.vscode-server/extensions /home/${USERNAME}/.vscode-server-insiders/extensions
+
+# Fix python installation location, and ipython installation

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -184,7 +184,7 @@ RUN apt-get update \
  && apt-get install -y zsh sudo \
  && rm -rf /var/lib/apt/lists/*
 
-## Create non-root user and group
+# Create non-root user and group
 
 ARG USERNAME="developer"
 ARG USER_UID="1000"
@@ -193,11 +193,11 @@ RUN groupadd --gid ${USER_GID} ${USERNAME} || true \
  && adduser --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} \
  && echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${USERNAME}
 
-## Use non-root user
+# Use non-root user
 
 USER ${USERNAME}
 
-## Install shell utilities
+# Install shell utilities
 
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \
  && git clone https://github.com/bhilburn/powerlevel9k.git /home/${USERNAME}/.oh-my-zsh/custom/themes/powerlevel9k \
@@ -208,3 +208,7 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
 ## Configure environment
 
 ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
+
+# Entrypoint
+
+CMD [ "/bin/bash" ]

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -2,7 +2,9 @@
 
 ARG BASE_IMAGE_VERSION="latest"
 
-FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION} as base
+# General purpose development image (root user)
+
+FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION} as root-user
 
 LABEL maintainer="lucas@loftorbital.com"
 
@@ -172,6 +174,10 @@ ARG VERSION
 ENV VERSION="${VERSION}"
 LABEL VERSION="${VERSION}"
 
+# Development image for humans (non-root user)
+
+FROM root-user as non-root-user
+
 # Install dev utilities
 
 RUN apt-get update \
@@ -199,6 +205,6 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
  && git clone https://github.com/zsh-users/zsh-syntax-highlighting.git /home/${USERNAME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting \
  && mkdir -p /home/${USERNAME}/.vscode-server/extensions /home/${USERNAME}/.vscode-server-insiders/extensions
 
-# Fix python installation location, and ipython installation by coping the ipython kernel to the python installation location
+## Configure environment
 
-# COPY --from=base /usr/local/lib/python3.11/site-packages/ostk /usr/local/lib/python3.11/site-packages/ostk
+ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG BASE_IMAGE_VERSION="latest"
 
-FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION}
+FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION} as base
 
 LABEL maintainer="lucas@loftorbital.com"
 
@@ -184,7 +184,8 @@ ARG USERNAME="vscode"
 ARG USER_UID="1000"
 ARG USER_GID=${USER_UID}
 RUN groupadd --gid ${USER_GID} ${USERNAME} || true \
- && adduser --uid ${USER_UID} --gid ${USER_GID} ${USERNAME}
+ && adduser --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} \
+ && echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${USERNAME}
 
 ## Use non-root user
 
@@ -198,4 +199,6 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
  && git clone https://github.com/zsh-users/zsh-syntax-highlighting.git /home/${USERNAME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting \
  && mkdir -p /home/${USERNAME}/.vscode-server/extensions /home/${USERNAME}/.vscode-server-insiders/extensions
 
-# Fix python installation location, and ipython installation
+# Fix python installation location, and ipython installation by coping the ipython kernel to the python installation location
+
+# COPY --from=base /usr/local/lib/python3.11/site-packages/ostk /usr/local/lib/python3.11/site-packages/ostk

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -186,7 +186,7 @@ RUN apt-get update \
 
 ## Create non-root user and group
 
-ARG USERNAME="vscode"
+ARG USERNAME="developer"
 ARG USER_UID="1000"
 ARG USER_GID=${USER_UID}
 RUN groupadd --gid ${USER_GID} ${USERNAME} || true \

--- a/tools/development/start.sh
+++ b/tools/development/start.sh
@@ -15,6 +15,7 @@ if [[ -z ${docker_image_version} ]]; then
 fi
 
 project_directory=$(git rev-parse --show-toplevel)
+project_name="astrodynamics"
 
 # Initialize variables
 
@@ -66,7 +67,7 @@ if [[ ! -z ${1} ]] && [[ ${1} == "--link" ]]; then
 
     done
 
-    command="${command} /bin/zsh"
+    command="${command} /bin/bash"
 
 fi
 
@@ -75,9 +76,10 @@ fi
 docker run \
     -it \
     --rm \
+    --name=open-space-toolkit-${project_name}-dev \
     "${options[@]}" \
     --volume="${project_directory}:/app:delegated" \
     --env="deps=${deps}" \
     --workdir="/app/build" \
     ${docker_development_image_repository}:${docker_image_version} \
-    /bin/zsh -c "${command}"
+    /bin/bash -c "${command}"

--- a/tools/development/start.sh
+++ b/tools/development/start.sh
@@ -66,7 +66,7 @@ if [[ ! -z ${1} ]] && [[ ${1} == "--link" ]]; then
 
     done
 
-    command="${command} /bin/bash"
+    command="${command} /bin/zsh"
 
 fi
 
@@ -75,10 +75,9 @@ fi
 docker run \
     -it \
     --rm \
-    --privileged \
     "${options[@]}" \
     --volume="${project_directory}:/app:delegated" \
     --env="deps=${deps}" \
     --workdir="/app/build" \
     ${docker_development_image_repository}:${docker_image_version} \
-    /bin/bash -c "${command}"
+    /bin/zsh -c "${command}"


### PR DESCRIPTION
This PR adds a nicer interface for our local dev container as non-root user and eliminates volume sharing permissions issues associated with build folders having root permissions when you exit the dev container.

This MR depends on this one https://github.com/open-space-collective/open-space-toolkit/pull/81 to be merged first and a new version of the ostk-base image to be pushed to docker hub.