### PR TITLE
feat: enrich and fix time conversion functions

### DIFF
--- a/bindings/python/test/test_converters.py
+++ b/bindings/python/test/test_converters.py
@@ -61,7 +61,10 @@ def test_coerce_to_datetime_success_iso():
     )
 
 
-def test_coerce_to_datetime_failure_iso():
+def test_coerce_to_datetime_failure():
+    with pytest.raises(TypeError):
+        coerce_to_datetime(False)
+
     with pytest.raises(Exception):
         coerce_to_datetime("some_ill_formed_iso")
 
@@ -100,7 +103,10 @@ def test_coerce_to_instant_success_iso():
     )
 
 
-def test_coerce_to_instant_failure_iso():
+def test_coerce_to_instant_failure():
+    with pytest.raises(TypeError):
+        coerce_to_instant(False)
+
     with pytest.raises(Exception):
         coerce_to_instant("some_ill_formed_iso")
 
@@ -176,9 +182,12 @@ def test_coerce_to_iso_success_iso():
     )
 
 
-def test_coerce_to_iso_failure_iso():
+def test_coerce_to_iso_failure():
+    with pytest.raises(TypeError):
+        coerce_to_iso(False)
+
     with pytest.raises(Exception):
-        coerce_to_instant("some_ill_formed_iso")
+        coerce_to_iso("some_ill_formed_iso")
 
 
 def test_coerce_to_interval_success_interval():

--- a/bindings/python/test/test_converters.py
+++ b/bindings/python/test/test_converters.py
@@ -33,9 +33,19 @@ def test_coerce_to_datetime_success_instant():
         2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc
     )
 
+    value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.TAI)
+    assert coerce_to_datetime(value) == datetime(
+        2020, 1, 2, 3, 3, 28, 123456, tzinfo=timezone.utc
+    )
+
 
 def test_coerce_to_datetime_success_datetime():
-    value = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    value = datetime(2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc)
+    assert coerce_to_datetime(value) == value
+
+    value = datetime(
+        2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone(timedelta(seconds=3600))
+    )
     assert coerce_to_datetime(value) == value
 
 
@@ -62,9 +72,19 @@ def test_coerce_to_instant_success_datetime():
         DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC
     )
 
+    value = datetime(
+        2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone(timedelta(seconds=3600))
+    )
+    assert coerce_to_instant(value) == Instant.date_time(
+        DateTime(2020, 1, 2, 2, 4, 5, 123, 456), Scale.UTC
+    )
+
 
 def test_coerce_to_instant_success_instant():
     value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC)
+    assert coerce_to_instant(value) == value
+
+    value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.TAI)
     assert coerce_to_instant(value) == value
 
 
@@ -92,6 +112,14 @@ def test_coerce_to_iso_success_datetime():
         == "2020-01-02T03:04:05.123456+00:00"
     )
 
+    value = datetime(
+        2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone(timedelta(seconds=3600))
+    )
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.123456+01:00"
+    )
+
     value = datetime(2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc)
     assert (
         coerce_to_iso(value, timespec="milliseconds") == "2020-01-02T03:04:05.123+00:00"
@@ -109,6 +137,12 @@ def test_coerce_to_iso_success_instant():
     assert (
         coerce_to_iso(value, timespec="microseconds")
         == "2020-01-02T03:04:05.123456+00:00"
+    )
+
+    value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.TAI)
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:03:28.123456+00:00"
     )
 
     value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC)

--- a/bindings/python/test/test_converters.py
+++ b/bindings/python/test/test_converters.py
@@ -1,5 +1,7 @@
 # Apache License 2.0
 
+import pytest
+
 from datetime import datetime, timedelta, timezone
 
 import numpy as np
@@ -17,6 +19,7 @@ from ostk.physics.coordinate import Frame
 
 from ostk.astrodynamics.converters import coerce_to_datetime
 from ostk.astrodynamics.converters import coerce_to_instant
+from ostk.astrodynamics.converters import coerce_to_iso
 from ostk.astrodynamics.converters import coerce_to_interval
 from ostk.astrodynamics.converters import coerce_to_duration
 from ostk.astrodynamics.converters import coerce_to_position
@@ -25,8 +28,10 @@ from ostk.astrodynamics.converters import coerce_to_quaternion
 
 
 def test_coerce_to_datetime_success_instant():
-    value = Instant.date_time(DateTime(2020, 1, 1), Scale.UTC)
-    assert coerce_to_datetime(value) == datetime(2020, 1, 1, tzinfo=timezone.utc)
+    value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC)
+    assert coerce_to_datetime(value) == datetime(
+        2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc
+    )
 
 
 def test_coerce_to_datetime_success_datetime():
@@ -34,14 +39,112 @@ def test_coerce_to_datetime_success_datetime():
     assert coerce_to_datetime(value) == value
 
 
