### PR TITLE
refactor: propulsion system to use Reals instead of Scalar

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
@@ -1,7 +1,5 @@
 /// Apache License 2.0
 
-#include <OpenSpaceToolkit/Physics/Unit.hpp>
-
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybind11::module& aModule)
@@ -9,8 +7,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
     using namespace pybind11;
 
     using ostk::core::type::Real;
-
-    using ostk::physics::unit::Mass;
 
     using ostk::astrodynamics::flight::system::PropulsionSystem;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/System/PropulsionSystem.cpp
@@ -10,9 +10,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
 
     using ostk::core::type::Real;
 
-    using ostk::physics::Unit;
     using ostk::physics::unit::Mass;
-    using ostk::physics::data::Scalar;
 
     using ostk::astrodynamics::flight::system::PropulsionSystem;
 
@@ -25,20 +23,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
 
             )doc"
         )
-
-            // .def(
-            //     init([](const Real& thrust, const Unit& thrustUnit, const Real& specificImpulse, const Unit&
-            //     specificImpulseUnit)
-            //     {
-            //         return PropulsionSystem(Scalar(thrust, thrustUnit), Scalar(specificImpulse,
-            //         specificImpulseUnit));
-            //     }
-            //     ),
-            //     arg("thrust"),
-            //     arg("thrust_unit"),
-            //     arg("specific_impulse"),
-            //     arg("specific_unit")
-            // )
 
             .def(
                 init<const Real&, const Real&>(),
@@ -56,8 +40,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
             .def(self == self)
             .def(self != self)
 
-            // .def("__str__", &(shiftToString<PropulsionSystem>))
-            // .def("__repr__", &(shiftToString<PropulsionSystem>))
+            .def("__str__", &(shiftToString<PropulsionSystem>))
+            .def("__repr__", &(shiftToString<PropulsionSystem>))
 
             .def(
                 "is_defined",
@@ -70,10 +54,50 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_System_PropulsionSystem(pybin
                 )doc"
             )
 
-            // .def("get_thrust", &PropulsionSystem::getThrust)
-            // .def("get_specific_impulse", &PropulsionSystem::getSpecificImpulse)
-            // .def("get_mass_flow_rate", &PropulsionSystem::getMassFlowRate) Scalar output
-            // .def("get_acceleration", &PropulsionSystem::getAcceleration, arg("mass"))
+            .def(
+                "get_thrust",
+                &PropulsionSystem::getThrust,
+                R"doc(
+                    Return the thrust.
+
+                    Returns:
+                        float: The thrust in Newton.
+                )doc"
+            )
+            .def(
+                "get_specific_impulse",
+                &PropulsionSystem::getSpecificImpulse,
+                R"doc(
+                    Return the specific impulse.
+
+                    Returns:
+                        float: The specific impulse in Seconds.
+                )doc"
+            )
+            .def(
+                "get_mass_flow_rate",
+                &PropulsionSystem::getMassFlowRate,
+                R"doc(
+                    Return the mass flow rate.
+
+                    Returns:
+                        float: The mass flow rate in Kilograms per Second.
+                )doc"
+            )
+            .def(
+                "get_acceleration",
+                &PropulsionSystem::getAcceleration,
+                arg("mass"),
+                R"doc(
+                    Return the acceleration.
+
+                    Args:
+                        mass (float): Mass in Kilograms.
+
+                    Returns:
+                        float: The acceleration in Meters per Second squared.
+                )doc"
+            )
 
             .def_static(
                 "undefined",

--- a/bindings/python/test/flight/system/test_propulsion_system.py
+++ b/bindings/python/test/flight/system/test_propulsion_system.py
@@ -23,6 +23,11 @@ def propulsion_system() -> PropulsionSystem:
     )
 
 
+@pytest.fixture
+def mass() -> Mass:
+    return Mass(90.0, Mass.Unit.Kilogram)
+
+
 class TestPropulsionSystem:
     def test_constructors(
         self,
@@ -44,3 +49,25 @@ class TestPropulsionSystem:
         propulsion_system: PropulsionSystem,
     ):
         assert propulsion_system.is_defined()
+
+    def test_getters(
+        self,
+        propulsion_system: PropulsionSystem,
+        mass: Mass,
+    ):
+        assert propulsion_system.get_thrust() == 1.0
+        assert propulsion_system.get_specific_impulse() == 150.0
+        assert propulsion_system.get_mass_flow_rate() is not None
+        assert propulsion_system.get_acceleration(mass) is not None
+
+    def test_static_methods(
+        self,
+        mass: Mass,
+    ):
+        assert PropulsionSystem.undefined().is_defined() is False
+
+        assert PropulsionSystem.default().is_defined() is True
+        assert PropulsionSystem.default().get_thrust() is not None
+        assert PropulsionSystem.default().get_specific_impulse() is not None
+        assert PropulsionSystem.default().get_mass_flow_rate() is not None
+        assert PropulsionSystem.default().get_acceleration(mass) is not None

--- a/bindings/python/test/guidance_law/test_qlaw.py
+++ b/bindings/python/test/guidance_law/test_qlaw.py
@@ -12,7 +12,6 @@ from ostk.physics.time import Instant
 from ostk.physics.coordinate import Frame
 from ostk.physics.unit import Length
 from ostk.physics.unit import Angle
