### PR TITLE
feat: add incorrect maneuver construction warnings and asserts

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
@@ -14,6 +14,7 @@
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
@@ -42,6 +43,7 @@ using ostk::mathematics::object::VectorXd;
 using ostk::mathematics::object::Vector3d;
 
 using ostk::physics::coordinate::Frame;
+using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Interval;
 using ostk::physics::unit::Mass;
@@ -57,6 +59,8 @@ class Maneuver
 {
    public:
     static const Shared<const Frame> DefaultAccelFrameSPtr;
+    static const Duration MinimumRecommendedDuration;
+    static const Duration MaximumRecommendedInterpolationInterval;
 
     /// @brief Constructor
     ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -60,6 +60,7 @@ Maneuver::Maneuver(
 
     const Duration maneuverDuration = instants_.accessLast() - instants_.accessFirst();
     Duration largestInterval = Duration::Zero();
+
     for (Size k = 0; k < instants_.getSize() - 1; ++k)
     {
         if (instants_[k] >= instants_[k + 1])
@@ -67,10 +68,7 @@ Maneuver::Maneuver(
             throw ostk::core::error::runtime::Wrong("Unsorted or Duplicate Instant Array");
         }
 
-        if (instants_[k + 1] - instants_[k] > largestInterval)
-        {
-            largestInterval = instants_[k + 1] - instants_[k];
-        }
+        largestInterval = std::max(largetInterval, instants_[k+1] - instants_[k]);
     }
 
     if (largestInterval > Maneuver::MaximumRecommendedInterpolationInterval)
@@ -89,7 +87,7 @@ Maneuver::Maneuver(
             << std::endl;
     }
 
-    // Ensure that the accelerations provided  have strictly positive magnitudes
+    // Ensure that the accelerations provided have strictly positive magnitudes
     if (std::any_of(
             accelerationProfileDefaultFrame_.begin(),
             accelerationProfileDefaultFrame_.end(),

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
@@ -1,4 +1,4 @@
-// /// Apache License 2.0
+/// Apache License 2.0
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
 #include <OpenSpaceToolkit/Core/Container/Pair.hpp>
@@ -246,8 +246,68 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Constructor)
         );
     }
 
+    // Maneuver with some intervals larger than the maximum recommended interpolation interval
     {
-        const Array<Real> positiveMassFlowRateProfile = {1.0e-5, 1.1e-5, 0.9e-5, 1.0e-5};
+        const Array<Instant> spacedOutInstants = {
+            Instant::J2000(),
+            Instant::J2000() + Maneuver::MaximumRecommendedInterpolationInterval * 2,
+            Instant::J2000() + Maneuver::MaximumRecommendedInterpolationInterval * 2.5,
+            Instant::J2000() + Maneuver::MaximumRecommendedInterpolationInterval * 3,
+        };
+
+        testing::internal::CaptureStdout();
+        Maneuver(
+            spacedOutInstants, defaultAccelerationProfileDefaultFrame_, defaultFrameSPtr_, defaultMassFlowRateProfile_
+        );
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+
+    // Maneuver with duration of less than minimum recommended duration
+    {
+        const Array<Instant> shortInstants = {
+            Instant::J2000(),
+            Instant::J2000() + Maneuver::MinimumRecommendedDuration / 4,
+            Instant::J2000() + Maneuver::MinimumRecommendedDuration / 3,
+            Instant::J2000() + Maneuver::MinimumRecommendedDuration / 2,
+        };
+
+        testing::internal::CaptureStdout();
+        Maneuver(
+            shortInstants, defaultAccelerationProfileDefaultFrame_, defaultFrameSPtr_, defaultMassFlowRateProfile_
+        );
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+
+    // Acceleration profile with accelerations of zero magnitude
+    {
+        const Array<Vector3d> incorrectAccelerationProfile = {
+            {0.0e-3, 0.0e-3, 0.0e-3},
+            {0.0e-3, 1.0e-3, 0.0e-3},
+            {0.0e-3, 0.0e-3, 1.0e-3},
+            {1.0e-3, 1.0e-3, 1.0e-3},
+        };
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver(
+                        defaultInstants_, incorrectAccelerationProfile, defaultFrameSPtr_, defaultMassFlowRateProfile_
+                    );
+                }
+                catch (const ostk::core::error::RuntimeError& e)
+                {
+                    EXPECT_EQ("Acceleration profile must have strictly positive magnitudes.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    // Mass flow rate profile with zero or positive mass flow rates
+    {
+        const Array<Real> incorrectMassFlowRateProfile = {0.0e-5, -1.1e-5, -0.9e-5, 1.0e-5};
 
         EXPECT_THROW(
             {
@@ -257,12 +317,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Constructor)
                         defaultInstants_,
                         defaultAccelerationProfileDefaultFrame_,
                         defaultFrameSPtr_,
-                        positiveMassFlowRateProfile
+                        incorrectMassFlowRateProfile
                     );
                 }
                 catch (const ostk::core::error::RuntimeError& e)
                 {
-                    EXPECT_EQ("Mass flow rate profile must be expressed in strictly negative numbers.", e.getMessage());
+                    EXPECT_EQ("Mass flow rate profile must have strictly negative values.", e.getMessage());
                     throw;
                 }
             },


### PR DESCRIPTION
Part of Maneuver validation effort.

This MR:
- [x] Ensure that a Maneuver rejects bad data upon creation that shouldn't actually qualify as a "maneuver" (such as zero accelerations in the profile or zero mass flow rates in the profile
- [x] Logs a warning if you might skip over maneuvers if the maneuver duration is shorter than the propagation timestep
- [x] Logs a warning if you might interpolate inaccurately with too big an interpolation step relative to the propagation step 