### PR TITLE
feat: add repropagation of intermediate states to sequence and segment

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -167,17 +167,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
         )
 
         .def(
-            "compute_delta_mass",
-            &Segment::Solution::computeDeltaMass,
-            R"doc(
-                Compute the delta mass.
-
-                Returns:
-                    Mass: The delta mass.
-
-            )doc"
-        )
-        .def(
             "compute_delta_v",
             &Segment::Solution::computeDeltaV,
             arg("specific_impulse"),
@@ -190,6 +179,34 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
                 Returns:
                     float: The delta V.
 
+            )doc"
+        )
+        .def(
+            "compute_delta_mass",
+            &Segment::Solution::computeDeltaMass,
+            R"doc(
+                Compute the delta mass.
+
+                Returns:
+                    Mass: The delta mass.
+
+            )doc"
+        )
+
+        .def(
+            "re_compute_states_at",
+            &Segment::Solution::reComputeStatesAt,
+            arg("instants"),
+            arg("numerical_solver"),
+            R"doc(
+                Recompute the states in this segment's solution at the given instants.
+
+                Args:
+                    instants (list[Instant]): The instants.
+                    numerical_solver (NumericalSolver): The numerical solver to use to recompute the states.
+
+                Returns:
+                    list[State]: The states at the desired instants.
             )doc"
         )
         .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -177,7 +177,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
                     specific_impulse (float): The specific impulse.
 
                 Returns:
-                    float: The delta V.
+                    float: The delta V (m/s).
 
             )doc"
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -194,19 +194,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
         )
 
         .def(
-            "re_compute_states_at",
-            &Segment::Solution::reComputeStatesAt,
+            "calculate_states_at",
+            &Segment::Solution::calculateStatesAt,
             arg("instants"),
             arg("numerical_solver"),
             R"doc(
-                Recompute the states in this segment's solution at the given instants.
+                Calculate the states in this segment's solution at the given instants.
 
                 Args:
-                    instants (list[Instant]): The instants.
-                    numerical_solver (NumericalSolver): The numerical solver to use to recompute the states.
+                    instants (list[Instant]): The instants at which the states will be calculated.
+                    numerical_solver (NumericalSolver): The numerical solver used to calculate the states.
 
                 Returns:
-                    list[State]: The states at the desired instants.
+                    list[State]: The states at the provided instants.
             )doc"
         )
         .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -147,18 +147,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
 
             )doc"
         )
-
-        .def(
-            "compute_delta_mass",
-            &Sequence::Solution::computeDeltaMass,
-            R"doc(
-                Compute the delta mass.
-
-                Returns:
-                    float: The delta mass.
-
-            )doc"
-        )
         .def(
             "compute_delta_v",
             &Sequence::Solution::computeDeltaV,
@@ -173,6 +161,34 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
 
             )doc",
             arg("specific_impulse")
+        )
+        .def(
+            "compute_delta_mass",
+            &Sequence::Solution::computeDeltaMass,
+            R"doc(
+                Compute the delta mass.
+
+                Returns:
+                    float: The delta mass.
+
+            )doc"
+        )
+
+        .def(
+            "re_compute_states_at",
+            &Sequence::Solution::reComputeStatesAt,
+            R"doc(
+                Recompute states in this sequence's solution at given instants.
+
+                Args:
+                    instants (list[Instant]): The instants.
+                    numerical_solver (NumericalSolver): The numerical solver to use to recompute the states.
+
+                Returns:
+                    list[State]: The states at the desired instants.
+                )doc",
+            arg("instants"),
+            arg("numerical_solver")
         )
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -175,17 +175,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
         )
 
         .def(
-            "re_compute_states_at",
+            "calculate_states_at",
             &Sequence::Solution::reComputeStatesAt,
             R"doc(
-                Recompute states in this sequence's solution at given instants.
+                Calculate states in this sequence's solution at provided instants.
 
                 Args:
-                    instants (list[Instant]): The instants.
-                    numerical_solver (NumericalSolver): The numerical solver to use to recompute the states.
+                    instants (list[Instant]): The instants at which the states will be calculated.
+                    numerical_solver (NumericalSolver): The numerical solver used to calculate the states.
 
                 Returns:
-                    list[State]: The states at the desired instants.
+                    list[State]: The states at the provided instants.
                 )doc",
             arg("instants"),
             arg("numerical_solver")

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -176,7 +176,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
 
         .def(
             "calculate_states_at",
-            &Sequence::Solution::reComputeStatesAt,
+            &Sequence::Solution::calculateStatesAt,
             R"doc(
                 Calculate states in this sequence's solution at provided instants.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -157,7 +157,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                     specific_impulse (float): The specific impulse.
 
                 Returns:
-                    float: The delta V.
+                    float: The delta V (m/s).
 
             )doc",
             arg("specific_impulse")

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -122,7 +122,7 @@ def maneuver_segment(
 
 
 @pytest.fixture
-def instant_array(state: State) -> list[Instant]:
+def instants(state: State) -> list[Instant]:
     return [state.get_instant(), state.get_instant() + Duration.minutes(1.0)]
 
 
@@ -217,7 +217,7 @@ class TestSegment:
         state: State,
         end_instant: Instant,
         maneuver_segment: Segment,
-        instant_array: list[Instant],
+        instants: list[Instant],
         numerical_solver: NumericalSolver,
     ):
         solution = maneuver_segment.solve(state)
@@ -248,13 +248,13 @@ class TestSegment:
 
         state_frame: Frame = state.get_frame()
 