-from ostk.physics.unit import Derived
 
 
 from ostk.astrodynamics.trajectory.orbit.model.kepler import COE

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp
@@ -5,11 +5,7 @@
 
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 
-#include <OpenSpaceToolkit/Physics/Data/Direction.hpp>
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
-#include <OpenSpaceToolkit/Physics/Unit.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Time.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
 namespace ostk
 {
@@ -22,34 +18,12 @@ namespace system
 
 using ostk::core::type::Real;
 
-using ostk::physics::data::Direction;
-using ostk::physics::data::Scalar;
-using ostk::physics::unit::Length;
 using ostk::physics::unit::Mass;
-using ostk::physics::unit::Time;
-using ostk::physics::unit::ElectricCurrent;
-using ostk::physics::unit::Angle;
-using ostk::physics::unit::Derived;
-using ostk::physics::Unit;
 
 /// @brief Define a propulsion system (constant thrust, constant Isp for now)
 class PropulsionSystem
 {
    public:
-    static Unit thrustSIUnit;
-    static Unit specificImpulseSIUnit;
-    static Unit massFlowRateSIUnit;  // TBI: Define in ostk physics as proper units
-
-    /// @brief Constructor
-    ///
-    /// @code{.cpp}
-    ///              PropulsionSystem propulsion = { ... };
-    /// @endcode
-    ///
-    /// @param aThrust Thrust (scalar)
-    /// @param aSpecificImpulse Specific impulse (scalar)
-    PropulsionSystem(const Scalar& aThrust, const Scalar& aSpecificImpulse);
-
     /// @brief Constructor
     ///
     /// @code{.cpp}
@@ -93,39 +67,39 @@ class PropulsionSystem
     /// @brief Get propulsion system's thrust
     ///
     /// @code{.cpp}
-    ///              Scalar thrust = propulsionSystem.getThrust();
+    ///              Real thrust = propulsionSystem.getThrust();
     /// @endcode
     ///
-    /// @return Scalar
-    Scalar getThrust() const;
+    /// @return Real
+    Real getThrust() const;
 
     /// @brief Get propulsion system's specific impulse
     ///              https://en.wikipedia.org/wiki/Specific_impulse
     ///
     /// @code{.cpp}
-    ///              Scalar specificImpulse = propulsionSystem.getSpecificImpulse();
+    ///              Real specificImpulse = propulsionSystem.getSpecificImpulse();
     /// @endcode
     ///
-    /// @return Scalar
-    Scalar getSpecificImpulse() const;
+    /// @return Real
+    Real getSpecificImpulse() const;
 
     /// @brief Get propulsion system's mass flow rate
     ///
     /// @code{.cpp}
-    ///              Scalar massFlowRate = propulsionSystem.getMassFlowRate();
+    ///              Real massFlowRate = propulsionSystem.getMassFlowRate();
     /// @endcode
     ///
-    /// @return Scalar
-    Scalar getMassFlowRate() const;
+    /// @return Real
+    Real getMassFlowRate() const;
 
     /// @brief Get propulsion system's acceleration
     ///
     /// @code{.cpp}
-    ///              Scalar acceleration = propulsionSystem.getAcceleration();
+    ///              Real acceleration = propulsionSystem.getAcceleration();
     /// @endcode
     ///
-    /// @return Scalar
-    Scalar getAcceleration(const Mass& aMass) const;
+    /// @return Real
+    Real getAcceleration(const Mass& aMass) const;
 
     /// @brief Undefined propulsion system
     ///
@@ -146,9 +120,9 @@ class PropulsionSystem
     static PropulsionSystem Default();
 
    private:
-    Scalar thrust_ = Scalar::Undefined();           /// Thrust [N]
-    Scalar specificImpulse_ = Scalar::Undefined();  /// Specific impulse [s]
-    Scalar massFlowRate_ = Scalar::Undefined();     /// Mass flow rate [kg/s]
+    Real thrust_;           /// Thrust [N]
+    Real specificImpulse_;  /// Specific impulse [s]
+    Real massFlowRate_;     /// Mass flow rate [kg/s]
 };
 
 }  // namespace system