+def test_coerce_to_datetime_success_iso():
+    value = "2020-01-02T03:04:05.123456+00:00"
+    assert coerce_to_datetime(value) == datetime(
+        2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc
+    )
+
+    value = "2020-01-02T03:04:05.123456+01:00"
+    assert coerce_to_datetime(value) == datetime(
+        2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone(timedelta(seconds=3600))
+    )
+
+
+def test_coerce_to_datetime_failure_iso():
+    with pytest.raises(Exception):
+        coerce_to_datetime("some_ill_formed_iso")
+
+
 def test_coerce_to_instant_success_datetime():
-    value = datetime(2020, 1, 1, tzinfo=timezone.utc)
-    assert coerce_to_instant(value) == Instant.date_time(DateTime(2020, 1, 1), Scale.UTC)
+    value = datetime(2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc)
+    assert coerce_to_instant(value) == Instant.date_time(
+        DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC
+    )
 
 
 def test_coerce_to_instant_success_instant():
-    value = Instant.date_time(DateTime(2020, 1, 1), Scale.UTC)
+    value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC)
     assert coerce_to_instant(value) == value
+
+
+def test_coerce_to_instant_success_iso():
+    value = "2020-01-02T03:04:05.123456+00:00"
+    assert coerce_to_instant(value) == Instant.date_time(
+        DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC
+    )
+
+    value = "2020-01-02T03:04:05.123456+01:00"
+    assert coerce_to_instant(value) == Instant.date_time(
+        DateTime(2020, 1, 2, 2, 4, 5, 123, 456), Scale.UTC
+    )
+
+
+def test_coerce_to_instant_failure_iso():
+    with pytest.raises(Exception):
+        coerce_to_instant("some_ill_formed_iso")
+
+
+def test_coerce_to_iso_success_datetime():
+    value = datetime(2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc)
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.123456+00:00"
+    )
+
+    value = datetime(2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc)
+    assert (
+        coerce_to_iso(value, timespec="milliseconds") == "2020-01-02T03:04:05.123+00:00"
+    )
+
+    value = datetime(2020, 1, 2, 3, 4, 5, 0, tzinfo=timezone.utc)
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.000000+00:00"
+    )
+
+
+def test_coerce_to_iso_success_instant():
+    value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC)
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.123456+00:00"
+    )
+
+    value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC)
+    assert (
+        coerce_to_iso(value, timespec="milliseconds") == "2020-01-02T03:04:05.123+00:00"
+    )
+
+    value = Instant.date_time(DateTime(2020, 1, 2, 3, 4, 5, 123), Scale.UTC)
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.123000+00:00"
+    )
+
+
+def test_coerce_to_iso_success_iso():
+    value = "2020-01-02T03:04:05.123456+00:00"
+    assert coerce_to_iso(value, timespec="microseconds") == value
+
+    value = "2020-01-02T03:04:05.123456+01:00"
+    assert coerce_to_iso(value, timespec="microseconds") == value
+
+    value = "2020-01-02T03:04:05.123456+00:00"
+    assert (
+        coerce_to_iso(value, timespec="milliseconds") == "2020-01-02T03:04:05.123+00:00"
+    )
+
+    value = "2020-01-02T03:04:05.123+00:00"
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.123000+00:00"
+    )
+
+
+def test_coerce_to_iso_failure_iso():
+    with pytest.raises(Exception):
+        coerce_to_instant("some_ill_formed_iso")
 
 
 def test_coerce_to_interval_success_interval():

--- a/bindings/python/test/test_converters.py
+++ b/bindings/python/test/test_converters.py
@@ -55,10 +55,21 @@ def test_coerce_to_datetime_success_iso():
         2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc
     )
 
+    value = "2020-01-02T03:04:05+00:00"
+    assert coerce_to_datetime(value) == datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
     value = "2020-01-02T03:04:05.123456+01:00"
     assert coerce_to_datetime(value) == datetime(
         2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone(timedelta(seconds=3600))
     )
+
+    value = "2020-01-02T03:04:05.123456Z"
+    assert coerce_to_datetime(value) == datetime(
+        2020, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc
+    )
+
+    value = "2020-01-02T03:04:05Z"
+    assert coerce_to_datetime(value) == datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
 
 
 def test_coerce_to_datetime_failure():
@@ -97,9 +108,32 @@ def test_coerce_to_instant_success_iso():
         DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC
     )
 
+    value = "2020-01-02T03:04:05+00:00"
+    assert coerce_to_instant(value) == Instant.date_time(
+        DateTime(2020, 1, 2, 3, 4, 5), Scale.UTC
+    )
+
     value = "2020-01-02T03:04:05.123456+01:00"
     assert coerce_to_instant(value) == Instant.date_time(
         DateTime(2020, 1, 2, 2, 4, 5, 123, 456), Scale.UTC
+    )
+
+    value = "2020-01-02T03:04:05.123456Z"
+    assert coerce_to_instant(value) == Instant.date_time(
+        DateTime(2020, 1, 2, 3, 4, 5, 123, 456), Scale.UTC
+    )
+
+    value = "2020-01-02T03:04:05Z"
+    assert coerce_to_instant(value) == Instant.date_time(
+        DateTime(
+            2020,
+            1,
+            2,
+            3,
+            4,
+            5,
+        ),
+        Scale.UTC,
     )
 
 
