### PR TITLE
style: change dynamics contributions observing to an array of vectorxds

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -108,7 +108,7 @@ class Segment
         /// @param aFrameSPtr Frame
         /// @param aCoordinatesSubsetSPtrArray Array of coordinates subsets
         /// @return Dynamics contribution
-        MatrixXd getDynamicsContribution(
+        Array<VectorXd> getDynamicsContributions(
             const Shared<Dynamics>& aDynamicsSPtr,
             const Shared<const Frame>& aFrameSPtr,
             const Array<Shared<const CoordinatesSubset>>& aCoordinatesSubsetSPtrArray =
@@ -120,7 +120,7 @@ class Segment
         /// @param aDynamicsSPtr Dynamics
         /// @param aFrameSPtr Frame
         /// @return Dynamics acceleration contribution
-        MatrixXd getDynamicsAccelerationContribution(
+        Array<Vector3d> getDynamicsAccelerationContributions(
             const Shared<Dynamics>& aDynamicsSPtr, const Shared<const Frame>& aFrameSPtr
         ) const;
 
@@ -128,7 +128,7 @@ class Segment
         ///
         /// @param aFrameSPtr Frame
         /// @return All segment dynamics contributions
-        Map<Shared<Dynamics>, MatrixXd> getAllDynamicsContributions(const Shared<const Frame>& aFrameSPtr) const;
+        Array<Map<Shared<Dynamics>, VectorXd>> getAllDynamicsContributions(const Shared<const Frame>& aFrameSPtr) const;
 
         /// @brief Print the segment solution
         ///


### PR DESCRIPTION
I've refactored the way that dynamics contributions for the duration of the Segment are returned to the user, as an Array<VectorXd> instead of a MatrixXd since I think its more clear for someone who wants to index through them later on. 

This is intended to go along with the dynamics refactoring and observing dynamics contributions discussion.