--- a/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.hpp
@@ -7,7 +7,6 @@
 
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
-#include <OpenSpaceToolkit/Physics/Data/Direction.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.hpp>

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/AtmosphericDrag.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/AtmosphericDrag.cpp
@@ -29,9 +29,6 @@ using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
-static const Derived::Unit GravitationalParameterSIUnit =
-    Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second);
-
 AtmosphericDrag::AtmosphericDrag(const Shared<const Celestial>& aCelestialSPtr)
     : AtmosphericDrag(aCelestialSPtr, String::Format("Atmospheric Drag [{}]", aCelestialSPtr->getName()))
 {

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/CentralBodyGravity.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/CentralBodyGravity.cpp
@@ -17,16 +17,9 @@ namespace dynamics
 using ostk::mathematics::object::Vector3d;
 
 using ostk::physics::coordinate::Position;
-using ostk::physics::data::Vector;
-using ostk::physics::unit::Derived;
-using ostk::physics::unit::Length;
-using ostk::physics::unit::Time;
 
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
-
-static const Derived::Unit GravitationalParameterSIUnit =
-    Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second);
 
 CentralBodyGravity::CentralBodyGravity(const Shared<const Celestial>& aCelestialObjectSPtr)
     : CentralBodyGravity(

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/PositionDerivative.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/PositionDerivative.cpp
@@ -3,8 +3,6 @@
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
-
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/PositionDerivative.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/ThirdBodyGravity.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/ThirdBodyGravity.cpp
@@ -19,16 +19,9 @@ using ostk::core::type::String;
 using ostk::mathematics::object::Vector3d;
 
 using ostk::physics::coordinate::Position;
-using ostk::physics::data::Vector;
-using ostk::physics::unit::Derived;
-using ostk::physics::unit::Length;
-using ostk::physics::unit::Time;
 
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
-
-static const Derived::Unit GravitationalParameterSIUnit =
-    Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second);
 
 ThirdBodyGravity::ThirdBodyGravity(const Shared<const Celestial>& aCelestialObjectSPtr)
     : ThirdBodyGravity(aCelestialObjectSPtr, String::Format("Third Body Gravity [{}]", aCelestialObjectSPtr->getName()))

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.cpp
@@ -35,8 +35,7 @@ Thruster::Thruster(
       satelliteSystem_(aSatelliteSystem),
       guidanceLaw_(aGuidanceLaw),
       massFlowRateCache_(
-          aSatelliteSystem.isDefined() ? aSatelliteSystem.accessPropulsionSystem().getMassFlowRate().getValue()
-                                       : Real::Undefined()
+          aSatelliteSystem.isDefined() ? aSatelliteSystem.accessPropulsionSystem().getMassFlowRate() : Real::Undefined()
       )
 {
 }
@@ -93,7 +92,7 @@ VectorXd Thruster::computeContribution(
     }
 
     const Real maximumThrustAccelerationMagnitude =
-        satelliteSystem_.accessPropulsionSystem().getAcceleration(Mass::Kilograms(x[6])).getValue();
+        satelliteSystem_.accessPropulsionSystem().getAcceleration(Mass::Kilograms(x[6]));
 
     const Vector3d acceleration = guidanceLaw_->calculateThrustAccelerationAt(
         anInstant, positionCoordinates, velocityCoordinates, maximumThrustAccelerationMagnitude, aFrameSPtr

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -18,66 +18,14 @@ namespace system
 
 using ostk::physics::environment::gravitational::Earth;
 
-ostk::physics::Unit PropulsionSystem::thrustSIUnit = Unit::Derived(Derived::Unit(
-    Length::Unit::Meter,
-    {1},
-    Mass::Unit::Kilogram,
-    {1},
-    Time::Unit::Second,
-    {-2},
-    ElectricCurrent::Unit::Undefined,
-    {0},
-    Angle::Unit::Undefined,
-    {0}
-));
-
-ostk::physics::Unit PropulsionSystem::specificImpulseSIUnit = Unit::Derived(Derived::Unit(
-    Length::Unit::Undefined,
-    {0},
-    Mass::Unit::Undefined,
-    {0},
-    Time::Unit::Second,
-    {1},
-    ElectricCurrent::Unit::Undefined,
-    {0},
-    Angle::Unit::Undefined,
-    {0}
-));
-
-ostk::physics::Unit PropulsionSystem::massFlowRateSIUnit = Unit::Derived(Derived::Unit(
-    Length::Unit::Undefined,
-    {0},
-    Mass::Unit::Kilogram,
-    {1},
-    Time::Unit::Second,
-    {-1},
-    ElectricCurrent::Unit::Undefined,
-    {0},
-    Angle::Unit::Undefined,
-    {0}
-));
-
-PropulsionSystem::PropulsionSystem(const Scalar& aThrust, const Scalar& aSpecificImpulse)
-{
-    if (aThrust.isDefined() && aSpecificImpulse.isDefined())
-    {
-        thrust_ = aThrust.inUnit(thrustSIUnit);
-        specificImpulse_ = aSpecificImpulse.inUnit(specificImpulseSIUnit);
-
-        massFlowRate_ = {
-            aThrust.getValue() / (aSpecificImpulse.getValue() * Earth::gravityConstant), massFlowRateSIUnit
-        };
-    }
-}
-
 PropulsionSystem::PropulsionSystem(const Real& aThrustInSIUnit, const Real& aSpecificImpulseInSIUnit)
+    : thrust_(aThrustInSIUnit),
+      specificImpulse_(aSpecificImpulseInSIUnit),
+      massFlowRate_(Real::Undefined())
 {
-    thrust_ = Scalar(aThrustInSIUnit, thrustSIUnit);
-    specificImpulse_ = Scalar(aSpecificImpulseInSIUnit, specificImpulseSIUnit);
-
     if (aThrustInSIUnit.isDefined() && aSpecificImpulseInSIUnit.isDefined())
     {
-        massFlowRate_ = {aThrustInSIUnit / (aSpecificImpulseInSIUnit * Earth::gravityConstant), massFlowRateSIUnit};
+        massFlowRate_ = {aThrustInSIUnit / (aSpecificImpulseInSIUnit * Earth::gravityConstant)};
     }
 }
 
@@ -123,7 +71,7 @@ void PropulsionSystem::print(std::ostream& anOutputStream, bool displayDecorator
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 
-Scalar PropulsionSystem::getThrust() const
+Real PropulsionSystem::getThrust() const
 {
     if (!this->isDefined())
     {
@@ -133,7 +81,7 @@ Scalar PropulsionSystem::getThrust() const
     return thrust_;
 }
 
-Scalar PropulsionSystem::getSpecificImpulse() const
+Real PropulsionSystem::getSpecificImpulse() const
 {
     if (!this->isDefined())
     {
@@ -143,7 +91,7 @@ Scalar PropulsionSystem::getSpecificImpulse() const
     return specificImpulse_;
 }
 
-Scalar PropulsionSystem::getMassFlowRate() const
+Real PropulsionSystem::getMassFlowRate() const
 {
     if (!this->isDefined())
     {
@@ -153,32 +101,29 @@ Scalar PropulsionSystem::getMassFlowRate() const
     return massFlowRate_;
 }
 
-Scalar PropulsionSystem::getAcceleration(const Mass& aMass) const
+Real PropulsionSystem::getAcceleration(const Mass& aMass) const
 {
     if (!this->isDefined())
     {
         throw ostk::core::error::runtime::Undefined("PropulsionSystem");
     }
 
-    return {
-        thrust_.getValue() / aMass.inKilograms(),
-        Unit::Derived(Derived::Unit::Acceleration(Length::Unit::Meter, Time::Unit::Second)),
-    };
+    return {thrust_ / aMass.inKilograms()};
 }
 
 PropulsionSystem PropulsionSystem::Undefined()
 {
     return {
-        Scalar(Real::Undefined(), thrustSIUnit),
-        Scalar(Real::Undefined(), specificImpulseSIUnit),
+        Real::Undefined(),
+        Real::Undefined(),
     };
 }
 
 PropulsionSystem PropulsionSystem::Default()
 {
     return {
-        Scalar(1.0, thrustSIUnit),
-        Scalar(1000.0, specificImpulseSIUnit),
+        1.0,
+        1000.0,
     };
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.cpp
@@ -66,7 +66,7 @@ void PropulsionSystem::print(std::ostream& anOutputStream, bool displayDecorator
     ostk::core::utils::Print::Line(anOutputStream)
         << "Specific Impulse:" << (specificImpulse_.isDefined() ? specificImpulse_.toString() : "Undefined");
     ostk::core::utils::Print::Line(anOutputStream)
-        << "Mass Flow Rate:" << (getMassFlowRate().isDefined() ? getMassFlowRate().toString() : "Undefined");
+        << "Mass Flow Rate:" << (massFlowRate_.isDefined() ? massFlowRate_.toString() : "Undefined");
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.test.cpp
@@ -4,7 +4,6 @@
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
@@ -14,14 +13,11 @@
 
 using ostk::core::type::Real;
 
-using ostk::physics::data::Scalar;
 using ostk::physics::unit::Length;
 using ostk::physics::unit::Mass;
 using ostk::physics::unit::Time;
-using ostk::physics::unit::ElectricCurrent;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Derived;
-using ostk::physics::Unit;
 
 using ostk::physics::environment::gravitational::Earth;
 
@@ -30,60 +26,38 @@ using ostk::astrodynamics::flight::system::PropulsionSystem;
 class OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem : public ::testing::Test
 {
    protected:
-    void SetUp() override
-    {
-        thrust_ = Scalar(0.01, PropulsionSystem::thrustSIUnit);
-        specificImpulse_ = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
-
-        propulsionSystem_ = {thrust_, specificImpulse_};
-    }
-
-    Scalar thrust_ = Scalar::Undefined();
-    Scalar specificImpulse_ = Scalar::Undefined();
-    PropulsionSystem propulsionSystem_ = PropulsionSystem::Undefined();
+    const Real thrust_ = 0.01;
+    const Real specificImpulse_ = 100.0;
+    const PropulsionSystem propulsionSystem_ = PropulsionSystem(thrust_, specificImpulse_);
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Constructor)
 {
     {
-        EXPECT_NO_THROW(PropulsionSystem propulsionSystem(thrust_, specificImpulse_));
+        EXPECT_NO_THROW(PropulsionSystem(thrust_, specificImpulse_));
     }
 
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
+        EXPECT_NO_THROW(PropulsionSystem(Real::Undefined(), specificImpulse_));
+    }
 
-        EXPECT_NO_THROW(PropulsionSystem propulsionSystem(thrust, specificImpulse));
+    {
+        EXPECT_NO_THROW(PropulsionSystem(thrust_, Real::Undefined()));
     }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOperator)
 {
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
-
-        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
-
-        EXPECT_TRUE(propulsionSystem == propulsionSystem_);
+        EXPECT_TRUE(PropulsionSystem(thrust_, specificImpulse_) == propulsionSystem_);
     }
 
     {
-        const Scalar thrust = Scalar(0.02, PropulsionSystem::thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
-
-        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
-
-        EXPECT_FALSE(propulsionSystem == propulsionSystem_);
+        EXPECT_FALSE(PropulsionSystem(0.02, specificImpulse_) == propulsionSystem_);
     }
 
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.45, PropulsionSystem::specificImpulseSIUnit);
-
-        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
-
-        EXPECT_FALSE(propulsionSystem == propulsionSystem_);
+        EXPECT_FALSE(PropulsionSystem(thrust_, 100.45) == propulsionSystem_);
     }
 
     {
@@ -94,30 +68,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, EqualToOpe
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, NotEqualToOperator)
 {
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
-
-        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
-
-        EXPECT_FALSE(propulsionSystem != propulsionSystem_);
+        EXPECT_FALSE(PropulsionSystem(thrust_, specificImpulse_) != propulsionSystem_);
     }
 
     {
-        const Scalar thrust = Scalar(0.02, PropulsionSystem::thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
-
-        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
-
-        EXPECT_TRUE(propulsionSystem != propulsionSystem_);
+        EXPECT_TRUE(PropulsionSystem(0.02, specificImpulse_) != propulsionSystem_);
     }
 
     {
-        const Scalar thrust = Scalar(0.01, PropulsionSystem::thrustSIUnit);
-        const Scalar specificImpulse = Scalar(100.45, PropulsionSystem::specificImpulseSIUnit);
-
-        const PropulsionSystem propulsionSystem = {thrust, specificImpulse};
-
-        EXPECT_TRUE(propulsionSystem != propulsionSystem_);
+        EXPECT_TRUE(PropulsionSystem(thrust_, 100.45) != propulsionSystem_);
     }
 
     {
@@ -163,11 +122,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_PropulsionSystem, Getters)
     }
 
     {
-        const Scalar massFlowRate = {
-            propulsionSystem_.getThrust().getValue() /
-                (propulsionSystem_.getSpecificImpulse().getValue() * Earth::gravityConstant),
-            PropulsionSystem::massFlowRateSIUnit
-        };
+        const Real massFlowRate =
+            propulsionSystem_.getThrust() / (propulsionSystem_.getSpecificImpulse() * Earth::gravityConstant);
         EXPECT_TRUE(propulsionSystem_.getMassFlowRate() == massFlowRate);
     }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
@@ -25,14 +25,7 @@ using ostk::mathematics::geometry::d3::object::Point;
 using ostk::mathematics::object::Matrix3d;
 using ostk::mathematics::object::Vector3d;
 
-using ostk::physics::data::Scalar;
-using ostk::physics::unit::Length;
 using ostk::physics::unit::Mass;
-using ostk::physics::unit::Time;
-using ostk::physics::unit::ElectricCurrent;
-using ostk::physics::unit::Angle;
-using ostk::physics::unit::Derived;
-using ostk::physics::Unit;
 
 using ostk::astrodynamics::flight::system::SatelliteSystem;
 using ostk::astrodynamics::flight::system::PropulsionSystem;
@@ -65,12 +58,9 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem : public ::te
         dragCoefficient_ = 1.2;
 
         // Define propulsion system
-        const Scalar thrust_ = Scalar(0.01, PropulsionSystem::thrustSIUnit);
-        const Scalar specificImpulse_ = Scalar(100.0, PropulsionSystem::specificImpulseSIUnit);
-
         propulsionSystem_ = {
-            thrust_,
-            specificImpulse_,
+            0.01,
+            100.0,
         };
 
         satelliteSystem_ = {
@@ -202,9 +192,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, EqualToOper
     }
 
     {
-        PropulsionSystem anotherPropulsionSystem = {
-            Scalar(0.099, PropulsionSystem::thrustSIUnit), Scalar(99.0, PropulsionSystem::specificImpulseSIUnit)
-        };
+        PropulsionSystem anotherPropulsionSystem = {0.099, 99.0};
         EXPECT_FALSE(
             satelliteSystem_ == SatelliteSystem(
                                     mass_,
@@ -307,9 +295,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, NotEqualToO
     }
 
     {
-        PropulsionSystem anotherPropulsionSystem = {
-            Scalar(0.099, PropulsionSystem::thrustSIUnit), Scalar(99.0, PropulsionSystem::specificImpulseSIUnit)
-        };
+        PropulsionSystem anotherPropulsionSystem = {0.099, 99.0};
         EXPECT_TRUE(
             satelliteSystem_ != SatelliteSystem(
                                     mass_,

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystemBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystemBuilder.test.cpp
@@ -26,14 +26,7 @@ using ostk::mathematics::geometry::d3::object::Point;
 using ostk::mathematics::object::Matrix3d;
 using ostk::mathematics::object::Vector3d;
 
-using ostk::physics::data::Scalar;
-using ostk::physics::unit::Length;
 using ostk::physics::unit::Mass;
-using ostk::physics::unit::Time;
-using ostk::physics::unit::ElectricCurrent;
-using ostk::physics::unit::Angle;
-using ostk::physics::unit::Derived;
-using ostk::physics::Unit;
 
 using ostk::astrodynamics::flight::system::SatelliteSystem;
 using ostk::astrodynamics::flight::system::SatelliteSystemBuilder;

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.test.cpp
@@ -15,7 +15,6 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Ephemeris/Analytical.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
@@ -48,8 +47,6 @@ using ostk::mathematics::object::VectorXd;
 using ostk::mathematics::object::Matrix3d;
 using ostk::mathematics::object::Vector3d;
 
-using ostk::physics::data::Scalar;
-
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::Velocity;
@@ -66,7 +63,6 @@ using ostk::physics::unit::Mass;
 using ostk::physics::unit::Length;
 using ostk::physics::unit::Derived;
 using ostk::physics::unit::Time;
-using ostk::physics::data::Direction;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
 using EarthMagneticModel = ostk::physics::environment::magnetic::Earth;
 using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
@@ -81,9 +77,6 @@ using ostk::astrodynamics::Dynamics;
 using ostk::astrodynamics::guidancelaw::ConstantThrust;
 
 using namespace boost::numeric::odeint;
-
-static const Derived::Unit GravitationalParameterSIUnit =
-    Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second);
 
 class OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust : public ::testing::Test
 {
@@ -130,15 +123,9 @@ class OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust : public ::testi
         LocalOrbitalFrameFactory::VNC(Frame::GCRF()),
     };
 
-    const Scalar thrust_ = Scalar(0.1, PropulsionSystem::thrustSIUnit);
-    const Scalar specificImpulse_ = Scalar(1500.0, PropulsionSystem::specificImpulseSIUnit);
-
     const Mass satelliteDryMass_ = Mass::Kilograms(100.0);
 
-    const PropulsionSystem propulsionSystem_ = PropulsionSystem(
-        thrust_,          // Thrust
-        specificImpulse_  // Isp
-    );
+    const PropulsionSystem propulsionSystem_ = {0.1, 1500.0};
 
     const ConstantThrust defaultConstantThrust_ = {localOrbitalFrameDirection_};
 

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
@@ -38,7 +38,6 @@ using ostk::mathematics::geometry::d3::object::Composite;
 using ostk::mathematics::geometry::d3::object::Cuboid;
 using ostk::mathematics::geometry::d3::object::Point;
 
-using ostk::physics::data::Scalar;
 using ostk::physics::unit::Derived;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Length;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -18,7 +18,6 @@
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Object/Point.hpp>
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
@@ -71,7 +70,6 @@ using ostk::mathematics::object::VectorXd;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::Velocity;
-using ostk::physics::data::Scalar;
 using ostk::physics::Environment;
 using ostk::physics::environment::Object;
 using ostk::physics::environment::object::Celestial;
@@ -118,10 +116,7 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator : public 
             {1.0, 2.0, 3.0}
         ));
 
-        const PropulsionSystem propulsionSystem = {
-            Scalar(0.1, PropulsionSystem::thrustSIUnit),
-            Scalar(1500.0, PropulsionSystem::specificImpulseSIUnit),
-        };
+        const PropulsionSystem propulsionSystem = {0.1, 1500.0};
 
         this->satelliteGeometry_ = satelliteGeometry;
         this->propulsionSystem_ = propulsionSystem;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
@@ -49,7 +49,6 @@ using ostk::physics::coordinate::Velocity;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Length;
 using ostk::physics::unit::Mass;
-using ostk::physics::data::Scalar;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
 using EarthMagneticModel = ostk::physics::environment::magnetic::Earth;
 using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
@@ -595,14 +594,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, Solve_2)
         std::make_shared<Thruster>(satelliteSystem, std::make_shared<ConstantThrust>(ConstantThrust::Intrack()))
     );
 
-    const Shared<const CoordinateBroker> coordinatesBrokerSPtr =
-        std::make_shared<CoordinateBroker>(CoordinateBroker({
-            CartesianPosition::Default(),
-            CartesianVelocity::Default(),
-            CoordinateSubset::Mass(),
-            CoordinateSubset::SurfaceArea(),
-            CoordinateSubset::DragCoefficient(),
-        }));
+    const Shared<const CoordinateBroker> coordinatesBrokerSPtr = std::make_shared<CoordinateBroker>(CoordinateBroker({
+        CartesianPosition::Default(),
+        CartesianVelocity::Default(),
+        CoordinateSubset::Mass(),
+        CoordinateSubset::SurfaceArea(),
+        CoordinateSubset::DragCoefficient(),
+    }));
 
     VectorXd coordinates(9);
     coordinates << 7000000.0, 0.0, 0.0, 0.0, 7546.05329, 0.0, mass + 100.0, surfaceArea, dragCoefficient;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/NRLMSIS00.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/NRLMSIS00.validation.cpp
@@ -16,7 +16,6 @@
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.hpp>
@@ -66,7 +65,6 @@ using ostk::mathematics::object::Vector3d;
 using ostk::mathematics::object::VectorXd;
 
 using ostk::physics::coordinate::Frame;
-using ostk::physics::data::Scalar;
 using ostk::physics::Environment;
 using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
@@ -109,10 +107,7 @@ class OpenSpaceToolkit_Astrodynamics_Validation_NRLMSIS00Validation : public ::t
             {1.0, 2.0, 3.0}
         ));
 
-        const PropulsionSystem propulsionSystem = {
-            Scalar(0.1, PropulsionSystem::thrustSIUnit),
-            Scalar(1500.0, PropulsionSystem::specificImpulseSIUnit),
-        };
+        const PropulsionSystem propulsionSystem = {0.1, 1500.0};
 
         this->satelliteGeometry_ = satelliteGeometry;
         this->propulsionSystem_ = propulsionSystem;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
@@ -19,7 +19,6 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
@@ -81,7 +80,6 @@ using ostk::mathematics::object::VectorXd;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::Velocity;
-using ostk::physics::data::Scalar;
 using ostk::physics::Environment;
 using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
@@ -129,10 +127,7 @@ class OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation : public ::testi
             {1.0, 2.0, 3.0}
         ));
 
-        const PropulsionSystem propulsionSystem = {
-            Scalar(0.1, PropulsionSystem::thrustSIUnit),
-            Scalar(1500.0, PropulsionSystem::specificImpulseSIUnit),
-        };
+        const PropulsionSystem propulsionSystem = {0.1, 1500.0};
 
         this->satelliteGeometry_ = satelliteGeometry;
         this->propulsionSystem_ = propulsionSystem;
@@ -662,12 +657,11 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster, Force
         LocalOrbitalFrameDirection(localOrbitalFrameThrustVector, localOrbitalFrameFactory);
 
     // Coordinates Broker (scenario-independent)
-    const Shared<const CoordinateBroker> coordinatesBrokerSPtr =
-        std::make_shared<CoordinateBroker>(CoordinateBroker({
-            CartesianPosition::Default(),
-            CartesianVelocity::Default(),
-            CoordinateSubset::Mass(),
-        }));
+    const Shared<const CoordinateBroker> coordinatesBrokerSPtr = std::make_shared<CoordinateBroker>(CoordinateBroker({
+        CartesianPosition::Default(),
+        CartesianVelocity::Default(),
+        CoordinateSubset::Mass(),
+    }));
 
     // Setup initial state
     VectorXd initialCoordinates(7);
@@ -683,10 +677,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster, Force
     };
 
     // Setup satellite system
-    PropulsionSystem propulsionSystem = {
-        Scalar(thrustReal, PropulsionSystem::thrustSIUnit),
-        Scalar(specificImpulseReal, PropulsionSystem::specificImpulseSIUnit),
-    };
+    PropulsionSystem propulsionSystem = {thrustReal, specificImpulseReal};
 
     const Composite satelliteGeometry(Cuboid(
         {0.0, 0.0, 0.0}, {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}}, {1.0, 2.0, 3.0}
@@ -1209,14 +1200,13 @@ TEST_P(
         LocalOrbitalFrameDirection(localOrbitalFrameThrustVector, localOrbitalFrameFactory);
 
     // Coordinates Broker (scenario-independent)
-    const Shared<const CoordinateBroker> coordinatesBrokerSPtr =
-        std::make_shared<CoordinateBroker>(CoordinateBroker({
-            CartesianPosition::Default(),
-            CartesianVelocity::Default(),
-            CoordinateSubset::Mass(),
-            CoordinateSubset::SurfaceArea(),
-            CoordinateSubset::DragCoefficient(),
-        }));
+    const Shared<const CoordinateBroker> coordinatesBrokerSPtr = std::make_shared<CoordinateBroker>(CoordinateBroker({
+        CartesianPosition::Default(),
+        CartesianVelocity::Default(),
+        CoordinateSubset::Mass(),
+        CoordinateSubset::SurfaceArea(),
+        CoordinateSubset::DragCoefficient(),
+    }));
 
     // Setup initial conditions
     VectorXd initialCoordinates(9);
@@ -1232,10 +1222,7 @@ TEST_P(
     };
 
     // Setup satellite system
-    PropulsionSystem propulsionSystem = {
-        Scalar(thrustReal, PropulsionSystem::thrustSIUnit),
-        Scalar(specificImpulseReal, PropulsionSystem::specificImpulseSIUnit),
-    };
+    PropulsionSystem propulsionSystem = {thrustReal, specificImpulseReal};
 
     const Composite satelliteGeometry(Cuboid(
         {0.0, 0.0, 0.0}, {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}}, {1.0, 2.0, 3.0}

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.self.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.self.validation.cpp
@@ -18,7 +18,6 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
@@ -74,7 +73,6 @@ using ostk::mathematics::object::VectorXd;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::Velocity;
-using ostk::physics::data::Scalar;
 using ostk::physics::Environment;
 using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
@@ -120,10 +118,7 @@ class OpenSpaceToolkit_Astrodynamics_Validation_SelfValidation : public ::testin
             {1.0, 2.0, 3.0}
         ));
 
-        const PropulsionSystem propulsionSystem = {
-            Scalar(0.1, PropulsionSystem::thrustSIUnit),
-            Scalar(1500.0, PropulsionSystem::specificImpulseSIUnit),
-        };
+        const PropulsionSystem propulsionSystem = {0.1, 1500.0};
 
         this->satelliteGeometry_ = satelliteGeometry;
         this->propulsionSystem_ = propulsionSystem;
@@ -194,10 +189,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_SelfValidation, ForceModel_Tabu
     );
     const Shared<Celestial> earthSPtr = std::make_shared<Celestial>(earth);
 
-    const PropulsionSystem propulsionSystem = {
-        Scalar(1e-1, PropulsionSystem::thrustSIUnit),
-        Scalar(3000.0, PropulsionSystem::specificImpulseSIUnit),
-    };
+    const PropulsionSystem propulsionSystem = {1e-1, 3000.0};
 
     const SatelliteSystem satelliteSystem = SatelliteSystemBuilder::Default()
                                                 .withPropulsionSystem(propulsionSystem)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/QLaw.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/QLaw.validation.cpp
@@ -15,7 +15,6 @@
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Object/Point.hpp>
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object.hpp>
@@ -69,7 +68,6 @@ using ostk::mathematics::object::VectorXd;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::Velocity;
-using ostk::physics::data::Scalar;
 using ostk::physics::Environment;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
 using ostk::physics::environment::Object;
@@ -117,10 +115,7 @@ class OpenSpaceToolkit_Astrodynamics_Validation_QLawValidation
             {1.0, 2.0, 3.0}
         ));
 
