### PR TITLE
refactor: add dynamics validation to propagator

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
@@ -72,13 +72,6 @@ class Propagator
    public:
     /// @brief Default integrator frame
     static const Shared<const Frame> IntegrationFrameSPtr;
-    /// @brief Map of valid dynamics set for propagation
-    ///
-    /// @code{.cpp}
-    ///              Map<String, Pair<Size, Size>> validDynamicsSet ={"TypeOfDynamics", {Min number allowed, Max number
-    ///              allowed}};
-    /// @endcode
-    static const Map<String, Pair<Size, Size>> ValidDynamicsSet;  // Map<String, Pair<Size, Size>>
 
     /// @brief Constructor
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
@@ -4,6 +4,9 @@
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_Propagator__
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Map.hpp>
+#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
+#include <OpenSpaceToolkit/Core/Type/Index.hpp>
 #include <OpenSpaceToolkit/Core/Type/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
@@ -42,6 +45,9 @@ namespace trajectory
 {
 
 using ostk::core::container::Array;
+using ostk::core::container::Map;
+using ostk::core::container::Pair;
+using ostk::core::type::Index;
 using ostk::core::type::Integer;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
@@ -53,18 +59,26 @@ using ostk::physics::coordinate::Velocity;
 using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 
-using ostk::astrodynamics::trajectory::state::NumericalSolver;
+using ostk::astrodynamics::Dynamics;
 using ostk::astrodynamics::EventCondition;
+using ostk::astrodynamics::flight::system::SatelliteSystem;
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::StateBuilder;
-using ostk::astrodynamics::Dynamics;
-using ostk::astrodynamics::flight::system::SatelliteSystem;
+using ostk::astrodynamics::trajectory::state::NumericalSolver;
 
 /// @brief Define a propagator to be used for numerical propagation
 class Propagator
 {
    public:
+    /// @brief Default integrator frame
     static const Shared<const Frame> IntegrationFrameSPtr;
+    /// @brief Map of valid dynamics set for propagation
+    ///
+    /// @code{.cpp}
+    ///              Map<String, Pair<Size, Size>> validDynamicsSet ={"TypeOfDynamics", {Min number allowed, Max number
+    ///              allowed}};
+    /// @endcode
+    static const Map<String, Pair<Size, Size>> ValidDynamicsSet;  // Map<String, Pair<Size, Size>>
 
     /// @brief Constructor
     ///
@@ -78,6 +92,17 @@ class Propagator
         const NumericalSolver& aNumericalSolver,
         const Array<Shared<Dynamics>>& aDynamicsArray = Array<Shared<Dynamics>>::Empty()
     );
+
+    /// @brief Copy constructor
+    ///
+    /// @param aPropagator A propagator (deep copy)
+    Propagator(const Propagator& aPropagator);
+
+    /// @brief Copy assignment operator
+    ///
+    /// @param aPropagator A propagator (deep copy)
+    /// @return A reference to this propagator
+    Propagator& operator=(const Propagator& aPropagator);
 
     /// @brief Equal to operator
     ///
@@ -213,7 +238,7 @@ class Propagator
     Array<Dynamics::Context> dynamicsContexts_ = Array<Dynamics::Context>::Empty();
     mutable NumericalSolver numericalSolver_;
 
-    void registerDynamicsContext(const Shared<Dynamics>& aDynamicsSPtr);
+    void validateDynamicsSet() const;
 };
 
 }  // namespace trajectory

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateBroker.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateBroker.hpp
@@ -105,8 +105,7 @@ class CoordinateBroker
     /// @param aCoordinateSubset the coordinate subsets of interest
     ///
     /// @return The coordinates of the subset
-    VectorXd extractCoordinate(const VectorXd& aFullCoordinatesVector, const CoordinateSubset& aCoordinateSubset)
-        const;
+    VectorXd extractCoordinate(const VectorXd& aFullCoordinatesVector, const CoordinateSubset& aCoordinateSubset) const;
 
     /// @brief Extract the coordinates of a given subset from the full coordinates vector
     ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
@@ -33,7 +33,6 @@ Propagated::Propagated(const Propagator& aPropagator, const State& aState, const
       propagator_(aPropagator),
       cachedStateArray_(1, aState),
       initialRevolutionNumber_(aRevolutionNumber)
-
 {
 }
 
@@ -44,7 +43,6 @@ Propagated::Propagated(
       propagator_(aPropagator),
       cachedStateArray_(aCachedStateArray),
       initialRevolutionNumber_(aRevolutionNumber)
-
 {
     sanitizeCachedArray();
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
@@ -412,12 +412,6 @@ void Propagator::validateDynamicsSet() const
             throw ostk::core::error::RuntimeError("Invalid Dynamics Set.");
         }
     }
-
-    // Special case to disallow both TabulatedDynamics and ThrusterDynamics
-    if (currentDynamicsSets["Tabulated"] > 0 && currentDynamicsSets["Thruster"] > 0)
-    {
-        throw ostk::core::error::RuntimeError("Invalid Dynamics Set.");
-    }
 }
 
 }  // namespace trajectory

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
@@ -365,47 +365,29 @@ void Propagator::validateDynamicsSet() const
     }
 
     // Check for mandatory dynamics
