### PR TITLE
feat: add state logging aware solve method for Sequence and Segment

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -16,6 +16,8 @@
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/InstantCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp>
 
@@ -42,6 +44,8 @@ using ostk::astro::trajectory::state::NumericalSolver;
 using ostk::astro::Dynamics;
 using ostk::astro::dynamics::Thruster;
 using ostk::astro::EventCondition;
+using ostk::astro::eventcondition::InstantCondition;
+using ostk::astro::eventcondition::RealCondition;
 
 /// @brief                      Represent a propagation segment for astrodynamics purposes
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -220,6 +220,17 @@ class Segment
 
     Solution solve(const State& aState, const Duration& maximumPropagationDuration = Duration::Days(30.0)) const;
 
+    /// @brief                  Solve the segment while reporting observed states at user defined intervals
+    ///
+    /// @param                  [in] aState Initial state for the segment
+    /// @param                  [in] aStep Interval between observed states
+    /// @param                  [in] maximumPropagationDuration Maximum duration for propagation. Defaults to 30 days
+    /// @return                 A Solution representing the result of the solve
+
+    Solution solveWhileObservingStatesAtFixedIntervals(
+        const State& aState, const Duration& aStep, const Duration& maximumPropagationDuration = Duration::Days(30.0)
+    ) const;
+
     /// @brief                  Print the segment
     ///
     /// @param                  [in] anOutputStream An output stream

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
@@ -144,13 +144,25 @@ class Sequence
 
     void addManeuverSegment(const Shared<EventCondition>& anEventConditionSPtr, const Shared<Thruster>& aThruster);
 
-    /// @brief                  Solve the sequence given an initial state, for a number of reptitions.
+    /// @brief                  Solve the sequence given an initial state, for a number of repititions.
     ///
     /// @param                  [in] aState Initial state for the sequence.
     /// @param                  [in] aRepetitionCount Number of repetitions. Defaults to 1, i.e. execute sequence once.
     /// @return                 A Solution that contains solutions for each segment.
 
     Solution solve(const State& aState, const Size& aRepetitionCount = 1) const;
+
+    /// @brief                  Solve the sequence given an initial state, for a number of repititions. While solving,
+    /// report observed states at user defined intervals.
+    ///
+    /// @param                  [in] aState Initial state for the sequence.
+    /// @param                  [in] aStep Interval between observed states.
+    /// @param                  [in] aRepetitionCount Number of repetitions. Defaults to 1, i.e. execute sequence once.
+    /// @return                 A Solution that contains solutions for each segment.
+
+    Solution solveWhileObservingStatesAtFixedIntervals(
+        const State& aState, const Duration& aStep, const Size& aRepetitionCount = 1
+    ) const;
 
     /// @brief                  Solve the sequence given an initial state.
     ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -338,6 +338,31 @@ Segment::Solution Segment::solve(const State& aState, const Duration& maximumPro
     };
 }
 
+Segment::Solution Segment::solveWhileObservingStatesAtFixedIntervals(
+    const State& aState, const Duration& aStep, const Duration& maximumPropagationDuration
+) const
+{
+    const Propagator propagator = {
+        numericalSolver_,
+        dynamics_,
+    };
+
+    // Do logic to determine instant array to propagate to with reportStep, and make sure its before
+    // maximumPropagationDuration
+    // Use eventCondition_ to determine the end of the propagation?
+    Array<Instant> instants = Array<Instant>::Empty();
+
+    const Array<State> states = propagator.calculateStatesAt(aState, instants);
+
+    return {
+        name_,
+        dynamics_,
+        propagator.accessNumericalSolver().accessObservedStates(),
+        true,  // TBI: do a check on whether or not the condition was actually met in the future
+        type_,
+    };
+}
+
 void Segment::print(std::ostream& anOutputStream, bool displayDecorator) const
 {
     if (displayDecorator)


### PR DESCRIPTION
Adding a `solveWhileObservingStatesAtFixedIntervals` method to both the `Sequence` and `Solver` classes.

In order to allow the cross validation app and parser to take the yaml scenario definition files with an list of segments and report & compare observed states at a fixed time interval specified by the yaml file, the `Propagator`'s `calculateStateAt(instant)` method must be used, instead of the `calculateStateToCondition` method. The `calculateStateToCondition` method does not use the `boost::odeint::integrate_times` method under the hood, and so can only return observed states at the variable timesteps taken.

This is probably not the cleanest solution or most permanent solution to unblock this use case for my validation app and parser, but I think its good enough for now and doesn't cause any breaking changes to the sequence/segments API. In the future I think we can modify the `Sequence` and `Segment` API genaralize/add another abstraction inside the `solve` method so that this use case can be handled with an extra argument supplied to the `solve` function, and make reporting at fixed step intervals with any type of propagator compatible with the range of `EventCondition` that are supported in the `Sequence/Segment` paradigm.