### PR TITLE
refactor!: tabulated dynamics getters into accessors only and add a specific getter for returning a matrixxd from coordinate subsets

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Tabulated.cpp
@@ -69,10 +69,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Tabulated(pybind11::module&
             )
 
             .def(
-                "get_instants",
-                &Tabulated::getInstants,
+                "access_instants",
+                &Tabulated::accessInstants,
                 R"doc(
-                    Get the contribution instants.
+                    Access the contribution instants.
 
                     Returns:
                         list[Instant]: The contribution instants.
@@ -81,10 +81,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Tabulated(pybind11::module&
             )
 
             .def(
-                "get_contribution_profile",
-                &Tabulated::getContributionProfile,
+                "access_contribution_profile",
+                &Tabulated::accessContributionProfile,
                 R"doc(
-                    Get the contribution profile.
+                    Access the contribution profile.
 
                     Returns:
                         np.ndarray: The contribution profile.
@@ -93,10 +93,26 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Dynamics_Tabulated(pybind11::module&
             )
 
             .def(
-                "get_frame",
-                &Tabulated::getFrame,
+                "get_contribution_profile_from_coordinate_subsets",
+                &Tabulated::getContributionProfileFromCoordinateSubsets,
+                arg("coordinate_subsets"),
                 R"doc(
-                    Get the reference frame.
+                    Get the contribution profile corresponding to a subset of coordinates.
+
+                    Args:
+                        coordinate_subsets (list[CoordinateSubset]): The coordinate subsets.
+
+                    Returns:
+                        numpy.ndarray: The contribution profile.
+
+                )doc"
+            )
+
+            .def(
+                "access_frame",
+                &Tabulated::accessFrame,
+                R"doc(
+                    Access the reference frame.
 
                     Returns:
                         Frame: The reference frame.

--- a/bindings/python/test/dynamics/test_tabulated.py
+++ b/bindings/python/test/dynamics/test_tabulated.py
@@ -91,18 +91,32 @@ class TestTabulated:
         assert isinstance(dynamics, Dynamics)
         assert dynamics.is_defined()
 
-    def test_getters(
+    def test_accessor(
         self,
         dynamics: Tabulated,
         instants: list[Instant],
         contribution_profile: np.ndarray,
         frame: Frame,
     ):
-        assert np.array_equal(dynamics.get_contribution_profile(), contribution_profile)
+        assert np.array_equal(
+            dynamics.access_contribution_profile(), contribution_profile
+        )
 
-        assert dynamics.get_instants() == instants
+        assert dynamics.access_instants() == instants
 
-        assert dynamics.get_frame() == frame
+        assert dynamics.access_frame() == frame
+
+    def test_getters(
+        self,
+        dynamics: Tabulated,
+        contribution_profile: np.ndarray,
+    ):
+        assert np.array_equal(
+            dynamics.get_contribution_profile_from_coordinate_subsets(
+                [CartesianVelocity.default()]
+            ),
+            contribution_profile[:, 0:3],
+        )
 
         assert dynamics.get_interpolation_type() == Interpolator.Type.Linear
 

--- a/bindings/python/test/flight/test_maneuver.py
+++ b/bindings/python/test/flight/test_maneuver.py
@@ -163,9 +163,11 @@ class TestManeuver:
         )
 
         assert tabulated_dynamics.is_defined()
-        assert tabulated_dynamics.get_instants() == maneuver.get_instants()
+        assert tabulated_dynamics.access_instants() == maneuver.get_instants()
 
-        contribution_profile: np.ndarray = tabulated_dynamics.get_contribution_profile()
+        contribution_profile: np.ndarray = (
+            tabulated_dynamics.access_contribution_profile()
+        )
 
         for i in range(len(instants)):
             assert contribution_profile[i][0:3] == pytest.approx(
@@ -175,7 +177,7 @@ class TestManeuver:
                 mass_flow_rate_profile[i], rel=1e-15
             )
 
-        assert tabulated_dynamics.get_frame() == frame
+        assert tabulated_dynamics.access_frame() == frame
 
     def test_from_tabulated_dynamics(
         self,
@@ -184,14 +186,14 @@ class TestManeuver:
         maneuver = Maneuver.from_tabulated_dynamics(tabulated_dynamics)
 
         assert maneuver.is_defined()
-        assert maneuver.get_instants() == tabulated_dynamics.get_instants()
+        assert maneuver.get_instants() == tabulated_dynamics.access_instants()
         assert (
             len(maneuver.get_acceleration_profile())
-            == tabulated_dynamics.get_contribution_profile().shape[0]
+            == tabulated_dynamics.access_contribution_profile().shape[0]
         )
         assert (
             len(maneuver.get_mass_flow_rate_profile())
-            == tabulated_dynamics.get_contribution_profile().shape[0]
+            == tabulated_dynamics.access_contribution_profile().shape[0]
         )
 
     def test_from_constant_mass_flow_rate(

--- a/include/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.hpp
@@ -75,30 +75,23 @@ class Tabulated : public Dynamics
     /// @return The instants
     const Array<Instant>& accessInstants() const;
 
-    /// @brief Get instants
-    ///
-    /// @return The instants
-    Array<Instant> getInstants() const;
-
     /// @brief Access contribution profile
     ///
     /// @return The contribution profile
     const MatrixXd& accessContributionProfile() const;
 
-    /// @brief Get contribution profile
+    /// @brief Get contribution profile corresponding to a subset of coordinates
     ///
+    /// @param aCoordinateSubsetArray A coordinate subset
     /// @return The contribution profile
-    MatrixXd getContributionProfile() const;
+    MatrixXd getContributionProfileFromCoordinateSubsets(
+        const Array<Shared<const CoordinateSubset>>& aCoordinateSubsetArray
+    ) const;
 
     /// @brief Access the frame
     ///
     /// @return The frame
     const Shared<const Frame>& accessFrame() const;
-
-    /// @brief Get the frame
-    ///
-    /// @return The frame
-    Shared<const Frame> getFrame() const;
 
     /// @brief Get the interpolation type
     ///
@@ -110,7 +103,7 @@ class Tabulated : public Dynamics
     /// @return True if dynamics is defined
     virtual bool isDefined() const override;
 
-    /// @brief Return the coordinate subsets that the instance reads from
+    /// @brief Return the coordinate subsets that the instance reads from (there are none for Tabulated dynamics)
     ///
     /// @return The coordinate subsets that the instance reads from
     virtual Array<Shared<const CoordinateSubset>> getReadCoordinateSubsets() const override;

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -232,20 +232,13 @@ Maneuver Maneuver::FromTabulatedDynamics(const Shared<Dynamics>& aTabulatedDynam
 
     if (tabulatedDynamicsSPtr)
     {
-        const Array<Shared<const CoordinateSubset>> expectedWriteCoordinateSubsets = {
-            CartesianVelocity::Default(), CoordinateSubset::Mass()
-        };
-
-        if (tabulatedDynamicsSPtr->getWriteCoordinateSubsets() != expectedWriteCoordinateSubsets)
-        {
-            throw ostk::core::error::runtime::Wrong("Tabulated Dynamics Write Coordinate Subsets");
-        }
-
-        const MatrixXd contributionProfile = tabulatedDynamicsSPtr->getContributionProfile();
+        const MatrixXd contributionProfile = tabulatedDynamicsSPtr->getContributionProfileFromCoordinateSubsets(
+            {CartesianVelocity::Default(), CoordinateSubset::Mass()}
+        );
         Array<Vector3d> accelerationProfile = Array<Vector3d>::Empty();
         Array<Real> massFlowRateProfile = Array<Real>::Empty();
 
-        for (Size i = 0; i < tabulatedDynamicsSPtr->getInstants().getSize(); i++)
+        for (Size i = 0; i < tabulatedDynamicsSPtr->accessInstants().getSize(); i++)
         {
             accelerationProfile.add(
                 Vector3d(contributionProfile(i, 0), contributionProfile(i, 1), contributionProfile(i, 2))
@@ -254,9 +247,9 @@ Maneuver Maneuver::FromTabulatedDynamics(const Shared<Dynamics>& aTabulatedDynam
         }
 
         return {
-            tabulatedDynamicsSPtr->getInstants(),
+            tabulatedDynamicsSPtr->accessInstants(),
             accelerationProfile,
-            tabulatedDynamicsSPtr->getFrame(),
+            tabulatedDynamicsSPtr->accessFrame(),
             massFlowRateProfile
         };
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.test.cpp
@@ -9,6 +9,7 @@
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
 
 #include <Global.test.hpp>
@@ -35,6 +36,7 @@ using ostk::physics::coordinate::Frame;
 
 using ostk::astrodynamics::dynamics::Tabulated;
 using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
 class OpenSpaceToolkit_Astrodynamics_Dynamics_Tabulated : public ::testing::Test
@@ -207,24 +209,116 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Tabulated, Accessors)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Tabulated, Getters)
 {
+    MatrixXd positionContributionsProfile_(defaultInstants_.getSize(), 3);
+    MatrixXd velocityContributionsProfile_(defaultInstants_.getSize(), 3);
+    MatrixXd massContributionsProfile_(defaultInstants_.getSize(), 1);
+    positionContributionsProfile_ << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0;
+    velocityContributionsProfile_ << 4.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0, 6.0;
+    massContributionsProfile_ << 7.0, 7.0, 7.0, 7.0;
+
+    MatrixXd extendedContributionProfile(defaultInstants_.getSize(), 7);
+    extendedContributionProfile << positionContributionsProfile_, velocityContributionsProfile_,
+        massContributionsProfile_;
+
     Tabulated tabulated = {
         defaultInstants_,
-        contributionProfile_,
-        defaultWriteCoordinateSubsets_,
+        extendedContributionProfile,
+        {CartesianPosition::Default(), CartesianVelocity::Default(), CoordinateSubset::Mass()},
         defaultFrameSPtr_,
         defaultInterpolationType_,
     };
 
+    EXPECT_THROW(
+        {
+            try
+            {
+                tabulated.getContributionProfileFromCoordinateSubsets({});
+            }
+            catch (const ostk::core::error::RuntimeError& e)
+            {
+                EXPECT_EQ("Specified Coordinate Subset array is empty.", e.getMessage());
+                throw;
+            }
+        },
+        ostk::core::error::RuntimeError
+    );
+
+    EXPECT_THROW(
+        {
+            try
+            {
+                tabulated.getContributionProfileFromCoordinateSubsets({CoordinateSubset::DragCoefficient()});
+            }
+            catch (const ostk::core::error::RuntimeError& e)
+            {
+                EXPECT_EQ("Coordinate subset not found in write coordinate subsets.", e.getMessage());
+                throw;
+            }
+        },
+        ostk::core::error::RuntimeError
+    );
+
+    // Test singular or correctly ordered subsets
     {
-        EXPECT_EQ(tabulated.getInstants(), defaultInstants_);
+        EXPECT_EQ(
+            tabulated.getContributionProfileFromCoordinateSubsets({CartesianPosition::Default()}),
+            positionContributionsProfile_
+        );
+
+        EXPECT_EQ(
+            tabulated.getContributionProfileFromCoordinateSubsets({CartesianVelocity::Default()}),
+            velocityContributionsProfile_
+        );
+
+        EXPECT_EQ(
+            tabulated.getContributionProfileFromCoordinateSubsets({CoordinateSubset::Mass()}), massContributionsProfile_
+        );
+
+        EXPECT_EQ(
+            tabulated.getContributionProfileFromCoordinateSubsets(
+                {CartesianPosition::Default(), CartesianVelocity::Default(), CoordinateSubset::Mass()}
+            ),
+            extendedContributionProfile
+        );
     }
 
+    // Test differently ordered subsets
     {
-        EXPECT_EQ(tabulated.getContributionProfile(), contributionProfile_);
-    }
+        {
+            MatrixXd differentOrderContributionProfile(defaultInstants_.getSize(), 6);
+            differentOrderContributionProfile << velocityContributionsProfile_, positionContributionsProfile_;
 
-    {
-        EXPECT_EQ(tabulated.getFrame(), defaultFrameSPtr_);
+            EXPECT_EQ(
+                tabulated.getContributionProfileFromCoordinateSubsets(
+                    {CartesianVelocity::Default(), CartesianPosition::Default()}
+                ),
+                differentOrderContributionProfile
+            );
+        }
+
+        {
+            MatrixXd differentOrderContributionProfile(defaultInstants_.getSize(), 4);
+            differentOrderContributionProfile << massContributionsProfile_, positionContributionsProfile_;
+
+            EXPECT_EQ(
+                tabulated.getContributionProfileFromCoordinateSubsets(
+                    {CoordinateSubset::Mass(), CartesianPosition::Default()}
+                ),
+                differentOrderContributionProfile
+            );
+        }
+
+        {
+            MatrixXd differentOrderContributionProfile(defaultInstants_.getSize(), 4);
+            differentOrderContributionProfile << massContributionsProfile_, velocityContributionsProfile_;
+
+            EXPECT_EQ(
+                tabulated.getContributionProfileFromCoordinateSubsets(
+                    {CoordinateSubset::Mass(), CartesianVelocity::Default()}
+                ),
+                differentOrderContributionProfile
+            );
+        }
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.test.cpp
@@ -212,9 +212,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Tabulated, Getters)
     MatrixXd positionContributionsProfile_(defaultInstants_.getSize(), 3);
     MatrixXd velocityContributionsProfile_(defaultInstants_.getSize(), 3);
     MatrixXd massContributionsProfile_(defaultInstants_.getSize(), 1);
-    positionContributionsProfile_ << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0;
-    velocityContributionsProfile_ << 4.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0, 6.0;
-    massContributionsProfile_ << 7.0, 7.0, 7.0, 7.0;
+    positionContributionsProfile_ << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0;
+    velocityContributionsProfile_ << -1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0, -10.0, -11.0, -12.0;
+    massContributionsProfile_ << 0.001, 0.002, 0.003, 0.004;
 
     MatrixXd extendedContributionProfile(defaultInstants_.getSize(), 7);
     extendedContributionProfile << positionContributionsProfile_, velocityContributionsProfile_,
@@ -248,6 +248,23 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Tabulated, Getters)
             try
             {
                 tabulated.getContributionProfileFromCoordinateSubsets({CoordinateSubset::DragCoefficient()});
+            }
+            catch (const ostk::core::error::RuntimeError& e)
+            {
+                EXPECT_EQ("Coordinate subset not found in write coordinate subsets.", e.getMessage());
+                throw;
+            }
+        },
+        ostk::core::error::RuntimeError
+    );
+
+    EXPECT_THROW(
+        {
+            try
+            {
+                tabulated.getContributionProfileFromCoordinateSubsets(
+                    {CartesianPosition::Default(), CoordinateSubset::DragCoefficient()}
+                );
             }
             catch (const ostk::core::error::RuntimeError& e)
             {

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
@@ -368,9 +368,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, ToTabulatedDynamics)
         const Shared<TabulatedDynamics> tabulatedDynamicsSPtr =
             defaultManeuver_.toTabulatedDynamics(defaultFrameSPtr_, Interpolator::Type::BarycentricRational);
 
-        EXPECT_EQ(tabulatedDynamicsSPtr->getInstants(), defaultInstants_);
+        EXPECT_EQ(tabulatedDynamicsSPtr->accessInstants(), defaultInstants_);
 
-        const MatrixXd contributionProfile = tabulatedDynamicsSPtr->getContributionProfile();
+        const MatrixXd contributionProfile = tabulatedDynamicsSPtr->accessContributionProfile();
 
         EXPECT_EQ(contributionProfile.rows(), 4);
         EXPECT_EQ(contributionProfile.cols(), defaultInstants_.getSize());
@@ -387,7 +387,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, ToTabulatedDynamics)
             CartesianVelocity::Default(), CoordinateSubset::Mass()
         };
         EXPECT_EQ(tabulatedDynamicsSPtr->getWriteCoordinateSubsets(), writeCoordinateSubsets);
-        EXPECT_EQ(tabulatedDynamicsSPtr->getFrame(), defaultFrameSPtr_);
+        EXPECT_EQ(tabulatedDynamicsSPtr->accessFrame(), defaultFrameSPtr_);
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
@@ -455,13 +455,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
                 {
                     Maneuver::FromTabulatedDynamics(wrongTabulatedDynamicsSPtr);
                 }
-                catch (const ostk::core::error::runtime::Wrong& e)
+                catch (const ostk::core::error::RuntimeError& e)
                 {
-                    EXPECT_EQ("{Tabulated Dynamics Write Coordinate Subsets} is wrong.", e.getMessage());
+                    EXPECT_EQ("Coordinate subset not found in write coordinate subsets.", e.getMessage());
                     throw;
                 }
             },
-            ostk::core::error::runtime::Wrong
+            ostk::core::error::RuntimeError
         );
     }
 
@@ -483,13 +483,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
                 {
                     Maneuver::FromTabulatedDynamics(wrongTabulatedDynamicsSPtr);
                 }
-                catch (const ostk::core::error::runtime::Wrong& e)
+                catch (const ostk::core::error::RuntimeError& e)
                 {
-                    EXPECT_EQ("{Tabulated Dynamics Write Coordinate Subsets} is wrong.", e.getMessage());
+                    EXPECT_EQ("Coordinate subset not found in write coordinate subsets.", e.getMessage());
                     throw;
                 }
             },
-            ostk::core::error::runtime::Wrong
+            ostk::core::error::RuntimeError
         );
     }
 }


### PR DESCRIPTION
This MR is in response to @phc1990 's comment [here](https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/340#discussion_r1500867108) about adding a `getContributionProfileFromCoordinateSubsets` to TabulatedDynamics as a stopgap to properly refactoring the way Dynamics are handled (and expanded and reduced) in the future.

Also I removed the redundant getters in `TabulatedDynamics` to keep with the pattern:
- accessors for member variables
- getters for member variables that you modify before returning or anything computed on the fly