### PR TITLE
chore: move benchmark and validation tests to separate CI

### DIFF
--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -9,6 +9,7 @@ on:
       - completed
     branches:
       - main
+      - chore/refactor-ci-again # TBR
 
 concurrency:
   group: main-${{ github.ref }}
@@ -57,7 +58,7 @@ jobs:
     needs:
       - prepare-environment
       - build-development-image
-    uses: open-space-collective/open-space-toolkit/.github/workflows/benchmark-validation.yml@chore/refactor-ci-again
+    uses: open-space-collective/open-space-toolkit/.github/workflows/benchmark-validation.yml@chore/refactor-ci-again # TBM
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - chore/refactor-ci-again # TBR
 
 env:
   PROJECT_NAME: open-space-toolkit-astrodynamics
@@ -51,7 +50,7 @@ jobs:
     needs:
       - prepare-environment
       - build-development-image
-    uses: open-space-collective/open-space-toolkit/.github/workflows/benchmark-validation.yml@chore/refactor-ci-again # TBM
+    uses: open-space-collective/open-space-toolkit/.github/workflows/benchmark-validation.yml@main
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -3,7 +3,10 @@
 name: Benchmark and Validate
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build and Test"]
+    types:
+      - completed
     branches:
       - main
 

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -3,17 +3,10 @@
 name: Benchmark and Validate
 
 on:
-  workflow_run:
-    workflows: ["Build and Test"]
-    types:
-      - completed
+  push:
     branches:
       - main
       - chore/refactor-ci-again # TBR
-
-concurrency:
-  group: main-${{ github.ref }}
-  cancel-in-progress: true
 
 env:
   PROJECT_NAME: open-space-toolkit-astrodynamics

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -3,7 +3,10 @@
 name: Benchmark and Validate
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build and Test"]
+    types:
+      - completed
     branches:
       - main
 
@@ -49,59 +52,13 @@ jobs:
       project_version: ${{ needs.prepare-environment.outputs.project_version }}
     secrets: inherit
 
-  benchmark-cpp:
-    name: Benchmark C++
-    runs-on: ubuntu-latest
+  benchmark-and-validate:
+    name: Benchmark and Validate
     needs:
       - prepare-environment
       - build-development-image
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull openspacecollective/${{ needs.prepare-environment.outputs.project_name }}-development:${{ needs.prepare-environment.outputs.project_version }}
-      - name: Run C++ Benchmark
-        run: make benchmark-cpp-standalone
-      - name: Download previous benchmark
-        uses: actions/cache@v1
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-      - uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'googlecpp'
-          output-file-path: bin/benchmark_result.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
-          alert-threshold: "200%"
-          comment-on-alert: true
-
-  validation-cpp:
-    name: Run C++ Validation Tests
-    runs-on: ubuntu-latest
-    needs:
-      - prepare-environment
-      - build-development-image
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull openspacecollective/${{ needs.prepare-environment.outputs.project_name }}-development:${{ needs.prepare-environment.outputs.project_version }}
-      - name: Run C++ Validation Tests
-        run: make validation-cpp-standalone
+    uses: open-space-collective/open-space-toolkit/.github/workflows/benchmark-validation.yml@chore/refactor-ci-again
+    with:
+      project_name: ${{ needs.prepare-environment.outputs.project_name }}
+      project_version: ${{ needs.prepare-environment.outputs.project_version }}
+    secrets: inherit

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,10 +8,6 @@ on:
       - main
   pull_request:
 
-concurrency:
-  group: main-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   PROJECT_NAME: open-space-toolkit-astrodynamics
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: main-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PROJECT_NAME: open-space-toolkit-astrodynamics
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,66 +67,18 @@ jobs:
       project_version: ${{ needs.prepare-environment.outputs.project_version }}
     secrets: inherit
 
-  benchmark-cpp:
-    name: Benchmark C++
-    runs-on: ubuntu-latest
+  benchmark-and-validate:
+    name: Benchmark and Validate
     needs:
       - prepare-environment
       - build-development-image
       - test
       - package
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull openspacecollective/${{ needs.prepare-environment.outputs.project_name }}-development:${{ needs.prepare-environment.outputs.project_version }}
-      - name: Run C++ Benchmark
-        run: make benchmark-cpp-standalone
-      - name: Download previous benchmark
-        uses: actions/cache@v1
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-      - uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'googlecpp'
-          output-file-path: bin/benchmark_result.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
-          alert-threshold: "200%"
-          comment-on-alert: true
-
-  validation-cpp:
-    name: Run C++ Validation Tests
-    runs-on: ubuntu-latest
-    needs:
-      - prepare-environment
-      - build-development-image
-      - test
-      - package
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull openspacecollective/${{ needs.prepare-environment.outputs.project_name }}-development:${{ needs.prepare-environment.outputs.project_version }}
-      - name: Run C++ Validation Tests
-        run: make validation-cpp-standalone
+    uses: open-space-collective/open-space-toolkit/.github/workflows/benchmark-validation.yml@chore/refactor-ci-again
+    with:
+      project_name: ${{ needs.prepare-environment.outputs.project_name }}
+      project_version: ${{ needs.prepare-environment.outputs.project_version }}
+    secrets: inherit
 
   release:
     name: Release
@@ -135,8 +87,7 @@ jobs:
       - build-development-image
       - test
       - package
-      - benchmark-cpp
-      - validation-cpp
+      - benchmark-and-validate
     uses: open-space-collective/open-space-toolkit/.github/workflows/release.yml@main
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       - build-development-image
       - test
       - package
-    uses: open-space-collective/open-space-toolkit/.github/workflows/benchmark-validation.yml@chore/refactor-ci-again
+    uses: open-space-collective/open-space-toolkit/.github/workflows/benchmark-validation.yml@main
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}


### PR DESCRIPTION
This should fix the issue with the benchmark and validation job on main being cancelled because it is running concurrently with the build-test job