### PR TITLE
feat: update pass constructor to allow partial passes from start/end

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -361,19 +361,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
             )
 
             .def_static(
-                "generate_pass_map",
-                &Orbit::GeneratePassMap,
+                "compute_passes",
+                &Orbit::ComputePasses,
                 arg("states"),
                 arg("initial_revolution_number"),
                 R"doc(
-                    Generate a pass map from a set of states.
+                    Compute passes from a set of states.
 
                     Args:
                         states (Array<State>): The states.
                         initial_revolution_number (Integer): The initial revolution number.
 
                     Returns:
-                        PassMap: The pass map.
+                        list[tuple[int, Pass]]: List of index-pass pairs
                 )doc"
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
@@ -183,7 +183,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
         )
         .def(
             "get_instant_at_pass_break",
-            &Pass::accessInstantAtPassBreak
+            &Pass::accessInstantAtPassBreak,
             R"doc(
                 Get the instant at the break of the pass.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
@@ -51,42 +51,26 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
 
         ;
 
-    enum_<Pass::Quarter>(
-        pass_class,
-        "Quarter",
-        R"doc(
-            The quarter of the `Pass`.
-        )doc"
-    )
-
-        .value("Undefined", Pass::Quarter::Undefined, "Undefined")
-        .value("First", Pass::Quarter::First, "First")
-        .value("Second", Pass::Quarter::Second, "Second")
-        .value("Third", Pass::Quarter::Third, "Third")
-        .value("Fourth", Pass::Quarter::Fourth, "Fourth")
-
-        ;
-
     pass_class
 
         .def(
-            init<const Pass::Type&, const Integer&, const Interval&, const Instant&, const Instant&, const Instant&>(),
-            arg("type"),
+            init<const Integer&, const Instant&, const Instant&, const Instant&, const Instant&, const Instant&>(),
             arg("revolution_number"),
-            arg("interval"),
-            arg("descending_node_instant"),
-            arg("north_point_instant"),
-            arg("south_point_instant"),
+            arg("instant_at_ascending_node"),
+            arg("instant_at_north_point"),
+            arg("instant_at_descending_node"),
+            arg("instant_at_south_point"),
+            arg("instant_at_pass_break"),
             R"doc(
                 Constructor.
 
                 Args:
-                    type (Pass.Type): The type of the pass.
                     revolution_number (int): The revolution number of the pass.
-                    interval (Interval): The interval of the pass.
-                    descending_node_instant (Instant): The instant at the descending node of the pass.
-                    north_point_instant (Instant): The instant at the north point of the pass.
-                    south_point_instant (Instant): The instant at the south point of the pass.
+                    instant_at_ascending_node (Instant): The instant at the ascending node of the pass.
+                    instant_at_north_point (Instant): The instant at the north point of the pass.
+                    instant_at_descending_node (Instant): The instant at the descending node of the pass.
+                    instant_at_south_point (Instant): The instant at the south point of the pass.
+                    instant_at_pass_break (Instant): The instant at which the pass breaks.
 
             )doc"
         )
@@ -143,13 +127,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             )doc"
         )
         .def(
-            "get_interval",
-            &Pass::getInterval,
+            "get_duration",
+            &Pass::getDuration,
             R"doc(
-                Get the interval of the pass.
+                Get the duration of the pass. Undefined if the pass is not complete.
 
                 Returns:
-                    Interval: The interval of the pass.
+                    Duration: The duration of the pass.
 
             )doc"
         )
@@ -165,17 +149,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             )doc"
         )
         .def(
-            "get_instant_at_descending_node",
-            &Pass::accessInstantAtDescendingNode,
-            R"doc(
-                Get the instant at the descending node of the pass.
-
-                Returns:
-                    Instant: The instant at the descending node of the pass.
-
-            )doc"
-        )
-        .def(
             "get_instant_at_north_point",
             &Pass::accessInstantAtNorthPoint,
             R"doc(
@@ -187,6 +160,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             )doc"
         )
         .def(
+            "get_instant_at_descending_node",
+            &Pass::accessInstantAtDescendingNode,
+            R"doc(
+                Get the instant at the descending node of the pass.
+
+                Returns:
+                    Instant: The instant at the descending node of the pass.
+
+            )doc"
+        )
+        .def(
             "get_instant_at_south_point",
             &Pass::accessInstantAtSouthPoint,
             R"doc(
@@ -194,6 +178,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
 
                 Returns:
                     Instant: The instant at the south point of the pass.
+
+            )doc"
+        )
+        .def(
+            "get_instant_at_pass_break",
+            &Pass::accessInstantAtSouthPoint,
+            R"doc(
+                Get the instant at the break of the pass.
+
+                Returns:
+                    Instant: The instant at the break of the pass.
 
             )doc"
         )
@@ -235,20 +230,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
                     str: The string representation of the pass phase.
             )doc",
             arg("phase")
-        )
-        .def_static(
-            "string_from_quarter",
-            &Pass::StringFromQuarter,
-            R"doc(
-                Get the string representation of a pass quarter.
-
-                Args:
-                    quarter (Pass.Quarter): The pass quarter.
-
-                Returns:
-                    str: The string representation of the pass quarter.
-            )doc",
-            arg("quarter")
         )
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
@@ -183,7 +183,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
         )
         .def(
             "get_instant_at_pass_break",
-            &Pass::accessInstantAtSouthPoint,
+            &Pass::accessInstantAtPassBreak
             R"doc(
                 Get the instant at the break of the pass.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Pass.cpp
@@ -70,7 +70,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
                     instant_at_north_point (Instant): The instant at the north point of the pass.
                     instant_at_descending_node (Instant): The instant at the descending node of the pass.
                     instant_at_south_point (Instant): The instant at the south point of the pass.
-                    instant_at_pass_break (Instant): The instant at which the pass breaks.
+                    instant_at_pass_break (Instant): The instant at break of the pass.
 
             )doc"
         )
@@ -142,6 +142,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             &Pass::accessInstantAtAscendingNode,
             R"doc(
                 Get the instant at the ascending node of the pass.
+                i.e. z = 0 & vz > 0 in an ECI frame.
 
                 Returns:
                     Instant: The instant at the ascending node of the pass.
@@ -153,6 +154,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             &Pass::accessInstantAtNorthPoint,
             R"doc(
                 Get the instant at the north point of the pass.
+                i.e. z = maximum and vz = 0 in an ECI frame.
 
                 Returns:
                     Instant: The instant at the north point of the pass.
@@ -164,6 +166,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             &Pass::accessInstantAtDescendingNode,
             R"doc(
                 Get the instant at the descending node of the pass.
+                i.e. z = 0 and vz < 0 in an ECI frame.
 
                 Returns:
                     Instant: The instant at the descending node of the pass.
@@ -175,6 +178,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             &Pass::accessInstantAtSouthPoint,
             R"doc(
                 Get the instant at the south point of the pass.
+                i.e. z = minimum and vz = 0 in an ECI frame.
 
                 Returns:
                     Instant: The instant at the south point of the pass.
