### PR TITLE
feat: Refactored CMakeLists, updated versions for OSTk Dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,9 +273,9 @@ ELSE ()
     MESSAGE (SEND_ERROR "[NLopt] not found.")
 ENDIF ()
 
-### Open Space Toolkit ▸ Core
+### Open Space Toolkit ▸ Core [3.0.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitCore" "2.2" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitCore" "3.0" REQUIRED)
 
 IF (NOT OpenSpaceToolkitCore_FOUND)
 
@@ -283,9 +283,9 @@ IF (NOT OpenSpaceToolkitCore_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ I/O
+### Open Space Toolkit ▸ I/O [3.0.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitIO" "2.1" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitIO" "3.0" REQUIRED)
 
 IF (NOT OpenSpaceToolkitIO_FOUND)
 
@@ -293,9 +293,9 @@ IF (NOT OpenSpaceToolkitIO_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Mathematics
+### Open Space Toolkit ▸ Mathematics [3.0.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitMathematics" "2.1" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitMathematics" "3.0" REQUIRED)
 
 IF (NOT OpenSpaceToolkitMathematics_FOUND)
 
@@ -303,9 +303,9 @@ IF (NOT OpenSpaceToolkitMathematics_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Physics
+### Open Space Toolkit ▸ Physics [6.0.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "5.3" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "6.0" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,22 @@ SET (Boost_USE_MULTITHREADED ON)
 
 FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS log log_setup thread)
 
-ADD_DEFINITIONS(-DBOOST_THREAD_DYN_LINK -DBOOST_STACKTRACE_USE_BACKTRACE -DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=</usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h>)
+## Stacktrace definitions
+# Detect system architecture
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    # Architecture-specific include for x86_64
+    set(BACKTRACE_INCLUDE "/usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    # Example path adjustment for aarch64, adjust the path as needed
+    set(BACKTRACE_INCLUDE "/usr/lib/gcc/aarch64-linux-gnu/9/include/backtrace.h")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+# Add definitions with architecture-specific path
+ADD_DEFINITIONS(-DBOOST_THREAD_DYN_LINK)
+ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE)
+ADD_DEFINITIONS(-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
 
 IF (NOT Boost_FOUND)
     MESSAGE (SEND_ERROR "[Boost] not found.")
@@ -260,7 +275,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Core
 
-FIND_PACKAGE ("OpenSpaceToolkitCore" "2.0" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitCore" "2.2" REQUIRED)
 
 IF (NOT OpenSpaceToolkitCore_FOUND)
 
@@ -270,7 +285,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ I/O
 
-FIND_PACKAGE ("OpenSpaceToolkitIO" "2.0" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitIO" "2.1" REQUIRED)
 
 IF (NOT OpenSpaceToolkitIO_FOUND)
 
@@ -280,7 +295,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Mathematics
 
-FIND_PACKAGE ("OpenSpaceToolkitMathematics" "2.0" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitMathematics" "2.1" REQUIRED)
 
 IF (NOT OpenSpaceToolkitMathematics_FOUND)
 
@@ -290,7 +305,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Physics
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "5.1" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "5.2" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Physics
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "5.2" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "5.3" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./'
 
 dev_username := developer
 
+
 ifeq ($(PLATFORM),amd64)
 platform := x86_64
 endif
@@ -31,6 +32,7 @@ endif
 
 platform ?= x86_64
 $(info Platform value is $(platform))
+
 
 pull: ## Pull all images
 
@@ -250,9 +252,9 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 
 .PHONY: build-packages-cpp-standalone
 
-build-packages-python: ##build-development-image ## Build Python packages
-	@ echo "Building platform $(platform) Python packages..."
-# @ $(MAKE) build-packages-python-standalone
+build-packages-python: build-development-image ## Build Python packages
+
+	@ $(MAKE) build-packages-python-standalone
 
 .PHONY: build-packages-python
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,17 @@ extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./'
 
 dev_username := developer
 
+ifeq ($(PLATFORM),amd64)
+platform := x86_64
+endif
+
+ifeq ($(PLATFORM),arm64)
+platform := aarch64
+endif
+
+platform ?= x86_64
+$(info Platform value is $(platform))
+
 pull: ## Pull all images
 
 	@ echo "Pulling images..."
@@ -226,6 +237,7 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 	@ echo "Building C++ packages..."
 
 	docker run \
+		--platform ${platform} \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \
@@ -238,9 +250,9 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 
 .PHONY: build-packages-cpp-standalone
 
-build-packages-python: build-development-image ## Build Python packages
-
-	@ $(MAKE) build-packages-python-standalone
+build-packages-python: ##build-development-image ## Build Python packages
+	@ echo "Building platform $(platform) Python packages..."
+# @ $(MAKE) build-packages-python-standalone
 
 .PHONY: build-packages-python
 
@@ -249,6 +261,7 @@ build-packages-python-standalone: ## Build Python packages (standalone)
 	@ echo "Building Python packages..."
 
 	docker run \
+		--platform ${platform} \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \

--- a/Makefile
+++ b/Makefile
@@ -22,16 +22,9 @@ extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./'
 dev_username := developer
 
 
-ifeq ($(PLATFORM),amd64)
-platform := x86_64
-endif
-
-ifeq ($(PLATFORM),arm64)
-platform := aarch64
-endif
-
-platform ?= x86_64
-$(info Platform value is $(platform))
+# Handle multi-platform builds locally (CI sets these env vars, but need defaults here)
+TARGETPLATFORM ?= linux/amd64
+$(info Target platform is $(TARGETPLATFORM))
 
 
 pull: ## Pull all images
@@ -239,7 +232,7 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 	@ echo "Building C++ packages..."
 
 	docker run \
-		--platform ${platform} \
+		--platform $(TARGETPLATFORM) \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \
@@ -263,7 +256,7 @@ build-packages-python-standalone: ## Build Python packages (standalone)
 	@ echo "Building Python packages..."
 
 	docker run \
-		--platform ${platform} \
+		--platform $(TARGETPLATFORM) \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -122,6 +122,15 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
     # Package directory name
     SET (PACKAGE_DIRECTORY_NAME ${NAME})
 
+    # Set platforme name for wheel
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+        SET (PLATFORM "manylinux2014_x86_64")
+    ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+        SET (PLATFORM "manylinux2014_aarch64")
+    ELSE()
+        MESSAGE (FATAL_ERROR "Unsupported platform")
+    ENDIF()
+
     # Get python extension for relevant shared library spotting
     STRING (REPLACE "." "" EXTENSION "${PYTHON_VERSION}")
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,3 +1,3 @@
 # Apache License 2.0
 
-open-space-toolkit-physics~=5.2.0
+open-space-toolkit-physics~=5.3.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,3 +1,3 @@
 # Apache License 2.0
 
-open-space-toolkit-physics~=5.1.0
+open-space-toolkit-physics~=5.2.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,3 +1,3 @@
 # Apache License 2.0
 
-open-space-toolkit-physics~=5.3.0
+open-space-toolkit-physics~=6.0.0

--- a/bindings/python/tools/python/setup.cfg.in
+++ b/bindings/python/tools/python/setup.cfg.in
@@ -3,6 +3,7 @@
 [bdist_wheel]
 python-tag=py${EXTENSION}
 bdist-dir=./dist${EXTENSION}
+plat-name=${PLATFORM}
 
 [metadata]
 name = open-space-toolkit-astrodynamics

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -143,7 +143,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG OSTK_PHYSICS_MAJOR="5"
-ARG OSTK_PHYSICS_MINOR="2"
+ARG OSTK_PHYSICS_MINOR="3"
 
 ## Force an image rebuild when new Physics patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR}.${OSTK_PHYSICS_MINOR} /tmp/open-space-toolkit-physics/versions.json

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -94,8 +94,9 @@ RUN git clone --branch v${BENCHMARK_VERSION} https://github.com/google/benchmark
 
 ## Open Space Toolkit ▸ Core
 
-ARG OSTK_CORE_MAJOR="2"
-ARG OSTK_CORE_MINOR="2"
+ARG TARGETPLATFORM
+ARG OSTK_CORE_MAJOR="3"
+ARG OSTK_CORE_MINOR="0"
 
 ## Force an image rebuild when new Core patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR}.${OSTK_CORE_MINOR} /tmp/open-space-toolkit-core/versions.json
@@ -103,15 +104,17 @@ ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/g
 RUN mkdir -p /tmp/open-space-toolkit-core \
  && cd /tmp/open-space-toolkit-core \
  && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
  && apt-get install -y ./*.deb \
  && rm -rf /tmp/open-space-toolkit-core
 
 ## Open Space Toolkit ▸ I/O
 
-ARG OSTK_IO_MAJOR="2"
-ARG OSTK_IO_MINOR="1"
+ARG TARGETPLATFORM
+ARG OSTK_IO_MAJOR="3"
+ARG OSTK_IO_MINOR="0"
 
 ## Force an image rebuild when new IO patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-io/git/matching-refs/tags/${OSTK_IO_MAJOR}.${OSTK_IO_MINOR} /tmp/open-space-toolkit-io/versions.json
@@ -119,31 +122,35 @@ ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-io/git
 RUN mkdir -p /tmp/open-space-toolkit-io \
  && cd /tmp/open-space-toolkit-io \
  && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
  && apt-get install -y ./*.deb \
  && rm -rf /tmp/open-space-toolkit-io
 
 ## Open Space Toolkit ▸ Mathematics
 
-ARG OSTK_MATHEMATICS_MAJOR="2"
-ARG OSTK_MATHEMATICS_MINOR="1"
+ARG TARGETPLATFORM
+ARG OSTK_MATHEMATICS_MAJOR="3"
+ARG OSTK_MATHEMATICS_MINOR="0"
 
-## Force an image rebuild when new Mathematics patch versions are detected
+## Force an image rebuild when new Math patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-mathematics/git/matching-refs/tags/${OSTK_MATHEMATICS_MAJOR}.${OSTK_MATHEMATICS_MINOR} /tmp/open-space-toolkit-mathematics/versions.json
 
 RUN mkdir -p /tmp/open-space-toolkit-mathematics \
  && cd /tmp/open-space-toolkit-mathematics \
  && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
  && apt-get install -y ./*.deb \
  && rm -rf /tmp/open-space-toolkit-mathematics
 
 ## Open Space Toolkit ▸ Physics
 
-ARG OSTK_PHYSICS_MAJOR="5"
-ARG OSTK_PHYSICS_MINOR="3"
+ARG TARGETPLATFORM
+ARG OSTK_PHYSICS_MAJOR="6"
+ARG OSTK_PHYSICS_MINOR="0"
 
 ## Force an image rebuild when new Physics patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR}.${OSTK_PHYSICS_MINOR} /tmp/open-space-toolkit-physics/versions.json
@@ -151,8 +158,9 @@ ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physic
 RUN mkdir -p /tmp/open-space-toolkit-physics \
  && cd /tmp/open-space-toolkit-physics \
  && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-physics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-physics-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-physics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-physics-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-physics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-physics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-physics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-physics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
  && apt-get install -y ./*.deb \
  && rm -rf /tmp/open-space-toolkit-physics
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -3,8 +3,7 @@
 ARG BASE_IMAGE_VERSION="latest"
 
 # General purpose development image (root user)
-
-FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION} as root-user
+FROM openspacecollective/open-space-toolkit-base-development:${BASE_IMAGE_VERSION} as root-user
 
 LABEL maintainer="lucas@loftorbital.com"
 
@@ -96,7 +95,7 @@ RUN git clone --branch v${BENCHMARK_VERSION} https://github.com/google/benchmark
 ## Open Space Toolkit ▸ Core
 
 ARG OSTK_CORE_MAJOR="2"
-ARG OSTK_CORE_MINOR="1"
+ARG OSTK_CORE_MINOR="2"
 
 ## Force an image rebuild when new Core patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR}.${OSTK_CORE_MINOR} /tmp/open-space-toolkit-core/versions.json
@@ -112,7 +111,7 @@ RUN mkdir -p /tmp/open-space-toolkit-core \
 ## Open Space Toolkit ▸ I/O
 
 ARG OSTK_IO_MAJOR="2"
-ARG OSTK_IO_MINOR="0"
+ARG OSTK_IO_MINOR="1"
 
 ## Force an image rebuild when new IO patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-io/git/matching-refs/tags/${OSTK_IO_MAJOR}.${OSTK_IO_MINOR} /tmp/open-space-toolkit-io/versions.json
@@ -128,7 +127,7 @@ RUN mkdir -p /tmp/open-space-toolkit-io \
 ## Open Space Toolkit ▸ Mathematics
 
 ARG OSTK_MATHEMATICS_MAJOR="2"
-ARG OSTK_MATHEMATICS_MINOR="0"
+ARG OSTK_MATHEMATICS_MINOR="1"
 
 ## Force an image rebuild when new Mathematics patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-mathematics/git/matching-refs/tags/${OSTK_MATHEMATICS_MAJOR}.${OSTK_MATHEMATICS_MINOR} /tmp/open-space-toolkit-mathematics/versions.json
@@ -144,7 +143,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG OSTK_PHYSICS_MAJOR="5"
-ARG OSTK_PHYSICS_MINOR="1"
+ARG OSTK_PHYSICS_MINOR="2"
 
 ## Force an image rebuild when new Physics patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR}.${OSTK_PHYSICS_MINOR} /tmp/open-space-toolkit-physics/versions.json

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -3,6 +3,7 @@
 ARG BASE_IMAGE_VERSION="latest"
 
 # General purpose development image (root user)
+
 FROM openspacecollective/open-space-toolkit-base-development:${BASE_IMAGE_VERSION} as root-user
 
 LABEL maintainer="lucas@loftorbital.com"


### PR DESCRIPTION
Added platform specific definitions, and updated Dockerfile for development with new versions and base image.

- Requires merge of https://github.com/open-space-collective/open-space-toolkit-core/pull/153 and ostk-core 3.0.0 release before passing
- Requires merge of https://github.com/open-space-collective/open-space-toolkit-io/pull/82 and ostk-io 3.0.0 release before passing
- Requires merge of https://github.com/open-space-collective/open-space-toolkit-mathematics/pull/121 and ostk-math 3.0.0 release before passing
- Requires merge of https://github.com/open-space-collective/open-space-toolkit-physics/pull/222 and ostk-physics 6.0.0 release before passing

Needs to be relased as ostk-astrodynamics 9.0.0