### PR TITLE
fix: non-root dev container ostk data issue

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -188,6 +188,10 @@ RUN groupadd --gid ${USER_GID} ${USERNAME} || true \
  && adduser --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} \
  && echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${USERNAME}
 
+# Change ownership of OSTK_PHYSICS_DATA_LOCAL_REPOSITORY
+
+RUN chown -R ${USERNAME}:${USERNAME} ${OSTK_PHYSICS_DATA_LOCAL_REPOSITORY}
+
 # Use non-root user
 
 USER ${USERNAME}


### PR DESCRIPTION
This MR adds:
- changes ownership of the ostk-data folder to the non-root user, otherwise anything that uses that folder fails
- adds ssh to the dev container so that you can push to git from within the dev container
- adds a default .zshrc config file  