@@ -185,7 +189,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Pass(pybind11::modu
             "get_instant_at_pass_break",
             &Pass::accessInstantAtPassBreak,
             R"doc(
-                Get the instant at the break of the pass.
+                Get the instant at the break of the pass,
+                i.e. the ascending node of the next pass.
 
                 Returns:
                     Instant: The instant at the break of the pass.

--- a/bindings/python/test/trajectory/orbit/test_pass.py
+++ b/bindings/python/test/trajectory/orbit/test_pass.py
@@ -18,8 +18,8 @@ def pass_() -> Pass:
     return Pass(
         123,
         Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC),
-        Instant.date_time(DateTime(2018, 1, 1, 0, 30, 0), Scale.UTC),
         Instant.date_time(DateTime(2018, 1, 1, 0, 15, 0), Scale.UTC),
+        Instant.date_time(DateTime(2018, 1, 1, 0, 30, 0), Scale.UTC),
         Instant.date_time(DateTime(2018, 1, 1, 0, 45, 0), Scale.UTC),
         Instant.date_time(DateTime(2018, 1, 1, 1, 0, 0), Scale.UTC),
     )
@@ -38,8 +38,8 @@ class TestPass:
     def test_get_revolution_number(self, pass_: Pass):
         assert pass_.get_revolution_number() is not None
 
-    def test_get_interval(self, pass_: Pass):
-        assert pass_.get_interval() is not None
+    def test_get_duration(self, pass_: Pass):
+        assert pass_.get_duration() is not None
 
     def test_get_instant_at_ascending_node(self, pass_: Pass):
         assert pass_.get_instant_at_ascending_node() is not None

--- a/bindings/python/test/trajectory/orbit/test_pass.py
+++ b/bindings/python/test/trajectory/orbit/test_pass.py
@@ -16,15 +16,12 @@ earth = Environment.default().access_celestial_object_with_name("Earth")
 @pytest.fixture
 def pass_() -> Pass:
     return Pass(
-        Pass.Type.Partial,
         123,
-        Interval.closed(
-            Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC),
-            Instant.date_time(DateTime(2018, 1, 1, 1, 0, 0), Scale.UTC),
-        ),
+        Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC),
         Instant.date_time(DateTime(2018, 1, 1, 0, 30, 0), Scale.UTC),
         Instant.date_time(DateTime(2018, 1, 1, 0, 15, 0), Scale.UTC),
         Instant.date_time(DateTime(2018, 1, 1, 0, 45, 0), Scale.UTC),
+        Instant.date_time(DateTime(2018, 1, 1, 1, 0, 0), Scale.UTC),
     )
 
 
@@ -47,14 +44,17 @@ class TestPass:
     def test_get_instant_at_ascending_node(self, pass_: Pass):
         assert pass_.get_instant_at_ascending_node() is not None
 
-    def test_get_instant_at_descending_node(self, pass_: Pass):
-        assert pass_.get_instant_at_descending_node() is not None
-
     def test_get_instant_at_north_point(self, pass_: Pass):
         assert pass_.get_instant_at_north_point() is not None
 
+    def test_get_instant_at_descending_node(self, pass_: Pass):
+        assert pass_.get_instant_at_descending_node() is not None
+
     def test_get_instant_at_south_point(self, pass_: Pass):
         assert pass_.get_instant_at_south_point() is not None
+
+    def test_get_instant_at_pass_break(self, pass_: Pass):
+        assert pass_.get_instant_at_pass_break() is not None
 
     def test_undefined(self):
         assert Pass.undefined().is_defined() is False
@@ -64,6 +64,3 @@ class TestPass:
 
     def test_string_from_phase(self):
         assert Pass.string_from_phase(Pass.Phase.Ascending) is not None
-
-    def test_string_from_quarter(self):
-        assert Pass.string_from_quarter(Pass.Quarter.First) is not None

--- a/bindings/python/test/trajectory/test_orbit.py
+++ b/bindings/python/test/trajectory/test_orbit.py
@@ -151,6 +151,6 @@ class TestOrbit:
             argument_of_latitude=Angle.degrees(50.0),
         ).is_defined()
 
-    def test_generate_pass_map(self, orbit: Orbit, states: list[State]):
-        pass_map: dict[int, Pass] = orbit.generate_pass_map(states, 1)
-        assert pass_map is not None
+    def test_compute_passes(self, orbit: Orbit, states: list[State]):
+        passes: list[tuple[int, Pass]] = orbit.compute_passes(states, 1)
+        assert passes is not None

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
@@ -220,8 +220,6 @@ class Orbit : public Trajectory
         const Instant& currentInstant,
         const std::function<double(double)>& getValue
     );