-        const PropulsionSystem propulsionSystem = {
-            Scalar(0.1, PropulsionSystem::thrustSIUnit),
-            Scalar(1500.0, PropulsionSystem::specificImpulseSIUnit),
-        };
+        const PropulsionSystem propulsionSystem = {0.1, 1500.0};
 
         this->satelliteGeometry_ = satelliteGeometry;
         this->propulsionSystem_ = propulsionSystem;
@@ -218,10 +213,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_QLawValidation, QLaw_Paper_Case
         {0.0, 0.0, 0.0}, {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}}, {1.0, 2.0, 3.0}
     ));
 
-    const PropulsionSystem propulsionSystem = {
-        Scalar(1.0, PropulsionSystem::thrustSIUnit),
-        Scalar(3100.0, PropulsionSystem::specificImpulseSIUnit),
-    };
+    const PropulsionSystem propulsionSystem = {1.0, 3100.0};
 
     const SatelliteSystem satelliteSystem = {
         mass,
@@ -318,10 +310,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_QLawValidation, QLaw_Paper_Case
         {0.0, 0.0, 0.0}, {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}}, {1.0, 2.0, 3.0}
     ));
 
-    const PropulsionSystem propulsionSystem = {
-        Scalar(2.0, PropulsionSystem::thrustSIUnit),
-        Scalar(2000.0, PropulsionSystem::specificImpulseSIUnit),
-    };
+    const PropulsionSystem propulsionSystem = {2.0, 2000.0};
 
     const SatelliteSystem satelliteSystem = {
         mass,
@@ -408,10 +397,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_QLawValidation, SSO_targeting)
         {0.0, 0.0, 0.0}, {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}}, {1.0, 2.0, 3.0}
     ));
 
