### PR TITLE
feat: connect maneuver class with segments and propagator

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Maneuver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Maneuver.cpp
@@ -161,8 +161,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Maneuver(pybind11::module& aM
             )doc"
         )
         .def_static(
-            "constant_mass_flow_rate_profile",
-            &Maneuver::ConstantMassFlowRateProfile,
+            "from_tabulated_dynamics",
+            &Maneuver::FromTabulatedDynamics,
+            arg("tabulated_dynamics"),
+            R"doc(
+            Create a maneuver from tabulated dynamics with cols 1-3 being acceleration and col 4 being mass flow rate.
+
+            Args:
+                tabulated_dynamics (Tabulated): The tabulated dynamics.
+
+            Returns:
+                Maneuver: The created maneuver.
+        )doc"
+        )
+        .def_static(
+            "from_constant_mass_flow_rate_profile",
+            &Maneuver::FromConstantMassFlowRateProfile,
             arg("instants"),
             arg("acceleration_profile"),
             arg("frame"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Maneuver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Maneuver.cpp
@@ -32,7 +32,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Maneuver(pybind11::module& aM
                     instants (list[Instant]): An array of instants, must be sorted.
                     acceleration_profile (list[numpy.ndarray]): An acceleration profile of the maneuver, one numpy.ndarray per instant in m/s^2.
                     frame (Frame): A frame in which the acceleration profile is defined.
-                    mass_flow_rate_profile (list[float]):  A mass flow rate profile of the maneuver, one float per instant in kg/s.
+                    mass_flow_rate_profile (list[float]):  A mass flow rate profile of the maneuver (negative numbers expected), one float per instant in kg/s.
             )doc"
         )
 
@@ -174,7 +174,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Maneuver(pybind11::module& aM
                     instants (list[Instant]): An array of instants, must be sorted.
                     acceleration_profile (list[numpy.ndarray]): An acceleration profile of the maneuver, one numpy.ndarray per instant.
                     frame (Frame): A frame in which the acceleration profile is defined.
-                    mass_flow_rate (float): The constant mass flow rate.
+                    mass_flow_rate (float): The constant mass flow rate (negative number expected).
 
                 Returns:
                     Maneuver: The created maneuver.

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
@@ -9,21 +9,24 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
     using ostk::core::type::Shared;
     using ostk::core::container::Array;
 
+    using ostk::mathematics::curvefitting::Interpolator;
+
     using ostk::physics::Environment;
     using ostk::physics::time::Instant;
 
-    using ostk::astrodynamics::trajectory::state::NumericalSolver;
-    using ostk::astrodynamics::EventCondition;
     using ostk::astrodynamics::Dynamics;
+    using ostk::astrodynamics::EventCondition;
+    using ostk::astrodynamics::flight::Maneuver;
     using ostk::astrodynamics::flight::system::SatelliteSystem;
     using ostk::astrodynamics::trajectory::Propagator;
     using ostk::astrodynamics::trajectory::State;
+    using ostk::astrodynamics::trajectory::state::NumericalSolver;
 
     class_<Propagator>(
         aModule,
         "Propagator",
         R"doc(
-            A `Propagator` that proapgates the provided `State` using it's `NumericalSolver` under the set `Dynamics`.
+            A `Propagator` that propagates the provided `State` using it's `NumericalSolver` under the set `Dynamics`.
 
         )doc"
     )
@@ -44,6 +47,33 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
 
             )doc"
         )
+
+        .def(
+            init<
+                const NumericalSolver&,
+                const Array<Shared<Dynamics>>&,
+                const Array<Maneuver>&,
+                const Interpolator::Type&>(),
+            arg("numerical_solver"),
+            arg("dynamics"),
+            arg("maneuvers"),
+            arg("interpolation_type") = DEFAULT_MANEUVER_PROPAGATION_INTERPOLATION_TYPE,
+            R"doc(
+                Construct a new `Propagator` object with maneuvers.
+
+                Args:
+                    numerical_solver (NumericalSolver) The numerical solver.
+                    dynamics (list[Dynamics]) The dynamics.
+                    maneuvers (list[Maneuver]) The maneuvers.
+                    interpolation_type (Interpolator.Type, optional) The interpolation type. Defaults to Barycentric Rational.
+
+                Returns:
+                    Propagator: The new `Propagator` object.
+            )doc"
+        )
+
+        .def(self == self)
+        .def(self != self)
 
         .def("__str__", &(shiftToString<Propagator>))
         .def("__repr__", &(shiftToString<Propagator>))
