### PR TITLE
refactor!:small changes to maneuver class based on vishwa's suggestions

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Maneuver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Maneuver.cpp
@@ -161,8 +161,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Maneuver(pybind11::module& aM
             )doc"
         )
         .def_static(
-            "from_tabulated_dynamics",
-            &Maneuver::FromTabulatedDynamics,
+            "tabulated_dynamics",
+            &Maneuver::TabulatedDynamics,
             arg("tabulated_dynamics"),
             R"doc(
             Create a maneuver from tabulated dynamics with cols 1-3 being acceleration and col 4 being mass flow rate.
@@ -175,8 +175,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Maneuver(pybind11::module& aM
         )doc"
         )
         .def_static(
-            "from_constant_mass_flow_rate_profile",
-            &Maneuver::FromConstantMassFlowRateProfile,
+            "constant_mass_flow_rate_profile",
+            &Maneuver::ConstantMassFlowRateProfile,
             arg("instants"),
             arg("acceleration_profile"),
             arg("frame"),

--- a/bindings/python/test/flight/test_maneuver.py
+++ b/bindings/python/test/flight/test_maneuver.py
@@ -183,7 +183,7 @@ class TestManeuver:
         self,
         tabulated_dynamics: TabulatedDynamics,
     ):
-        maneuver = Maneuver.from_tabulated_dynamics(tabulated_dynamics)
+        maneuver = Maneuver.tabulated_dynamics(tabulated_dynamics)
 
         assert maneuver.is_defined()
         assert maneuver.get_instants() == tabulated_dynamics.access_instants()
@@ -203,7 +203,7 @@ class TestManeuver:
         frame: Frame,
     ):
         mass_flow_rate: float = -1.0e-5