-    try
+    const auto centralBodyGravityIt = dynamicsMap.find(std::type_index(typeid(CentralBodyGravity)));
+    if (centralBodyGravityIt == dynamicsMap.end() || centralBodyGravityIt->second.getSize() != 1)
     {
-        if (dynamicsMap.at(std::type_index(typeid(CentralBodyGravity))).getSize() != 1)
-        {
-            throw ostk::core::error::RuntimeError("Propagator needs exactly one Central Body Gravity Dynamics.");
-        }
-        if (dynamicsMap.at(std::type_index(typeid(PositionDerivative))).getSize() != 1)
-        {
-            throw ostk::core::error::RuntimeError("Propagator needs exactly one Position Derivative Dynamics.");
-        }
+        throw ostk::core::error::RuntimeError("Propagator needs exactly one Central Body Gravity Dynamics.");
     }
-    catch (const std::out_of_range& e)
+
+    const auto positionDerivativeIt = dynamicsMap.find(std::type_index(typeid(PositionDerivative)));
+    if (positionDerivativeIt == dynamicsMap.end() || positionDerivativeIt->second.getSize() != 1)
     {
-        throw ostk::core::error::RuntimeError(
-            "Propagator needs at minimum a Central Body Gravity and Position Derivative Dynamics."
-        );
+        throw ostk::core::error::RuntimeError("Propagator needs exactly one Position Derivative Dynamics.");
     }
 
     // Check for optional dynamics number limits
-    try
+    const auto atmosphericDragIt = dynamicsMap.find(std::type_index(typeid(AtmosphericDrag)));
+    if (atmosphericDragIt != dynamicsMap.end() && atmosphericDragIt->second.getSize() > 1)
     {
-        if (dynamicsMap.at(std::type_index(typeid(AtmosphericDrag))).getSize() > 1)
-        {
-            throw ostk::core::error::RuntimeError("Propagator can have at most one Atmospheric Drag Dynamics.");
-        }
-    }
-    catch (const std::out_of_range& e)
-    {
-        // Do nothing
+        throw ostk::core::error::RuntimeError("Propagator can have at most one Atmospheric Drag Dynamics.");
     }
 
-    try
+    const auto thrusterIt = dynamicsMap.find(std::type_index(typeid(Thruster)));
+    if (thrusterIt != dynamicsMap.end() && thrusterIt->second.getSize() > 1)
     {
-        if (dynamicsMap.at(std::type_index(typeid(Thruster))).getSize() > 1)
-        {
-            throw ostk::core::error::RuntimeError("Propagator can have at most one Thruster Dynamics.");
-        }
-    }
-    catch (const std::out_of_range& e)
-    {
-        // Do nothing
+        throw ostk::core::error::RuntimeError("Propagator can have at most one Thruster Dynamics.");
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
@@ -69,7 +69,6 @@ using ostk::astrodynamics::trajectory::Propagator;
 using ostk::astrodynamics::trajectory::orbit::model::Propagated;
 using ostk::astrodynamics::trajectory::state::NumericalSolver;
 
-/* UNIT TESTS */
 class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated : public ::testing::Test
 {
    protected:

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -971,6 +971,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Validat
         {
             Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
             propagator.setDynamics({std::make_shared<CentralBodyGravity>(earthSpherical_)});
+
             EXPECT_THROW(
                 {
                     try
@@ -979,10 +980,24 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Validat
                     }
                     catch (const ostk::core::error::RuntimeError& e)
                     {
-                        EXPECT_EQ(
-                            "Propagator needs at minimum a Central Body Gravity and Position Derivative Dynamics.",
-                            e.getMessage()
-                        );
+                        EXPECT_EQ("Propagator needs exactly one Position Derivative Dynamics.", e.getMessage());
+                        throw;
+                    }
+                },
+                ostk::core::error::RuntimeError
+            );
+
+            propagator.setDynamics({std::make_shared<PositionDerivative>()});
+
+            EXPECT_THROW(
+                {
+                    try
+                    {
+                        propagator.calculateStateAt(state, state.getInstant());
+                    }
+                    catch (const ostk::core::error::RuntimeError& e)
+                    {
+                        EXPECT_EQ("Propagator needs exactly one Central Body Gravity Dynamics.", e.getMessage());
                         throw;
                     }
                 },


### PR DESCRIPTION
This MR refactors the propagator slightly by adding some dynamics validation logic so that propagation can't be done with a set of dynamics that doesn't make sense. 
- It defines a maximum and minimum number of each type of dynamics that can be used for propagation in a map, and perform a "propagation-time" check that occurs as the first step of the `calculateXAt()` methods being called, so that the user can add whatever dynamics they want one by one and/or remove dynamics using `.addDynamics` and `.setDynamics` and `.clearDynamics` until they have a good dynamics set, which is only validated before it will actually be used to calculate a state.

This MR refactors the `Propagator` unit tests in some places to be more concise, and also adds a deep copy constructor and deep copy assignement operator to the `Propagator` so that if a `Propagator` needs to be duplicated, the dynamics inside of it are also duplicated because if they're not both propagators would still be sharing the same dynamics which could be an insidious issue.