-
-    static Array<State> GenerateStates(const Model& aModel, const Array<Instant>& anInstantGrid);
 };
 
 }  // namespace trajectory

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
@@ -33,6 +33,7 @@ namespace trajectory
 {
 
 using ostk::core::ctnr::Array;
+using ostk::core::ctnr::Pair;
 using ostk::core::ctnr::Map;
 using ostk::core::types::Index;
 using ostk::core::types::Integer;
@@ -190,7 +191,9 @@ class Orbit : public Trajectory
 
     static String StringFromFrameType(const Orbit::FrameType& aFrameType);
 
-    static Map<Index, Pass> GeneratePassMap(const Array<State>& aStateArray, const Integer& anInitialRevolutionNumber);
+    static Array<Pair<Index, Pass>> ComputePasses(
+        const Array<State>& aStateArray, const Integer& anInitialRevolutionNumber
+    );
 
    private:
     const orbit::Model* modelPtr_;
@@ -203,7 +206,8 @@ class Orbit : public Trajectory
     String generateFrameName(const Orbit::FrameType& aFrameType) const;
 
     /// @brief Find the Instant at which the return value of `getValue` crosses zero.
-    /// Use a bisection search to find the Instant between `previousInstant` and `nextInstant` at which the return value of `getValue` crosses zero. 
+    /// Use a bisection search to find the Instant between `previousInstant` and `nextInstant` at which the return value
+    /// of `getValue` crosses zero.
     ///
     /// @param anEpoch An orbit epoch from which to measure
     /// @param previousInstant lower bound of search

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.hpp
@@ -133,9 +133,9 @@ class Pass
     /// @return The instant at the south point of the pass.
     const Instant& accessInstantAtSouthPoint() const;
 
-    /// @brief Accesses the instant at the pass break of the pass.
+    /// @brief Accesses the instant at the break of the pass.
     ///
-    /// @return The instant at the pass break of the pass.
+    /// @return The instant at the break of the pass.
     const Instant& accessInstantAtPassBreak() const;
 
     /// @brief Print

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.hpp
@@ -6,8 +6,8 @@
 #include <OpenSpaceToolkit/Core/Types/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Types/String.hpp>
 
+#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
-#include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 
 namespace ostk
 {
@@ -21,93 +21,155 @@ namespace orbit
 using ostk::core::types::Integer;
 using ostk::core::types::String;
 
-using ostk::physics::time::Interval;
 using ostk::physics::time::Instant;
+using ostk::physics::time::Duration;
 
-/// @brief A revolution of an orbiting object
+/// @class Pass
+/// @brief A revolution of an orbiting object.
 ///
-/// @ref                        http://help.agi.com/stk/11.3.0/index.htm#vo/sat_pass.htm
+/// @details This class represents a pass, which is a revolution of an orbiting object.
+/// It provides methods to get the type of the pass, the revolution number, and the instants at various points of the
+/// pass.
+/// @see http://help.agi.com/stk/11.3.0/index.htm#vo/sat_pass.htm
 class Pass
 {
    public:
+    /// @enum Type
+    /// @brief The type of the pass.
     enum class Type
     {
-
-        Undefined,
-        Complete,
-        Partial
-
+        Undefined,  ///< The type is undefined.
+        Complete,   ///< The pass is a complete revolution.
+        Partial     ///< The pass is a partial revolution.
     };
 
+    /// @enum Phase
+    /// @brief The phase of the pass.
     enum class Phase
     {
-
-        Undefined,
-        Ascending,
-        Descending
-
+        Undefined,  ///< The phase is undefined.
+        Ascending,  ///< The pass is in the ascending phase.
+        Descending  ///< The pass is in the descending phase.
     };
 
-    enum class Quarter
-    {
-
-        Undefined,
-        First,
-        Second,
-        Third,
-        Fourth
-
-    };
-
+    /// @brief Constructs a pass.
+    ///
+    /// @param aRevolutionNumber The revolution number of the pass.
+    /// @param anInstantAtAscendingNode The instant at the ascending node of the pass.
+    /// @param anInstantAtNorthPoint The instant at the north point of the pass.
+    /// @param anInstantAtDescendingNode The instant at the descending node of the pass.
+    /// @param anInstantAtSouthPoint The instant at the south point of the pass.
+    /// @param anInstantAtPassBreak The instant at the pass break, i.e. next ascending node.
     Pass(
-        const Pass::Type& aType,
         const Integer& aRevolutionNumber,
-        const Interval& anInterval,
-        const Instant& anInstantAtDescendingNode,
+        const Instant& anInstantAtAscendingNode,
         const Instant& anInstantAtNorthPoint,
-        const Instant& anInstantAtSouthPoint
+        const Instant& anInstantAtDescendingNode,
+        const Instant& anInstantAtSouthPoint,
+        const Instant& anInstantAtPassBreak
     );
 
+    /// @brief Equality operator.
+    ///
+    /// @param aPass The pass to compare to.
+    /// @return True if the passes are equal.
     bool operator==(const Pass& aPass) const;
 
+    /// @brief Inequality operator.
+    ///
+    /// @param aPass The pass to compare to.
+    /// @return True if the passes are not equal.
     bool operator!=(const Pass& aPass) const;
 
+    /// @brief Output stream operator.
+    ///
+    /// @param [in,out] anOutputStream The output stream.
+    /// @param aPass The pass to output.
+    /// @return The output stream.
     friend std::ostream& operator<<(std::ostream& anOutputStream, const Pass& aPass);
 
+    /// @brief Checks if the pass is defined.
+    ///
+    /// @return True if the pass is defined.
     bool isDefined() const;
 
+    /// @brief Checks if the pass is complete.
+    ///
+    /// @return True if the pass is complete.
     bool isComplete() const;
 
+    /// @brief Gets the type of the pass.
+    ///
+    /// @return The type of the pass.
     Pass::Type getType() const;
 
+    /// @brief Gets the revolution number of the pass.
+    ///
+    /// @return The revolution number of the pass.
     Integer getRevolutionNumber() const;
 
-    Interval getInterval() const;
+    /// @brief Gets the duration of the pass.
+    ///
+    /// @return The duration of the pass.
+    Duration getDuration() const;
 
+    /// @brief Accesses the instant at the ascending node of the pass.
+    ///
+    /// @return The instant at the ascending node of the pass.
     const Instant& accessInstantAtAscendingNode() const;
 
-    const Instant& accessInstantAtDescendingNode() const;
-
+    /// @brief Accesses the instant at the north point of the pass.
+    ///
+    /// @return The instant at the north point of the pass.
     const Instant& accessInstantAtNorthPoint() const;
 
+    /// @brief Accesses the instant at the descending node of the pass.
+    ///
+    /// @return The instant at the descending node of the pass.
+    const Instant& accessInstantAtDescendingNode() const;
+
+    /// @brief Accesses the instant at the south point of the pass.
+    ///
+    /// @return The instant at the south point of the pass.
     const Instant& accessInstantAtSouthPoint() const;
 
+    /// @brief Accesses the instant at the pass break of the pass.
+    ///
+    /// @return The instant at the pass break of the pass.
+    const Instant& accessInstantAtPassBreak() const;
+
+    /// @brief Print
+    ///
+    /// @param anOutputStream The output stream.
+    /// @param displayDecorator Whether or not to display the decorator
+    void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
+
+    /// @brief Creates an undefined pass.
+    ///
+    /// @return An undefined pass.
     static Pass Undefined();
 
+    /// @brief Converts a pass type to a string.
+    ///
+    /// @param aType The pass type.
+    /// @return The string representation of the pass type.
     static String StringFromType(const Pass::Type& aType);
 
+    /// @brief Converts a pass phase to a string.
+    ///
+    /// @param aPhase The pass phase.
+    /// @return The string representation of the pass phase.
     static String StringFromPhase(const Pass::Phase& aPhase);
-
-    static String StringFromQuarter(const Pass::Quarter& aQuarter);
 
    private:
     Pass::Type type_;
 
     Integer revolutionNumber_;
-    Interval interval_;
-    Instant instantAtDescendingNode_;
+    Instant instantAtAscendingNode_;
     Instant instantAtNorthPoint_;
+    Instant instantAtDescendingNode_;
     Instant instantAtSouthPoint_;
+    Instant instantAtPassBreak_;
 };
 
 }  // namespace orbit

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -1040,7 +1040,9 @@ Array<Pair<Index, Pass>> Orbit::ComputePasses(const Array<State>& aStateArray, c
 
     if (aStateArray.getSize() < 2)
     {
-        throw ostk::core::error::Runtime("Greater than 2 states required to compute passes: {}", aStateArray.getSize());
+        throw ostk::core::error::RuntimeError(
+            "Greater than 2 states required to compute passes: {}", aStateArray.getSize()
+        );
     }
 
     for (Index i = 1; i < aStateArray.getSize(); ++i)

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -1040,7 +1040,7 @@ Array<Pair<Index, Pass>> Orbit::ComputePasses(const Array<State>& aStateArray, c
 
     if (aStateArray.getSize() < 2)
     {
-        return passMap;
+        throw ostk::core::error::Runtime("Greater than 2 states required to compute passes: {}", aStateArray.getSize());
     }
 
     for (Index i = 1; i < aStateArray.getSize(); ++i)

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -1164,17 +1164,6 @@ Array<Pair<Index, Pass>> Orbit::ComputePasses(const Array<State>& aStateArray, c
         passBreak,
     };
 
-    if (!passMap.isEmpty())
-    {
-        const Index& lastPassIndex = passMap.accessLast().first;
-
-        // Don't add the remaining pass if there are no states left
-        if (lastPassIndex == currentIndex - 1)
-        {
-            return passMap;
-        }
-    }
-
     passMap.add({currentIndex, pass});
 
     return passMap;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.cpp
@@ -35,9 +35,9 @@ Pass::Pass(
     {
         type_ = Pass::Type::Undefined;
     }
-    else if (!anInstantAtNorthPoint.isDefined() || !anInstantAtSouthPoint.isDefined() ||
+    else if ((!anInstantAtNorthPoint.isDefined() || !anInstantAtSouthPoint.isDefined() ||
         !anInstantAtDescendingNode.isDefined() || !anInstantAtAscendingNode.isDefined() ||
-        !anInstantAtPassBreak.isDefined())
+        !anInstantAtPassBreak.isDefined()) && revolutionNumber_.isDefined())
     {
         type_ = Pass::Type::Partial;
     }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.cpp
@@ -15,23 +15,70 @@ namespace orbit
 {
 
 Pass::Pass(
-    const Pass::Type& aType,
     const Integer& aRevolutionNumber,
-    const Interval& anInterval,
-    const Instant& anInstantAtDescendingNode,
+    const Instant& anInstantAtAscendingNode,
     const Instant& anInstantAtNorthPoint,
-    const Instant& anInstantAtSouthPoint
+    const Instant& anInstantAtDescendingNode,
+    const Instant& anInstantAtSouthPoint,
+    const Instant& anInstantAtPassBreak
 )
-    : type_(aType),
-      revolutionNumber_(aRevolutionNumber),
-      interval_(anInterval),
-      instantAtDescendingNode_(anInstantAtDescendingNode),
+    : revolutionNumber_(aRevolutionNumber),
+      instantAtAscendingNode_(anInstantAtAscendingNode),
       instantAtNorthPoint_(anInstantAtNorthPoint),
-      instantAtSouthPoint_(anInstantAtSouthPoint)
+      instantAtDescendingNode_(anInstantAtDescendingNode),
+      instantAtSouthPoint_(anInstantAtSouthPoint),
+      instantAtPassBreak_(anInstantAtPassBreak)
 {
-    if ((aType == Pass::Type::Complete) && (!anInstantAtNorthPoint.isDefined() || !anInstantAtSouthPoint.isDefined()))
+    if (!anInstantAtNorthPoint.isDefined() && !anInstantAtSouthPoint.isDefined() &&
+        !anInstantAtDescendingNode.isDefined() && !anInstantAtAscendingNode.isDefined() &&
+        !anInstantAtPassBreak.isDefined())
     {
-        throw ostk::core::error::RuntimeError("Complete pass must have both north and south points defined.");
+        type_ = Pass::Type::Undefined;
+    }
+    else if (!anInstantAtNorthPoint.isDefined() || !anInstantAtSouthPoint.isDefined() ||
+        !anInstantAtDescendingNode.isDefined() || !anInstantAtAscendingNode.isDefined() ||
+        !anInstantAtPassBreak.isDefined())
+    {
+        type_ = Pass::Type::Partial;
+    }
+    else
+    {
+        type_ = Pass::Type::Complete;
+    }
+
+    if (instantAtAscendingNode_.isDefined())
+    {
+        if (instantAtNorthPoint_.isDefined())
+        {
+            if (instantAtAscendingNode_ > instantAtNorthPoint_)
+            {
+                throw ostk::core::error::RuntimeError("Ascending node must be before north point.");
+            }
+
+            if (instantAtDescendingNode_.isDefined())
+            {
+                if (instantAtNorthPoint_ > instantAtDescendingNode_)
+                {
+                    throw ostk::core::error::RuntimeError("North point must be before descending node.");
+                }
+
+                if (instantAtSouthPoint_.isDefined())
+                {
+                    if (instantAtDescendingNode_ > instantAtSouthPoint_)
+                    {
+                        throw ostk::core::error::RuntimeError("Descending node must be before south point.");
+                    }
+
+                    if (instantAtPassBreak_.isDefined())
+                    {
+                        if (instantAtSouthPoint_ > instantAtPassBreak_)
+                        {
+                            throw ostk::core::error::RuntimeError("South point must be before pass break.");
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -43,10 +90,16 @@ bool Pass::operator==(const Pass& aPass) const
     }
 
     bool isEqual = (type_ == aPass.type_) && (revolutionNumber_ == aPass.revolutionNumber_) &&
-                   (interval_ == aPass.interval_) &&
+                   (instantAtAscendingNode_.isDefined() == aPass.instantAtAscendingNode_.isDefined()) &&
                    (instantAtDescendingNode_.isDefined() == aPass.instantAtDescendingNode_.isDefined()) &&
                    (instantAtNorthPoint_.isDefined() == aPass.instantAtNorthPoint_.isDefined()) &&
-                   (instantAtSouthPoint_.isDefined() == aPass.instantAtSouthPoint_.isDefined());
+                   (instantAtSouthPoint_.isDefined() == aPass.instantAtSouthPoint_.isDefined()) &&
+                   (instantAtPassBreak_.isDefined() == aPass.instantAtPassBreak_.isDefined());
+
+    if (instantAtAscendingNode_.isDefined() && aPass.instantAtAscendingNode_.isDefined())
+    {
+        isEqual = isEqual && (instantAtAscendingNode_ == aPass.instantAtAscendingNode_);
+    }
 
     if (instantAtDescendingNode_.isDefined() && aPass.instantAtDescendingNode_.isDefined())
     {
@@ -63,6 +116,11 @@ bool Pass::operator==(const Pass& aPass) const
         isEqual = isEqual && (instantAtSouthPoint_ == aPass.instantAtSouthPoint_);
     }
 
+    if (instantAtPassBreak_.isDefined() && aPass.instantAtPassBreak_.isDefined())
+    {
+        isEqual = isEqual && (instantAtPassBreak_ == aPass.instantAtPassBreak_);
+    }
+
     return isEqual;
 }
 
@@ -73,30 +131,7 @@ bool Pass::operator!=(const Pass& aPass) const
 
 std::ostream& operator<<(std::ostream& anOutputStream, const Pass& aPass)
 {
-    ostk::core::utils::Print::Header(anOutputStream, "Pass");
-
-    ostk::core::utils::Print::Line(anOutputStream) << "Type:" << Pass::StringFromType(aPass.type_);
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Revolution #:" << (aPass.revolutionNumber_.isDefined() ? aPass.revolutionNumber_.toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Start time:" << (aPass.interval_.isDefined() ? aPass.interval_.accessStart().toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "End time:" << (aPass.interval_.isDefined() ? aPass.interval_.accessEnd().toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Duration:" << (aPass.interval_.isDefined() ? aPass.interval_.getDuration().toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Ascending node:" << (aPass.interval_.isDefined() ? aPass.interval_.accessStart().toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "North point:"
-        << (aPass.instantAtNorthPoint_.isDefined() ? aPass.instantAtNorthPoint_.toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Descending node:"
-        << (aPass.instantAtDescendingNode_.isDefined() ? aPass.instantAtDescendingNode_.toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "South point:"
-        << (aPass.instantAtSouthPoint_.isDefined() ? aPass.instantAtSouthPoint_.toString() : "Undefined");
-
-    ostk::core::utils::Print::Footer(anOutputStream);
+    aPass.print(anOutputStream);
 
     return anOutputStream;
 }
@@ -136,14 +171,19 @@ Integer Pass::getRevolutionNumber() const
     return revolutionNumber_;
 }
 
-Interval Pass::getInterval() const
+Duration Pass::getDuration() const
 {
     if (!this->isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Pass");
     }
 
-    return interval_;
+    if (type_ == Pass::Type::Complete)
+    {
+        return instantAtPassBreak_ - instantAtAscendingNode_;
+    }
+
+    return Duration::Undefined();
 }
 
 const Instant& Pass::accessInstantAtAscendingNode() const
@@ -153,17 +193,7 @@ const Instant& Pass::accessInstantAtAscendingNode() const
         throw ostk::core::error::runtime::Undefined("Pass");
     }
 
-    return interval_.accessStart();
-}
-
-const Instant& Pass::accessInstantAtDescendingNode() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Pass");
-    }
-
-    return instantAtDescendingNode_;
+    return instantAtAscendingNode_;
 }
 
 const Instant& Pass::accessInstantAtNorthPoint() const
@@ -176,6 +206,16 @@ const Instant& Pass::accessInstantAtNorthPoint() const
     return instantAtNorthPoint_;
 }
 
+const Instant& Pass::accessInstantAtDescendingNode() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Pass");
+    }
+
+    return instantAtDescendingNode_;
+}
+
 const Instant& Pass::accessInstantAtSouthPoint() const
 {
     if (!this->isDefined())
@@ -186,12 +226,49 @@ const Instant& Pass::accessInstantAtSouthPoint() const
     return instantAtSouthPoint_;
 }
 
+const Instant& Pass::accessInstantAtPassBreak() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Pass");
+    }
+
+    return instantAtPassBreak_;
+}
+
+void Pass::print(std::ostream& anOutputStream, bool displayDecorator) const
+{
+    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Pass") : void();
+
+    const Duration duration = this->getDuration();
+
+    ostk::core::utils::Print::Line(anOutputStream) << "Type:" << Pass::StringFromType(type_);
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Revolution #:" << (revolutionNumber_.isDefined() ? revolutionNumber_.toString() : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Duration:" << (duration.isDefined() ? duration.toString() : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Ascending node:"
+        << (instantAtAscendingNode_.isDefined() ? instantAtAscendingNode_.toString() : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "North point:" << (instantAtNorthPoint_.isDefined() ? instantAtNorthPoint_.toString() : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Descending node:"
+        << (instantAtDescendingNode_.isDefined() ? instantAtDescendingNode_.toString() : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "South point:" << (instantAtSouthPoint_.isDefined() ? instantAtSouthPoint_.toString() : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Pass break:" << (instantAtPassBreak_.isDefined() ? instantAtPassBreak_.toString() : "Undefined");
+
+    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+}
+
 Pass Pass::Undefined()
 {
     return {
-        Pass::Type::Undefined,
         Integer::Undefined(),
-        Interval::Undefined(),
+        Instant::Undefined(),
+        Instant::Undefined(),
         Instant::Undefined(),
         Instant::Undefined(),
         Instant::Undefined(),
@@ -233,32 +310,6 @@ String Pass::StringFromPhase(const Pass::Phase& aPhase)
 
         default:
             throw ostk::core::error::runtime::Wrong("Phase");
-    }
-
-    return String::Empty();
-}
-
-String Pass::StringFromQuarter(const Pass::Quarter& aQuarter)
-{
-    switch (aQuarter)
-    {
-        case Pass::Quarter::Undefined:
-            return "Undefined";
-
-        case Pass::Quarter::First:
-            return "First";
-
-        case Pass::Quarter::Second:
-            return "Second";
-
-        case Pass::Quarter::Third:
-            return "Third";
-
-        case Pass::Quarter::Fourth:
-            return "Fourth";
-
-        default:
-            throw ostk::core::error::runtime::Wrong("Quarter");
     }
 
     return String::Empty();

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.cpp
@@ -31,7 +31,7 @@ Pass::Pass(
 {
     if (!anInstantAtNorthPoint.isDefined() && !anInstantAtSouthPoint.isDefined() &&
         !anInstantAtDescendingNode.isDefined() && !anInstantAtAscendingNode.isDefined() &&
-        !anInstantAtPassBreak.isDefined())
+        !anInstantAtPassBreak.isDefined() && !revolutionNumber_.isDefined())
     {
         type_ = Pass::Type::Undefined;
     }
@@ -240,7 +240,7 @@ void Pass::print(std::ostream& anOutputStream, bool displayDecorator) const
 {
     displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Pass") : void();
 
-    const Duration duration = this->getDuration();
+    const Duration duration = this->isDefined() ? this->getDuration() : Duration::Undefined();
 
     ostk::core::utils::Print::Line(anOutputStream) << "Type:" << Pass::StringFromType(type_);
     ostk::core::utils::Print::Line(anOutputStream)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -31,6 +31,7 @@
 
 using ostk::core::ctnr::Array;
 using ostk::core::ctnr::Map;
+using ostk::core::ctnr::Pair;
 using ostk::core::ctnr::Table;
 using ostk::core::filesystem::File;
 using ostk::core::filesystem::Path;
@@ -343,22 +344,36 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassAt)
 
             EXPECT_GT(
                 Duration::Microseconds(1.0),
-                Duration::Between(referencePassStartInstant, pass.getInterval().getStart()).getAbsolute()
+                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
             );
             EXPECT_GT(
                 Duration::Microseconds(1.0),
-                Duration::Between(referencePassEndInstant, pass.getInterval().getEnd()).getAbsolute()
+                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
             );
         }
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePasses)
 {
+    // undefined revolution number
     {
-        EXPECT_THROW(Orbit::GeneratePassMap({}, Integer::Undefined()), ostk::core::error::runtime::Undefined);
+        EXPECT_THROW(Orbit::ComputePasses({}, Integer::Undefined()), ostk::core::error::runtime::Undefined);
     }
 
+    // states < 2
+    {
+        const Array<State> states = {
+            {
+                Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC),
+                Position::Meters({0.0, 0.0, 0.0}, Frame::GCRF()),
+                Velocity::MetersPerSecond({1.0, 0.0, 0.0}, Frame::GCRF()),
+            },
+        };
+        EXPECT_TRUE(Orbit::ComputePasses(states, 1).isEmpty());
+    }
+
+    // states out of order
     {
         const Array<State> states = {
             {
@@ -372,7 +387,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
                 Velocity::MetersPerSecond({1.0, 0.0, 0.0}, Frame::GCRF()),
             }
         };
-        EXPECT_THROW(Orbit::GeneratePassMap(states, 1), ostk::core::error::RuntimeError);
+        EXPECT_THROW(Orbit::ComputePasses(states, 1), ostk::core::error::RuntimeError);
     }
 
     // partial revolution
@@ -411,30 +426,16 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
             Interval::Closed(startInstant, endInstant).generateGrid(Duration::Seconds(20.0));
         const Array<State> states = orbit.getStatesAt(instants);
 
-        const Map<Index, Pass> passMap = Orbit::GeneratePassMap(states, 1);
+        const Array<Pair<Index, Pass>> passMap = Orbit::ComputePasses(states, 1);
 
         for (const auto &row : passMap)
         {
             const Pass &pass = row.second;
 
             EXPECT_TRUE(pass.isDefined());
-
-            if (pass.accessInstantAtNorthPoint().isDefined())
-            {
-                EXPECT_LT(pass.accessInstantAtAscendingNode(), pass.accessInstantAtNorthPoint());
-
-                if (pass.accessInstantAtDescendingNode().isDefined())
-                {
-                    EXPECT_LT(pass.accessInstantAtNorthPoint(), pass.accessInstantAtDescendingNode());
-
-                    if (pass.accessInstantAtSouthPoint().isDefined())
-                    {
-                        EXPECT_LT(pass.accessInstantAtDescendingNode(), pass.accessInstantAtSouthPoint());
-                        EXPECT_LT(pass.accessInstantAtSouthPoint(), pass.getInterval().getEnd());
-                    }
-                }
-            }
         }
+
+        EXPECT_EQ(passMap.accessLast().second.getType(), Pass::Type::Partial);
     }
 
     {
@@ -481,7 +482,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
             Interval::Closed(startInstant, endInstant).generateGrid(Duration::Seconds(20.0));
         const Array<State> states = orbit.getStatesAt(instants);
 
-        const Map<Index, Pass> passMap = Orbit::GeneratePassMap(states, 1);
+        const Array<Pair<Index, Pass>> passMap = Orbit::ComputePasses(states, 1);
 
         EXPECT_EQ(referenceData.getRowCount(), passMap.size() - 1);  // We're generating 1 pass over the reference data
 
@@ -517,25 +518,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
 
             EXPECT_TRUE(pass.isDefined());
 
-            if (pass.accessInstantAtNorthPoint().isDefined())
-            {
-                EXPECT_LT(pass.accessInstantAtAscendingNode(), pass.accessInstantAtNorthPoint());
-
-                if (pass.accessInstantAtDescendingNode().isDefined())
-                {
-                    EXPECT_LT(pass.accessInstantAtNorthPoint(), pass.accessInstantAtDescendingNode());
-
-                    if (pass.accessInstantAtSouthPoint().isDefined())
-                    {
-                        EXPECT_LT(pass.accessInstantAtDescendingNode(), pass.accessInstantAtSouthPoint());
-                        EXPECT_LT(pass.accessInstantAtSouthPoint(), pass.getInterval().getEnd());
-                    }
-                }
-            }
-
             EXPECT_EQ(pass.getRevolutionNumber(), referenceRow[0].accessInteger());
-            EXPECT_LT(std::fabs((referencePassStartInstant - pass.getInterval().getStart()).inSeconds()), 1e-6);
-            EXPECT_LT(std::fabs((referencePassEndInstant - pass.getInterval().getEnd()).inSeconds()), 1e-6);
+            EXPECT_LT(std::fabs((referencePassStartInstant - pass.accessInstantAtAscendingNode()).inSeconds()), 1e-6);
+            EXPECT_LT(std::fabs((referencePassEndInstant - pass.accessInstantAtPassBreak()).inSeconds()), 1e-6);
             EXPECT_LT(
                 std::fabs((referencePassAscendingNodeInstant - pass.accessInstantAtAscendingNode()).inSeconds()), 1e-6
             );
@@ -578,7 +563,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeneratePassMap)
             states.add(sgp4.calculateStateAt(instant));
         }
 
-        EXPECT_NO_THROW(Orbit::GeneratePassMap(states, 8502));
+        EXPECT_NO_THROW(Orbit::ComputePasses(states, 8502));
     }
 }
 
@@ -639,11 +624,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
 
             EXPECT_GT(
                 Duration::Microseconds(1.0),
-                Duration::Between(referencePassStartInstant, pass.getInterval().getStart()).getAbsolute()
+                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
             );
             EXPECT_GT(
                 Duration::Microseconds(1.0),
-                Duration::Between(referencePassEndInstant, pass.getInterval().getEnd()).getAbsolute()
+                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
             );
         }
     }