@@ -179,6 +213,35 @@ def test_coerce_to_iso_success_iso():
     assert (
         coerce_to_iso(value, timespec="microseconds")
         == "2020-01-02T03:04:05.123000+00:00"
+    )
+
+    value = "2020-01-02T03:04:05+00:00"
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.000000+00:00"
+    )
+
+    value = "2020-01-02T03:04:05.123456Z"
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.123456+00:00"
+    )
+
+    value = "2020-01-02T03:04:05.123456Z"
+    assert (
+        coerce_to_iso(value, timespec="milliseconds") == "2020-01-02T03:04:05.123+00:00"
+    )
+
+    value = "2020-01-02T03:04:05.123Z"
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.123000+00:00"
+    )
+
+    value = "2020-01-02T03:04:05Z"
+    assert (
+        coerce_to_iso(value, timespec="microseconds")
+        == "2020-01-02T03:04:05.000000+00:00"
     )
 
 

--- a/bindings/python/tools/python/ostk/astrodynamics/converters.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/converters.py
@@ -1,7 +1,5 @@
 # Apache License 2.0
 
-from typing import Union
-
 from datetime import datetime, timedelta, timezone
 
 import numpy as np
@@ -17,7 +15,7 @@ from ostk.physics.coordinate import Velocity
 from ostk.physics.coordinate import Frame
 
 
-def coerce_to_datetime(value: Union[Instant, datetime, str]) -> datetime:
+def coerce_to_datetime(value: Instant | datetime | str) -> datetime:
     """
     Return datetime from value.
 
@@ -31,17 +29,16 @@ def coerce_to_datetime(value: Union[Instant, datetime, str]) -> datetime:
     if isinstance(value, datetime):
         return value
 
-    elif isinstance(value, Instant):
+    if isinstance(value, Instant):
         return value.get_date_time(Scale.UTC).replace(tzinfo=timezone.utc)
 
-    elif isinstance(value, str):
+    if isinstance(value, str):
         return datetime.fromisoformat(value)
 
-    else:
-        raise TypeError("Argument must be a datetime, an Instant, or a str.")
+    raise TypeError("Argument must be a datetime, an Instant, or a str.")
 
 
-def coerce_to_instant(value: Union[Instant, datetime, str]) -> Instant:
+def coerce_to_instant(value: Instant | datetime | str) -> Instant:
     """
     Return Instant from value.
 
@@ -55,25 +52,24 @@ def coerce_to_instant(value: Union[Instant, datetime, str]) -> Instant:
     if isinstance(value, Instant):
         return value
 
-    elif isinstance(value, datetime):
+    if isinstance(value, datetime):
         return Instant.date_time(value.astimezone(tz=timezone.utc), Scale.UTC)
 
-    elif isinstance(value, str):
+    if isinstance(value, str):
         return coerce_to_instant(coerce_to_datetime(value))
 
-    else:
-        raise TypeError("Argument must be a datetime, an Instant, or a str.")
+    raise TypeError("Argument must be a datetime, an Instant, or a str.")
 
 
 def coerce_to_iso(
-    value: Union[Instant, datetime, str], timespec: str = "microseconds"
+    value: Instant | datetime | str, timespec: str = "microseconds"
 ) -> Instant:
     """
     Return an ISO string from value.
 
     Args:
         value (Instant | datetime | str): A value to coerce.
-        timespec (str): A time resolution ("microseconds" by default).
+        timespec (str): A time resolution. Defaults to "microseconds".
 
     Returns:
         str: The coerced ISO string.
@@ -82,14 +78,13 @@ def coerce_to_iso(
     if isinstance(value, str):
         return coerce_to_iso(coerce_to_datetime(value), timespec=timespec)
 
-    elif isinstance(value, datetime):
+    if isinstance(value, datetime):
         return value.isoformat(timespec=timespec)
 
-    elif isinstance(value, Instant):
+    if isinstance(value, Instant):
         return coerce_to_iso(coerce_to_datetime(value), timespec=timespec)
 
-    else:
-        raise TypeError("Argument must be a datetime, an Instant, or a str.")
+    raise TypeError("Argument must be a datetime, an Instant, or a str.")
 
 
 def coerce_to_interval(

--- a/bindings/python/tools/python/ostk/astrodynamics/converters.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/converters.py
@@ -76,7 +76,7 @@ def coerce_to_iso(
         timespec (str): A time resolution ("microseconds" by default).
 
     Returns:
-        Instant: The coerced ISO string.
+        str: The coerced ISO string.
     """
 
     if isinstance(value, str):


### PR DESCRIPTION
- ✅ Enrich conversion to `datetime` and `Instant` to consider ISO strings
- ✅ Create a `coerce_to_iso` for `datetime`, `Instant` and ISO strings
- ✅ Fix `datetime` to `Instant` conversion where scale was assumed to be in UTC
- ✅ Enriched tests