### PR TITLE
fix: update Propulsion System scalar constructor

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/SatelliteSystemBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/SatelliteSystemBuilder.cpp
@@ -23,7 +23,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_SatelliteSystemBuilder
             aModule,
             "SatelliteSystemBuilder",
             R"doc(
-                A Satellite System Builder.
+                A Satellite System Builder, meant to simplify creation of a SatelliteSystem, by allowing 
+                you to only specify the parameters you want. There are two ways of doing this:
+                
+                Chaining together your desired parameters like so:
+                SatelliteSystemBuilder().withDryMass(X).withArea(Y)
+
+                Using the default SatelliteSystem and changing one parameters like so:
+                SatelliteSystemBuilder::Default().withDryMass(X)
 
                 Group:
                     system

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystemBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystemBuilder.hpp
@@ -41,12 +41,11 @@ using ostk::astro::flight::system::PropulsionSystem;
 
 /// @brief                      Satellite System builder, meant to simplify creation of a SatelliteSystem, by allowing 
 ///                             you to only specify the parameters you want. There are two ways of doing this:
-///                             
-///                             Chaining together your desired parameters like so:
+/// @code                             
 ///                             SatelliteSystemBuilder().withDryMass(X).withArea(Y)
 ///
-///                             Using the default SatelliteSystem and changing one parameters like so:
 ///                             SatelliteSystemBuilder::Default().withDryMass(X)
+/// @endcode
 
 
 class SatelliteSystemBuilder

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystemBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystemBuilder.hpp
@@ -39,7 +39,15 @@ using ostk::astro::flight::System;
 using ostk::astro::flight::system::SatelliteSystem;
 using ostk::astro::flight::system::PropulsionSystem;
 
-/// @brief                      Satellite System builder
+/// @brief                      Satellite System builder, meant to simplify creation of a SatelliteSystem, by allowing 
+///                             you to only specify the parameters you want. There are two ways of doing this:
+///                             
+///                             Chaining together your desired parameters like so:
+///                             SatelliteSystemBuilder().withDryMass(X).withArea(Y)
+///
+///                             Using the default SatelliteSystem and changing one parameters like so:
+///                             SatelliteSystemBuilder::Default().withDryMass(X)
+
 
 class SatelliteSystemBuilder
 {

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -68,13 +68,6 @@ PropulsionSystem::PropulsionSystem(const Scalar& aThrust, const Scalar& aSpecifi
             aThrust.getValue() / (aSpecificImpulse.getValue() * Earth::gravityConstant), massFlowRateSIUnit
         };
     }
-
-    else
-    {
-        thrust_ = aThrust;
-        thrust_ = aSpecificImpulse;
-        massFlowRate_ = Scalar::Undefined();
-    }
 }
 
 PropulsionSystem::PropulsionSystem(const Real& aThrustInSIUnit, const Real& aSpecificImpulseInSIUnit)


### PR DESCRIPTION
It seems there was an error before, and anyways, I think all three mem vars `thrust_`, `specificImpulse_`, and `massFlowRate_` should remain undefined (as defaulted in the .hpp) if the input scalars are not defined.