@@ -703,11 +688,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
 
             EXPECT_GT(
                 Duration::Milliseconds(1.0),
-                Duration::Between(referencePassStartInstant, pass.getInterval().getStart()).getAbsolute()
+                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
             );
             EXPECT_GT(
                 Duration::Milliseconds(1.0),
-                Duration::Between(referencePassEndInstant, pass.getInterval().getEnd()).getAbsolute()
+                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
             );
         }
     }
@@ -767,11 +752,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
 
             EXPECT_GT(
                 Duration::Milliseconds(2.0),
-                Duration::Between(referencePassStartInstant, pass.getInterval().getStart()).getAbsolute()
+                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
             );
             EXPECT_GT(
                 Duration::Milliseconds(2.0),
-                Duration::Between(referencePassEndInstant, pass.getInterval().getEnd()).getAbsolute()
+                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
             );
         }
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -370,7 +370,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePasses)
                 Velocity::MetersPerSecond({1.0, 0.0, 0.0}, Frame::GCRF()),
             },
         };
-        EXPECT_TRUE(Orbit::ComputePasses(states, 1).isEmpty());
+        EXPECT_THROW(Orbit::ComputePasses(states, 1).isEmpty(), ostk::core::error::RuntimeError);
     }
 
     // states out of order

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.test.cpp
@@ -192,7 +192,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, Constructor)
     // undefined
     {
         const Pass pass = {
-            defaultRevolutionNumber_,
+            Integer::Undefined(),
             Instant::Undefined(),
             Instant::Undefined(),
             Instant::Undefined(),
@@ -480,7 +480,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, IsDefined)
 
     {
         const Pass pass = {
-            defaultRevolutionNumber_,
+            Integer::Undefined(),
             Instant::Undefined(),
             Instant::Undefined(),
             Instant::Undefined(),

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Pass.test.cpp
@@ -21,51 +21,185 @@ using ostk::astro::trajectory::orbit::Pass;
 class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass : public ::testing::Test
 {
    protected:
-    const Pass::Type defaultPassType_ = Pass::Type::Complete;
     const Integer defaultRevolutionNumber_ = 1;
-    const Interval defaultPassInterval_ = Interval::Closed(Instant::J2000(), Instant::J2000() + Duration::Hours(1.0));
-    const Instant defaultInstantAtDescendingNode_ = Instant::J2000() + Duration::Minutes(30.0);
+    const Instant defaultInstantAtAscendingNode_ = Instant::J2000();
     const Instant defaultInstantAtNorthPoint_ = Instant::J2000() + Duration::Minutes(15.0);
+    const Instant defaultInstantAtDescendingNode_ = Instant::J2000() + Duration::Minutes(30.0);
     const Instant defaultInstantAtSouthPoint_ = Instant::J2000() + Duration::Minutes(45.0);
+    const Instant defaultInstantAtPassBreak_ = Instant::J2000() + Duration::Hours(1.0);
 
-    Pass defaultPass_ = {
-        defaultPassType_,
+    const Pass defaultPass_ = {
         defaultRevolutionNumber_,
-        defaultPassInterval_,
-        defaultInstantAtDescendingNode_,
+        defaultInstantAtAscendingNode_,
         defaultInstantAtNorthPoint_,
+        defaultInstantAtDescendingNode_,
         defaultInstantAtSouthPoint_,
+        defaultInstantAtPassBreak_,
     };
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, Constructor)
 {
+    // Instant orders
     {
+        // ascending node > north point
         EXPECT_THROW(
             Pass(
-                defaultPassType_,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtAscendingNode_,
                 defaultInstantAtDescendingNode_,
-                Instant::Undefined(),
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_
+            ),
+            ostk::core::error::RuntimeError
+        );
+
+        // north point > descending node
+        EXPECT_THROW(
+            Pass(
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_
+            ),
+            ostk::core::error::RuntimeError
+        );
+
+        // descending node > south point
+        EXPECT_THROW(
+            Pass(
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtPassBreak_
+            ),
+            ostk::core::error::RuntimeError
+        );
+
+        // south point > pass break
+        EXPECT_THROW(
+            Pass(
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtPassBreak_,
                 defaultInstantAtSouthPoint_
             ),
             ostk::core::error::RuntimeError
         );
     }
 
+    // complete
     {
-        EXPECT_THROW(
+        EXPECT_EQ(
             Pass(
-                defaultPassType_,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 defaultInstantAtNorthPoint_,
-                Instant::Undefined()
-            ),
-            ostk::core::error::RuntimeError
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_
+            )
+                .getType(),
+            Pass::Type::Complete
         );
+    }
+
+    // partial
+    {
+        {
+            EXPECT_EQ(
+                Pass(
+                    defaultRevolutionNumber_,
+                    Instant::Undefined(),
+                    defaultInstantAtNorthPoint_,
+                    defaultInstantAtDescendingNode_,
+                    defaultInstantAtSouthPoint_,
+                    defaultInstantAtPassBreak_
+                )
+                    .getType(),
+                Pass::Type::Partial
+            );
+        }
+
+        {
+            EXPECT_EQ(
+                Pass(
+                    defaultRevolutionNumber_,
+                    defaultInstantAtAscendingNode_,
+                    Instant::Undefined(),
+                    defaultInstantAtDescendingNode_,
+                    defaultInstantAtSouthPoint_,
+                    defaultInstantAtPassBreak_
+                )
+                    .getType(),
+                Pass::Type::Partial
+            );
+        }
+
+        {
+            EXPECT_EQ(
+                Pass(
+                    defaultRevolutionNumber_,
+                    defaultInstantAtAscendingNode_,
+                    defaultInstantAtNorthPoint_,
+                    Instant::Undefined(),
+                    defaultInstantAtSouthPoint_,
+                    defaultInstantAtPassBreak_
+                )
+                    .getType(),
+                Pass::Type::Partial
+            );
+        }
+
+        {
+            EXPECT_EQ(
+                Pass(
+                    defaultRevolutionNumber_,
+                    defaultInstantAtAscendingNode_,
+                    defaultInstantAtNorthPoint_,
+                    defaultInstantAtDescendingNode_,
+                    Instant::Undefined(),
+                    defaultInstantAtPassBreak_
+                )
+                    .getType(),
+                Pass::Type::Partial
+            );
+        }
+
+        {
+            EXPECT_EQ(
+                Pass(
+                    defaultRevolutionNumber_,
+                    defaultInstantAtAscendingNode_,
+                    defaultInstantAtNorthPoint_,
+                    defaultInstantAtDescendingNode_,
+                    defaultInstantAtSouthPoint_,
+                    Instant::Undefined()
+                )
+                    .getType(),
+                Pass::Type::Partial
+            );
+        }
+    }
+
+    // undefined
+    {
+        const Pass pass = {
+            defaultRevolutionNumber_,
+            Instant::Undefined(),
+            Instant::Undefined(),
+            Instant::Undefined(),
+            Instant::Undefined(),
+            Instant::Undefined(),
+        };
+        EXPECT_FALSE(pass.isDefined());
     }
 }
 
@@ -75,49 +209,49 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, EqualToOperator)
         EXPECT_TRUE(defaultPass_ == defaultPass_);
     }
 
-    // descending node
+    // Ascending node
     {
         // undefined
         {
             const Pass pass_1 = {
-                Pass::Type::Complete,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
                 Instant::Undefined(),
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
             };
 
             const Pass pass_2 = {
-                Pass::Type::Complete,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
                 Instant::Undefined(),
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
             };
 
             EXPECT_TRUE(pass_1 == pass_2);
         }
 
-        // descending node undefined in first pass, defined in second
+        // Ascending point undefined in first pass, defined in second
         {
             const Pass pass_1 = {
-                Pass::Type::Complete,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
                 Instant::Undefined(),
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
             };
 
             const Pass pass_2 = {
-                Pass::Type::Complete,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
             };
 
             EXPECT_FALSE(pass_1 == pass_2);
@@ -129,21 +263,22 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, EqualToOperator)
         // undefined
         {
             const Pass pass_1 = {
-                Pass::Type::Partial,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 Instant::Undefined(),
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
             };
 
             const Pass pass_2 = {
-                Pass::Type::Partial,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 Instant::Undefined(),
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
+
             };
 
             EXPECT_TRUE(pass_1 == pass_2);
@@ -152,21 +287,70 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, EqualToOperator)
         // north point undefined in first pass, defined in second
         {
             const Pass pass_1 = {
-                Pass::Type::Partial,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 Instant::Undefined(),
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
             };
 
             const Pass pass_2 = {
-                Pass::Type::Partial,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
+            };
+
+            EXPECT_FALSE(pass_1 == pass_2);
+        }
+    }
+
+    // descending node
+    {
+        // undefined
+        {
+            const Pass pass_1 = {
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                Instant::Undefined(),
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
+            };
+
+            const Pass pass_2 = {
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                Instant::Undefined(),
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
+            };
+
+            EXPECT_TRUE(pass_1 == pass_2);
+        }
+
+        // descending node undefined in first pass, defined in second
+        {
+            const Pass pass_1 = {
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                Instant::Undefined(),
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
+            };
+
+            const Pass pass_2 = {
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
             };
 
             EXPECT_FALSE(pass_1 == pass_2);
@@ -178,21 +362,21 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, EqualToOperator)
         // undefined
         {
             const Pass pass_1 = {
-                Pass::Type::Partial,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
                 Instant::Undefined(),
+                defaultInstantAtPassBreak_,
             };
 
             const Pass pass_2 = {
-                Pass::Type::Partial,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
                 Instant::Undefined(),
+                defaultInstantAtPassBreak_,
             };
 
             EXPECT_TRUE(pass_1 == pass_2);
@@ -201,21 +385,70 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, EqualToOperator)
         // south point undefined in first pass, defined in second
         {
             const Pass pass_1 = {
-                Pass::Type::Partial,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
+                Instant::Undefined(),
+                defaultInstantAtPassBreak_,
+            };
+
+            const Pass pass_2 = {
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
+            };
+
+            EXPECT_FALSE(pass_1 == pass_2);
+        }
+    }
+
+    // pass break
+    {
+        // undefined
+        {
+            const Pass pass_1 = {
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtSouthPoint_,
                 Instant::Undefined(),
             };
 
             const Pass pass_2 = {
-                Pass::Type::Partial,
                 defaultRevolutionNumber_,
-                defaultPassInterval_,
-                defaultInstantAtDescendingNode_,
+                defaultInstantAtAscendingNode_,
                 defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
                 defaultInstantAtSouthPoint_,
+                Instant::Undefined(),
+            };
+
+            EXPECT_TRUE(pass_1 == pass_2);
+        }
+
+        // pass break undefined in first pass, defined in second
+        {
+            const Pass pass_1 = {
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtSouthPoint_,
+                Instant::Undefined(),
+            };
+
+            const Pass pass_2 = {
+                defaultRevolutionNumber_,
+                defaultInstantAtAscendingNode_,
+                defaultInstantAtNorthPoint_,
+                defaultInstantAtDescendingNode_,
+                defaultInstantAtSouthPoint_,
+                defaultInstantAtPassBreak_,
             };
 
             EXPECT_FALSE(pass_1 == pass_2);
@@ -247,12 +480,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, IsDefined)
 
     {
         const Pass pass = {
-            Pass::Type::Undefined,
             defaultRevolutionNumber_,
-            defaultPassInterval_,
-            defaultInstantAtDescendingNode_,
-            defaultInstantAtNorthPoint_,
-            defaultInstantAtSouthPoint_,
+            Instant::Undefined(),
+            Instant::Undefined(),
+            Instant::Undefined(),
+            Instant::Undefined(),
+            Instant::Undefined(),
         };
 
         EXPECT_FALSE(pass.isDefined());
@@ -271,12 +504,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, IsComplete)
 
     {
         const Pass pass = {
-            Pass::Type::Partial,
             defaultRevolutionNumber_,
-            defaultPassInterval_,
-            defaultInstantAtDescendingNode_,
+            defaultInstantAtAscendingNode_,
             defaultInstantAtNorthPoint_,
+            defaultInstantAtDescendingNode_,
             defaultInstantAtSouthPoint_,
+            Instant::Undefined(),
         };
         EXPECT_FALSE(pass.isComplete());
     }
@@ -289,7 +522,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, GetType)
     }
 
     {
-        EXPECT_EQ(defaultPass_.getType(), defaultPassType_);
+        EXPECT_EQ(defaultPass_.getType(), Pass::Type::Complete);
     }
 }
 
