### PR TITLE
build: use the shorthand seed data env var

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -161,12 +161,7 @@ RUN mkdir -p /tmp/open-space-toolkit-physics \
 
 RUN git clone --branch main --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
 
-ENV OSTK_PHYSICS_COORDINATE_FRAME_PROVIDERS_IERS_MANAGER_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data/coordinate/frame/providers/iers"
-ENV OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_MANAGER_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data/environment/ephemerides/spice"
-ENV OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data/environment/gravitational/earth"
-ENV OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data/environment/magnetic/earth"
-ENV OSTK_PHYSICS_ENVIRONMENT_ATMOSPHERIC_EARTH_MANAGER_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data/environment/atmospheric/earth"
-ENV OSTK_PHYSICS_DATA_MANIFEST_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data"
+ENV OSTK_PHYSICS_DATA_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data"
 
 # Labels
 


### PR DESCRIPTION
Tiny change to use the slightly cleaner syntax for setting the OSTk data environment.