### PR TITLE
fix: incomplete solve namespace update and OSTk physics bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Physics
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "5.0" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "5.1" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solver.cpp
@@ -9,6 +9,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solver(pybind11::module& aModule)
     auto solver = aModule.def_submodule("solver");
 
     // Add objects to "solver" submodule
-    OpenSpaceToolkitAstrodynamicsPy_Solvers_TemporalConditionSolver(solver);
-    OpenSpaceToolkitAstrodynamicsPy_Solvers_FiniteDifferenceSolver(solver);
+    OpenSpaceToolkitAstrodynamicsPy_Solver_TemporalConditionSolver(solver);
+    OpenSpaceToolkitAstrodynamicsPy_Solver_FiniteDifferenceSolver(solver);
 }

--- a/bindings/python/test/solvers/test_finite_difference_solver.py
+++ b/bindings/python/test/solvers/test_finite_difference_solver.py
@@ -9,7 +9,7 @@ from ostk.physics.coordinate import Frame
 from ostk.physics.time import Instant
 from ostk.physics.time import Duration
 
-from ostk.astrodynamics.solvers import FiniteDifferenceSolver
+from ostk.astrodynamics.solver import FiniteDifferenceSolver
 from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory.state import CoordinateSubset
 

--- a/bindings/python/test/solvers/test_temporal_condition_solver.py
+++ b/bindings/python/test/solvers/test_temporal_condition_solver.py
@@ -15,7 +15,7 @@ from ostk.astrodynamics.trajectory import Orbit
 from ostk.astrodynamics.trajectory.orbit.model import Kepler
 from ostk.astrodynamics.trajectory.orbit.model.kepler import COE
 from ostk.astrodynamics.access import Generator
-from ostk.astrodynamics.solvers import TemporalConditionSolver
+from ostk.astrodynamics.solver import TemporalConditionSolver
 
 
 @pytest.fixture


### PR DESCRIPTION
The [solver namespace update](https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/351) was done incompletely, forgetting a couple items in the bindings. This fixes that.

The[ OSTk physics bump to 5.1.0 ](https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/347)update was done incompletely, and this also fixes that.