@@ -123,6 +153,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
             &Propagator::clearDynamics,
             R"doc(
                 Clear the dynamics.
+
+            )doc"
+        )
+
+        .def(
+            "add_maneuver",
+            &Propagator::addManeuver,
+            arg("maneuver"),
+            arg("interpolation_type") = DEFAULT_MANEUVER_PROPAGATION_INTERPOLATION_TYPE,
+            R"doc(
+                Add a maneuver.
+
+                Args:
+                    maneuver (Maneuver) The maneuver.
+                    interpolation_type (Interpolator.Type, optional) The interpolation type. Defaults to Barycentric Rational.
 
             )doc"
         )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -12,10 +12,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
 
     using ostk::physics::time::Duration;
 
+    using ostk::astrodynamics::Dynamics;
+    using ostk::astrodynamics::flight::Maneuver;
+    using ostk::astrodynamics::trajectory::Segment;
     using ostk::astrodynamics::trajectory::state::NumericalSolver;
     using ostk::astrodynamics::trajectory::state::CoordinateSubset;
-    using ostk::astrodynamics::trajectory::Segment;
-    using ostk::astrodynamics::Dynamics;
 
     class_<Segment> segment(
         aModule,
@@ -185,6 +186,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
 
                 Returns:
                     Mass: The delta mass.
+
+            )doc"
+        )
+
+        .def(
+            "extract_maneuvers",
+            &Segment::Solution::extractManeuvers,
+            arg("frame"),
+            R"doc(
+            Extract maneuvers from the (maneuvering) segment.
+
+            Returns:
+                list[Maneuver]: The list of maneuvers.
 
             )doc"
         )

--- a/bindings/python/test/dynamics/test_tabulated.py
+++ b/bindings/python/test/dynamics/test_tabulated.py
@@ -38,16 +38,16 @@ def instants() -> list[Instant]:
 def contribution_profile() -> np.ndarray:
     return np.array(
         [
-            [1.0, 2.0, 3.0],
-            [4.0, 5.0, 6.0],
-            [7.0, 8.0, 9.0],
-            [10.0, 11.0, 12.0],
-            [13.0, 14.0, 15.0],
-            [16.0, 17.0, 18.0],
-            [19.0, 20.0, 21.0],
-            [22.0, 23.0, 24.0],
-            [25.0, 26.0, 27.0],
-            [28.0, 29.0, 30.0],
+            [1.0, 2.0, 3.0, -1.0],
+            [4.0, 5.0, 6.0, -1.0],
+            [7.0, 8.0, 9.0, -1.0],
+            [10.0, 11.0, 12.0, -1.0],
+            [13.0, 14.0, 15.0, -1.0],
+            [16.0, 17.0, 18.0, -1.0],
+            [19.0, 20.0, 21.0, -1.0],
+            [22.0, 23.0, 24.0, -1.0],
+            [25.0, 26.0, 27.0, -1.0],
+            [28.0, 29.0, 30.0, -1.0],
         ]
     )
 
@@ -56,6 +56,7 @@ def contribution_profile() -> np.ndarray:
 def coordinate_subsets() -> list[CoordinateSubset]:
     return [
         CartesianVelocity.default(),
+        CoordinateSubset.mass(),
     ]
 
 
@@ -120,4 +121,4 @@ class TestTabulated:
             )
 
             assert new_contribution is not None
-            assert len(new_contribution) == 3
+            assert len(new_contribution) == 4

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
@@ -67,7 +67,8 @@ class Maneuver
     /// @param anInstantArray An array of instants, must be sorted
     /// @param anAccelerationProfile An acceleration profile of the maneuver, one Vector3d per instant in m/s^2
     /// @param aFrameSPtr A frame in which the acceleration profile is defined