@@ -304,14 +537,30 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, GetRevolutionNumber
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, GetInterval)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, GetDuration)
 {
     {
-        EXPECT_THROW(Pass::Undefined().getInterval(), ostk::core::error::runtime::Undefined);
+        EXPECT_THROW(Pass::Undefined().getDuration(), ostk::core::error::runtime::Undefined);
     }
 
     {
-        EXPECT_EQ(defaultPass_.getInterval(), defaultPassInterval_);
+        EXPECT_TRUE(defaultPass_.getDuration().isDefined());
+    }
+
+    {
+        const Pass pass = {
+            defaultRevolutionNumber_,
+            defaultInstantAtAscendingNode_,
+            defaultInstantAtNorthPoint_,
+            defaultInstantAtDescendingNode_,
+            Instant::Undefined(),
+            defaultInstantAtPassBreak_,
+        };
+        EXPECT_FALSE(pass.getDuration().isDefined());
+    }
+
+    {
+        EXPECT_EQ(defaultPass_.getDuration(), defaultInstantAtPassBreak_ - defaultInstantAtAscendingNode_);
     }
 }
 
@@ -322,18 +571,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, AccessInstantAtAsce
     }
 
     {
-        EXPECT_EQ(defaultPass_.accessInstantAtAscendingNode(), defaultPassInterval_.getStart());
-    }
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, AccessInstantAtDescendingNode)
-{
-    {
-        EXPECT_THROW(Pass::Undefined().accessInstantAtDescendingNode(), ostk::core::error::runtime::Undefined);
-    }
-
-    {
-        EXPECT_EQ(defaultPass_.accessInstantAtDescendingNode(), defaultInstantAtDescendingNode_);
+        EXPECT_EQ(defaultPass_.accessInstantAtAscendingNode(), defaultInstantAtAscendingNode_);
     }
 }
 