-        maneuver = Maneuver.from_constant_mass_flow_rate_profile(
+        maneuver = Maneuver.constant_mass_flow_rate_profile(
             instants=instants,
             acceleration_profile=acceleration_profile,
             frame=frame,

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
@@ -46,7 +46,7 @@ using ostk::physics::time::Instant;
 using ostk::physics::time::Interval;
 using ostk::physics::unit::Mass;
 
-using TabulatedDynamics = ostk::astrodynamics::dynamics::Tabulated;
+using ostk::astrodynamics::dynamics::Tabulated;
 using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
@@ -187,7 +187,7 @@ class Maneuver
     /// @brief Convert the maneuver to a Tabulated Dynamics object
     ///
     /// @code{.cpp}
-    ///                  Shared<TabulatedDynamics> tabulatedDynamicsSPtr = maneuver.toTabulatedDynamics(Frame::GCRF(),
+    ///                  Shared<Tabulated> tabulatedDynamicsSPtr = maneuver.toTabulatedDynamics(Frame::GCRF(),
     ///                  Interpolator::Type::BarycentricRational);
     /// @endcode
     ///
@@ -195,7 +195,7 @@ class Maneuver
     /// @param (optional) anInterpolationType The interpolation type to use in the Tabulated Dynamics object
     ///
     /// @return A shared pointer to the Tabulated Dynamics object
-    Shared<TabulatedDynamics> toTabulatedDynamics(
+    Shared<Tabulated> toTabulatedDynamics(
         const Shared<const Frame>& aFrameSPtr = DefaultAccelFrameSPtr,
         const Interpolator::Type& anInterpolationType = DEFAULT_MANEUVER_INTERPOLATION_TYPE
     ) const;
@@ -210,20 +210,18 @@ class Maneuver
     /// rate
     ///
     /// @code{.cpp}
-    ///                  Shared<Dynamics> tabulatedDynamicsSPtr = std::make_shared<TabulatedDynamics>(tabulated);
-    ///                  Maneuver maneuver = Maneuver::FromTabulatedDynamics(tabulatedDynamicsSPtr);
+    ///                  Maneuver maneuver = Maneuver::TabulatedDynamics(tabulated);
     /// @endcode
     ///
-    /// @param aTabulatedDynamicsSPtr A shared pointer to a Dynamics object (that is downcastable to a TabulatedDynamics
-    /// object)
+    /// @param aTabulatedDynamics A TabulatedDynamics object
     ///
     /// @return A maneuver
-    static Maneuver FromTabulatedDynamics(const Shared<Dynamics>& aTabulatedDynamicsSPtr);
+    static Maneuver TabulatedDynamics(const Tabulated& aTabulatedDynamics);
 
     /// @brief Create a maneuver from a constant mass flow rate profile
     ///
     /// @code{.cpp}
-    ///                  Maneuver maneuver = Maneuver::FromConstantMassFlowRateProfile(...);
+    ///                  Maneuver maneuver = Maneuver::ConstantMassFlowRateProfile(...);
     /// @endcode
     ///
     /// @param anInstantArray An array of instants, must be sorted
@@ -232,7 +230,7 @@ class Maneuver
     /// @param aMassFlowRate A constant mass flow rate that will be used for all the instants in the maneuver in kg/s
     ///
     /// @return A maneuver
-    static Maneuver FromConstantMassFlowRateProfile(
+    static Maneuver ConstantMassFlowRateProfile(
         const Array<Instant>& anInstantArray,
         const Array<Vector3d>& anAccelerationProfile,
         const Shared<const Frame>& aFrameSPtr,

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.cpp
@@ -109,12 +109,12 @@ MatrixXd Tabulated::getContributionProfileFromCoordinateSubsets(
     );
 
     Index customMatrixColIndex = 0;
-    for (const auto desiredCoordinateSubsetSPtr : aCoordinateSubsetArray)
+    for (const auto& desiredCoordinateSubsetSPtr : aCoordinateSubsetArray)
     {
         bool coordinateSubsetFound = false;
         Index existingMatrixColIndex = 0;
 
-        for (const auto existingCoordinateSubsetSPtr : writeCoordinateSubsets_)
+        for (const auto& existingCoordinateSubsetSPtr : writeCoordinateSubsets_)
         {
             if (*desiredCoordinateSubsetSPtr == *existingCoordinateSubsetSPtr)
             {

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -58,9 +58,9 @@ Maneuver::Maneuver(
 
     for (Size k = 0; k < instants_.getSize() - 1; ++k)
     {
-        if (instants_[k] > instants_[k + 1])
+        if (instants_[k] >= instants_[k + 1])
         {
-            throw ostk::core::error::runtime::Wrong("Unsorted Instant Array");
+            throw ostk::core::error::runtime::Wrong("Unsorted or Duplicate Instant Array");
         }
     }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -112,7 +112,7 @@ Array<Maneuver> Segment::Solution::extractManeuvers(const Shared<const Frame>& a
 {
     if (this->states.isEmpty())
     {
-        throw ostk::core::error::RuntimeError("No states exist within segment.");
+        throw ostk::core::error::RuntimeError("No states exist within Segment Solution.");
     }
 
     if (this->segmentType != Segment::Type::Maneuver)
@@ -155,7 +155,7 @@ Array<Maneuver> Segment::Solution::extractManeuvers(const Shared<const Frame>& a
         Interpolator::Type::Linear,
     };
 
-    return {Maneuver::FromTabulatedDynamics(std::make_shared<TabulatedDynamics>(tabulatedDynamics))};
+    return {Maneuver::TabulatedDynamics(tabulatedDynamics)};
 }
 
 Array<State> Segment::Solution::calculateStatesAt(

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
@@ -398,43 +398,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
         const Shared<TabulatedDynamics> tabulatedDynamicsSPtr =
             defaultManeuver_.toTabulatedDynamics(defaultFrameSPtr_, Interpolator::Type::BarycentricRational);
 
-        const Maneuver maneuver = Maneuver::FromTabulatedDynamics(tabulatedDynamicsSPtr);
+        const Maneuver maneuver = Maneuver::TabulatedDynamics(*tabulatedDynamicsSPtr);
 
         EXPECT_EQ(maneuver.getInstants(), defaultInstants_);
         EXPECT_EQ(maneuver.getAccelerationProfile(defaultFrameSPtr_), defaultAccelerationProfileDefaultFrame_);
         EXPECT_EQ(maneuver.getMassFlowRateProfile(), defaultMassFlowRateProfile_);
-    }
-
-    // Verify creation from dynamics
-    {
-        const Shared<Dynamics> tabulatedDynamicsSPtr =
-            defaultManeuver_.toTabulatedDynamics(defaultFrameSPtr_, Interpolator::Type::BarycentricRational);
-
-        const Maneuver maneuver = Maneuver::FromTabulatedDynamics(tabulatedDynamicsSPtr);
-
-        EXPECT_EQ(maneuver.getInstants(), defaultInstants_);
-        EXPECT_EQ(maneuver.getAccelerationProfile(defaultFrameSPtr_), defaultAccelerationProfileDefaultFrame_);
-        EXPECT_EQ(maneuver.getMassFlowRateProfile(), defaultMassFlowRateProfile_);
-    }
-
-    // Nullptr fail
-    {
-        const Shared<Dynamics> tabulatedDynamicsSPtr = nullptr;
-
-        EXPECT_THROW(
-            {
-                try
-                {
-                    Maneuver::FromTabulatedDynamics(tabulatedDynamicsSPtr);
-                }
-                catch (const ostk::core::error::runtime::Undefined& e)
-                {
-                    EXPECT_EQ("{Tabulated Dynamics} is undefined.", e.getMessage());
-                    throw;
-                }
-            },
-            ostk::core::error::runtime::Undefined
-        );
     }
 
     // Wrong dynamics coordinate subsets fail
@@ -453,7 +421,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
             {
                 try
                 {
-                    Maneuver::FromTabulatedDynamics(wrongTabulatedDynamicsSPtr);
+                    Maneuver::TabulatedDynamics(*wrongTabulatedDynamicsSPtr);
                 }
                 catch (const ostk::core::error::RuntimeError& e)
                 {
@@ -481,7 +449,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
             {
                 try
                 {
-                    Maneuver::FromTabulatedDynamics(wrongTabulatedDynamicsSPtr);
+                    Maneuver::TabulatedDynamics(*wrongTabulatedDynamicsSPtr);
                 }
                 catch (const ostk::core::error::RuntimeError& e)
                 {
@@ -494,10 +462,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromTabulatedDynamics)
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, FromConstantMassFlowRateProfile)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, ConstantMassFlowRateProfile)
 {
     {
-        const Maneuver maneuver = Maneuver::FromConstantMassFlowRateProfile(
+        const Maneuver maneuver = Maneuver::ConstantMassFlowRateProfile(
             defaultInstants_, defaultAccelerationProfileDefaultFrame_, defaultFrameSPtr_, defaultConstantMassFlowRate_
         );
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
@@ -186,6 +186,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Constructor)
         );
     }
 
+    // Unsorted instant array
     {
         const Array<Instant> unorderedInstants = {
             Instant::J2000() + Duration::Seconds(1.0),
@@ -207,7 +208,37 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Constructor)
                 }
                 catch (const ostk::core::error::runtime::Wrong& e)
                 {
-                    EXPECT_EQ("{Unsorted Instant Array} is wrong.", e.getMessage());
+                    EXPECT_EQ("{Unsorted or Duplicate Instant Array} is wrong.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::runtime::Wrong
+        );
+    }
+
+    // Instant array with duplicates
+    {
+        const Array<Instant> duplicateInstants = {
+            Instant::J2000(),
+            Instant::J2000() + Duration::Seconds(1.0),
+            Instant::J2000() + Duration::Seconds(1.0),
+            Instant::J2000() + Duration::Seconds(5.0),
+        };
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver(
+                        duplicateInstants,
+                        defaultAccelerationProfileDefaultFrame_,
+                        defaultFrameSPtr_,
+                        defaultMassFlowRateProfile_
+                    );
+                }
+                catch (const ostk::core::error::runtime::Wrong& e)
+                {
+                    EXPECT_EQ("{Unsorted or Duplicate Instant Array} is wrong.", e.getMessage());
                     throw;
                 }
             },


### PR DESCRIPTION
Small MR to address @vishwa2710's comment on the Maneuver class' interface with other OSTk objects on these two MRs:
https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/340
https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/365