-    /// @param aMassFlowRateProfile A mass flow rate profile of the maneuver, one Real per instant in kg/s
+    /// @param aMassFlowRateProfile A mass flow rate profile of the maneuver (negative numbers expected), one Real per
+    /// instant in kg/s
     Maneuver(
         const Array<Instant>& anInstantArray,
         const Array<Vector3d>& anAccelerationProfile,
@@ -205,17 +206,33 @@ class Maneuver
     /// @param (optional) displayDecorators If true, display decorators
     void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
 
+    /// @brief Create a maneuver from a tabulated dynamics with cols 1-3 being acceleration and col 4 being mass flow
+    /// rate
+    ///
+    /// @code{.cpp}
+    ///                  Shared<Dynamics> tabulatedDynamicsSPtr = std::make_shared<TabulatedDynamics>(tabulated);
+    ///                  Maneuver maneuver = Maneuver::FromTabulatedDynamics(tabulatedDynamicsSPtr);
+    /// @endcode
+    ///
+    /// @param aTabulatedDynamicsSPtr A shared pointer to a Dynamics object (that is downcastable to a TabulatedDynamics
+    /// object)
+    ///
+    /// @return A maneuver
+    static Maneuver FromTabulatedDynamics(const Shared<Dynamics>& aTabulatedDynamicsSPtr);
+
     /// @brief Create a maneuver from a constant mass flow rate profile
     ///
     /// @code{.cpp}
-    ///                  Maneuver maneuver = Maneuver::ConstantMassFlowRateProfile(...);
+    ///                  Maneuver maneuver = Maneuver::FromConstantMassFlowRateProfile(...);
     /// @endcode
     ///
     /// @param anInstantArray An array of instants, must be sorted
     /// @param anAccelerationProfile An acceleration profile of the maneuver, one Vector3d per instant in m/s^2
     /// @param aFrameSPtr A frame in which the acceleration profile is defined
     /// @param aMassFlowRate A constant mass flow rate that will be used for all the instants in the maneuver in kg/s
-    static Maneuver ConstantMassFlowRateProfile(
+    ///
+    /// @return A maneuver
+    static Maneuver FromConstantMassFlowRateProfile(
         const Array<Instant>& anInstantArray,
         const Array<Vector3d>& anAccelerationProfile,
         const Shared<const Frame>& aFrameSPtr,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -12,11 +12,12 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp>
 
@@ -38,12 +39,12 @@ using ostk::physics::time::Instant;
 using ostk::physics::time::Duration;
 using ostk::physics::unit::Mass;
 
-using ostk::astrodynamics::trajectory::State;
-using ostk::astrodynamics::trajectory::state::NumericalSolver;
-using ostk::astrodynamics::trajectory::orbit::model::Propagated;
 using ostk::astrodynamics::Dynamics;
 using ostk::astrodynamics::dynamics::Thruster;
 using ostk::astrodynamics::EventCondition;
+using ostk::astrodynamics::flight::Maneuver;
+using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::NumericalSolver;
 
 /// @brief Represent a propagation segment for astrodynamics purposes
 class Segment
@@ -104,6 +105,12 @@ class Segment
         /// @brief Compute delta mass
         /// @return Delta mass
         Mass computeDeltaMass() const;
+
+        /// @brief Extract maneuvers from the (maneuvering) segment
+        ///
+        /// @param aFrameSPtr Frame
+        /// @return Array of maneuvers
+        Array<Maneuver> extractManeuvers(const Shared<const Frame>& aFrameSPtr) const;
 
         /// @brief Calculate intermediate states at specified Instants using the provided Numerical Solver
         ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
@@ -41,6 +41,21 @@ Propagator::Propagator(const NumericalSolver& aNumericalSolver, const Array<Shar
     this->setDynamics(aDynamicsArray);
 }
 
+Propagator::Propagator(
+    const NumericalSolver& aNumericalSolver,
+    const Array<Shared<Dynamics>>& aDynamicsArray,
+    const Array<Maneuver>& aManeuverArray,
+    const Interpolator::Type& anInterpolationType
+)
+    : Propagator(aNumericalSolver, aDynamicsArray)
+{
+    // TBM: in the future maybe sanitize the instants of each maneuver to make sure none of them are overalapping
+    for (const Maneuver& maneuver : aManeuverArray)
+    {
+        this->addManeuver(maneuver, anInterpolationType);
+    }
+}
+
 Propagator::Propagator(const Propagator& aPropagator)
     : coordinatesBrokerSPtr_(std::make_shared<CoordinateBroker>(*aPropagator.coordinatesBrokerSPtr_)),
       dynamicsContexts_(aPropagator.dynamicsContexts_),
@@ -134,6 +149,11 @@ void Propagator::setDynamics(const Array<Shared<Dynamics>>& aDynamicsArray)
     {
         this->addDynamics(aDynamicsSPtr);
     }
+}
+
+void Propagator::addManeuver(const Maneuver& aManeuver, const Interpolator::Type& anInterpolationType)
+{
+    this->addDynamics(aManeuver.toTabulatedDynamics(IntegrationFrameSPtr, anInterpolationType));
 }
 
 void Propagator::addDynamics(const Shared<Dynamics>& aDynamicsSPtr)

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
@@ -393,6 +393,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, ToTabulatedDynamics)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
 {
+    // Verify creation from tabulated dynamics
     {
         const Shared<TabulatedDynamics> tabulatedDynamicsSPtr =
             defaultManeuver_.toTabulatedDynamics(defaultFrameSPtr_, Interpolator::Type::BarycentricRational);
@@ -404,6 +405,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
         EXPECT_EQ(maneuver.getMassFlowRateProfile(), defaultMassFlowRateProfile_);
     }
 
+    // Verify creation from dynamics
     {
         const Shared<Dynamics> tabulatedDynamicsSPtr =
             defaultManeuver_.toTabulatedDynamics(defaultFrameSPtr_, Interpolator::Type::BarycentricRational);
@@ -442,6 +444,34 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
         const Shared<TabulatedDynamics> wrongTabulatedDynamicsSPtr = std::make_shared<TabulatedDynamics>(
             defaultInstants_,
             MatrixXd::Zero(defaultInstants_.getSize(), 3),
+            writeCoordinateSubsets,
+            defaultFrameSPtr_,
+            Interpolator::Type::BarycentricRational
+        );
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver::FromTabulatedDynamics(wrongTabulatedDynamicsSPtr);
+                }
+                catch (const ostk::core::error::runtime::Wrong& e)
+                {
+                    EXPECT_EQ("{Tabulated Dynamics Write Coordinate Subsets} is wrong.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::runtime::Wrong
+        );
+    }
+
+    // Wrong dynamics coordinate subsets fail
+    {
+        const Array<Shared<const CoordinateSubset>> writeCoordinateSubsets = {CoordinateSubset::Mass()};
+
+        const Shared<TabulatedDynamics> wrongTabulatedDynamicsSPtr = std::make_shared<TabulatedDynamics>(
+            defaultInstants_,
+            MatrixXd::Zero(defaultInstants_.getSize(), 1),
             writeCoordinateSubsets,
             defaultFrameSPtr_,
             Interpolator::Type::BarycentricRational

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
@@ -16,6 +16,7 @@
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
+#include <OpenSpaceToolkit/Astrodynamics/Dynamics.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
@@ -42,6 +43,7 @@ using ostk::physics::time::Instant;
 using ostk::physics::time::Interval;
 using ostk::physics::unit::Mass;
 
+using ostk::astrodynamics::Dynamics;
 using TabulatedDynamics = ostk::astrodynamics::dynamics::Tabulated;
 using ostk::astrodynamics::flight::Maneuver;
 using ostk::astrodynamics::flight::system::PropulsionSystem;
@@ -68,8 +70,8 @@ class OpenSpaceToolkit_Astrodynamics_Flight_Maneuver : public ::testing::Test
     const Shared<const Frame> defaultFrameSPtr_ = Frame::GCRF();
     const Shared<const Frame> secondFrameSPtr_ = Frame::ITRF();
 
-    const Array<Real> defaultMassFlowRateProfile_ = {1.0e-5, 1.1e-5, 0.9e-5, 1.0e-5};
-    const Real defaultConstantMassFlowRate_ = 0.5e-5;
+    const Array<Real> defaultMassFlowRateProfile_ = {-1.0e-5, -1.1e-5, -0.9e-5, -1.0e-5};
+    const Real defaultConstantMassFlowRate_ = -0.5e-5;
 
     const Maneuver defaultManeuver_ = {
         defaultInstants_, defaultAccelerationProfileDefaultFrame_, defaultFrameSPtr_, defaultMassFlowRateProfile_
@@ -120,6 +122,54 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Constructor)
     }
 
     {
+        const Array<Real> shorterMassFlowRateProfile = {-1.0e-5, -1.1e-5, -0.9e-5};
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver(
+                        defaultInstants_,
+                        defaultAccelerationProfileDefaultFrame_,
+                        defaultFrameSPtr_,
+                        shorterMassFlowRateProfile
+                    );
+                }
+                catch (const ostk::core::error::RuntimeError& e)
+                {
+                    EXPECT_EQ(
+                        "Mass flow rate profile must have the same number of elements as the number of instants.",
+                        e.getMessage()
+                    );
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    {
+        const Array<Instant> emptyInstants = {defaultInstants_[0]};
+        const Array<Vector3d> emptyAccelerationProfile = {defaultAccelerationProfileDefaultFrame_[0]};
+        const Array<Real> emptyMassFlowRateProfile = {defaultMassFlowRateProfile_[0]};
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver(emptyInstants, emptyAccelerationProfile, defaultFrameSPtr_, emptyMassFlowRateProfile);
+                }
+                catch (const ostk::core::error::RuntimeError& e)
+                {
+                    EXPECT_EQ("At least two instants are required to define a maneuver.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    {
         EXPECT_THROW(
             {
                 try
@@ -162,6 +212,30 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Constructor)
                 }
             },
             ostk::core::error::runtime::Wrong
+        );
+    }
+
+    {
+        const Array<Real> positiveMassFlowRateProfile = {1.0e-5, 1.1e-5, 0.9e-5, 1.0e-5};
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver(
+                        defaultInstants_,
+                        defaultAccelerationProfileDefaultFrame_,
+                        defaultFrameSPtr_,
+                        positiveMassFlowRateProfile
+                    );
+                }
+                catch (const ostk::core::error::RuntimeError& e)
+                {
+                    EXPECT_EQ("Mass flow rate profile must be expressed in negative numbers.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
         );
     }
 }
@@ -267,24 +341,23 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Getters)
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, CalculateScalarQuantities)
 {
     {
-        EXPECT_NEAR(0.0013941812040755494, defaultManeuver_.calculateDeltaV(), 1.0e-15);
+        EXPECT_DOUBLE_EQ(0.0013941812040755494, defaultManeuver_.calculateDeltaV());
     }
 
     {
-        EXPECT_NEAR(1.26e-4, defaultManeuver_.calculateDeltaMass().inKilograms(), 1.0e-15);
+        EXPECT_DOUBLE_EQ(1.26e-4, defaultManeuver_.calculateDeltaMass().inKilograms());
     }
 
     {
-        EXPECT_NEAR(
-            0.13941806994799905, defaultManeuver_.calculateAverageThrust(Mass(100.0, Mass::Unit::Kilogram)), 1.0e-15
+        EXPECT_DOUBLE_EQ(
+            0.13941817086711084, defaultManeuver_.calculateAverageThrust(Mass(100.0, Mass::Unit::Kilogram))
         );
     }
 
     {
-        EXPECT_NEAR(
-            789.81592393369704,
-            defaultManeuver_.calculateAverageSpecificImpulse(Mass(100.0, Mass::Unit::Kilogram)),
-            1.0e-15
+        EXPECT_DOUBLE_EQ(
+            789.81649564955535, defaultManeuver_.calculateAverageSpecificImpulse(Mass(100.0, Mass::Unit::Kilogram))
+
         );
     }
 }
@@ -318,10 +391,83 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, ToTabulatedDynamics)
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, ConstantMassFlowRateProfile)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
 {
     {
-        const Maneuver maneuver = Maneuver::ConstantMassFlowRateProfile(
+        const Shared<TabulatedDynamics> tabulatedDynamicsSPtr =
+            defaultManeuver_.toTabulatedDynamics(defaultFrameSPtr_, Interpolator::Type::BarycentricRational);
+
+        const Maneuver maneuver = Maneuver::FromTabulatedDynamics(tabulatedDynamicsSPtr);
+
+        EXPECT_EQ(maneuver.getInstants(), defaultInstants_);
+        EXPECT_EQ(maneuver.getAccelerationProfile(defaultFrameSPtr_), defaultAccelerationProfileDefaultFrame_);
+        EXPECT_EQ(maneuver.getMassFlowRateProfile(), defaultMassFlowRateProfile_);
+    }
+
+    {
+        const Shared<Dynamics> tabulatedDynamicsSPtr =
+            defaultManeuver_.toTabulatedDynamics(defaultFrameSPtr_, Interpolator::Type::BarycentricRational);
+
+        const Maneuver maneuver = Maneuver::FromTabulatedDynamics(tabulatedDynamicsSPtr);
+
+        EXPECT_EQ(maneuver.getInstants(), defaultInstants_);
+        EXPECT_EQ(maneuver.getAccelerationProfile(defaultFrameSPtr_), defaultAccelerationProfileDefaultFrame_);
+        EXPECT_EQ(maneuver.getMassFlowRateProfile(), defaultMassFlowRateProfile_);
+    }
+
+    // Nullptr fail
+    {
+        const Shared<Dynamics> tabulatedDynamicsSPtr = nullptr;
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver::FromTabulatedDynamics(tabulatedDynamicsSPtr);
+                }
+                catch (const ostk::core::error::runtime::Undefined& e)
+                {
+                    EXPECT_EQ("{Tabulated Dynamics} is undefined.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::runtime::Undefined
+        );
+    }
+
+    // Wrong dynamics coordinate subsets fail
+    {
+        const Array<Shared<const CoordinateSubset>> writeCoordinateSubsets = {CartesianVelocity::Default()};
+
+        const Shared<TabulatedDynamics> wrongTabulatedDynamicsSPtr = std::make_shared<TabulatedDynamics>(
+            defaultInstants_,
+            MatrixXd::Zero(defaultInstants_.getSize(), 3),
+            writeCoordinateSubsets,
+            defaultFrameSPtr_,
+            Interpolator::Type::BarycentricRational
+        );
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver::FromTabulatedDynamics(wrongTabulatedDynamicsSPtr);
+                }
+                catch (const ostk::core::error::runtime::Wrong& e)
+                {
+                    EXPECT_EQ("{Tabulated Dynamics Write Coordinate Subsets} is wrong.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::runtime::Wrong
+        );
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromConstantMassFlowRateProfile)
+{
+    {
+        const Maneuver maneuver = Maneuver::FromConstantMassFlowRateProfile(
             defaultInstants_, defaultAccelerationProfileDefaultFrame_, defaultFrameSPtr_, defaultConstantMassFlowRate_
         );
 


### PR DESCRIPTION
This MR will connect the `Maneuver` class from[ this MR](https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/333) to other classes in OSTk in order to be leverage with them. This MR adds methods to add extract maneuvers from a `SegmentSolution` once it has been solved and then repopagate over them seemlessly with the  `Propagator` by allow it to have maneuvers added to its dynamics as `TabulatedDynamics`. 

Progress:

- [x] Add logic to other classes interacting with Maneuver object
- [x] Add bindings for these new methods
- [x] Add unit tests for the new methods