### PR TITLE
refactor: change the index returned by pass map to be the last index

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -1032,7 +1032,6 @@ Map<Index, Pass> Orbit::GeneratePassMap(const Array<State>& aStateArray, const I
 
     Map<Index, Pass> passMap;
 
-    Index index = 0;
     Integer revolutionNumber = anInitialRevolutionNumber;
     Instant previousPassEndInstant = Instant::Undefined();
 
@@ -1130,9 +1129,8 @@ Map<Index, Pass> Orbit::GeneratePassMap(const Array<State>& aStateArray, const I
                     southPointCrossing,
                 };
 
-                passMap.insert({index, pass});
+                passMap.insert({currentIndex, pass});
 
-                index = currentIndex;
                 revolutionNumber++;
 
                 southPointCrossing = Instant::Undefined();
@@ -1167,7 +1165,7 @@ Map<Index, Pass> Orbit::GeneratePassMap(const Array<State>& aStateArray, const I
                 southPointCrossing,
             };
 
-            passMap.insert({index, pass});
+            passMap.insert({currentIndex, pass});
         }
 
         previousStatePtr = &state;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -482,6 +482,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
         EXPECT_EQ(referenceData.getRowCount(), passMap.size() - 1);  // We're generating 1 pass over the reference data
 
         Index i = 0;
+        Index stateIndex = 0;
         for (const auto& row : passMap)
         {
             // Ignore the lass pass, as it is not complete
@@ -490,6 +491,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
                 break;
             }
 
+            // test computed Pass
             const Pass& pass = row.second;
 
             const auto& referenceRow = referenceData[i];
@@ -536,9 +538,17 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
             EXPECT_LT(
                 std::fabs((referencePassDescendingNodeInstant - pass.accessInstantAtDescendingNode()).inSeconds()), 1e-6
             );
-            EXPECT_LT(std::fabs((referencePassEndInstant - pass.getInterval().getEnd()).inSeconds()), 1e-6);
             EXPECT_LT(std::fabs((referencePassNorthPointInstant - pass.accessInstantAtNorthPoint()).inSeconds()), 3.0);
             EXPECT_LT(std::fabs((referencePassSouthPointInstant - pass.accessInstantAtSouthPoint()).inSeconds()), 3.0);
+
+            // test state index
+            const Index& endStateIndex = row.first;
+
+            EXPECT_TRUE(referencePassStartInstant <= states[stateIndex].accessInstant());
+            EXPECT_TRUE(referencePassEndInstant >= states[endStateIndex - 1].accessInstant());
+
+            stateIndex = endStateIndex;
+
             ++i;
         }
     }


### PR DESCRIPTION
Previously, the index being returned is the first state within the pass.
This is a bit awkward when looping over it, as you need the index from the second pass to find the states that are within the first pass.
Instead here I propose having the end state index be returned with the pass.
That way, we can conveniently (in python) do the following:

current_index = 0
for index, pass in pass_map.items():
    pass_states = states[current_index : index]
    index = current_index
    ....