-    const PropulsionSystem propulsionSystem = {
-        Scalar(1.0, PropulsionSystem::thrustSIUnit),
-        Scalar(1000.0, PropulsionSystem::specificImpulseSIUnit),
-    };
+    const PropulsionSystem propulsionSystem = {1.0, 1000.0};
 
     const SatelliteSystem satelliteSystem = {
         mass,

--- a/validation/OpenSpaceToolkit/Astrodynamics/Framework.validation.cpp
+++ b/validation/OpenSpaceToolkit/Astrodynamics/Framework.validation.cpp
@@ -19,7 +19,6 @@
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Object/Point.hpp>
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.hpp>
@@ -38,7 +37,6 @@
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Time.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
@@ -88,7 +86,6 @@ using ostk::mathematics::object::Matrix3d;
 using ostk::mathematics::object::Vector3d;
 using ostk::mathematics::object::VectorXd;
 
-using ostk::physics::data::Scalar;
 using ostk::physics::Environment;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
@@ -106,7 +103,6 @@ using ostk::physics::time::Interval;
 using ostk::physics::time::Time;
 using ostk::physics::time::Scale;
 using ostk::physics::unit::Angle;
-using ostk::physics::unit::Derived;
 using ostk::physics::unit::Length;
 using ostk::physics::unit::Mass;
 using ostk::physics::environment::object::celestial::Earth;

--- a/validation/OpenSpaceToolkit/Astrodynamics/Parser.hpp
+++ b/validation/OpenSpaceToolkit/Astrodynamics/Parser.hpp
@@ -23,7 +23,6 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
-#include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>

--- a/validation/OpenSpaceToolkit/Astrodynamics/Parser.test.cpp
+++ b/validation/OpenSpaceToolkit/Astrodynamics/Parser.test.cpp
@@ -33,7 +33,6 @@ using ostk::mathematics::object::VectorXd;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::Velocity;
-using ostk::physics::data::Scalar;
 using ostk::physics::Environment;
 using ostk::physics::environment::Object;
 using ostk::physics::environment::object::Celestial;
@@ -106,12 +105,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_Parser, CreateSatelliteSystem)
         EXPECT_EQ(satelliteSystem.getMass(), Mass::Kilograms(0.0));
         EXPECT_EQ(satelliteSystem.getCrossSectionalSurfaceArea(), 1.0);
         EXPECT_EQ(satelliteSystem.getDragCoefficient(), 2.2);