@@ -348,6 +586,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, AccessInstantAtNort
     }
 }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, AccessInstantAtDescendingNode)
+{
+    {
+        EXPECT_THROW(Pass::Undefined().accessInstantAtDescendingNode(), ostk::core::error::runtime::Undefined);
+    }
+
+    {
+        EXPECT_EQ(defaultPass_.accessInstantAtDescendingNode(), defaultInstantAtDescendingNode_);
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, AccessInstantAtSouthPoint)
 {
     {
@@ -356,6 +605,28 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, AccessInstantAtSout
 
     {
         EXPECT_EQ(defaultPass_.accessInstantAtSouthPoint(), defaultInstantAtSouthPoint_);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, AccessInstantAtPassBreak)
+{
+    {
+        EXPECT_THROW(Pass::Undefined().accessInstantAtPassBreak(), ostk::core::error::runtime::Undefined);
+    }
+
+    {
+        EXPECT_EQ(defaultPass_.accessInstantAtPassBreak(), defaultInstantAtPassBreak_);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, Print)
+{
+    {
+        testing::internal::CaptureStdout();
+
+        EXPECT_NO_THROW(defaultPass_.print(std::cout, true));
+        EXPECT_NO_THROW(defaultPass_.print(std::cout, false));
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
     }
 }
 
@@ -378,13 +649,4 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, StringFromPhase)
     EXPECT_EQ(Pass::StringFromPhase(Pass::Phase::Undefined), "Undefined");
     EXPECT_EQ(Pass::StringFromPhase(Pass::Phase::Ascending), "Ascending");
     EXPECT_EQ(Pass::StringFromPhase(Pass::Phase::Descending), "Descending");
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Pass, StringFromQuarter)
-{
-    EXPECT_EQ(Pass::StringFromQuarter(Pass::Quarter::Undefined), "Undefined");
-    EXPECT_EQ(Pass::StringFromQuarter(Pass::Quarter::First), "First");
-    EXPECT_EQ(Pass::StringFromQuarter(Pass::Quarter::Second), "Second");
-    EXPECT_EQ(Pass::StringFromQuarter(Pass::Quarter::Third), "Third");
-    EXPECT_EQ(Pass::StringFromQuarter(Pass::Quarter::Fourth), "Fourth");
 }


### PR DESCRIPTION
- [x] Add tests to cover the remaining edge cases

The main lift here is having explicit definitions for all the parameters for a Pass. This was necessary as a Pass can be partial from both sides:
```
|        ----------------|
|--------------          |
```
Therefore we want explicit definitions for the ascending node, north point, descending node, south point and the pass break.
Where pass break is the ascending node for the _next_ pass.

This is also necessary to properly define whether the pass is complete or partial.

Note: While there are some breaking changes here, since this function was recently released and is not used anywhere (yet) we don't necessarily have to do a major version increase here.