-        propagated_states = solution.re_compute_states_at(
-            instant_array,
+        propagated_states = solution.calculate_states_at(
+            instants,
             numerical_solver,
         )
 
         assert propagated_states is not None
-        assert len(propagated_states) == len(instant_array)
+        assert len(propagated_states) == len(instants)
 
         first_dynamics_contribution = solution.get_dynamics_contribution(
             solution.dynamics[0], state_frame

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -122,6 +122,11 @@ def maneuver_segment(
 
 
 @pytest.fixture
+def instant_array(state: State) -> list[Instant]:
+    return [state.get_instant(), state.get_instant() + Duration.minutes(1.0)]
+
+
+@pytest.fixture
 def thruster_dynamics() -> Thruster:
     return Thruster(
         satellite_system=SatelliteSystem.default(),
@@ -212,6 +217,8 @@ class TestSegment:
         state: State,
         end_instant: Instant,
         maneuver_segment: Segment,
+        instant_array: list[Instant],
+        numerical_solver: NumericalSolver,
     ):
         solution = maneuver_segment.solve(state)
 
@@ -240,6 +247,14 @@ class TestSegment:
         assert solution.compute_delta_v(1500.0) is not None
 
         state_frame: Frame = state.get_frame()
+
+        propagated_states = solution.re_compute_states_at(
+            instant_array,
+            numerical_solver,
+        )
+
+        assert propagated_states is not None
+        assert len(propagated_states) == len(instant_array)
 
         first_dynamics_contribution = solution.get_dynamics_contribution(
             solution.dynamics[0], state_frame

--- a/bindings/python/test/trajectory/test_sequence.py
+++ b/bindings/python/test/trajectory/test_sequence.py
@@ -335,7 +335,7 @@ def segment_solution(
 
 
 @pytest.fixture
-def instant_array(state: State) -> list[Instant]:
+def instants(state: State) -> list[Instant]:
     return [state.get_instant(), state.get_instant() + Duration.minutes(1.0)]
 
 
@@ -429,7 +429,7 @@ class TestSequence:
         repetition_count: int,
         sequence: Sequence,
         segments: list[Segment],
-        instant_array: list[Instant],
+        instants: list[Instant],
         numerical_solver: NumericalSolver,
     ):
         solution = sequence.solve(
@@ -452,13 +452,13 @@ class TestSequence:
         assert solution.compute_delta_mass() is not None
         assert solution.compute_delta_v(1500.0) is not None
 
-        propagated_states = solution.re_compute_states_at(
-            instant_array,
+        propagated_states = solution.calculate_states_at(
+            instants,
             numerical_solver,
         )
 
         assert propagated_states is not None
-        assert len(propagated_states) == len(instant_array)
+        assert len(propagated_states) == len(instants)
 
     def test_solve_to_condition(
         self,

--- a/bindings/python/test/trajectory/test_sequence.py
+++ b/bindings/python/test/trajectory/test_sequence.py
@@ -425,7 +425,10 @@ class TestSequence:
         sequence: Sequence,
         segments: list[Segment],
     ):
-        solution = sequence.solve(state, repetition_count)
+        solution = sequence.solve(
+            state=state,
+            repetition_count=repetition_count,
+        )
 
         assert len(solution.segment_solutions) == len(segments)
 

--- a/bindings/python/test/trajectory/test_sequence.py
+++ b/bindings/python/test/trajectory/test_sequence.py
@@ -334,6 +334,11 @@ def segment_solution(
     )
 
 
+@pytest.fixture
+def instant_array(state: State) -> list[Instant]:
+    return [state.get_instant(), state.get_instant() + Duration.minutes(1.0)]
+
+
 class TestSequence:
     def test_get_segments(
         self,
@@ -424,6 +429,8 @@ class TestSequence:
         repetition_count: int,
         sequence: Sequence,
         segments: list[Segment],
+        instant_array: list[Instant],
+        numerical_solver: NumericalSolver,
     ):
         solution = sequence.solve(
             state=state,
@@ -444,6 +451,14 @@ class TestSequence:
 
         assert solution.compute_delta_mass() is not None
         assert solution.compute_delta_v(1500.0) is not None
+
+        propagated_states = solution.re_compute_states_at(
+            instant_array,
+            numerical_solver,
+        )
+
+        assert propagated_states is not None
+        assert len(propagated_states) == len(instant_array)
 
     def test_solve_to_condition(
         self,

--- a/include/OpenSpaceToolkit/Astrodynamics/Conjunction/Messages/CCSDS/CDM.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Conjunction/Messages/CCSDS/CDM.hpp
@@ -13,7 +13,7 @@
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
 
-#include <OpenSpaceToolkit/Mathematics/Objects/Matrix.hpp>
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IAU/Theory.hpp>

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/InstantCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/InstantCondition.hpp
@@ -29,7 +29,7 @@ class InstantCondition : public RealCondition
     /// @endcode
     ///
     /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aDuration An instantn
+    /// @param aDuration An instant
     InstantCondition(const Criterion& aCriterion, const Instant& anInstant);
 
     /// @brief Virtual destructor

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Propagated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Propagated.hpp
@@ -108,10 +108,8 @@ class Propagated : public ostk::astro::trajectory::orbit::Model
     /// @return Integer
     virtual Integer getRevolutionNumberAtEpoch() const override;
 
-    /// @brief Calculate the state at an instant, utilizing internal cached state array to propagated
-    /// shortest amount of time
-    /// @brief Does not have macro-level sorting optimization, should not be used with disorded instant
-    /// array
+    /// @brief Calculate the state at an instant, given initial state
+
     /// @code{.cpp}
     ///              State state = propagated.calculateStateAt(anInstant) ;
     /// @endcode
@@ -119,13 +117,16 @@ class Propagated : public ostk::astro::trajectory::orbit::Model
     /// @return State
     virtual State calculateStateAt(const Instant& anInstant) const override;
 
-    /// @brief Calculate the state at an instant, given initial state
+    /// @brief Calculate the state at an instant, utilizing internal cached state array to propagated
+    /// shortest amount of time. Does not have macro-level sorting optimization, should not be used with disorded
+    /// instant array
+
     /// @code{.cpp}
-    ///              State state = propagated.calculateStateAt(aState, anInstant) ;
+    ///              Array<State> states = propagated.calculateStatesAt(anInstantArray) ;
     /// @endcode
     /// @param aState An initial state
-    /// @param anInstant An instant
-    /// @return State
+    /// @param anInstantArray An instant
+    /// @return Array<State>
     virtual Array<State> calculateStatesAt(const Array<Instant>& anInstantArray) const override;
 
     /// @brief Calculate the revolution number at an instant

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
@@ -169,7 +169,7 @@ class Propagator
 
     /// @brief Calculate the states at an array of instants, given an initial state
     /// @brief Can only be used with sorted instants array
-
+    ///
     /// @code{.cpp}
     ///              Array<State> states = propagator.calculateStatesAt(aState, anInstantArray);
     /// @endcode

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
@@ -156,7 +156,7 @@ class Propagator
 
     /// @brief Calculate the state subject to an Event Condition, given initial state and maximum end time
     /// @code{.cpp}
-    ///              NumericalSolver::ConditionSolution state = propagator.calculateStateAt(aState, anInstant,
+    ///              NumericalSolver::ConditionSolution state = propagator.calculateStateToCondition(aState, anInstant,
     ///              anEventCondition);
     /// @endcode
     /// @param aState An initial state
@@ -169,6 +169,7 @@ class Propagator
 
     /// @brief Calculate the states at an array of instants, given an initial state
     /// @brief Can only be used with sorted instants array
+
     /// @code{.cpp}
     ///              Array<State> states = propagator.calculateStatesAt(aState, anInstantArray);
     /// @endcode

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -8,7 +8,7 @@
 #include <OpenSpaceToolkit/Core/Types/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
 
-#include <OpenSpaceToolkit/Mathematics/Objects/Matrix.hpp>
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
@@ -16,6 +16,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Propagated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp>
 
@@ -39,6 +40,7 @@ using ostk::physics::units::Mass;
 
 using ostk::astro::trajectory::State;
 using ostk::astro::trajectory::state::NumericalSolver;
+using ostk::astro::trajectory::orbit::models::Propagated;
 using ostk::astro::Dynamics;
 using ostk::astro::dynamics::Thruster;
 using ostk::astro::EventCondition;
@@ -53,6 +55,7 @@ class Segment
         Maneuver  ///< Maneuver
     };
 
+    /// @brief Once a segment is set up with an event condition, it can be solved, resulting in this segment's Solution.
     struct Solution
     {
        public:
@@ -102,6 +105,14 @@ class Segment
         /// @return Delta mass
         Mass computeDeltaMass() const;
 
+        /// @brief Calculate (using numerical propagation) intermediate states at specified instants
+        ///
+        /// @param aNumericalSolver a numerical solver to use for the propagation between states
+        /// @param anInstantArray an array of instants
+        /// @return States at specified instants
+        Array<State> reComputeStatesAt(const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver)
+            const;
+
         /// @brief Get dynamics contribution
         ///
         /// @param aDynamicsSPtr Dynamics
@@ -143,11 +154,11 @@ class Segment
         /// @return An output stream
         friend std::ostream& operator<<(std::ostream& anOutputStream, const Solution& aSolution);
 
-        String name;                       /// Name of the segment.
-        Array<Shared<Dynamics>> dynamics;  /// List of dynamics used.
-        Array<State> states;               /// Array of states for the segment.
-        bool conditionIsSatisfied;         /// True if the event condition is satisfied.
-        Segment::Type segmentType;         /// Type of segment.
+        String name;                       // Name of the segment.
+        Array<Shared<Dynamics>> dynamics;  // List of dynamics used.
+        Array<State> states;               // Array of states for the segment.
+        bool conditionIsSatisfied;         // True if the event condition is satisfied.
+        Segment::Type segmentType;         // Type of segment.
     };
 
     /// @brief Output stream operator

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -105,12 +105,12 @@ class Segment
         /// @return Delta mass
         Mass computeDeltaMass() const;
 
-        /// @brief Calculate (using numerical propagation) intermediate states at specified instants
+        /// @brief Calculate intermediate states at specified Instants using the provided Numerical Solver
         ///
         /// @param aNumericalSolver a numerical solver to use for the propagation between states
         /// @param anInstantArray an array of instants
         /// @return States at specified instants
-        Array<State> reComputeStatesAt(const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver)
+        Array<State> calculateStatesAt(const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver)
             const;
 
         /// @brief Get dynamics contribution

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
@@ -40,7 +40,7 @@ using ostk::astro::dynamics::Thruster;
 class Sequence
 {
    public:
-    /// @brief Once a sequence is set up with multiple segments, it can be solved, resulting in this sequences's
+    /// @brief Once a sequence is set up with one or more segments, it can be solved, resulting in this sequences's
     /// Solution.
     struct Solution
     {
@@ -86,12 +86,12 @@ class Sequence
         /// @return Delta mass
         Mass computeDeltaMass() const;
 
-        /// @brief Recompute states in this sequence's solution at a given instants.
+        /// @brief Calculate states in this sequence's solution at the provided instants.
         ///
         /// @param anInstantArray An array of instants.
-        /// @param aNumericalSolver A numerical solver to be used for the re-propagation.
-        /// @return Array of states at desired instants.
-        Array<State> reComputeStatesAt(const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver)
+        /// @param aNumericalSolver A numerical solver to be used for the propagation.
+        /// @return Array of states at provided instants.
+        Array<State> calculateStatesAt(const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver)
             const;
 
         /// @brief Print the sequence solution

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
@@ -6,10 +6,13 @@
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 #include <OpenSpaceToolkit/Core/Types/Size.hpp>
 
+#include <OpenSpaceToolkit/Mathematics/Objects/Vector.hpp>
+
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Units/Mass.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Models/Propagated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 
@@ -30,31 +33,82 @@ using ostk::physics::units::Mass;
 using ostk::astro::trajectory::Segment;
 using ostk::astro::trajectory::State;
 using ostk::astro::flight::system::SatelliteSystem;
+using ostk::astro::trajectory::orbit::models::Propagated;
 using ostk::astro::dynamics::Thruster;
 
 /// @brief Represent a sequence of trajectory segments executed in order.
 class Sequence
 {
    public:
+    /// @brief Once a sequence is set up with multiple segments, it can be solved, resulting in this sequences's
+    /// Solution.
     struct Solution
     {
-        Array<Segment::Solution> segmentSolutions;
-        bool executionIsComplete;
+       public:
+        /// @brief Constructor
+        ///
+        /// @param aSegmentSolutionArray An array of segment solutions.
+        /// @param executionIsComplete True if the sequence was executed completely, false otherwise.
+        /// @return An instance of Solution
+        Solution(const Array<Segment::Solution>& aSegmentSolutionArray, const bool& executionIsComplete);
 
+        /// @brief Access Start Instant
+        /// @return Start Instant
         const Instant& accessStartInstant() const;
+
+        /// @brief Access end instant
+        /// @return End Instant
         const Instant& accessEndInstant() const;
 
+        /// @brief Get all states (at variable intervals) that were computed when solving the sequence.
+        /// @return Array of states.
         Array<State> getStates() const;
+
+        /// @brief Get initial mass
+        /// @return Initial mass
         Mass getInitialMass() const;
+
+        /// @brief Get final mass
+        /// @return Final mass
         Mass getFinalMass() const;
+
+        /// @brief Get propagation duration
+        /// @return Propagation duration
         Duration getPropagationDuration() const;
 
-        Mass computeDeltaMass() const;
+        /// @brief Compute delta V
+        ///
+        /// @param aSpecificImpulse Specific impulse
+        /// @return Delta V
         Real computeDeltaV(const Real& aSpecificImpulse) const;
 
+        /// @brief Compute delta mass
+        /// @return Delta mass
+        Mass computeDeltaMass() const;
+
+        /// @brief Recompute states in this sequence's solution at a given instants.
+        ///
+        /// @param anInstantArray An array of instants.
+        /// @param aNumericalSolver A numerical solver to be used for the re-propagation.
+        /// @return Array of states at desired instants.
+        Array<State> reComputeStatesAt(const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver)
+            const;
+
+        /// @brief Print the sequence solution
+        ///
+        /// @param anOutputStream An output stream
+        /// @param (optional) displayDecorators If true, display decorators
         void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
+        /// @brief Output stream operator
+        ///
+        /// @param anOutputStream An output stream
+        /// @param aSolution A Solution
+        /// @return An output stream
         friend std::ostream& operator<<(std::ostream& anOutputStream, const Solution& aSolution);
+
+        Array<Segment::Solution> segmentSolutions;  // Array of segment soln contained within this sequence soln
+        bool executionIsComplete;                   // True if the sequence was executed completely, false otherwise
     };
 
     /// @brief Constructor

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -111,7 +111,7 @@ Array<State> Segment::Solution::reComputeStatesAt(
 {
     if (this->states.isEmpty())
     {
-        throw ostk::core::error::RuntimeError("No states available.");
+        throw ostk::core::error::RuntimeError("No states exist within segment.");
     }
 
     if (anInstantArray.isEmpty())

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -127,11 +127,12 @@ Array<State> Segment::Solution::calculateStatesAt(
         }
     }
 
-    if ((accessStartInstant() > anInstantArray.accessLast()) || (accessEndInstant() < anInstantArray.accessFirst()))
+    for (const Instant& instant : anInstantArray)
     {
-        throw ostk::core::error::RuntimeError(
-            "Trying to calculate state outside of segment bounds. No solution available."
-        );
+        if (instant < this->accessStartInstant() || instant > this->accessEndInstant())
+        {
+            throw ostk::core::error::RuntimeError("Instant outside of segment.");
+        }
     }
 
     const Propagated propagated = {
@@ -141,9 +142,6 @@ Array<State> Segment::Solution::calculateStatesAt(
         },
         this->states,
     };
-
-    // TBI: Implement proper caching during dynamics contribution observing MR
-    // this->states = propagated.calculateStatesAt(anInstantArray);
 
     return propagated.calculateStatesAt(anInstantArray);
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -105,7 +105,7 @@ Mass Segment::Solution::computeDeltaMass() const
     return Mass::Kilograms(getInitialMass().inKilograms() - getFinalMass().inKilograms());
 }
 
-Array<State> Segment::Solution::reComputeStatesAt(
+Array<State> Segment::Solution::calculateStatesAt(
     const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver
 ) const
 {

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.cpp
@@ -107,14 +107,14 @@ Array<State> Sequence::Solution::calculateStatesAt(
         {
             if ((instant >= segmentSolution.accessStartInstant()) && (instant < segmentSolution.accessEndInstant()))
             {
-                instantsPerSegment.add(instant);
+                segmentInstants.add(instant);
             }
             else if ((i == this->segmentSolutions.getSize() - 1) && (instant == this->accessEndInstant()))
             {
-                instantsPerSegment.add(instant);
+                segmentInstants.add(instant);
             }
         }
-        intermediateStates.add(segmentSolution.calculateStatesAt(instantsPerSegment, aNumericalSolver));
+        intermediateStates.add(segmentSolution.calculateStatesAt(segmentInstants, aNumericalSolver));
     }
 
     return intermediateStates;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.cpp
@@ -85,7 +85,7 @@ Mass Sequence::Solution::computeDeltaMass() const
     return Mass::Kilograms(getInitialMass().inKilograms() - getFinalMass().inKilograms());
 }
 
-Array<State> Sequence::Solution::reComputeStatesAt(
+Array<State> Sequence::Solution::calculateStatesAt(
     const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver
 ) const
 {
@@ -99,24 +99,22 @@ Array<State> Sequence::Solution::reComputeStatesAt(
     // Process the instant array so that it is done segment by segment
     for (Size i = 0; i < this->segmentSolutions.getSize(); i++)
     {
-        const Segment::Solution segmentSolution = this->segmentSolutions[i];
-        // Get the segment start and end instants and only keep the instants that are within the segment
-        Array<Instant> instantsPerSegment = Array<Instant>::Empty();
+        const Segment::Solution& segmentSolution = this->segmentSolutions.at(i);
+        // Filter instants to be within segment bounds
+        Array<Instant> segmentInstants = Array<Instant>::Empty();
 
         for (const Instant& instant : anInstantArray)
         {
-            // If the instant is within the segment (closed on left, open on right), add it
             if ((instant >= segmentSolution.accessStartInstant()) && (instant < segmentSolution.accessEndInstant()))
             {
                 instantsPerSegment.add(instant);
             }
-            // If we are on the last segment and the instant is the last instant, add it
             else if ((i == this->segmentSolutions.getSize() - 1) && (instant == this->accessEndInstant()))
             {
                 instantsPerSegment.add(instant);
             }
         }
-        intermediateStates.add(segmentSolution.reComputeStatesAt(instantsPerSegment, aNumericalSolver));
+        intermediateStates.add(segmentSolution.calculateStatesAt(instantsPerSegment, aNumericalSolver));
     }
 
     return intermediateStates;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.cpp
@@ -17,29 +17,35 @@ namespace trajectory
 
 using ostk::physics::time::Duration;
 
+Sequence::Solution::Solution(const Array<Segment::Solution>& aSegmentSolutionArray, const bool& anExecutionIsComplete)
+    : segmentSolutions(aSegmentSolutionArray),
+      executionIsComplete(anExecutionIsComplete)
+{
+}
+
 const Instant& Sequence::Solution::accessStartInstant() const
 {
-    return segmentSolutions.accessFirst().accessStartInstant();
+    return this->segmentSolutions.accessFirst().accessStartInstant();
 }
 
 const Instant& Sequence::Solution::accessEndInstant() const
 {
-    return segmentSolutions.accessLast().accessEndInstant();
+    return this->segmentSolutions.accessLast().accessEndInstant();
 }
 
 Array<State> Sequence::Solution::getStates() const
 {
-    if (segmentSolutions.isEmpty())
+    if (this->segmentSolutions.isEmpty())
     {
         throw ostk::core::error::RuntimeError("Segment solutions are empty.");
     }
 
-    Array<State> states = segmentSolutions.accessFirst().states;
+    Array<State> states = this->segmentSolutions.accessFirst().states;
 
-    for (Index i = 1; i < segmentSolutions.getSize(); ++i)
+    for (Index i = 1; i < this->segmentSolutions.getSize(); ++i)
     {
         const Array<State>& segmentStates =
-            Array<State>(segmentSolutions[i].states.begin() + 1, segmentSolutions[i].states.end());
+            Array<State>(this->segmentSolutions[i].states.begin() + 1, this->segmentSolutions[i].states.end());
 
         states.add(segmentStates);
     }
@@ -49,17 +55,29 @@ Array<State> Sequence::Solution::getStates() const
 
 Mass Sequence::Solution::getInitialMass() const
 {
-    return segmentSolutions.accessFirst().getInitialMass();
+    return this->segmentSolutions.accessFirst().getInitialMass();
 }
 
 Mass Sequence::Solution::getFinalMass() const
 {
-    return segmentSolutions.accessLast().getFinalMass();
+    return this->segmentSolutions.accessLast().getFinalMass();
 }
 
 Duration Sequence::Solution::getPropagationDuration() const
 {
-    return accessEndInstant() - accessStartInstant();
+    return this->accessEndInstant() - this->accessStartInstant();
+}
+
+Real Sequence::Solution::computeDeltaV(const Real& aSpecificImpulse) const
+{
+    Real deltaV = 0.0;
+
+    for (const auto& segmentSolution : this->segmentSolutions)
+    {
+        deltaV += segmentSolution.computeDeltaV(aSpecificImpulse);
+    }
+
+    return deltaV;
 }
 
 Mass Sequence::Solution::computeDeltaMass() const
@@ -67,16 +85,41 @@ Mass Sequence::Solution::computeDeltaMass() const
     return Mass::Kilograms(getInitialMass().inKilograms() - getFinalMass().inKilograms());
 }
 
-Real Sequence::Solution::computeDeltaV(const Real& aSpecificImpulse) const
+Array<State> Sequence::Solution::reComputeStatesAt(
+    const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver
+) const
 {
-    Real deltaV = 0.0;
-
-    for (const auto& segmentSolution : segmentSolutions)
+    if (this->segmentSolutions.isEmpty())
     {
-        deltaV += segmentSolution.computeDeltaV(aSpecificImpulse);
+        throw ostk::core::error::RuntimeError("Segment solutions are empty.");
     }
 
-    return deltaV;
+    Array<State> intermediateStates = Array<State>::Empty();
+
+    // Process the instant array so that it is done segment by segment
+    for (Size i = 0; i < this->segmentSolutions.getSize(); i++)
+    {
+        const Segment::Solution segmentSolution = this->segmentSolutions[i];
+        // Get the segment start and end instants and only keep the instants that are within the segment
+        Array<Instant> instantsPerSegment = Array<Instant>::Empty();
+
+        for (const Instant& instant : anInstantArray)
+        {
+            // If the instant is within the segment (closed on left, open on right), add it
+            if ((instant >= segmentSolution.accessStartInstant()) && (instant < segmentSolution.accessEndInstant()))
+            {
+                instantsPerSegment.add(instant);
+            }
+            // If we are on the last segment and the instant is the last instant, add it
+            else if ((i == this->segmentSolutions.getSize() - 1) && (instant == this->accessEndInstant()))
+            {
+                instantsPerSegment.add(instant);
+            }
+        }
+        intermediateStates.add(segmentSolution.reComputeStatesAt(instantsPerSegment, aNumericalSolver));
+    }
+
+    return intermediateStates;
 }
 
 void Sequence::Solution::print(std::ostream& anOutputStream, bool displayDecorator) const
@@ -87,12 +130,12 @@ void Sequence::Solution::print(std::ostream& anOutputStream, bool displayDecorat
     }
 
     ostk::core::utils::Print::Line(anOutputStream)
-        << "Execution is complete: " << (executionIsComplete ? "True" : "False");
+        << "Execution is complete: " << (this->executionIsComplete ? "True" : "False");
 
     ostk::core::utils::Print::Separator(anOutputStream, "Segment Solutions");
 
     bool hasManeuver = false;
-    for (const auto& segmentSolution : segmentSolutions)
+    for (const auto& segmentSolution : this->segmentSolutions)
     {
         segmentSolution.print(anOutputStream, false);
 
@@ -226,7 +269,7 @@ Sequence::Solution Sequence::solve(const State& aState, const Size& aRepetitionC
         throw ostk::core::error::runtime::Wrong("Repetition count.");
     }
 
-    Array<Segment::Solution> segmentSolutions;
+    Array<Segment::Solution> segmentSolutions = Array<Segment::Solution>::Empty();
 
     State initialState = aState;
     State finalState = State::Undefined();
@@ -267,7 +310,7 @@ Sequence::Solution Sequence::solveToCondition(
     const State& aState, const EventCondition& anEventCondition, const Duration& aMaximumPropagationDuration
 ) const
 {
-    Array<Segment::Solution> segmentSolutions;
+    Array<Segment::Solution> segmentSolutions = Array<Segment::Solution>::Empty();
 
     State initialState = aState;
     State finalState = State::Undefined();

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -60,7 +60,7 @@ RootSolver NumericalSolver::getRootSolver() const
         throw ostk::core::error::runtime::Undefined("NumericalSolver");
     }
 
-    return this->rootSolver_;
+    return rootSolver_;
 }
 
 Array<State> NumericalSolver::getObservedStates() const

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -220,8 +220,29 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Calcul
             Segment::Solution(defaultName_, defaultDynamics_, {}, true, Segment::Type::Coast);
 
         EXPECT_THROW(
-            segmentSolution.reComputeStatesAt({Instant::J2000()}, defaultNumericalSolver_),
+            segmentSolution.calculateStatesAt({Instant::J2000()}, defaultNumericalSolver_),
             ostk::core::error::RuntimeError
+        );
+    }
+
+    // Test that the returns an empty state array if an empty instant array is provided
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        const Array<State> propagatedStates = segmentSolution.calculateStatesAt({}, defaultNumericalSolver_);
+
+        EXPECT_EQ(0, propagatedStates.getSize());
+    }
+
+    // Test that the function throws when the instant array is out of order
+    {
+        const Segment::Solution segmentSolution =
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
+
+        EXPECT_THROW(
+            segmentSolution.calculateStatesAt({Instant::Now(), Instant::J2000()}, defaultNumericalSolver_),
+            ostk::core::error::runtime::Wrong
         );
     }
 
@@ -231,10 +252,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Calcul
             defaultState_.getInstant(), defaultState_.getInstant() + Duration::Minutes(1.0)
         };
         const Segment::Solution segmentSolution =
-            Segment::Solution(defaultName_, defaultDynamics_, {}, true, Segment::Type::Coast);
+            Segment::Solution(defaultName_, defaultDynamics_, {defaultState_}, true, Segment::Type::Coast);
 
         EXPECT_THROW(
-            segmentSolution.reComputeStatesAt(instantArrayOutsideSegment, defaultNumericalSolver_),
+            segmentSolution.calculateStatesAt(instantArrayOutsideSegment, defaultNumericalSolver_),
             ostk::core::error::RuntimeError
         );
     }
@@ -256,7 +277,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Calcul
         const Segment::Solution segmentSolution =
             Segment::Solution(defaultName_, defaultDynamics_, {defaultState_, state1}, true, Segment::Type::Coast);
 
-        const Array<State> propagatedStates = segmentSolution.reComputeStatesAt(instantArray, defaultNumericalSolver_);
+        const Array<State> propagatedStates = segmentSolution.calculateStatesAt(instantArray, defaultNumericalSolver_);
 
         for (Size i = 0; i < instantArray.getSize(); i++)
         {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -212,9 +212,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Comput
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_ReComputeStatesAt)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_CalculateStatesAt)
 {
-    {  // Test that the function throws when the segment has no states
+    // Test that the function throws when the segment has no states
+    {
         const Segment::Solution segmentSolution =
             Segment::Solution(defaultName_, defaultDynamics_, {}, true, Segment::Type::Coast);
 
@@ -224,7 +225,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_ReComp
         );
     }
 
-    {  // Test that the function throws when an instant outside the segment is desired
+    // Test that the function throws when an instant outside the segment is desired
+    {
         const Array<Instant> instantArrayOutsideSegment = {
             defaultState_.getInstant(), defaultState_.getInstant() + Duration::Minutes(1.0)
         };
@@ -237,7 +239,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_ReComp
         );
     }
 
-    {  // Test successfull result for propagation to states within segment including bounds
+    // Test successfull result for propagation to states within segment including bounds
+    {
         const Array<Instant> instantArray = {
             defaultState_.getInstant(),
             defaultState_.getInstant() + Duration::Minutes(1.0),

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
@@ -187,7 +187,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_Calc
     {
         Sequence::Solution sequenceSolution = {{}, true};
         EXPECT_THROW(
-            sequenceSolution.reComputeStatesAt({Instant::J2000()}, defaultNumericalSolver_),
+            sequenceSolution.calculateStatesAt({Instant::J2000()}, defaultNumericalSolver_),
             ostk::core::error::RuntimeError
         );
     }
@@ -214,7 +214,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_Calc
 
     const Segment::Solution segmentSolution2 = {
         "A Segment",
-        defaultDynamics_, 
+        defaultDynamics_,
         {state2, state3},
         true,
         Segment::Type::Coast,
@@ -224,7 +224,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_Calc
     {
         const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
 
-        const Array<State> propagatedStates = sequenceSolution.reComputeStatesAt(
+        const Array<State> propagatedStates = sequenceSolution.calculateStatesAt(
             {
                 state1.getInstant(),
                 state2.getInstant(),
@@ -243,7 +243,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_Calc
     {
         const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
 
-        const Array<State> propagatedStatesInBetween = sequenceSolution.reComputeStatesAt(
+        const Array<State> propagatedStatesInBetween = sequenceSolution.calculateStatesAt(
             {
                 state1.getInstant() + Duration::Minutes(0.5),
                 state2.getInstant() + Duration::Minutes(0.5),
@@ -260,7 +260,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_Calc
     {
         const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
 
-        const Array<State> propagatedStatesOutsideSequence = sequenceSolution.reComputeStatesAt(
+        const Array<State> propagatedStatesOutsideSequence = sequenceSolution.calculateStatesAt(
             {
                 state1.getInstant() - Duration::Minutes(0.5),
                 state3.getInstant() + Duration::Minutes(0.5),

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
@@ -115,7 +115,11 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence : public ::testing::Tes
     const Array<Segment> defaultSegments_ = {coastSegment_};
 
     const Segment::Solution defaultSegmentSolution_ = {
-        "A Segment", defaultDynamics_, {defaultState_}, true, Segment::Type::Coast
+        "A Segment",
+        defaultDynamics_,
+        {defaultState_},
+        true,
+        Segment::Type::Coast,
     };
 
     const Size defaultRepetitionCount_ = 2;
@@ -130,7 +134,8 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence : public ::testing::Tes
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_GetStates)
 {
-    {  // Test throw with empty sequence solving
+    // Test throw with empty sequence solving
+    {
         Sequence::Solution sequenceSolution = {{}, true};
         EXPECT_THROW(sequenceSolution.getStates(), ostk::core::error::RuntimeError);
     }
@@ -148,14 +153,23 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_GetS
     };
 
     const Segment::Solution segmentSolution1 = {
-        "A Segment", defaultDynamics_, {state1, state2}, true, Segment::Type::Coast
+        "A Segment",
+        defaultDynamics_,
+        {state1, state2},
+        true,
+        Segment::Type::Coast,
     };
 
     const Segment::Solution segmentSolution2 = {
-        "A Segment", defaultDynamics_, {state2, state3}, true, Segment::Type::Coast
+        "A Segment",
+        defaultDynamics_,
+        {state2, state3},
+        true,
+        Segment::Type::Coast,
     };
 
-    {  // Test regular states
+    // Test regular states
+    {
         const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
 
         const Array<State> states = sequenceSolution.getStates();
@@ -167,9 +181,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_GetS
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_ReComputeStatesAt)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_CalculateStatesAt)
 {
-    {  // Test throw with empty sequence solving
+    // Test throw with empty sequence solving
+    {
         Sequence::Solution sequenceSolution = {{}, true};
         EXPECT_THROW(
             sequenceSolution.reComputeStatesAt({Instant::J2000()}, defaultNumericalSolver_),
@@ -190,14 +205,23 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_ReCo
     };
 
     const Segment::Solution segmentSolution1 = {
-        "A Segment", defaultDynamics_, {state1, state2}, true, Segment::Type::Coast
+        "A Segment",
+        defaultDynamics_,
+        {state1, state2},
+        true,
+        Segment::Type::Coast,
     };
 
     const Segment::Solution segmentSolution2 = {
-        "A Segment", defaultDynamics_, {state2, state3}, true, Segment::Type::Coast
+        "A Segment",
+        defaultDynamics_, 
+        {state2, state3},
+        true,
+        Segment::Type::Coast,
     };
 
-    {  // Test regular states success
+    // Test regular states success
+    {
         const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
 
         const Array<State> propagatedStates = sequenceSolution.reComputeStatesAt(
@@ -215,7 +239,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_ReCo
         EXPECT_EQ(propagatedStates.getSize(), 3);
     }
 
-    {  // Test regular states in between success
+    // Test regular states in between success
+    {
         const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
 
         const Array<State> propagatedStatesInBetween = sequenceSolution.reComputeStatesAt(
@@ -231,7 +256,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_ReCo
         EXPECT_EQ(propagatedStatesInBetween.getSize(), 2);
     }
 
-    {  // Test regular states out of range failure
+    // Test regular states out of range failure
+    {
         const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
 
         const Array<State> propagatedStatesOutsideSequence = sequenceSolution.reComputeStatesAt(

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
@@ -96,7 +96,7 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence : public ::testing::Tes
     };
 
     const NumericalSolver defaultNumericalSolver_ = {
-        NumericalSolver::LogType::LogAdaptive,
+        NumericalSolver::LogType::NoLog,
         NumericalSolver::StepperType::RungeKuttaDopri5,
         1e-3,
         1.0e-12,
@@ -114,6 +114,10 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence : public ::testing::Tes
 
     const Array<Segment> defaultSegments_ = {coastSegment_};
 
+    const Segment::Solution defaultSegmentSolution_ = {
+        "A Segment", defaultDynamics_, {defaultState_}, true, Segment::Type::Coast
+    };
+
     const Size defaultRepetitionCount_ = 2;
     const Duration defaultMaximumPropagationDuration_ = Duration::Days(7.0);
     Sequence defaultSequence_ = {
@@ -124,11 +128,121 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence : public ::testing::Tes
     };
 };
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_getStates)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_GetStates)
 {
-    {
+    {  // Test throw with empty sequence solving
         Sequence::Solution sequenceSolution = {{}, true};
         EXPECT_THROW(sequenceSolution.getStates(), ostk::core::error::RuntimeError);
+    }
+
+    const State state1 = defaultState_;
+    const State state2 = {
+        defaultState_.getInstant() + Duration::Minutes(1.0),
+        defaultState_.getPosition(),
+        defaultState_.getVelocity(),
+    };
+    const State state3 = {
+        defaultState_.getInstant() + Duration::Minutes(2.0),
+        defaultState_.getPosition(),
+        defaultState_.getVelocity(),
+    };
+
+    const Segment::Solution segmentSolution1 = {
+        "A Segment", defaultDynamics_, {state1, state2}, true, Segment::Type::Coast
+    };
+
+    const Segment::Solution segmentSolution2 = {
+        "A Segment", defaultDynamics_, {state2, state3}, true, Segment::Type::Coast
+    };
+
+    {  // Test regular states
+        const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
+
+        const Array<State> states = sequenceSolution.getStates();
+
+        EXPECT_EQ(states[0], state1);
+        EXPECT_EQ(states[1], state2);
+        EXPECT_EQ(states[2], state3);
+        EXPECT_EQ(states.getSize(), 3);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_ReComputeStatesAt)
+{
+    {  // Test throw with empty sequence solving
+        Sequence::Solution sequenceSolution = {{}, true};
+        EXPECT_THROW(
+            sequenceSolution.reComputeStatesAt({Instant::J2000()}, defaultNumericalSolver_),
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    const State state1 = defaultState_;
+    const State state2 = {
+        defaultState_.getInstant() + Duration::Minutes(1.0),
+        defaultState_.getPosition(),
+        defaultState_.getVelocity(),
+    };
+    const State state3 = {
+        defaultState_.getInstant() + Duration::Minutes(2.0),
+        defaultState_.getPosition(),
+        defaultState_.getVelocity(),
+    };
+
+    const Segment::Solution segmentSolution1 = {
+        "A Segment", defaultDynamics_, {state1, state2}, true, Segment::Type::Coast
+    };
+
+    const Segment::Solution segmentSolution2 = {
+        "A Segment", defaultDynamics_, {state2, state3}, true, Segment::Type::Coast
+    };
+
+    {  // Test regular states success
+        const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
+
+        const Array<State> propagatedStates = sequenceSolution.reComputeStatesAt(
+            {
+                state1.getInstant(),
+                state2.getInstant(),
+                state3.getInstant(),
+            },
+            defaultNumericalSolver_
+        );
+
+        EXPECT_EQ(propagatedStates[0].getInstant(), state1.getInstant());
+        EXPECT_EQ(propagatedStates[1].getInstant(), state2.getInstant());
+        EXPECT_EQ(propagatedStates[2].getInstant(), state3.getInstant());
+        EXPECT_EQ(propagatedStates.getSize(), 3);
+    }
+
+    {  // Test regular states in between success
+        const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
+
+        const Array<State> propagatedStatesInBetween = sequenceSolution.reComputeStatesAt(
+            {
+                state1.getInstant() + Duration::Minutes(0.5),
+                state2.getInstant() + Duration::Minutes(0.5),
+            },
+            defaultNumericalSolver_
+        );
+
+        EXPECT_EQ(propagatedStatesInBetween[0].getInstant(), state1.getInstant() + Duration::Minutes(0.5));
+        EXPECT_EQ(propagatedStatesInBetween[1].getInstant(), state2.getInstant() + Duration::Minutes(0.5));
+        EXPECT_EQ(propagatedStatesInBetween.getSize(), 2);
+    }
+
+    {  // Test regular states out of range failure
+        const Sequence::Solution sequenceSolution = {{segmentSolution1, segmentSolution2}, true};
+
+        const Array<State> propagatedStatesOutsideSequence = sequenceSolution.reComputeStatesAt(
+            {
+                state1.getInstant() - Duration::Minutes(0.5),
+                state3.getInstant() + Duration::Minutes(0.5),
+            },
+            defaultNumericalSolver_
+        );
+
+        EXPECT_EQ(propagatedStatesOutsideSequence.getSize(), 0);
     }
 }
 
@@ -137,11 +251,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_Prin
     {
         testing::internal::CaptureStdout();
 
-        const Segment::Solution segmentSolution = {
-            "A Segment", {}, {defaultState_, defaultState_}, true, Segment::Type::Coast
-        };
+        Sequence::Solution sequenceSolution = {{defaultSegmentSolution_}, true};
 
-        Sequence::Solution sequenceSolution = {{segmentSolution}, true};
         EXPECT_NO_THROW(sequenceSolution.print(std::cout, true));
         EXPECT_NO_THROW(sequenceSolution.print(std::cout, false));
 
@@ -154,11 +265,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, SequenceSolution_Stre
     {
         testing::internal::CaptureStdout();
 
-        const Segment::Solution segmentSolution = {
-            "A Segment", {}, {defaultState_, defaultState_}, true, Segment::Type::Coast
-        };
+        Sequence::Solution sequenceSolution = {{defaultSegmentSolution_}, true};
 
-        EXPECT_NO_THROW(std::cout << segmentSolution << std::endl);
+        EXPECT_NO_THROW(std::cout << sequenceSolution << std::endl);
 
         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
     }


### PR DESCRIPTION
This MR adds a `reComputeStatesAt(instant,numericalSolver)` method to the `Sequence` and `Segment` objects.

This specific method is needed for my validation framework because when the sequence is first solved, it is done so with a variable step size propagator since the event conditions can't be known ahead of time. Therefore, the states that are "observed" and stored in the `Segment` object are at random timestamps corresponding to the variable steps the propagator took. 

I want to be able to obtain the propagated states at an arbitrary instant array in order to be able to compare them with states generated by GMAT or Orekit at those same instants. Therefore, the only option here is to re-propagate the states in a rather dumb and not efficient way after the segment has been solved and its starting and ending instant has been determined.