-        EXPECT_EQ(
-            satelliteSystem.getPropulsionSystem(),
-            PropulsionSystem(
-                Scalar(0.01, PropulsionSystem::thrustSIUnit), Scalar(3000.0, PropulsionSystem::specificImpulseSIUnit)
-            )
-        );
+        EXPECT_EQ(satelliteSystem.getPropulsionSystem(), PropulsionSystem(0.01, 3000.0));
     }
 }
 


### PR DESCRIPTION
After going down a rabbit hole of trying to add python bindings for the `physics::data::Scalar` class (which currently lacks them) in OSTk physics, I have deemed that much harder than it seems on the surface and come up with an alternative medium term solution.

Context on the cpp side for OSTk physics:
- There is lots of convoluted code deep down inside of physics::Unit, which would take a non-trivial amount of time to modify if needed
- the tests for physics::Unit are weak, and the tests for physics::unit::Derived are non-existant (which is scary because we use physics::unit::Derived in a lot of places in astro
- the tests for data::Scalar and data::Vector and data::Direction are non-existant
- all derived units should be defined inside of physics::Unit, not as the Thrust and SpecificImpulse and MassFlowRate ones are currently defined inside of `PropulsionSystem`

Context on the python side for OSTk physics
-  physics::Unit,  physics::data::Scalar, physics::data::Vector, and physics::data::Direction are not bound to python at all as classes, and in order to add bindings to physics::data::Scalar, you need to add bindings to physics::Unit, which is not trivial at all due to the aforementioned convolutedness of physics::Unit
- if data::Scalar and data::Vector were to be bound to python, cpp tests would need to be added for them as well, which would again take time

Context on how the above relates to OSTk astro:
- ostk::physics::Unit is only used in two places in OSTk astro (AtmosphericDragDynamics (not at the API level) and PropulsionSystem (indeed at the API level)
- data::Scalar is only used in PropulsionSystem and data::Vector is used nowhere in OSTk astro
- SatelliteSystem, dynamics, and propagation all do their computations and store their variables in unitless Reals or VectorXds
- after the bonanza of ostk releases over the past couple days, no more breaking changes 🙏 

Path forward:
- One day I think we will need a complete overhaul of the unit system in OSTk, by either a) completely removing it, b) replacing it with templated compile-time unit checking or boost::units 
- **However, in the meantime, and based on all the context above I think the best solution is to remove the use of data::Scalar from PropulsionSystem and store its quantities in SI for 1) consistency with everything else in astro and 2) the fact that you can't use the getters in Python for `PropulsionSystem` without adding Scalar bindings, and we are going to be using the `PropulsionSystem` object a lot in the near future in the guidance service and everything related to it**

There is a corresponding [MR](https://github.com/open-space-collective/open-space-toolkit-physics/pull/205) in physics that comments out pybound methods that won't work because they return data::Scalar and data::Vector.