### PR TITLE
test: re-add ConstantThrust and ThrusterDynamics validation tests

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.hpp
@@ -24,9 +24,9 @@ namespace astrodynamics
 namespace dynamics
 {
 
+using ostk::core::container::Array;
 using ostk::core::type::Shared;
 using ostk::core::type::Real;
-using ostk::core::container::Array;
 
 using ostk::mathematics::curvefitting::Interpolator;
 using ostk::mathematics::object::Vector3d;
@@ -44,6 +44,7 @@ using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 class Tabulated : public Dynamics
 {
    public:
+    static const Shared<const Frame> DefaultContributionFrameSPtr;
     /// @brief Constructor
     ///
     /// @param anInstantArray An array of instants, must be sorted

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
@@ -14,6 +14,7 @@
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
@@ -42,6 +43,7 @@ using ostk::mathematics::object::VectorXd;
 using ostk::mathematics::object::Vector3d;
 
 using ostk::physics::coordinate::Frame;
+using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Interval;
 using ostk::physics::unit::Mass;
@@ -57,6 +59,8 @@ class Maneuver
 {
    public:
     static const Shared<const Frame> DefaultAccelFrameSPtr;
+    static const Duration MinimumRecommendedDuration;
+    static const Duration MaximumRecommendedInterpolationInterval;
 
     /// @brief Constructor
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -5,6 +5,7 @@
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
 #include <OpenSpaceToolkit/Core/Container/Map.hpp>
+#include <OpenSpaceToolkit/Core/Type/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 
@@ -30,6 +31,7 @@ namespace trajectory
 
 using ostk::core::container::Array;
 using ostk::core::container::Map;
+using ostk::core::type::Integer;
 using ostk::core::type::Shared;
 using ostk::core::type::String;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.cpp
@@ -18,6 +18,8 @@ using ostk::core::type::Index;
 
 using ostk::mathematics::object::VectorXd;
 
+const Shared<const Frame> Tabulated::DefaultContributionFrameSPtr = Frame::GCRF();
+
 Tabulated::Tabulated(
     const Array<Instant>& anInstantArray,
     const MatrixXd& aContributionProfile,
@@ -170,13 +172,6 @@ VectorXd Tabulated::computeContribution(
     const Instant& anInstant, [[maybe_unused]] const VectorXd& x, const Shared<const Frame>& aFrameSPtr
 ) const
 {
-    // TBM: Convert this using the Maneuver class' conversion method. Also, find a way to check and vet whether or not
-    // the frame is local, or quasi-inertial
-    if (aFrameSPtr != frameSPtr_)
-    {
-        throw ostk::core::error::runtime::Wrong("Frame");
-    }
-
     if (anInstant < instants_.accessFirst() || anInstant > instants_.accessLast())
     {
         return VectorXd::Zero(interpolators_.getSize());
@@ -188,6 +183,33 @@ VectorXd Tabulated::computeContribution(
     for (Index i = 0; i < interpolators_.getSize(); ++i)
     {
         contribution(i) = interpolators_[i]->evaluate(epoch);
+    }
+
+    // Transform the contribution to the desired frame if necessary
+    if (frameSPtr_ != aFrameSPtr)
+    {
+        if (!frameSPtr_->isQuasiInertial() && aFrameSPtr->isQuasiInertial())
+        {
+            // TBM: Replace with an actual proper logging mechanism
+            std::cout << "WARNING: This TabulatedDynamics has its contributions stored in a non quasi-inertial frame, "
+                         "but they are being requested in a quasi-inertial frame. Ensure that the trajectory "
+                         "used to generate the contributions with this TabulatedDynamics in the first place "
+                         "is still valid, otherwise this may lead to inaccurate results."
+                         "inaccurate results."
+                      << std::endl;
+        }
+
+        Size coordinateSubsetIndex = 0;
+        for (const auto& coordinateSubset : writeCoordinateSubsets_)
+        {
+            if (coordinateSubset->getSize() == 3)
+            {
+                contribution.segment(coordinateSubsetIndex, coordinateSubsetIndex + 3) =
+                    frameSPtr_->getTransformTo(aFrameSPtr, anInstant)
+                        .applyToVector(contribution.segment(coordinateSubsetIndex, coordinateSubsetIndex + 3));
+            }
+            coordinateSubsetIndex += coordinateSubset->getSize();
+        }
     }
 
     return contribution;

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.cpp
@@ -91,18 +91,19 @@ VectorXd Thruster::computeContribution(
         throw ostk::core::error::RuntimeError("Out of fuel.");
     }
 
-    const Real maximumThrustAccelerationMagnitude =
+    const Real maximumAccelerationMagnitude =
         satelliteSystem_.accessPropulsionSystem().getAcceleration(Mass::Kilograms(x[6]));
 
     const Vector3d acceleration = guidanceLaw_->calculateThrustAccelerationAt(
-        anInstant, positionCoordinates, velocityCoordinates, maximumThrustAccelerationMagnitude, aFrameSPtr
+        anInstant, positionCoordinates, velocityCoordinates, maximumAccelerationMagnitude, aFrameSPtr
     );
 
-    const Real effectiveThrustFraction = acceleration.norm() / maximumThrustAccelerationMagnitude;
+    const Real effectiveAccelerationFraction = acceleration.norm() / maximumAccelerationMagnitude;
 
     // Compute contribution
     VectorXd contribution(4);
-    contribution << acceleration[0], acceleration[1], acceleration[2], -effectiveThrustFraction * massFlowRateCache_;
+    contribution << acceleration[0], acceleration[1], acceleration[2],
+        -effectiveAccelerationFraction * massFlowRateCache_;
 
     return contribution;
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -165,51 +165,63 @@ Interval Maneuver::getInterval() const
 
 Real Maneuver::calculateDeltaV() const
 {
-    // TBI: replace this logic with a more accurate calculation using a numerical integrator and better quadrature rule
-    Real weightedAccelerationMagnitudeSum = 0.0;
-    Real totalTime = 0.0;
-
-    for (Size i = 0; i < instants_.getSize(); i++)
+    // Use simple forward trapezoidal rule to calculate the total delta-v
+    Real totalDeltaV = 0.0;
+    for (Size i = 0; i < instants_.getSize() - 1; i++)
     {
-        const Real timeStep = (instants_[i] - instants_.accessFirst()).inSeconds();
-        weightedAccelerationMagnitudeSum += timeStep * accelerationProfileDefaultFrame_[i].norm();
-        totalTime += timeStep;
+        const Real durationI = (instants_[i] - instants_.accessFirst()).inSeconds();
+        const Real durationIPlusOne = (instants_[i + 1] - instants_.accessFirst()).inSeconds();
+
+        const Real accelMagnitudeI = accelerationProfileDefaultFrame_[i].norm();
+        const Real accelMagnitudeIPlusOne = accelerationProfileDefaultFrame_[i + 1].norm();
+
+        totalDeltaV += ((accelMagnitudeI + accelMagnitudeIPlusOne) / 2.0) * (durationIPlusOne - durationI);
     }
 
-    return weightedAccelerationMagnitudeSum / totalTime;
+    return totalDeltaV;
 }
 
 Mass Maneuver::calculateDeltaMass() const
 {
-    // TBI: replace this logic with a more accurate calculation using a numerical integrator and better quadrature rule
-    Real weightedMassSum = 0.0;
-
-    for (Size i = 0; i < instants_.getSize(); i++)
+    // Use simple forward trapezoidal rule to calculate the total delta-mass
+    Real totalDeltaMass = 0.0;
+    for (Size i = 0; i < instants_.getSize() - 1; i++)
     {
-        const Real timeStep = (instants_[i] - instants_.accessFirst()).inSeconds();
+        const Real durationI = (instants_[i] - instants_.accessFirst()).inSeconds();
+        const Real durationIPlusOne = (instants_[i + 1] - instants_.accessFirst()).inSeconds();
 
-        weightedMassSum += timeStep * -massFlowRateProfile_[i];
+        totalDeltaMass +=
+            ((-massFlowRateProfile_[i] + -massFlowRateProfile_[i + 1]) / 2.0) * (durationIPlusOne - durationI);
     }
 
-    return {weightedMassSum, Mass::Unit::Kilogram};
+    return {totalDeltaMass, Mass::Unit::Kilogram};
 }
 
 Real Maneuver::calculateAverageThrust(const Mass& anInitialSpacecraftMass) const
 {
-    // TBI: replace this logic with a more accurate calculation using a numerical integrator and better quadrature rule
-    Real weightedThrustSum = 0.0;
-    Real weightedMassSum = anInitialSpacecraftMass.inKilograms();
-    Real totalTime = 0.0;
-
-    for (Size i = 0; i < instants_.getSize(); i++)
+    Array<Real> thrustPerIntervals = Array<Real>::Empty();
+    Array<Real> intervalDurations = Array<Real>::Empty();
+    Real currentMass = anInitialSpacecraftMass.inKilograms();
+    for (Size i = 0; i < instants_.getSize() - 1; i++)
     {
-        const Real timeStep = (instants_[i] - instants_.accessFirst()).inSeconds();
-        weightedMassSum += -massFlowRateProfile_[i];
-        weightedThrustSum += timeStep * accelerationProfileDefaultFrame_[i].norm() * weightedMassSum;
-        totalTime += timeStep;
+        const Real currentIntervalDuration = (instants_[i + 1] - instants_[i]).inSeconds();
+
+        currentMass += ((massFlowRateProfile_[i] + massFlowRateProfile_[i + 1]) / 2.0) * currentIntervalDuration;
+        const Real currentThrust =
+            (accelerationProfileDefaultFrame_[i].norm() + accelerationProfileDefaultFrame_[i + 1].norm()) / 2 *
+            currentMass;
+
+        thrustPerIntervals.add(currentThrust);
+        intervalDurations.add(currentIntervalDuration);
     }
 
-    return weightedThrustSum / totalTime;
+    Real weightedThrustSum = 0.0;
+    for (Size j = 0; j < thrustPerIntervals.getSize(); j++)
+    {
+        weightedThrustSum += thrustPerIntervals[j] * intervalDurations[j];
+    }
+
+    return weightedThrustSum / std::accumulate(intervalDurations.begin(), intervalDurations.end(), 0.0);
 }
 
 Real Maneuver::calculateAverageSpecificImpulse(const Mass& anInitialSpacecraftMass) const
@@ -251,7 +263,8 @@ void Maneuver::print(std::ostream& anOutputStream, bool displayDecorator) const
 
     ostk::core::utils::Print::Line(anOutputStream) << "Interval:" << this->getInterval().toString();
 
-    ostk::core::utils::Print::Line(anOutputStream) << "Total delta-v:" << this->calculateDeltaV().toString();
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Total delta-v:" << this->calculateDeltaV().toString() << " [m/s]";
     ostk::core::utils::Print::Line(anOutputStream) << "Total mass consumed:" << this->calculateDeltaMass().toString();
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -304,14 +304,13 @@ Array<Vector3d> Maneuver::convertAccelerationProfileFrame(const Shared<const Fra
     }
 
     // Convert to the desired frame if necessary
-    Array<Vector3d> accelerationProfileInCustomFrame = Array<Vector3d>(instants_.getSize(), Vector3d::Zero());
+    Array<Vector3d> accelerationProfileInDefaultFrame = Array<Vector3d>(instants_.getSize(), Vector3d::Zero());
     for (Size i = 0; i < instants_.getSize(); i++)
     {
-        // TBI: fine a way to check and vet whether or not the frame is local, or quasi-inertial
-        accelerationProfileInCustomFrame[i] = aFrameSPtr->getTransformTo(Maneuver::DefaultAccelFrameSPtr, instants_[i])
-                                                  .applyToVector(accelerationProfileDefaultFrame_[i]);
+        accelerationProfileInDefaultFrame[i] = aFrameSPtr->getTransformTo(Maneuver::DefaultAccelFrameSPtr, instants_[i])
+                                                   .applyToVector(accelerationProfileDefaultFrame_[i]);
     }
-    return accelerationProfileInCustomFrame;
+    return accelerationProfileInDefaultFrame;
 }
 
 }  // namespace flight

--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
@@ -212,19 +212,21 @@ Vector3d QLaw::computeThrustDirection(const Vector6d& aCOEVector, const double& 
 
     const Vector3d thrustDirection = dQ_dOE.transpose() * derivativeMatrix;
 
-    double etaRelative = 0.0;
-    double etaAbsolute = 0.0;
-
     if (parameters_.relativeEffectivityThreshold.isDefined() || parameters_.absoluteEffectivityThreshold.isDefined())
     {
+        double etaRelative = 0.0;
+        double etaAbsolute = 0.0;
+
         std::tie(etaRelative, etaAbsolute) = computeEffectivity(aCOEVector, thrustDirection, dQ_dOE);
 
+        // If the effectivity is below the threshold, do not thrust.
         if ((parameters_.relativeEffectivityThreshold.isDefined()) &&
             (etaRelative < parameters_.relativeEffectivityThreshold))
         {
             return {0.0, 0.0, 0.0};
         }
 
+        // If the effectivity is below the threshold, do not thrust.
         if ((parameters_.absoluteEffectivityThreshold.isDefined()) &&
             (etaAbsolute < parameters_.absoluteEffectivityThreshold))
         {

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
@@ -49,9 +49,30 @@ Propagator::Propagator(
 )
     : Propagator(aNumericalSolver, aDynamicsArray)
 {
-    // TBM: in the future maybe sanitize the instants of each maneuver to make sure none of them are overalapping
     for (const Maneuver& maneuver : aManeuverArray)
     {
+        // Check if the maneuver's first and last instants overlap with any other maneuver
+        Size duplicateManeuverCounter = 0;
+        for (const Maneuver& otherManeuver : aManeuverArray)
+        {
+            if (maneuver != otherManeuver)  // Skip self-comparison
+            {
+                if (maneuver.getInstants()[0] <=
+                        otherManeuver.getInstants()[otherManeuver.getInstants().getSize() - 1] &&
+                    maneuver.getInstants()[maneuver.getInstants().getSize() - 1] >= otherManeuver.getInstants()[0])
+                {
+                    throw ostk::core::error::RuntimeError("Maneuvers cannot overlap in time.");
+                }
+            }
+            else
+            {
+                duplicateManeuverCounter++;
+            }
+        }
+        if (duplicateManeuverCounter != 1)
+        {
+            throw ostk::core::error::RuntimeError("Maneuvers cannot be duplicated.");
+        }
         this->addManeuver(maneuver, anInterpolationType);
     }
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -132,6 +132,11 @@ Array<Maneuver> Segment::Solution::extractManeuvers(const Shared<const Frame>& a
         }
     }
 
+    if (thrusterDynamics == nullptr)
+    {
+        throw ostk::core::error::RuntimeError("No Thruster dynamics found in Maneuvering segment.");
+    }
+
     const Array<Instant> instantArray = this->states.map<Instant>(
         [](const State& aState) -> Instant
         {
@@ -139,23 +144,74 @@ Array<Maneuver> Segment::Solution::extractManeuvers(const Shared<const Frame>& a
         }
     );
 
-    // TBI: Implement logic to check if "multiple" maneuvers (stop and start) actually occured during this segment
-    const MatrixXd thrusterContributionProfile = this->getDynamicsContribution(
+    const MatrixXd fullSegmentContributions = this->getDynamicsContribution(
         thrusterDynamics, aFrameSPtr, {CartesianVelocity::Default(), CoordinateSubset::Mass()}
     );
 
-    // Don't actually need to interpolate, because we convert straight to a maneuver, but specifying linear
-    // interpolation allows us to get away with segments that only have two states, as opposed to needing more than two
-    // states present to use the other higher order interpolators
-    const TabulatedDynamics tabulatedDynamics = {
-        instantArray,
-        thrusterContributionProfile,
-        {CartesianVelocity::Default(), CoordinateSubset::Mass()},
-        aFrameSPtr,
-        Interpolator::Type::Linear,
-    };
+    const Size numberOfStates = static_cast<Size>(fullSegmentContributions.rows());
 
-    return {Maneuver::TabulatedDynamics(tabulatedDynamics)};
+    // Check if there are any breaks in the thrusting (stop and start) and split the dynamics into separate maneuvers
+    Array<Pair<Size, Size>> maneuveringBlockStartStopIndices = Array<Pair<Size, Size>>::Empty();
+    Integer maneuverStart = -1;
+    for (Size i = 0; i < numberOfStates; i++)
+    {
+        if (fullSegmentContributions.row(i).norm() != 0.0)  // If thrusting
+        {
+            // If a new block hasn't started yet, mark its start
+            if (maneuverStart == -1)
+            {
+                maneuverStart = i;
+            }
+
+            // If end of segment is thrusting, close last block
+            if (i == numberOfStates - 1)
+            {
+                // Store stop index as i + 1 because you don't get a chance to "close this
+                // block" by seeing the thrust go to zero on the next iteration, since the loop ends on this iteration
+                maneuveringBlockStartStopIndices.add(Pair<Size, Size>(maneuverStart, i + 1));
+            }
+        }
+        else  // If not thrusting
+        {
+            // If we have reached the end of a block, save the start and end indices
+            if (maneuverStart != -1)
+            {
+                maneuveringBlockStartStopIndices.add(Pair<Size, Size>(maneuverStart, i));
+
+                maneuverStart = -1;  // Close the block by marking the start as -1
+            }
+        }
+    }
+
+    // If no thrusting has occured during this maneuvering segment (which is possible), return an empty array
+    if (maneuveringBlockStartStopIndices.isEmpty())
+    {
+        return {};
+    }
+
+    Array<ostk::astrodynamics::flight::Maneuver> extractedManeuvers =
+        Array<ostk::astrodynamics::flight::Maneuver>::Empty();
+    for (Pair<Size, Size> startStopPair : maneuveringBlockStartStopIndices)
+    {
+        const Size blockLength = startStopPair.second - startStopPair.first;
+        const Array<Instant> maneuverInstantsBlock =
+            Array<Instant>(instantArray.begin() + startStopPair.first, instantArray.begin() + startStopPair.second);
+        const MatrixXd maneuverContributionBlock =
+            fullSegmentContributions.block(startStopPair.first, 0, blockLength, fullSegmentContributions.cols());
+
+        extractedManeuvers.add(ostk::astrodynamics::flight::Maneuver::TabulatedDynamics(TabulatedDynamics(
+            maneuverInstantsBlock,
+            maneuverContributionBlock,
+            {CartesianVelocity::Default(), CoordinateSubset::Mass()},
+            aFrameSPtr,
+            Interpolator::Type::Linear  // Don't actually need to interpolate, because we convert straight to a
+                                        // maneuver, but specifying linear
+            // interpolation allows us to get away with segments that only have two states, as opposed to needing more
+            // than two states present to use the other higher order interpolators
+        )));
+    }
+
+    return extractedManeuvers;
 }
 
 Array<State> Segment::Solution::calculateStatesAt(

--- a/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.test.cpp
@@ -162,5 +162,3 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster, ComputeContribution)
         EXPECT_TRUE(acceleration.isNear(expectedAcceleration, 1e-12));
     }
 }
-
-// Add more tests based on public methods of Thruster class

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.test.cpp
@@ -1,4 +1,4 @@
-// /// Apache License 2.0
+/// Apache License 2.0
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
 #include <OpenSpaceToolkit/Core/Container/Pair.hpp>
@@ -246,8 +246,68 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Constructor)
         );
     }
 
+    // Maneuver with some intervals larger than the maximum recommended interpolation interval
     {
-        const Array<Real> positiveMassFlowRateProfile = {1.0e-5, 1.1e-5, 0.9e-5, 1.0e-5};
+        const Array<Instant> spacedOutInstants = {
+            Instant::J2000(),
+            Instant::J2000() + Maneuver::MaximumRecommendedInterpolationInterval * 2,
+            Instant::J2000() + Maneuver::MaximumRecommendedInterpolationInterval * 2.5,
+            Instant::J2000() + Maneuver::MaximumRecommendedInterpolationInterval * 3,
+        };
+
+        testing::internal::CaptureStdout();
+        Maneuver(
+            spacedOutInstants, defaultAccelerationProfileDefaultFrame_, defaultFrameSPtr_, defaultMassFlowRateProfile_
+        );
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+
+    // Maneuver with duration of less than minimum recommended duration
+    {
+        const Array<Instant> shortInstants = {
+            Instant::J2000(),
+            Instant::J2000() + Maneuver::MinimumRecommendedDuration / 4,
+            Instant::J2000() + Maneuver::MinimumRecommendedDuration / 3,
+            Instant::J2000() + Maneuver::MinimumRecommendedDuration / 2,
+        };
+
+        testing::internal::CaptureStdout();
+        Maneuver(
+            shortInstants, defaultAccelerationProfileDefaultFrame_, defaultFrameSPtr_, defaultMassFlowRateProfile_
+        );
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+
+    // Acceleration profile with accelerations of zero magnitude
+    {
+        const Array<Vector3d> incorrectAccelerationProfile = {
+            {0.0e-3, 0.0e-3, 0.0e-3},
+            {0.0e-3, 1.0e-3, 0.0e-3},
+            {0.0e-3, 0.0e-3, 1.0e-3},
+            {1.0e-3, 1.0e-3, 1.0e-3},
+        };
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Maneuver(
+                        defaultInstants_, incorrectAccelerationProfile, defaultFrameSPtr_, defaultMassFlowRateProfile_
+                    );
+                }
+                catch (const ostk::core::error::RuntimeError& e)
+                {
+                    EXPECT_EQ("Acceleration profile must have strictly positive magnitudes.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    // Mass flow rate profile with zero or positive mass flow rates
+    {
+        const Array<Real> incorrectMassFlowRateProfile = {0.0e-5, -1.1e-5, -0.9e-5, 1.0e-5};
 
         EXPECT_THROW(
             {
@@ -257,12 +317,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Maneuver, Constructor)
                         defaultInstants_,
                         defaultAccelerationProfileDefaultFrame_,
                         defaultFrameSPtr_,
-                        positiveMassFlowRateProfile
+                        incorrectMassFlowRateProfile
                     );
                 }
                 catch (const ostk::core::error::RuntimeError& e)
                 {
-                    EXPECT_EQ("Mass flow rate profile must be expressed in strictly negative numbers.", e.getMessage());
+                    EXPECT_EQ("Mass flow rate profile must have strictly negative values.", e.getMessage());
                     throw;
                 }
             },

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.test.cpp
@@ -26,6 +26,9 @@
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameDirection.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.hpp>
@@ -67,16 +70,15 @@ using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth
 using EarthMagneticModel = ostk::physics::environment::magnetic::Earth;
 using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 
+using ostk::astrodynamics::Dynamics;
+using ostk::astrodynamics::dynamics::Thruster;
+using ostk::astrodynamics::flight::system::SatelliteSystem;
+using ostk::astrodynamics::flight::system::PropulsionSystem;
+using ostk::astrodynamics::guidancelaw::ConstantThrust;
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameDirection;
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameFactory;
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameTransformProvider;
 using ostk::astrodynamics::trajectory::state::NumericalSolver;
-using ostk::astrodynamics::flight::system::SatelliteSystem;
-using ostk::astrodynamics::flight::system::PropulsionSystem;
-using ostk::astrodynamics::Dynamics;
-using ostk::astrodynamics::guidancelaw::ConstantThrust;
-
-using namespace boost::numeric::odeint;
 
 class OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust : public ::testing::Test
 {
@@ -89,48 +91,24 @@ class OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust : public ::testi
             {1.0, 2.0, 3.0}
         ));
 
-        localOrbitalFrameDirection_ =
-            LocalOrbitalFrameDirection({1.0, 0.0, 0.0}, LocalOrbitalFrameFactory::VNC(Frame::GCRF()));
-
-        this->satelliteSystem_ = {
-            satelliteDryMass_, satelliteGeometry, Matrix3d::Identity(), 1.2, 2.1, propulsionSystem_
+        this->defaultSatelliteSystem_ = {
+            satelliteDryMass_, satelliteGeometry, Matrix3d::Identity(), 1.2, 2.1, defaultPropulsionSystem_
         };
-
-        startStateVector_.resize(7);
-        startStateVector_ << 7000000.0, 0.0, 0.0, 0.0, 7546.05329, 0.0, 200.0;
     }
-
-    // Current state and instant setup, choose equinox as instant to make geometry simple
-    // Earth pulls in the -X direction, Sun pulls in the +X direction, and Moon in the +Y direction
-    const Instant startInstant_ = Instant::DateTime(DateTime(2021, 3, 20, 12, 0, 0), Scale::UTC);
-
-    const Earth earth_ = {
-        EarthGravitationalModel::Spherical.gravitationalParameter_,
-        EarthGravitationalModel::Spherical.equatorialRadius_,
-        EarthGravitationalModel::Spherical.flattening_,
-        EarthGravitationalModel::Spherical.J2_,
-        EarthGravitationalModel::Spherical.J4_,
-        std::make_shared<Analytical>(Frame::ITRF()),
-        std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::Undefined),
-        std::make_shared<EarthMagneticModel>(EarthMagneticModel::Type::Undefined),
-        std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential),
-    };
 
     const Shared<const Frame> gcrfSPtr_ = Frame::GCRF();
 
     LocalOrbitalFrameDirection localOrbitalFrameDirection_ = {
         {1.0, 0.0, 0.0},
-        LocalOrbitalFrameFactory::VNC(Frame::GCRF()),
+        LocalOrbitalFrameFactory::VNC(gcrfSPtr_),
     };
-
-    const Mass satelliteDryMass_ = Mass::Kilograms(100.0);
-
-    const PropulsionSystem propulsionSystem_ = {0.1, 1500.0};
 
     const ConstantThrust defaultConstantThrust_ = {localOrbitalFrameDirection_};
 
-    NumericalSolver::StateVector startStateVector_;
-    SatelliteSystem satelliteSystem_ = SatelliteSystem::Undefined();
+    const PropulsionSystem defaultPropulsionSystem_ = {0.1, 1500.0};
+    const Mass satelliteDryMass_ = Mass::Kilograms(100.0);
+
+    SatelliteSystem defaultSatelliteSystem_ = SatelliteSystem::Undefined();
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust, Constructor)
@@ -176,138 +154,132 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust, Getters)
     }
 }
 
-/* Contribution computation validation test */
-// TEST_F(OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust, calculateThrustAccelerationAt)
-// {
-//     {
-//         // Test Case (thrust direction, local orbital frame, reference data)
-//         const Array<Tuple<Shared<const LocalOrbitalFrameFactory>, Vector3d, String>> testCases = {
-//             {LocalOrbitalFrameFactory::VNC(gcrfSPtr_),
-//              Vector3d({1.0, 0.0, 0.0}),
-//              "Orekit_ConstantThrustManeuver_VNC_inclined_1hr_run.csv"},
-//             {LocalOrbitalFrameFactory::QSW(gcrfSPtr_),
-//              Vector3d({0.0, 1.0, 0.0}),
-//              "Orekit_ConstantThrustManeuver_QSW_inclined_1hr_run.csv"},
-//             {LocalOrbitalFrameFactory::TNW(gcrfSPtr_),
-//              Vector3d({1.0, 0.0, 0.0}),
-//              "Orekit_ConstantThrustManeuver_TNW_inclined_1hr_run.csv"},
-//             {LocalOrbitalFrameFactory::LVLH(gcrfSPtr_),
-//              Vector3d({1.0, 0.0, 0.0}),
-//              "Orekit_ConstantThrustManeuver_LVLH_inclined_1hr_run.csv"},
-//             {LocalOrbitalFrameFactory::VVLH(gcrfSPtr_),
-//              Vector3d({1.0, 0.0, 0.0}),
-//              "Orekit_ConstantThrustManeuver_VVLH_inclined_1hr_run.csv"}
-//         };
+/* Include Thruster Dynamics computeContribution validation test */
+TEST_F(OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust, calculateThrustAccelerationAt)
+{
+    {
+        // Test Case (thrust direction, local orbital frame, reference data)
+        const Array<Tuple<Shared<const LocalOrbitalFrameFactory>, Vector3d, String>> testCases = {
+            {LocalOrbitalFrameFactory::VNC(gcrfSPtr_),
+             Vector3d({1.0, 0.0, 0.0}),
+             "Orekit_ConstantThrustManeuver_VNC_inclined_1hr_run.csv"},
+            {LocalOrbitalFrameFactory::QSW(gcrfSPtr_),
+             Vector3d({0.0, 1.0, 0.0}),
+             "Orekit_ConstantThrustManeuver_QSW_inclined_1hr_run.csv"},
+            {LocalOrbitalFrameFactory::TNW(gcrfSPtr_),
+             Vector3d({1.0, 0.0, 0.0}),
+             "Orekit_ConstantThrustManeuver_TNW_inclined_1hr_run.csv"},
+            {LocalOrbitalFrameFactory::LVLH(gcrfSPtr_),
+             Vector3d({1.0, 0.0, 0.0}),
+             "Orekit_ConstantThrustManeuver_LVLH_inclined_1hr_run.csv"},
+            {LocalOrbitalFrameFactory::VVLH(gcrfSPtr_),
+             Vector3d({1.0, 0.0, 0.0}),
+             "Orekit_ConstantThrustManeuver_VVLH_inclined_1hr_run.csv"}
+        };
 
-//         // Loop through test cases
-//         for (const auto testCase : testCases)
-//         {
-//             // Extract test case input data
-//             const Shared<const LocalOrbitalFrameFactory> localOrbitalFrameFactory = std::get<0>(testCase);
-//             const Vector3d localOrbitalFrameThrustVector = std::get<1>(testCase);
-//             const String referenceDataFileName = std::get<2>(testCase);
+        // Loop through test cases
+        for (const auto testCase : testCases)
+        {
+            // Extract test case input data
+            const Shared<const LocalOrbitalFrameFactory> localOrbitalFrameFactory = std::get<0>(testCase);
+            const Vector3d localOrbitalFrameThrustVector = std::get<1>(testCase);
+            const String referenceDataFileName = std::get<2>(testCase);
 
-//             // Define constant thrust thruster dynamics
-//             LocalOrbitalFrameDirection localOrbitalFrameDirection =
-//                 LocalOrbitalFrameDirection(localOrbitalFrameThrustVector, localOrbitalFrameFactory);
-//             Shared<ConstantThrust> thrusterDynamicsSPtr =
-//                 std::make_shared<ConstantThrust>(satelliteSystem_, localOrbitalFrameDirection);
+            // Define constant thrust thruster dynamics
+            LocalOrbitalFrameDirection localOrbitalFrameDirection =
+                LocalOrbitalFrameDirection(localOrbitalFrameThrustVector, localOrbitalFrameFactory);
+            const Shared<Thruster> thrusterDynamicsSPtr = std::make_shared<Thruster>(
+                defaultSatelliteSystem_, std::make_shared<ConstantThrust>(localOrbitalFrameDirection)
+            );
 
-//             // Reference data setup
-//             const Table referenceData = Table::Load(
-//                 File::Path(
-//                     Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster/" +
-//                     referenceDataFileName)
-//                 ),
-//                 Table::Format::CSV,
-//                 true
-//             );
+            // Reference data setup
+            const Table referenceData = Table::Load(
+                File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/" + referenceDataFileName)
+                ),
+                Table::Format::CSV,
+                true
+            );
 
-//             // Initialize reference data arrays
-//             Array<Instant> instantArray = Array<Instant>::Empty();
-//             Array<Vector3d> referencePositionArrayGCRF = Array<Vector3d>::Empty();
-//             Array<Vector3d> referenceVelocityArrayGCRF = Array<Vector3d>::Empty();
-//             Array<double> referenceMassArray = Array<double>::Empty();
-//             Array<Vector3d> referenceManeuverAccelerationArrayGCRF = Array<Vector3d>::Empty();
+            // Initialize reference data arrays
+            Array<Instant> instantArray = Array<Instant>::Empty();
+            Array<Vector3d> referencePositionArrayGCRF = Array<Vector3d>::Empty();
+            Array<Vector3d> referenceVelocityArrayGCRF = Array<Vector3d>::Empty();
+            Array<double> referenceMassArray = Array<double>::Empty();
+            Array<Vector3d> referenceManeuverAccelerationArrayGCRF = Array<Vector3d>::Empty();
 
-//             for (const auto& referenceRow : referenceData)
-//             {
-//                 instantArray.add(Instant::DateTime(
-//                     DateTime::Parse(referenceRow[0].accessString(), DateTime::Format::ISO8601), Scale::UTC
-//                 ));
-//                 referencePositionArrayGCRF.add(
-//                     Vector3d(referenceRow[1].accessReal(), referenceRow[2].accessReal(),
-//                     referenceRow[3].accessReal())
-//                 );
-//                 referenceVelocityArrayGCRF.add(
-//                     Vector3d(referenceRow[4].accessReal(), referenceRow[5].accessReal(),
-//                     referenceRow[6].accessReal())
-//                 );
-//                 referenceManeuverAccelerationArrayGCRF.add(Vector3d(
-//                     referenceRow[16].accessReal(), referenceRow[17].accessReal(), referenceRow[18].accessReal()
-//                 ));
-//                 referenceMassArray.add(referenceRow[22].accessReal());
-//             }
+            for (const auto& referenceRow : referenceData)
+            {
+                instantArray.add(Instant::DateTime(
+                    DateTime::Parse(referenceRow[0].accessString(), DateTime::Format::ISO8601), Scale::UTC
+                ));
+                referencePositionArrayGCRF.add(
+                    Vector3d(referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal())
+                );
+                referenceVelocityArrayGCRF.add(
+                    Vector3d(referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal())
+                );
+                referenceManeuverAccelerationArrayGCRF.add(Vector3d(
+                    referenceRow[16].accessReal(), referenceRow[17].accessReal(), referenceRow[18].accessReal()
+                ));
+                referenceMassArray.add(referenceRow[22].accessReal());
+            }
 
-//             // Validation loop
-//             for (size_t i = 1; i < instantArray.getSize() - 1; i++)
-//             {
-//                 // Current state and instant setup from Orekit test case
-//                 VectorXd OrekitStateCoordinates(7);
-//                 OrekitStateCoordinates << referencePositionArrayGCRF[i], referenceVelocityArrayGCRF[i],
-//                     referenceMassArray[i];  // Check size input Dynamics
+            // Validation loop
+            for (size_t i = 1; i < instantArray.getSize() - 1; i++)
+            {
+                // Current state and instant setup from Orekit test case
+                VectorXd OrekitStateCoordinates(7);
+                OrekitStateCoordinates << referencePositionArrayGCRF[i], referenceVelocityArrayGCRF[i],
+                    referenceMassArray[i];  // Check size input Dynamics
 
-//                 const VectorXd maneuverContributionFromOrekitStateGCRF =
-//                     thrusterDynamicsSPtr->computeContribution(instantArray[i], OrekitStateCoordinates, gcrfSPtr_);
+                const VectorXd maneuverContributionFromOrekitStateGCRF =
+                    thrusterDynamicsSPtr->computeContribution(instantArray[i], OrekitStateCoordinates, gcrfSPtr_);
 
-//                 const double referenceStepSize = 30.0;
+                const double referenceStepSize = 30.0;
 
-//                 const double maneuverComputationErrorAccelerationContributionXGCRF =
-//                     std::abs(maneuverContributionFromOrekitStateGCRF[0] -
-//                     referenceManeuverAccelerationArrayGCRF[i][0]);
-//                 const double maneuverComputationErrorAccelerationContributionYGCRF =
-//                     std::abs(maneuverContributionFromOrekitStateGCRF[1] -
-//                     referenceManeuverAccelerationArrayGCRF[i][1]);
-//                 const double maneuverComputationErrorAccelerationContributionZGCRF =
-//                     std::abs(maneuverContributionFromOrekitStateGCRF[2] -
-//                     referenceManeuverAccelerationArrayGCRF[i][2]);
-//                 const double maneuverComputationErrorMassContributionGCRF = std::abs(
-//                     maneuverContributionFromOrekitStateGCRF[3] -
-//                     ((referenceMassArray[i + 1] - referenceMassArray[i]) / referenceStepSize)
-//                 );
-//                 const double maneuverComputationAccelerationContributionErrorGCRF =
-//                     (maneuverContributionFromOrekitStateGCRF.segment(0, 3) -
-//                     referenceManeuverAccelerationArrayGCRF[i])
-//                         .norm();
+                const double maneuverComputationErrorAccelerationContributionXGCRF =
+                    std::abs(maneuverContributionFromOrekitStateGCRF[0] - referenceManeuverAccelerationArrayGCRF[i][0]);
+                const double maneuverComputationErrorAccelerationContributionYGCRF =
+                    std::abs(maneuverContributionFromOrekitStateGCRF[1] - referenceManeuverAccelerationArrayGCRF[i][1]);
+                const double maneuverComputationErrorAccelerationContributionZGCRF =
+                    std::abs(maneuverContributionFromOrekitStateGCRF[2] - referenceManeuverAccelerationArrayGCRF[i][2]);
+                const double maneuverComputationErrorMassContributionGCRF = std::abs(
+                    maneuverContributionFromOrekitStateGCRF[3] -
+                    ((referenceMassArray[i + 1] - referenceMassArray[i]) / referenceStepSize)
+                );
+                const double maneuverComputationAccelerationContributionErrorGCRF =
+                    (maneuverContributionFromOrekitStateGCRF.segment(0, 3) - referenceManeuverAccelerationArrayGCRF[i])
+                        .norm();
 
-//                 ASSERT_GT(5e-10, maneuverComputationErrorAccelerationContributionXGCRF);
-//                 ASSERT_GT(5e-10, maneuverComputationErrorAccelerationContributionYGCRF);
-//                 ASSERT_GT(5e-10, maneuverComputationErrorAccelerationContributionZGCRF);
-//                 ASSERT_GT(1e-9, maneuverComputationErrorMassContributionGCRF);
-//                 ASSERT_GT(1e-9, maneuverComputationAccelerationContributionErrorGCRF);
+                ASSERT_GT(5e-10, maneuverComputationErrorAccelerationContributionXGCRF);
+                ASSERT_GT(5e-10, maneuverComputationErrorAccelerationContributionYGCRF);
+                ASSERT_GT(5e-10, maneuverComputationErrorAccelerationContributionZGCRF);
+                ASSERT_GT(1e-9, maneuverComputationErrorMassContributionGCRF);
+                ASSERT_GT(1e-9, maneuverComputationAccelerationContributionErrorGCRF);
 
-//                 // Results console output
-//                 // std::cout << "**************************************" << std::endl;
-//                 // std::cout.setf(std::ios::scientific,std::ios::floatfield);
-//                 // std::cout << "Instant is: " << instantArray[i] << std::endl;
-//                 // std::cout << "Maneuver contribution computation X GCRF error is: " <<
-//                 // maneuverComputationErrorAccelerationContributionXGCRF << "m/s^2" << std::endl; std::cout <<
-//                 "Maneuver
-//                 // contribution computation Y GCRF error is: " <<
-//                 maneuverComputationErrorAccelerationContributionYGCRF
-//                 // << "m/s^2" << std::endl; std::cout << "Maneuver contribution computation Z GCRF error is: " <<
-//                 // maneuverComputationErrorAccelerationContributionZGCRF << "m/s^2" << std::endl; std::cout <<
-//                 "Maneuver
-//                 // contribution computation Mass error is: " << maneuverComputationErrorMassContributionGCRF << "kg"
-//                 <<
-//                 // std::endl; std::cout << "Maneuver contribution computation Acceleration GCRF Norm error is: " <<
-//                 // maneuverComputationAccelerationContributionErrorGCRF << "m/s^2" << std::endl;
-//                 // std::cout.setf(std::ios::fixed,std::ios::floatfield);
-//                 // std::cout << "**************************************" << std::endl;
-//             }
-//         }
-//     }
-// }
+                // Results console output
+                // std::cout << "**************************************" << std::endl;
+                // std::cout.setf(std::ios::scientific,std::ios::floatfield);
+                // std::cout << "Instant is: " << instantArray[i] << std::endl;
+                // std::cout << "Maneuver contribution computation X GCRF error is: " <<
+                // maneuverComputationErrorAccelerationContributionXGCRF << "m/s^2" << std::endl; std::cout <<
+                // "Maneuver
+                //     // contribution computation Y GCRF error is: " <<
+                //     maneuverComputationErrorAccelerationContributionYGCRF
+                // << "m/s^2" << std::endl; std::cout << "Maneuver contribution computation Z GCRF error is: " <<
+                // maneuverComputationErrorAccelerationContributionZGCRF << "m/s^2" << std::endl; std::cout <<
+                // "Maneuver
+                //     // contribution computation Mass error is: " << maneuverComputationErrorMassContributionGCRF <<
+                //     "kg"
+                //     <<
+                // std::endl; std::cout << "Maneuver contribution computation Acceleration GCRF Norm error is: " <<
+                // maneuverComputationAccelerationContributionErrorGCRF << "m/s^2" << std::endl;
+                // std::cout.setf(std::ios::fixed,std::ios::floatfield);
+                // std::cout << "**************************************" << std::endl;
+            }
+        }
+    }
+}
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust, Intrack)
 {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -218,6 +218,61 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Constru
             Propagator(defaultNumericalSolver_, defaultDynamics_, {defaultManeuver_}, Interpolator::Type::Linear)
         );
     }
+
+    // Check if there are any overlapping maneuvers
+    {
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Propagator(
+                        defaultNumericalSolver_,
+                        defaultDynamics_,
+                        {defaultManeuver_,
+                         Maneuver(
+                             {
+                                 Instant::J2000() + Duration::Seconds(30.0),
+                                 Instant::J2000() + Duration::Seconds(60.0) + Duration::Seconds(30.0),
+                             },
+                             defaultManeuverAccelerationProfile_,
+                             gcrfSPtr_,
+                             defaultManeuverMassFlowRateProfile_
+                         )},
+                        Interpolator::Type::Linear
+                    );
+                }
+                catch (const ostk::core::error::RuntimeError& e)
+                {
+                    EXPECT_EQ("Maneuvers cannot overlap in time.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    // Check if there are any of the same maneuvers
+    {
+        EXPECT_THROW(
+            {
+                try
+                {
+                    Propagator(
+                        defaultNumericalSolver_,
+                        defaultDynamics_,
+                        {defaultManeuver_, defaultManeuver_},
+                        Interpolator::Type::Linear
+                    );
+                }
+                catch (const ostk::core::error::RuntimeError& e)
+                {
+                    EXPECT_EQ("Maneuvers cannot be duplicated.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, CopyConstructor)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -21,6 +21,10 @@
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/AtmosphericDrag.hpp>
@@ -32,10 +36,13 @@
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/InstantCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameDirection.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateBroker.hpp>
@@ -68,6 +75,10 @@ using ostk::physics::time::Instant;
 using ostk::physics::time::Duration;
 using ostk::physics::time::DateTime;
 using ostk::physics::time::Scale;
+using ostk::physics::unit::Derived;
+using ostk::physics::unit::Angle;
+using ostk::physics::unit::Length;
+using ostk::physics::unit::Mass;
 
 using ostk::astrodynamics::Dynamics;
 using ostk::astrodynamics::dynamics::AtmosphericDrag;
@@ -81,8 +92,10 @@ using ostk::astrodynamics::eventcondition::RealCondition;
 using ostk::astrodynamics::flight::Maneuver;
 using ostk::astrodynamics::flight::system::SatelliteSystem;
 using ostk::astrodynamics::guidancelaw::ConstantThrust;
+using ostk::astrodynamics::guidancelaw::QLaw;
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameDirection;
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameFactory;
+using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::Segment;
 using ostk::astrodynamics::trajectory::state::CoordinateBroker;
@@ -139,9 +152,9 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Segment : public ::testing::Test
     const NumericalSolver defaultNumericalSolver_ = {
         NumericalSolver::LogType::NoLog,
         NumericalSolver::StepperType::RungeKuttaDopri5,
-        1e-2,
-        1.0e-15,
-        1.0e-15,
+        5.0,
+        1.0e-12,
+        1.0e-12,
     };
     const Shared<InstantCondition> defaultInstantCondition_ = std::make_shared<InstantCondition>(
         InstantCondition::Criterion::AnyCrossing, defaultState_.accessInstant() + Duration::Minutes(15.0)
@@ -274,48 +287,255 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Extrac
         EXPECT_EQ(0, segmentSolution.extractManeuvers(defaultFrameSPtr_).getSize());
     }
 
+    // Check that it throws when no thruster dynamics are found in a maneuvering segment
     {
-        const Array<Shared<Dynamics>> dynamicsWithThruster = {
-            defaultDynamics_ +
-            Array<Shared<Dynamics>>(1, std::dynamic_pointer_cast<Dynamics>(defaultThrusterDynamicsSPtr_))
-        };
         const Segment::Solution segmentSolution = Segment::Solution(
-            defaultName_,
-            dynamicsWithThruster,
-            {initialStateWithMass_, intermediateStateWithMass_, finalStateWithMass_},
-            true,
-            Segment::Type::Maneuver
+            defaultName_, defaultDynamics_, {initialStateWithMass_, finalStateWithMass_}, true, Segment::Type::Maneuver
         );
 
-        const Array<Maneuver> maneuvers = segmentSolution.extractManeuvers(defaultFrameSPtr_);
+        EXPECT_THROW(
+            {
+                try
+                {
+                    segmentSolution.extractManeuvers(defaultFrameSPtr_);
+                }
+                catch (const ostk::core::error::runtime::Undefined& e)
+                {
+                    EXPECT_EQ("No Thruster dynamics found in Maneuvering segment.", e.getMessage());
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    // Check that a maneuver can be extracted when a thruster dynamics is found in a maneuvering segment
+    {
+        const Shared<RealCondition> durationCondition = std::make_shared<RealCondition>(
+            RealCondition::DurationCondition(RealCondition::Criterion::AnyCrossing, Duration::Minutes(15.0))
+        );
+
+        // Create maneuvering segment
+        Segment maneuverSegment = Segment::Maneuver(
+            "Maneuvring Segment",
+            durationCondition,
+            defaultThrusterDynamicsSPtr_,
+            defaultDynamics_,
+            {
+                NumericalSolver::LogType::NoLog,
+                NumericalSolver::StepperType::RungeKuttaDopri5,
+                5.0,
+                1.0e-12,
+                1.0e-12,
+            }
+        );
+
+        const Mass initialWetMass = Mass::Kilograms(200.0);
+        VectorXd initialCoordinatesWithWetMass(7);
+        initialCoordinatesWithWetMass << +7000000.000000, +0000000.000000, -0000000.000000, +00000.00000000,
+            -05719.55029824, -04922.36372519, initialWetMass.inKilograms();
+
+        const State initialStateWithWetMass = {
+            Instant::J2000(), initialCoordinatesWithWetMass, Frame::GCRF(), thrustCoordinateBrokerSPtr_
+        };
+
+        const Segment::Solution maneuveringSegmentSolution = maneuverSegment.solve(initialStateWithWetMass);
+
+        const MatrixXd accelerationProfile = maneuveringSegmentSolution.getDynamicsAccelerationContribution(
+            defaultThrusterDynamicsSPtr_, defaultFrameSPtr_
+        );
+
+        const Array<Maneuver> maneuvers = maneuveringSegmentSolution.extractManeuvers(defaultFrameSPtr_);
         EXPECT_EQ(1, maneuvers.getSize());
-        EXPECT_EQ(3, maneuvers[0].getInstants().getSize());
-        EXPECT_EQ(3, maneuvers[0].getAccelerationProfile().getSize());
-        EXPECT_EQ(3, maneuvers[0].getMassFlowRateProfile().getSize());
+        EXPECT_EQ(maneuveringSegmentSolution.states.getSize(), maneuvers[0].getInstants().getSize());
+        EXPECT_EQ(maneuveringSegmentSolution.states.getSize(), maneuvers[0].getAccelerationProfile().getSize());
+        EXPECT_EQ(maneuveringSegmentSolution.states.getSize(), maneuvers[0].getMassFlowRateProfile().getSize());
 
         for (Size i = 0; i < maneuvers[0].getInstants().getSize(); i++)
         {
-            EXPECT_EQ(segmentSolution.states[i].getInstant(), maneuvers[0].getInstants()[i]);
+            EXPECT_EQ(maneuveringSegmentSolution.states[i].getInstant(), maneuvers[0].getInstants()[i]);
         }
 
-        // TBI: uncomment these functions below and compare them onces the functions in the maneuver class are replaced
-        // with more accurate calculations logic using a numerical integrator and better quadrature rule
+        // Check that metrics from the maneuvering segment solution are the same as the ones from the extracted maneuver
+        EXPECT_NEAR(
+            maneuveringSegmentSolution.computeDeltaV(defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()
+            ),
+            maneuvers[0].calculateDeltaV(),
+            1e-10 * maneuveringSegmentSolution.computeDeltaV(
+                        defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()  // Scale to relative error
+                    )
+        );
+        EXPECT_NEAR(
+            maneuveringSegmentSolution.computeDeltaMass().inKilograms(),
+            maneuvers[0].calculateDeltaMass().inKilograms(),
+            1e-10 * maneuveringSegmentSolution.computeDeltaMass().inKilograms()  // Scale to relative error
+        );
 
-        // EXPECT_DOUBLE_EQ(
-        //     segmentSolution.computeDeltaMass().inKilograms(), maneuvers[0].calculateDeltaMass().inKilograms()
-        // );
-        // EXPECT_DOUBLE_EQ(
-        //     segmentSolution.computeDeltaV(defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()),
-        //     maneuvers[0].calculateDeltaV()
-        // );
-        // EXPECT_DOUBLE_EQ(
-        //     defaultSatelliteSystem_.getPropulsionSystem().getThrust(),
-        //     maneuvers[0].calculateAverageThrust(defaultSatelliteSystem_.getMass())
-        // );
-        // EXPECT_DOUBLE_EQ(
-        //     defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse(),
-        //     maneuvers[0].calculateAverageSpecificImpulse(defaultSatelliteSystem_.getMass())
-        // );
+        // These are not as close as the dV and dM above likely due to the midpoint trapezoidal rule used to calculate
+        // thrusts at each profile interval midpoint
+        EXPECT_NEAR(
+            defaultSatelliteSystem_.getPropulsionSystem().getThrust(),
+            maneuvers[0].calculateAverageThrust(initialWetMass),
+            5e-6 * defaultSatelliteSystem_.getPropulsionSystem().getThrust()  // Scale to relative error
+        );
+
+        EXPECT_NEAR(
+            defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse(),
+            maneuvers[0].calculateAverageSpecificImpulse(initialWetMass),
+            5e-6 * defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()  // Scale to relative error
+        );
+    }
+
+    // Check that multiple (or no) maneuvers can be extracted when more than one maneuvers are carried out per
+    // maneuvering segment
+    {
+        const COE currentCOE = {
+            Length::Meters(6800.0e3),
+            0.01,
+            Angle::Degrees(80.0),
+            Angle::Degrees(0.0),
+            Angle::Degrees(0.0),
+            Angle::Degrees(90.0),
+        };
+
+        const COE targetCOE = {
+            currentCOE.getSemiMajorAxis(),
+            currentCOE.getEccentricity(),
+            currentCOE.getInclination() + Angle::Degrees(0.1),
+            currentCOE.getRaan(),
+            currentCOE.getAop(),
+            currentCOE.getTrueAnomaly(),
+        };
+
+        const QLaw::Parameters qLawParameters = {
+            {
+                {
+                    COE::Element::Inclination,
+                    {
+                        1.0,   // Control element weight
+                        1e-4,  // Convergence threshold of 0.0001
+                    },
+                },
+            },
+            3,                           // M value
+            4,                           // N value
+            2,                           // R value
+            0.01,                        // B value
+            100,                         // K value
+            1.0,                         // Periapsis weight
+            Length::Kilometers(6578.0),  // Minimum periapsis
+            0.5,                         // Absolute effectivity threshold
+        };
+
+        const QLaw qlaw = {
+            targetCOE,
+            Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit()),
+            qLawParameters,
+            QLaw::GradientStrategy::Analytical,
+        };
+
+        const Shared<Thruster> qLawThrusterDynamicsSPtr =
+            std::make_shared<Thruster>(defaultSatelliteSystem_, std::make_shared<QLaw>(qlaw));
+
+        const Shared<RealCondition> durationCondition = std::make_shared<RealCondition>(
+            RealCondition::DurationCondition(RealCondition::Criterion::AnyCrossing, Duration::Minutes(90.0))
+        );
+
+        // Create maneuvering segment
+        Segment maneuverSegment = Segment::Maneuver(
+            "Maneuvring Segment",
+            durationCondition,
+            qLawThrusterDynamicsSPtr,
+            defaultDynamics_,
+            {
+                NumericalSolver::LogType::NoLog,
+                NumericalSolver::StepperType::RungeKuttaDopri5,
+                5.0,
+                1.0e-8,  // Reducing tolerances so that the solving doesn't take forever
+                1.0e-8,  // Reducing tolerances so that the solving doesn't take forever
+            }
+        );
+
+        // Check that multiple maneuvers can be extracted when more than one maneuvers are carried out per maneuvering
+        // segment
+        {
+            const COE::CartesianState cartesianStatePair = currentCOE.getCartesianState(
+                Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit()),
+                defaultFrameSPtr_
+            );
+            VectorXd currentCoordinates(7);
+            currentCoordinates << cartesianStatePair.first.accessCoordinates(),
+                cartesianStatePair.second.accessCoordinates(), 200.0;
+            const State currentState = {
+                Instant::J2000(),
+                currentCoordinates,
+                defaultFrameSPtr_,
+                thrustCoordinateBrokerSPtr_,
+            };
+
+            const Segment::Solution maneuveringSegmentSolution = maneuverSegment.solve(currentState);
+
+            const Array<Maneuver> maneuvers = maneuveringSegmentSolution.extractManeuvers(defaultFrameSPtr_);
+
+            EXPECT_EQ(2, maneuvers.getSize());
+
+            // Hardcoded values for the expected maneuvers from this QLaw solve. If QLaw is changed, this likely will
+            // break
+            Size numberOfInstantInFirstManeuver = 31;
+            Size startingIndexFirstManeuver = 16;
+            Size numberOfInstantInSecondManeuver = 30;
+            Size startingIndexSecondManeuver = 71;
+
+            // First maneuver
+            EXPECT_EQ(numberOfInstantInFirstManeuver, maneuvers[0].getInstants().getSize());
+            EXPECT_EQ(numberOfInstantInFirstManeuver, maneuvers[0].getAccelerationProfile().getSize());
+            EXPECT_EQ(numberOfInstantInFirstManeuver, maneuvers[0].getMassFlowRateProfile().getSize());
+
+            for (Size i = 0; i < maneuvers[0].getInstants().getSize(); i++)
+            {
+                EXPECT_EQ(
+                    maneuveringSegmentSolution.states[startingIndexFirstManeuver + i].getInstant(),
+                    maneuvers[0].getInstants()[i]
+                );
+            }
+
+            // Second maneuver
+            EXPECT_EQ(numberOfInstantInSecondManeuver, maneuvers[1].getInstants().getSize());
+            EXPECT_EQ(numberOfInstantInSecondManeuver, maneuvers[1].getAccelerationProfile().getSize());
+            EXPECT_EQ(numberOfInstantInSecondManeuver, maneuvers[1].getMassFlowRateProfile().getSize());
+
+            for (Size j = 0; j < maneuvers[1].getInstants().getSize(); j++)
+            {
+                EXPECT_EQ(
+                    maneuveringSegmentSolution.states[startingIndexSecondManeuver + j].getInstant(),
+                    maneuvers[1].getInstants()[j]
+                );
+            }
+        }
+
+        // Check that when no thrusting is performed in a maneuvering segment that no maneuvers are outputted
+        {
+            // Pretend that we are already at the target COE, so no thrusting will occur
+            const COE::CartesianState cartesianStatePair = targetCOE.getCartesianState(
+                Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit()),
+                defaultFrameSPtr_
+            );
+            VectorXd currentCoordinates(7);
+            currentCoordinates << cartesianStatePair.first.accessCoordinates(),
+                cartesianStatePair.second.accessCoordinates(), 200.0;
+            const State currentState = {
+                Instant::J2000(),
+                currentCoordinates,
+                defaultFrameSPtr_,
+                thrustCoordinateBrokerSPtr_,
+            };
+
+            const Segment::Solution maneuveringSegmentSolution = maneuverSegment.solve(currentState);
+
+            const Array<Maneuver> maneuvers = maneuveringSegmentSolution.extractManeuvers(defaultFrameSPtr_);
+
+            EXPECT_EQ(0, maneuvers.getSize());
+        }
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
@@ -41,6 +41,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/PositionDerivative.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/Thruster.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/PropulsionSystem.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystemBuilder.hpp>
@@ -100,8 +101,9 @@ using ostk::astrodynamics::Dynamics;
 using ostk::astrodynamics::dynamics::AtmosphericDrag;
 using ostk::astrodynamics::dynamics::CentralBodyGravity;
 using ostk::astrodynamics::dynamics::PositionDerivative;
-using ostk::astrodynamics::dynamics::Tabulated;
 using ostk::astrodynamics::dynamics::Thruster;
+using TabulatedDynamics = ostk::astrodynamics::dynamics::Tabulated;
+using ostk::astrodynamics::flight::Maneuver;
 using ostk::astrodynamics::flight::system::PropulsionSystem;
 using ostk::astrodynamics::flight::system::SatelliteSystem;
 using ostk::astrodynamics::flight::system::SatelliteSystemBuilder;
@@ -116,6 +118,8 @@ using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPositio
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 using ostk::astrodynamics::trajectory::state::NumericalSolver;
 
+// TBM: All of these validation tests currently do not fit within the OSTk validation framework, but the intention is to
+// move them there in the future.
 class OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation : public ::testing::Test
 {
    protected:
@@ -153,14 +157,6 @@ class OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation : public ::testi
     const NumericalSolver defaultNumericalSolver_ = {
         NumericalSolver::LogType::NoLog,
         NumericalSolver::StepperType::RungeKuttaFehlberg78,
-        5.0,
-        1.0e-15,
-        1.0e-15,
-    };
-
-    const NumericalSolver defaultRK4_ = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKutta4,
         5.0,
         1.0e-15,
         1.0e-15,
@@ -535,84 +531,111 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_EGM
     }
 }
 
-// TBI: Specific class for parameterized tests on thruster dynamics, could inherit from base fixture for common
-class OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster
-    : public ::testing::TestWithParam<
-          Tuple<std::string, Shared<const LocalOrbitalFrameFactory>, Vector3d, Real, Real, Real, Real, Real, Real>>
+class OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster : public ::testing::TestWithParam<Tuple<
+                                                                               std::string,
+                                                                               bool,
+                                                                               Shared<const LocalOrbitalFrameFactory>,
+                                                                               Vector3d,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real,
+                                                                               Real>>
 {
    protected:
     void SetUp() override
     {
-        const Composite satelliteGeometry(Cuboid(
+        this->satelliteGeometry_ = Composite(Cuboid(
             {0.0, 0.0, 0.0},
             {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}},
             {1.0, 2.0, 3.0}
         ));
 
-        this->satelliteGeometry_ = satelliteGeometry;
-
+        // Dynamics without atmosphere
         this->earthSpherical_ = std::make_shared<Celestial>(Earth::Spherical());
-        this->defaultDynamics_ = {
+        this->centralBodyGravitySPtr_ = std::make_shared<CentralBodyGravity>(earthSpherical_);
+        this->defaultDynamicsWithoutAtmosphere_ = {
             std::make_shared<PositionDerivative>(),
-            std::make_shared<CentralBodyGravity>(earthSpherical_),
+            centralBodyGravitySPtr_,
         };
 
-        this->defaultPropagator_ = {defaultNumericalSolver_, defaultDynamics_};
+        // Dynamics with atmosphere
+        this->earthSphericalWithAtmosphere_ = std::make_shared<Celestial>(Earth::FromModels(
+            std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::Spherical),
+            std::make_shared<EarthMagneticModel>(EarthMagneticModel::Type::Undefined),
+            std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
+        ));
+        this->atmosphericDragSPtr_ = std::make_shared<AtmosphericDrag>(earthSphericalWithAtmosphere_);
+        this->defaultDynamicsWithAtmosphere_ = {
+            std::make_shared<PositionDerivative>(),
+            centralBodyGravitySPtr_,
+            atmosphericDragSPtr_,
+        };
     }
 
     const NumericalSolver defaultNumericalSolver_ = {
         NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaFehlberg78,
+        NumericalSolver::StepperType::RungeKuttaDopri5,
         5.0,
-        1.0e-15,
-        1.0e-15,
+        1.0e-12,
+        1.0e-12,
     };
-
-    const NumericalSolver defaultRK4_ = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKutta4,
-        5.0,
-        1.0e-15,
-        1.0e-15,
-    };
-
-    const Mass satelliteDryMass_ = Mass(100.0, Mass::Unit::Kilogram);
-    const Mass propellantMass_ = Mass(15.0, Mass::Unit::Kilogram);
 
     const Shared<const Frame> gcrfSPtr_ = Frame::GCRF();
 
-    Array<Shared<Dynamics>> defaultDynamics_ = Array<Shared<Dynamics>>::Empty();
+    const Mass propellantMass_ = Mass(15.0, Mass::Unit::Kilogram);
     Composite satelliteGeometry_ = Composite::Undefined();
+
+    Array<Shared<Dynamics>> defaultDynamics_ = Array<Shared<Dynamics>>::Empty();
+
+    Array<Shared<Dynamics>> defaultDynamicsWithoutAtmosphere_ = Array<Shared<Dynamics>>::Empty();
     Shared<Celestial> earthSpherical_ = nullptr;
-    Propagator defaultPropagator_ = Propagator::Undefined();
+    Shared<CentralBodyGravity> centralBodyGravitySPtr_ = nullptr;
+
+    Array<Shared<Dynamics>> defaultDynamicsWithAtmosphere_ = Array<Shared<Dynamics>>::Empty();
+    Shared<Celestial> earthSphericalWithAtmosphere_ = nullptr;
+    Shared<AtmosphericDrag> atmosphericDragSPtr_ = nullptr;
+
+    Shared<const CoordinateBroker> coordinatesBrokerSPtr_ = std::make_shared<CoordinateBroker>(CoordinateBroker({
+        CartesianPosition::Default(),
+        CartesianVelocity::Default(),
+        CoordinateSubset::Mass(),
+    }));
 };
 
 TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster, ForceModel_Thrust)
 {
-    // Improvements:
-    // percentage diff to add
-    // add multiple "segments" propagation cases
-
-    // Setup environment
-
     // Access the test parameters
     const auto parameters = GetParam();
 
-    const String referenceDataFileName = std::get<0>(parameters);
-    Shared<const LocalOrbitalFrameFactory> localOrbitalFrameFactory = std::get<1>(parameters);
-    const Vector3d localOrbitalFrameThrustVector = std::get<2>(parameters);
-    const Real satelliteDryMassReal = std::get<3>(parameters);
-    const Real thrustReal = std::get<4>(parameters);
-    const Real specificImpulseReal = std::get<5>(parameters);
-
-    // Reference data setup
-    const Table referenceData = Table::Load(File::Path(Path::Parse(referenceDataFileName)), Table::Format::CSV, true);
+    const String param_referenceDataFileName = std::get<0>(parameters);
+    const bool param_withAtmosphere = std::get<1>(parameters);
+    Shared<const LocalOrbitalFrameFactory> param_localOrbitalFrameFactory = std::get<2>(parameters);
+    const Vector3d param_localOrbitalFrameThrustVector = std::get<3>(parameters);
+    const Real param_satelliteDryMassReal = std::get<4>(parameters);
+    const Real param_thrustReal = std::get<5>(parameters);
+    const Real param_specificImpulseReal = std::get<6>(parameters);
+    const Real param_crossSectionReal = std::get<7>(parameters);
+    const Real param_dragCoeffReal = std::get<8>(parameters);
+    const Real param_positionErrorGCRFTolerance = std::get<9>(parameters);
+    const Real param_velocityErrorGCRFTolerance = std::get<10>(parameters);
+    const Real param_accelerationErrorGCRFTolerance = std::get<11>(parameters);
+    const Real param_massErrorTolerance = std::get<12>(parameters);
+    const Real param_positionErrorLOFTolerance = std::get<13>(parameters);
+    const Real param_velocityErrorLOFTolerance = std::get<14>(parameters);
+    const Real param_accelerationErrorLOFTolerance = std::get<15>(parameters);
 
     // Initialize reference data arrays
     Array<Instant> instantArray = Array<Instant>::Empty();
     Array<Vector3d> referencePositionArrayGCRF = Array<Vector3d>::Empty();
     Array<Vector3d> referenceVelocityArrayGCRF = Array<Vector3d>::Empty();
-    Array<Vector3d> referenceTotalAccelerationArrayGCRF = Array<Vector3d>::Empty();
     Array<Vector3d> referenceManeuverAccelerationArrayGCRF = Array<Vector3d>::Empty();
 
     Array<Vector3d> referencePositionArrayLOF = Array<Vector3d>::Empty();
@@ -620,7 +643,8 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster, Force
     Array<Vector3d> referenceManeuverAccelerationArrayLOF = Array<Vector3d>::Empty();
     Array<double> referenceMassArray = Array<double>::Empty();
 
-    for (const auto& referenceRow : referenceData)
+    for (const auto& referenceRow :
+         Table::Load(File::Path(Path::Parse(param_referenceDataFileName)), Table::Format::CSV, true))
     {
         instantArray.add(
             Instant::DateTime(DateTime::Parse(referenceRow[0].accessString(), DateTime::Format::ISO8601), Scale::UTC)
@@ -632,9 +656,6 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster, Force
         referenceVelocityArrayGCRF.add(
             Vector3d(referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal())
         );
-        referenceTotalAccelerationArrayGCRF.add(
-            Vector3d(referenceRow[13].accessReal(), referenceRow[14].accessReal(), referenceRow[15].accessReal())
-        );
         referenceManeuverAccelerationArrayGCRF.add(
             Vector3d(referenceRow[16].accessReal(), referenceRow[17].accessReal(), referenceRow[18].accessReal())
         );
@@ -645,198 +666,333 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster, Force
         referenceVelocityArrayLOF.add(
             Vector3d(referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal())
         );
-        referenceManeuverAccelerationArrayLOF.add(
-            Vector3d(referenceRow[19].accessReal(), referenceRow[20].accessReal(), referenceRow[21].accessReal())
-        );
 
-        referenceMassArray.add(referenceRow[22].accessReal());
+        if (!param_withAtmosphere)  // Different indices for the mass in the with and without atmosphere csv files
+        {
+            referenceManeuverAccelerationArrayLOF.add(
+                Vector3d(referenceRow[19].accessReal(), referenceRow[20].accessReal(), referenceRow[21].accessReal())
+            );
+            referenceMassArray.add(referenceRow[22].accessReal());
+        }
+        else
+        {
+            referenceManeuverAccelerationArrayLOF.add(Vector3d::Zero());
+            referenceMassArray.add(referenceRow[28].accessReal());
+        }
     }
-
-    // Local Orbital Frame Direction
-    const LocalOrbitalFrameDirection thrustDirection =
-        LocalOrbitalFrameDirection(localOrbitalFrameThrustVector, localOrbitalFrameFactory);
-
-    // Coordinates Broker (scenario-independent)
-    const Shared<const CoordinateBroker> coordinatesBrokerSPtr = std::make_shared<CoordinateBroker>(CoordinateBroker({
-        CartesianPosition::Default(),
-        CartesianVelocity::Default(),
-        CoordinateSubset::Mass(),
-    }));
 
     // Setup initial state
     VectorXd initialCoordinates(7);
-
     initialCoordinates << referencePositionArrayGCRF[0], referenceVelocityArrayGCRF[0],
-        propellantMass_.inKilograms() + satelliteDryMassReal;
+        propellantMass_.inKilograms() + param_satelliteDryMassReal;
+
+    // If cross validation with atmospheric drag is being included
+    if (param_withAtmosphere)
+    {
+        initialCoordinates.resize(9);
+        initialCoordinates << referencePositionArrayGCRF[0], referenceVelocityArrayGCRF[0],
+            propellantMass_.inKilograms() + param_satelliteDryMassReal, param_crossSectionReal, param_dragCoeffReal;
+
+        coordinatesBrokerSPtr_ = std::make_shared<CoordinateBroker>(CoordinateBroker({
+            CartesianPosition::Default(),
+            CartesianVelocity::Default(),
+            CoordinateSubset::Mass(),
+            CoordinateSubset::SurfaceArea(),
+            CoordinateSubset::DragCoefficient(),
+        }));
+
+        defaultDynamics_ = defaultDynamicsWithAtmosphere_;
+    }
+    else
+    {
+        defaultDynamics_ = defaultDynamicsWithoutAtmosphere_;
+    }
 
     const State initialState = {
         instantArray[0],
         initialCoordinates,
         gcrfSPtr_,
-        coordinatesBrokerSPtr,
+        coordinatesBrokerSPtr_,
     };
 
     // Setup satellite system
-    PropulsionSystem propulsionSystem = {thrustReal, specificImpulseReal};
-
-    const Composite satelliteGeometry(Cuboid(
-        {0.0, 0.0, 0.0}, {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}}, {1.0, 2.0, 3.0}
-    ));
-
+    PropulsionSystem propulsionSystem = {param_thrustReal, param_specificImpulseReal};
     SatelliteSystem satelliteSystem = {
-        Mass::Kilograms(satelliteDryMassReal),
-        satelliteGeometry,
+        Mass::Kilograms(param_satelliteDryMassReal),
+        satelliteGeometry_,
         Matrix3d::Identity(),
-        1.0,
-        2.1,
+        param_crossSectionReal,
+        param_dragCoeffReal,
         propulsionSystem,
     };
 
-    // Setup validation tolerances
-    const Real positionErrorGCRFTolerance = std::get<6>(parameters);
-    const Real velocityErrorGCRFTolerance = std::get<7>(parameters);
-    const Real MassErrorTolerance = std::get<8>(parameters);
-
-    // Setup dynamics
-    const Earth earth = Earth::FromModels(
-        std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::Spherical),
-        std::make_shared<EarthMagneticModel>(EarthMagneticModel::Type::Undefined),
-        std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Undefined)
-    );
-    const Shared<Celestial> earthSPtr = std::make_shared<Celestial>(earth);
-
+    // Create dynamics with thruster
+    const LocalOrbitalFrameDirection thrustDirection =
+        LocalOrbitalFrameDirection(param_localOrbitalFrameThrustVector, param_localOrbitalFrameFactory);
     Shared<ConstantThrust> constantThrustSPtr = std::make_shared<ConstantThrust>(thrustDirection);
 
+    Array<Shared<Dynamics>> dynamicsWithThruster = defaultDynamics_;
     Shared<Thruster> thrusterDynamicsSPtr = std::make_shared<Thruster>(satelliteSystem, constantThrustSPtr);
-    Shared<CentralBodyGravity> centralBodyGravitySPtr = std::make_shared<CentralBodyGravity>(earthSPtr);
+    dynamicsWithThruster.add(thrusterDynamicsSPtr);
+    Propagator propagatorWithThruster = {defaultNumericalSolver_, dynamicsWithThruster};
 
-    const Array<Shared<Dynamics>> dynamics = {
-        std::make_shared<PositionDerivative>(), centralBodyGravitySPtr, thrusterDynamicsSPtr
+    // Propagate all states with thruster to be able to extract contributions for tabulated dynamics
+    const Array<State> propagatedStateArray_Thruster =
+        propagatorWithThruster.calculateStatesAt(initialState, instantArray);
+    MatrixXd thrusterContributionsGCRF(propagatedStateArray_Thruster.getSize(), 4);
+    for (Size i = 0; i < propagatedStateArray_Thruster.getSize(); i++)
+    {
+        const VectorXd thrusterContributionGCRF =
+            dynamicsWithThruster[dynamicsWithThruster.getSize() - 1]->computeContribution(
+                propagatedStateArray_Thruster[i].accessInstant(),
+                propagatedStateArray_Thruster[i].accessCoordinates(),
+                gcrfSPtr_
+            );
+        thrusterContributionsGCRF.row(i) = thrusterContributionGCRF;
+    }
+
+    // Create tabulated dynamics
+    const TabulatedDynamics tabulated = {
+        instantArray,
+        thrusterContributionsGCRF,
+        {CartesianVelocity::Default(), CoordinateSubset::Mass()},
+        gcrfSPtr_,
     };
 
-    // Setup Propagator model and orbit
-    const Propagator propagator = {defaultRK4_, dynamics};
+    // Create dynamics with tabulated and propagator with tabulated
+    Array<Shared<Dynamics>> dynamicsWithTabulated = defaultDynamics_;
+    Shared<TabulatedDynamics> tabulatedSPtr = std::make_shared<TabulatedDynamics>(tabulated);
+    dynamicsWithTabulated.add(tabulatedSPtr);
+    Propagator propagatorWithTabulated = {defaultNumericalSolver_, dynamicsWithTabulated};
+    const Array<State> propagatedStateArray_Tabulated =
+        propagatorWithTabulated.calculateStatesAt(initialState, instantArray);
 
-    // Propagate all states with OSTk
-    const Array<State> propagatedStateArray = propagator.calculateStatesAt(initialState, instantArray);
+    // Create maneuver from tabulated and propagator with maneuver
+    const Maneuver maneuver = Maneuver::TabulatedDynamics(tabulated);
+    Propagator maneuverPropagator = {defaultNumericalSolver_, defaultDynamics_, {maneuver}};
+    const Array<State> propagatedStateArray_Maneuver = maneuverPropagator.calculateStatesAt(initialState, instantArray);
 
     // Validation loop
     for (size_t i = 0; i < instantArray.getSize() - 1; i++)
     {
-        // GCRF Compare
-        const Position positionGCRF = propagatedStateArray[i].inFrame(gcrfSPtr_).getPosition();
-        const Velocity velocityGCRF = propagatedStateArray[i].inFrame(gcrfSPtr_).getVelocity();
-        const double mass = propagatedStateArray[i].extractCoordinate(CoordinateSubset::Mass())[0];
+        // Get GCRF Position
+        const Position positionGCRF_Thruster = propagatedStateArray_Thruster[i].inFrame(gcrfSPtr_).getPosition();
+        const Position positionGCRF_Tabulated = propagatedStateArray_Tabulated[i].inFrame(gcrfSPtr_).getPosition();
+        const Position positionGCRF_Maneuver = propagatedStateArray_Maneuver[i].inFrame(gcrfSPtr_).getPosition();
 
-        VectorXd OSTkStateCoordinatesGCRF(7);
-        OSTkStateCoordinatesGCRF << positionGCRF.accessCoordinates(), velocityGCRF.accessCoordinates(), mass;
+        // Get GCRF Position Error
+        const double positionErrorGCRF_Thruster =
+            (positionGCRF_Thruster.accessCoordinates() - referencePositionArrayGCRF[i]).norm();
+        const double positionErrorGCRF_Tabulated =
+            (positionGCRF_Tabulated.accessCoordinates() - referencePositionArrayGCRF[i]).norm();
+        const double positionErrorGCRF_Maneuver =
+            (positionGCRF_Maneuver.accessCoordinates() - referencePositionArrayGCRF[i]).norm();
 
-        const VectorXd maneuverContributionGCRF =
-            thrusterDynamicsSPtr->computeContribution(instantArray[i], OSTkStateCoordinatesGCRF, gcrfSPtr_);
-        const VectorXd centralBodyGravityContributionGCRF =
-            centralBodyGravitySPtr->computeContribution(instantArray[i], positionGCRF.accessCoordinates(), gcrfSPtr_);
-        const VectorXd totalAccelerationGCRF =
-            maneuverContributionGCRF.segment(0, 3) + centralBodyGravityContributionGCRF;
+        // Get GCRF Velocity
+        const Velocity velocityGCRF_Thruster = propagatedStateArray_Thruster[i].inFrame(gcrfSPtr_).getVelocity();
+        const Velocity velocityGCRF_Tabulated = propagatedStateArray_Tabulated[i].inFrame(gcrfSPtr_).getVelocity();
+        const Velocity velocityGCRF_Maneuver = propagatedStateArray_Maneuver[i].inFrame(gcrfSPtr_).getVelocity();
 
-        const Vector3d OrekitCentralBodyGravityContributionGCRF =
-            referenceTotalAccelerationArrayGCRF[i] - referenceManeuverAccelerationArrayGCRF[i];
+        // Get GCRF Velocity Error
+        const double velocityErrorGCRF_Thruster =
+            (velocityGCRF_Thruster.accessCoordinates() - referenceVelocityArrayGCRF[i]).norm();
+        const double velocityErrorGCRF_Tabulated =
+            (velocityGCRF_Tabulated.accessCoordinates() - referenceVelocityArrayGCRF[i]).norm();
+        const double velocityErrorGCRF_Maneuver =
+            (velocityGCRF_Maneuver.accessCoordinates() - referenceVelocityArrayGCRF[i]).norm();
 
-        // LOF Compare
-        Shared<const Frame> lofSPtr = localOrbitalFrameFactory->generateFrame(
-            instantArray[i], positionGCRF.accessCoordinates(), velocityGCRF.accessCoordinates()
+        // Get Mass
+        const double mass_Thruster = propagatedStateArray_Thruster[i].extractCoordinate(CoordinateSubset::Mass())[0];
+        const double mass_Tabulated = propagatedStateArray_Tabulated[i].extractCoordinate(CoordinateSubset::Mass())[0];
+        const double mass_Maneuver = propagatedStateArray_Maneuver[i].extractCoordinate(CoordinateSubset::Mass())[0];
+
+        // Get Mass Error
+        const double massError_Thruster = std::abs(mass_Thruster - referenceMassArray[i]);
+        const double massError_Tabulated = std::abs(mass_Tabulated - referenceMassArray[i]);
+        const double massError_Maneuver = std::abs(mass_Maneuver - referenceMassArray[i]);
+
+        // Put position, velocity, and mass together into a state
+        VectorXd OSTkStateCoordinatesGCRF_Thruster(7);
+        OSTkStateCoordinatesGCRF_Thruster << positionGCRF_Thruster.accessCoordinates(),
+            velocityGCRF_Thruster.accessCoordinates(), mass_Thruster;
+        VectorXd OSTkStateCoordinatesGCRF_Tabulated(7);
+        OSTkStateCoordinatesGCRF_Tabulated << positionGCRF_Tabulated.accessCoordinates(),
+            velocityGCRF_Tabulated.accessCoordinates(), mass_Tabulated;
+        VectorXd OSTkStateCoordinatesGCRF_Maneuver(7);
+        OSTkStateCoordinatesGCRF_Maneuver << positionGCRF_Maneuver.accessCoordinates(),
+            velocityGCRF_Maneuver.accessCoordinates(), mass_Maneuver;
+
+        // Get GCRF Acceleration
+        const VectorXd maneuverContributionGCRF_Thruster =
+            thrusterDynamicsSPtr->computeContribution(instantArray[i], OSTkStateCoordinatesGCRF_Thruster, gcrfSPtr_);
+        const VectorXd maneuverContributionGCRF_Tabulated =
+            tabulatedSPtr->computeContribution(instantArray[i], OSTkStateCoordinatesGCRF_Tabulated, gcrfSPtr_);
+        const VectorXd maneuverAccelerationGCRF_Maneuver = maneuver.toTabulatedDynamics(gcrfSPtr_)->computeContribution(
+            instantArray[i], OSTkStateCoordinatesGCRF_Maneuver, gcrfSPtr_
         );
-        State lofState = propagatedStateArray[i].inFrame(lofSPtr);
 
-        const VectorXd maneuverContributionLOF =
-            thrusterDynamicsSPtr->computeContribution(instantArray[i], OSTkStateCoordinatesGCRF, lofSPtr);
+        // Get GCRF Acceleration Error
+        const double maneuverAccelerationErrorGCRF_Thruster =
+            (maneuverContributionGCRF_Thruster.segment(0, 3) - referenceManeuverAccelerationArrayGCRF[i]).norm();
+        const double maneuverAccelerationErrorGCRF_Tabulated =
+            (maneuverContributionGCRF_Tabulated.segment(0, 3) - referenceManeuverAccelerationArrayGCRF[i]).norm();
+        const double maneuverAccelerationErrorGCRF_Maneuver =
+            (maneuverAccelerationGCRF_Maneuver.segment(0, 3) - referenceManeuverAccelerationArrayGCRF[i]).norm();
 
-        const Position positionLOF = lofState.getPosition();
-        const Velocity velocityLOF = lofState.getVelocity();
+        // Get LOF
+        Shared<const Frame> lofSPtr = param_localOrbitalFrameFactory->generateFrame(
+            instantArray[i], positionGCRF_Thruster.accessCoordinates(), velocityGCRF_Thruster.accessCoordinates()
+        );
 
-        const double positionErrorGCRF = (positionGCRF.accessCoordinates() - referencePositionArrayGCRF[i]).norm();
-        const double velocityErrorGCRF = (velocityGCRF.accessCoordinates() - referenceVelocityArrayGCRF[i]).norm();
-        const double maneuverAccelerationContributionErrorGCRF =
-            (maneuverContributionGCRF.segment(0, 3) - referenceManeuverAccelerationArrayGCRF[i]).norm();
-        const double positionErrorLOF = (positionLOF.accessCoordinates() - referencePositionArrayLOF[i]).norm();
-        const double velocityErrorLOF = (velocityLOF.accessCoordinates() - referencePositionArrayLOF[i]).norm();
-        const double maneuverAccelerationContributionErrorLOF =
-            (maneuverContributionLOF.segment(0, 3) - referenceManeuverAccelerationArrayLOF[i]).norm();
-        const double totalAccelerationErrorGCRF =
-            (totalAccelerationGCRF - referenceTotalAccelerationArrayGCRF[i]).norm();
-        const double centralBodyGravityAccelerationContributionErrorGCRF =
-            (OrekitCentralBodyGravityContributionGCRF - centralBodyGravityContributionGCRF).norm();
-        const double massError = std::abs(mass - referenceMassArray[i]);
+        // Get LOF State
+        State lofState_Thruster = propagatedStateArray_Thruster[i].inFrame(lofSPtr);
+        State lofState_Tabulated = propagatedStateArray_Tabulated[i].inFrame(lofSPtr);
+        State lofState_Maneuver = propagatedStateArray_Maneuver[i].inFrame(lofSPtr);
 
-        // Frames verification
-        ASSERT_EQ(*Frame::GCRF(), *positionGCRF.accessFrame());
-        ASSERT_EQ(*Frame::GCRF(), *velocityGCRF.accessFrame());
-        ASSERT_EQ(*lofSPtr, *positionLOF.accessFrame());
-        ASSERT_EQ(*lofSPtr, *velocityLOF.accessFrame());
+        // Get LOF Position Error
+        const double positionErrorLOF_Thruster =
+            (lofState_Thruster.getPosition().accessCoordinates() - referencePositionArrayLOF[i]).norm();
+        const double positionErrorLOF_Tabulated =
+            (lofState_Tabulated.getPosition().accessCoordinates() - referencePositionArrayLOF[i]).norm();
+        const double positionErrorLOF_Maneuver =
+            (lofState_Maneuver.getPosition().accessCoordinates() - referencePositionArrayLOF[i]).norm();
 
-        // GCRF Errors
-        // State
-        ASSERT_GT(positionErrorGCRFTolerance, positionErrorGCRF);
-        ASSERT_GT(velocityErrorGCRFTolerance, velocityErrorGCRF);
-        ASSERT_GT(MassErrorTolerance, massError);
+        // Get LOF Velocity Error
+        const double velocityErrorLOF_Thruster =
+            (lofState_Thruster.getVelocity().accessCoordinates() - referencePositionArrayLOF[i]).norm();
+        const double velocityErrorLOF_Tabulated =
+            (lofState_Tabulated.getVelocity().accessCoordinates() - referencePositionArrayLOF[i]).norm();
+        const double velocityErrorLOF_Maneuver =
+            (lofState_Maneuver.getVelocity().accessCoordinates() - referencePositionArrayLOF[i]).norm();
 
-        // Accelerations from dynamics
-        ASSERT_GT(1e-9, maneuverAccelerationContributionErrorGCRF);
-        ASSERT_GT(5e-8, centralBodyGravityAccelerationContributionErrorGCRF);
-        ASSERT_GT(5e-8, totalAccelerationErrorGCRF);
+        // Get LOF Acceleration
+        const VectorXd maneuverContributionLOF_Thruster =
+            thrusterDynamicsSPtr->computeContribution(instantArray[i], OSTkStateCoordinatesGCRF_Thruster, lofSPtr);
+        const VectorXd maneuverContributionLOF_Tabulated =
+            tabulatedSPtr->computeContribution(instantArray[i], OSTkStateCoordinatesGCRF_Tabulated, lofSPtr);
+        const VectorXd maneuverContributionLOF_Maneuver = maneuver.toTabulatedDynamics(gcrfSPtr_)->computeContribution(
+            instantArray[i], OSTkStateCoordinatesGCRF_Maneuver, lofSPtr
+        );
 
-        // LOF Errors
-        // State
-        ASSERT_GT(1e-15, positionErrorLOF);
-        ASSERT_GT(1e-15, velocityErrorLOF);
+        // Get LOF Acceleration Error
+        const double maneuverAccelerationErrorLOF_Thruster =
+            (maneuverContributionLOF_Thruster.segment(0, 3) - referenceManeuverAccelerationArrayLOF[i]).norm();
+        const double maneuverAccelerationErrorLOF_Tabulated =
+            (maneuverContributionLOF_Tabulated.segment(0, 3) - referenceManeuverAccelerationArrayLOF[i]).norm();
+        const double maneuverAccelerationErrorLOF_Maneuver =
+            (maneuverContributionLOF_Maneuver.segment(0, 3) - referenceManeuverAccelerationArrayLOF[i]).norm();
 
-        // Acceleration from dynamics
-        ASSERT_GT(1e-8, maneuverAccelerationContributionErrorLOF);
+        // Frames verification with Thruster Dynamics
+        ASSERT_EQ(*Frame::GCRF(), *positionGCRF_Thruster.accessFrame());
+        ASSERT_EQ(*Frame::GCRF(), *velocityGCRF_Thruster.accessFrame());
+        ASSERT_EQ(*lofSPtr, *(lofState_Thruster.getPosition()).accessFrame());
+        ASSERT_EQ(*lofSPtr, *(lofState_Thruster.getVelocity()).accessFrame());
+
+        // Frames verification with Tabulated Dynamics
+        ASSERT_EQ(*Frame::GCRF(), *positionGCRF_Tabulated.accessFrame());
+        ASSERT_EQ(*Frame::GCRF(), *velocityGCRF_Tabulated.accessFrame());
+        ASSERT_EQ(*lofSPtr, *(lofState_Tabulated.getPosition()).accessFrame());
+        ASSERT_EQ(*lofSPtr, *(lofState_Tabulated.getVelocity()).accessFrame());
+
+        // Frames verification with Maneuver
+        ASSERT_EQ(*Frame::GCRF(), *positionGCRF_Maneuver.accessFrame());
+        ASSERT_EQ(*Frame::GCRF(), *velocityGCRF_Maneuver.accessFrame());
+        ASSERT_EQ(*lofSPtr, *(lofState_Maneuver.getPosition()).accessFrame());
+        ASSERT_EQ(*lofSPtr, *(lofState_Maneuver.getVelocity()).accessFrame());
+
+        // GCRF Errors with Thruster Dynamics
+        ASSERT_GT(param_positionErrorGCRFTolerance, positionErrorGCRF_Thruster);
+        ASSERT_GT(param_velocityErrorGCRFTolerance, velocityErrorGCRF_Thruster);
+        ASSERT_GT(param_accelerationErrorGCRFTolerance, maneuverAccelerationErrorGCRF_Thruster);
+        ASSERT_GT(param_massErrorTolerance, massError_Thruster);
+
+        // GCRF Errors with Tabulated Dynamics
+        ASSERT_GT(param_positionErrorGCRFTolerance, positionErrorGCRF_Tabulated);
+        ASSERT_GT(param_velocityErrorGCRFTolerance, velocityErrorGCRF_Tabulated);
+        ASSERT_GT(param_accelerationErrorGCRFTolerance, maneuverAccelerationErrorGCRF_Tabulated);
+        ASSERT_GT(param_massErrorTolerance, massError_Tabulated);
+
+        // GCRF Errors with Maneuver
+        ASSERT_GT(param_positionErrorGCRFTolerance, positionErrorGCRF_Maneuver);
+        ASSERT_GT(param_velocityErrorGCRFTolerance, velocityErrorGCRF_Maneuver);
+        ASSERT_GT(param_accelerationErrorGCRFTolerance, maneuverAccelerationErrorGCRF_Maneuver);
+        ASSERT_GT(param_massErrorTolerance, massError_Maneuver);
+
+        // LOF Errors with Thruster Dynamics
+        ASSERT_GT(param_positionErrorLOFTolerance, positionErrorLOF_Thruster);
+        ASSERT_GT(param_velocityErrorLOFTolerance, velocityErrorLOF_Thruster);
+        if (!param_withAtmosphere)
+        {
+            ASSERT_GT(param_accelerationErrorLOFTolerance, maneuverAccelerationErrorLOF_Thruster);
+        }
+
+        // LOF Errors with Tabulated Dynamics
+        ASSERT_GT(param_positionErrorLOFTolerance, positionErrorLOF_Tabulated);
+        ASSERT_GT(param_velocityErrorLOFTolerance, velocityErrorLOF_Tabulated);
+        if (!param_withAtmosphere)
+        {
+            ASSERT_GT(param_accelerationErrorLOFTolerance, maneuverAccelerationErrorLOF_Tabulated);
+        }
+
+        // LOF Errors with Maneuver
+        ASSERT_GT(param_positionErrorLOFTolerance, positionErrorLOF_Maneuver);
+        ASSERT_GT(param_velocityErrorLOFTolerance, velocityErrorLOF_Maneuver);
+        if (!param_withAtmosphere)
+        {
+            ASSERT_GT(param_accelerationErrorLOFTolerance, maneuverAccelerationErrorLOF_Maneuver);
+        }
 
         // Results console output
+        // if (i >= instantArray.getSize() - 2)
+        // {
+        //     std::cout << "**************************************" << std::endl;
+        //     std::cout.setf(std::ios::scientific, std::ios::floatfield);
+        //     std::cout << "Instant: " << instantArray[i] << std::endl;
+        //     std::cout << "Position Error GCRF for Thruster: " << positionErrorGCRF_Thruster << "m" << std::endl;
+        //     std::cout << "Position Error GCRF for Tabulated: " << positionErrorGCRF_Tabulated << "m" << std::endl;
+        //     std::cout << "Position Error GCRF for Maneuver: " << positionErrorGCRF_Maneuver << "m" << std::endl;
 
-        // std::cout << "**************************************" << std::endl;
-        // std::cout.setf(std::ios::scientific,std::ios::floatfield);
-        // std::cout << "Instant is: " << instantArray[i] << std::endl;
-        // // Quaternion quat = gcrfSPtr_->getTransformTo(lofSPtr, instantArray[i]).getOrientation();
-        // // std::cout << lofSPtr->getOriginIn(gcrfSPtr_, instantArray[i]) << std::endl;
-        // // std::cout << quat << std::endl ;
-        // std::cout << "Position OSTk is: " << positionGCRF.accessCoordinates() << "m" << std::endl;
-        // std::cout << "Position Orekit is: " << referencePositionArrayGCRF[i] << "m" << std::endl;
-        // std::cout << "Velocity OSTk is: " << velocityGCRF.accessCoordinates() << "m/s" << std::endl;
-        // std::cout << "Velocity Orekit is: " << referenceVelocityArrayGCRF[i] << "m/s" << std::endl;
-        // std::cout << "Position error GCRF is: " << positionErrorGCRF << "m" << std::endl;
-        // std::cout << "Velocity error GCRF is: " << velocityErrorGCRF << "m/s" << std::endl;
-        // std::cout << "Position OSTk LOF is: " << positionLOF.accessCoordinates() << "m" << std::endl;
-        // std::cout << "Position Orekit LOF is: " << referencePositionArrayLOF[i] << "m" << std::endl;
-        // std::cout << "Velocity OSTk LOF is: " << velocityLOF.accessCoordinates() << "m/s" << std::endl;
-        // std::cout << "Velocity Orekit LOF is: " << referenceVelocityArrayLOF[i] << "m/s" << std::endl;
-        // std::cout << "Position error LOF is: " << positionErrorLOF << "m" << std::endl;
-        // std::cout << "Velocity error LOF is: " << velocityErrorLOF << "m/s" << std::endl;
-        // std::cout << "Mass OSTk is: " << mass << "kg" << std::endl;
-        // std::cout << "Mass Orekit is: " << referenceMassArray[i] << "kg" << std::endl;
-        // std::cout << "Mass error is: " << massError << "kg" << std::endl;
-        // std::cout << "Maneuver acceleration error GCRF X is: " << maneuverContributionGCRF[0] -
-        // referenceManeuverAccelerationArrayGCRF[i][0] << "m/s^2" << std::endl; std::cout << "Maneuver acceleration
-        // error GCRF Y is: " << maneuverContributionGCRF[1] - referenceManeuverAccelerationArrayGCRF[i][1] <<
-        // "m/s^2"
-        // << std::endl; std::cout << "Maneuver acceleration error GCRF Z is: " << maneuverContributionGCRF[2] -
-        // referenceManeuverAccelerationArrayGCRF[i][2] << "m/s^2" << std::endl; std::cout << "Maneuver acceleration
-        // error LOF X is: " << maneuverContributionLOF[0] - referenceManeuverAccelerationArrayLOF[i][0] << "m/s^2"
-        // <<
-        // std::endl; std::cout << "Maneuver acceleration error LOF Y is: " << maneuverContributionLOF[1] -
-        // referenceManeuverAccelerationArrayLOF[i][1] << "m/s^2" << std::endl; std::cout << "Maneuver acceleration
-        // error LOF Z is: " << maneuverContributionLOF[2] - referenceManeuverAccelerationArrayLOF[i][2] << "m/s^2"
-        // <<
-        // std::endl; std::cout << "Maneuver acceleration error GCRF is: " <<
-        // maneuverAccelerationContributionErrorGCRF
-        // << "m/s^2" << std::endl; // Do it in percentage std::cout << "Maneuver acceleration error LOF is: " <<
-        // maneuverAccelerationContributionErrorLOF << "m/s^2" << std::endl; std::cout << "Total acceleration
-        // (central
-        // body + maneuver) error GCRF is: " << totalAccelerationErrorGCRF << "m/s^2" << std::endl; std::cout <<
-        // "Central body acceleration contribution error GCRF is: " <<
-        // centralBodyGravityAccelerationContributionErrorGCRF << "m/s^2" << std::endl;
-        // std::cout.setf(std::ios::fixed,std::ios::floatfield);
-        // std::cout << "**************************************" << std::endl;
+        //     std::cout << "Velocity Error GRCRF for Thruster: " << velocityErrorGCRF_Thruster << "m/s" << std::endl;
+        //     std::cout << "Velocity Error GCRF for Tabulated: " << velocityErrorGCRF_Tabulated << "m/s" << std::endl;
+        //     std::cout << "Velocity Error GCRF for Maneuver: " << velocityErrorGCRF_Maneuver << "m/s" << std::endl;
+
+        //     std::cout << "Acceleration Error GCRF for Thruster: " << maneuverAccelerationErrorGCRF_Thruster <<
+        //     "m/s^2"
+        //               << std::endl;
+        //     std::cout << "Acceleration Error GCRF for Tabulated: " << maneuverAccelerationErrorGCRF_Tabulated <<
+        //     "m/s^2"
+        //               << std::endl;
+        //     std::cout << "Acceleration Error GCRF for Maneuver: " << maneuverAccelerationErrorGCRF_Maneuver <<
+        //     "m/s^2"
+        //               << std::endl;
+
+        //     std::cout << "Mass Error for Thruster: " << massError_Thruster << "kg" << std::endl;
+        //     std::cout << "Mass Error for Tabulated: " << massError_Tabulated << "kg" << std::endl;
+        //     std::cout << "Mass Error for Maneuver: " << massError_Maneuver << "kg" << std::endl;
+
+        //     std::cout << "Position Error LOF for Thruster: " << positionErrorLOF_Thruster << "m" << std::endl;
+        //     std::cout << "Position Error LOF for Tabulated: " << positionErrorLOF_Tabulated << "m" << std::endl;
+        //     std::cout << "Position Error LOF for Maneuver: " << positionErrorLOF_Maneuver << "m" << std::endl;
+
+        //     std::cout << "Velocity Error LOF for Thruster: " << velocityErrorLOF_Thruster << "m/s" << std::endl;
+        //     std::cout << "Velocity Error LOF for Tabulated: " << velocityErrorLOF_Tabulated << "m/s" << std::endl;
+        //     std::cout << "Velocity Error LOF for Maneuver: " << velocityErrorLOF_Maneuver << "m/s" << std::endl;
+
+        //     if (!param_withAtmosphere)
+        //     {
+        //         std::cout << "Acceleration Error LOF for Thruster: " << maneuverAccelerationErrorLOF_Thruster <<
+        //         "m/s^2"
+        //                   << std::endl;
+        //         // std::cout << "Acceleration Error LOF for Tabulated: " << maneuverAccelerationErrorLOF_Tabulated <<
+        //         // "m/s^2"
+        //         //           << std::endl;
+        //         // std::cout << "Acceleration Error LOF for Maneuver: " << maneuverAccelerationErrorLOF_Maneuver <<
+        //         // "m/s^2"
+        //         //           << std::endl;
+        //     }
+        //     std::cout.setf(std::ios::fixed, std::ios::floatfield);
+        //     std::cout << "**************************************" << std::endl;
+        // }
     }
 }
 
@@ -845,727 +1001,565 @@ INSTANTIATE_TEST_SUITE_P(
     ForceModel_Thrust,
     OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster,
     ::testing::Values(
+        //
+        //
+        // Without atmosphere
+        //
+        //
         // Test Case 0
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_1.0_0.0_"
             "0.0_30.0.csv",                                // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 1: Start date in 2021
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2021-05-13T12-34-13.345_115.0_0.1_1500.0_3600.0_VNC_1.0_0.0_"
             "0.0_30.0.csv",                                // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 2: QSW LOF
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_QSW_0.0_1.0_"
             "0.0_30.0.csv",                                // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::QSW(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({0.0, 1.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 3: TNW LOF
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_TNW_1.0_0.0_"
             "0.0_30.0.csv",                                // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::TNW(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 4: LVLH LOF
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_LVLH_1.0_0.0_"
             "0.0_30.0.csv",                                 // Scenario validation data file path
+            false,                                          // With atmosphere
             LocalOrbitalFrameFactory::LVLH(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust
             Vector3d({1.0, 0.0, 0.0}),                      // Thrust direction in Local Orbital Frame
             100.0,                                          // Satellite dry mass [kg]
             0.1,                                            // Thrust [N]
             1500.0,                                         // Specific impulse [s]
-            7e-4,                                           // Position error GCRF tolerance [m]
-            8e-7,                                           // Velocity error GCRF tolerance [m/s]
-            1e-9                                            // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                            // Cross section [m^2]
+            0.0,                                            // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 5: VVLH LOF
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VVLH_1.0_0.0_"
             "0.0_30.0.csv",                                 // Scenario validation data file path
+            false,                                          // With atmosphere
             LocalOrbitalFrameFactory::VVLH(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                      // Thrust direction in Local Orbital Frame
             100.0,                                          // Satellite dry mass [kg]
             0.1,                                            // Thrust [N]
             1500.0,                                         // Specific impulse [s]
-            7e-4,                                           // Position error GCRF tolerance [m]
-            8e-7,                                           // Velocity error GCRF tolerance [m/s]
-            1e-9                                            // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                            // Cross section [m^2]
+            0.0,                                            // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 6: Increase spacecraft mass to 1000kg
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_1015.0_0.1_1500.0_3600.0_VNC_1.0_0.0_"
             "0.0_30.0.csv",                                // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             1000.0,                                        // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 7: Increase maneuver duration to 4h
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_14400.0_VNC_1.0_0.0_"
             "0.0_30.0.csv",                                // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            3e-3,                                          // Position error GCRF tolerance [m]
-            3e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-4,  // Position error GCRF tolerance [m]
+            8e-7,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-5,  // Position error LOF tolerance [m]
+            8e-8,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 8: Increase spacecraft mass to 1000kg and LVLH
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_1015.0_0.1_1500.0_3600.0_LVLH_1.0_0."
             "0_0.0_30.0.csv",                               // Scenario validation data file path
+            false,                                          // With atmosphere
             LocalOrbitalFrameFactory::LVLH(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                      // Thrust direction in Local Orbital Frame
             1000.0,                                         // Satellite dry mass [kg]
             0.1,                                            // Thrust [N]
             1500.0,                                         // Specific impulse [s]
-            7e-4,                                           // Position error GCRF tolerance [m]
-            8e-7,                                           // Velocity error GCRF tolerance [m/s]
-            1e-9                                            // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                            // Cross section [m^2]
+            0.0,                                            // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 9: Increase maneuver duration to 4h and LVLH
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_14400.0_LVLH_1.0_0."
             "0_0.0_30.0.csv",                               // Scenario validation data file path
+            false,                                          // With atmosphere
             LocalOrbitalFrameFactory::LVLH(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                      // Thrust direction in Local Orbital Frame
             100.0,                                          // Satellite dry mass [kg]
             0.1,                                            // Thrust [N]
             1500.0,                                         // Specific impulse [s]
-            3e-3,                                           // Position error GCRF tolerance [m]
-            3e-6,                                           // Velocity error GCRF tolerance [m/s]
-            1e-9                                            // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                            // Cross section [m^2]
+            0.0,                                            // Drag coefficient [-]
+            // Assertion tolerances
+            8e-4,  // Position error GCRF tolerance [m]
+            8e-7,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-5,  // Position error LOF tolerance [m]
+            8e-8,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 10: Increase thrust to 10N
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_10.0_1500.0_3600.0_VNC_1.0_0.0_"
             "0.0_30.0.csv",                                // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             10.0,                                          // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-4,  // Position error GCRF tolerance [m]
+            8e-7,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-4,  // Position error LOF tolerance [m]
+            8e-7,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 11: Equatorial orbit
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_0.0_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_1.0_0.0_0."
             "0_30.0.csv",                                  // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 12: Thrust Vector on +Z and Equatorial
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7000000.0_0.0_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_0.0_0.0_1."
             "0_30.0.csv",                                  // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({0.0, 0.0, 1.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
         ),
         // Test Case 13: Higher altitude orbit (~1000km)
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_7500000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_1.0_0.0_"
             "0.0_30.0.csv",                                // Scenario validation data file path
+            false,                                         // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
-            7e-4,                                          // Position error GCRF tolerance [m]
-            8e-7,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
-        )
-    )
-);
-
-class OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster_Drag_Exponential
-    : public ::testing::TestWithParam<Tuple<
-          std::string,
-          Shared<const LocalOrbitalFrameFactory>,
-          Vector3d,
-          Real,
-          Real,
-          Real,
-          Real,
-          Real,
-          Real,
-          Real,
-          Real>>
-{
-   protected:
-    void SetUp() override
-    {
-        const Composite satelliteGeometry(Cuboid(
-            {0.0, 0.0, 0.0},
-            {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}},
-            {1.0, 2.0, 3.0}
-        ));
-
-        this->satelliteGeometry_ = satelliteGeometry;
-
-        this->earthSpherical_ = std::make_shared<Celestial>(Earth::Spherical());
-        this->defaultDynamics_ = {
-            std::make_shared<PositionDerivative>(),
-            std::make_shared<CentralBodyGravity>(earthSpherical_),
-        };
-
-        this->defaultPropagator_ = {defaultNumericalSolver_, defaultDynamics_};
-    }
-
-    const NumericalSolver defaultNumericalSolver_ = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaFehlberg78,
-        5.0,
-        1.0e-15,
-        1.0e-15,
-    };
-
-    const NumericalSolver defaultRK4_ = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKutta4,
-        5.0,
-        1.0e-15,
-        1.0e-15,
-    };
-
-    const Mass satelliteDryMass_ = Mass(100.0, Mass::Unit::Kilogram);
-    const Mass propellantMass_ = Mass(15.0, Mass::Unit::Kilogram);
-
-    const Shared<const Frame> gcrfSPtr_ = Frame::GCRF();
-
-    Array<Shared<Dynamics>> defaultDynamics_ = Array<Shared<Dynamics>>::Empty();
-    Composite satelliteGeometry_ = Composite::Undefined();
-    Shared<Celestial> earthSpherical_ = nullptr;
-    Propagator defaultPropagator_ = Propagator::Undefined();
-};
-
-TEST_P(
-    OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster_Drag_Exponential,
-    ForceModel_Thrust_Drag_Exponential
-)
-{
-    // Setup environment
-
-    // Access the test parameters
-    const auto parameters = GetParam();
-
-    const String referenceDataFileName = std::get<0>(parameters);
-    Shared<const LocalOrbitalFrameFactory> localOrbitalFrameFactory = std::get<1>(parameters);
-    const Vector3d localOrbitalFrameThrustVector = std::get<2>(parameters);
-    const Real satelliteDryMassReal = std::get<3>(parameters);
-    const Real thrustReal = std::get<4>(parameters);
-    const Real specificImpulseReal = std::get<5>(parameters);
-    const Real crossSectionReal = std::get<6>(parameters);
-    const Real dragCoefficientReal = std::get<7>(parameters);
-
-    // Reference data setup
-    const Table referenceData = Table::Load(File::Path(Path::Parse(referenceDataFileName)), Table::Format::CSV, true);
-
-    // Initialize reference data arrays
-    Array<Instant> instantArray = Array<Instant>::Empty();
-    Array<Vector3d> referencePositionArrayGCRF = Array<Vector3d>::Empty();
-    Array<Vector3d> referenceVelocityArrayGCRF = Array<Vector3d>::Empty();
-    Array<Vector3d> referenceCentralBodyGravityArrayGCRF = Array<Vector3d>::Empty();
-    Array<Vector3d> referenceDragArrayGCRF = Array<Vector3d>::Empty();
-    Array<Vector3d> referenceTotalAccelerationArrayGCRF = Array<Vector3d>::Empty();
-    Array<Vector3d> referenceManeuverAccelerationArrayGCRF = Array<Vector3d>::Empty();
-
-    Array<Vector3d> referencePositionArrayLOF = Array<Vector3d>::Empty();
-    Array<Vector3d> referenceVelocityArrayLOF = Array<Vector3d>::Empty();
-    Array<Vector3d> referenceManeuverDragAccelerationArrayLOF = Array<Vector3d>::Empty();
-    Array<double> referenceMassArray = Array<double>::Empty();
-
-    for (const auto& referenceRow : referenceData)
-    {
-        instantArray.add(
-            Instant::DateTime(DateTime::Parse(referenceRow[0].accessString(), DateTime::Format::ISO8601), Scale::UTC)
-        );
-
-        referencePositionArrayGCRF.add(
-            Vector3d(referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal())
-        );
-        referenceVelocityArrayGCRF.add(
-            Vector3d(referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal())
-        );
-        referenceTotalAccelerationArrayGCRF.add(
-            Vector3d(referenceRow[13].accessReal(), referenceRow[14].accessReal(), referenceRow[15].accessReal())
-        );
-        referenceManeuverAccelerationArrayGCRF.add(
-            Vector3d(referenceRow[16].accessReal(), referenceRow[17].accessReal(), referenceRow[18].accessReal())
-        );
-
-        referencePositionArrayLOF.add(
-            Vector3d(referenceRow[7].accessReal(), referenceRow[8].accessReal(), referenceRow[9].accessReal())
-        );
-        referenceVelocityArrayLOF.add(
-            Vector3d(referenceRow[10].accessReal(), referenceRow[11].accessReal(), referenceRow[12].accessReal())
-        );
-        referenceManeuverDragAccelerationArrayLOF.add(
-            Vector3d(referenceRow[19].accessReal(), referenceRow[20].accessReal(), referenceRow[21].accessReal())
-        );
-
-        referenceCentralBodyGravityArrayGCRF.add(
-            Vector3d(referenceRow[22].accessReal(), referenceRow[23].accessReal(), referenceRow[24].accessReal())
-        );
-
-        referenceDragArrayGCRF.add(
-            Vector3d(referenceRow[25].accessReal(), referenceRow[26].accessReal(), referenceRow[27].accessReal())
-        );
-
-        referenceMassArray.add(referenceRow[28].accessReal());
-    }
-
-    // Local Orbital Frame Direction
-    const LocalOrbitalFrameDirection thrustDirection =
-        LocalOrbitalFrameDirection(localOrbitalFrameThrustVector, localOrbitalFrameFactory);
-
-    // Coordinates Broker (scenario-independent)
-    const Shared<const CoordinateBroker> coordinatesBrokerSPtr = std::make_shared<CoordinateBroker>(CoordinateBroker({
-        CartesianPosition::Default(),
-        CartesianVelocity::Default(),
-        CoordinateSubset::Mass(),
-        CoordinateSubset::SurfaceArea(),
-        CoordinateSubset::DragCoefficient(),
-    }));
-
-    // Setup initial conditions
-    VectorXd initialCoordinates(9);
-
-    initialCoordinates << referencePositionArrayGCRF[0], referenceVelocityArrayGCRF[0],
-        propellantMass_.inKilograms() + satelliteDryMassReal, crossSectionReal, dragCoefficientReal;
-
-    const State initialState = {
-        instantArray[0],
-        initialCoordinates,
-        gcrfSPtr_,
-        coordinatesBrokerSPtr,
-    };
-
-    // Setup satellite system
-    PropulsionSystem propulsionSystem = {thrustReal, specificImpulseReal};
-
-    const Composite satelliteGeometry(Cuboid(
-        {0.0, 0.0, 0.0}, {Vector3d {1.0, 0.0, 0.0}, Vector3d {0.0, 1.0, 0.0}, Vector3d {0.0, 0.0, 1.0}}, {1.0, 2.0, 3.0}
-    ));
-
-    SatelliteSystem satelliteSystem = {
-        Mass::Kilograms(satelliteDryMassReal),
-        satelliteGeometry,
-        Matrix3d::Identity(),
-        crossSectionReal,
-        dragCoefficientReal,
-        propulsionSystem,
-    };
-
-    // Setup validation tolerances
-    const Real positionErrorGCRFTolerance = std::get<8>(parameters);
-    const Real velocityErrorGCRFTolerance = std::get<9>(parameters);
-    const Real MassErrorTolerance = std::get<10>(parameters);
-
-    // Setup dynamics
-    const Earth earth = Earth::FromModels(
-        std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::Spherical),
-        std::make_shared<EarthMagneticModel>(EarthMagneticModel::Type::Undefined),
-        std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
-    );
-    const Shared<Celestial> earthSPtr = std::make_shared<Celestial>(earth);
-
-    const Shared<ConstantThrust> guidanceLawSPtr = std::make_shared<ConstantThrust>(thrustDirection);
-    const Shared<Thruster> thrusterDynamicsSPtr = std::make_shared<Thruster>(satelliteSystem, guidanceLawSPtr);
-    const Shared<CentralBodyGravity> centralBodyGravitySPtr = std::make_shared<CentralBodyGravity>(earthSPtr);
-    const Shared<AtmosphericDrag> atmosphericDragSPtr = std::make_shared<AtmosphericDrag>(earthSPtr);
-
-    const Array<Shared<Dynamics>> dynamics = {
-        std::make_shared<PositionDerivative>(), centralBodyGravitySPtr, atmosphericDragSPtr, thrusterDynamicsSPtr
-    };
-
-    // Setup Propagator model and orbit
-    const Propagator propagator = {defaultRK4_, dynamics};
-
-    // Propagate all states with OSTk
-    const Array<State> propagatedStateArray = propagator.calculateStatesAt(initialState, instantArray);
-
-    // Validation loop
-    for (size_t i = 0; i < instantArray.getSize() - 1; i++)
-    {
-        // GCRF Compare
-        const Position positionGCRF = propagatedStateArray[i].inFrame(gcrfSPtr_).getPosition();
-        const Velocity velocityGCRF = propagatedStateArray[i].inFrame(gcrfSPtr_).getVelocity();
-        const double mass = propagatedStateArray[i].extractCoordinate(CoordinateSubset::Mass())[0];
-
-        VectorXd OSTkStateCoordinatesGCRF(9);
-        OSTkStateCoordinatesGCRF << positionGCRF.accessCoordinates(), velocityGCRF.accessCoordinates(), mass,
-            crossSectionReal, dragCoefficientReal;
-
-        const VectorXd maneuverContributionGCRF =
-            thrusterDynamicsSPtr->computeContribution(instantArray[i], OSTkStateCoordinatesGCRF, gcrfSPtr_);
-        const VectorXd centralBodyGravityContributionGCRF =
-            centralBodyGravitySPtr->computeContribution(instantArray[i], positionGCRF.accessCoordinates(), gcrfSPtr_);
-        const VectorXd dragContributionGCRF = atmosphericDragSPtr->computeContribution(
-            instantArray[i], OSTkStateCoordinatesGCRF, gcrfSPtr_
-        );  // Remove mass from state for drag, not anymore
-        const VectorXd totalAccelerationGCRF =
-            maneuverContributionGCRF.segment(0, 3) + centralBodyGravityContributionGCRF + dragContributionGCRF;
-
-        // LOF Compare
-        Shared<const Frame> lofSPtr = localOrbitalFrameFactory->generateFrame(
-            instantArray[i], positionGCRF.accessCoordinates(), velocityGCRF.accessCoordinates()
-        );
-        State lofState = propagatedStateArray[i].inFrame(lofSPtr);
-
-        const Position positionLOF = lofState.getPosition();
-        const Velocity velocityLOF = lofState.getVelocity();
-
-        const double positionErrorGCRF = (positionGCRF.accessCoordinates() - referencePositionArrayGCRF[i]).norm();
-        const double velocityErrorGCRF = (velocityGCRF.accessCoordinates() - referenceVelocityArrayGCRF[i]).norm();
-        const double maneuverAccelerationContributionErrorGCRF =
-            (maneuverContributionGCRF.segment(0, 3) - referenceManeuverAccelerationArrayGCRF[i]).norm();
-        const double centralBodyGravityAccelerationContributionErrorGCRF =
-            (centralBodyGravityContributionGCRF.segment(0, 3) - referenceCentralBodyGravityArrayGCRF[i])
-                .norm();  // Name TBC
-        const double dragAccelerationContributionErrorGCRF =
-            (dragContributionGCRF.segment(0, 3) - referenceDragArrayGCRF[i]).norm();
-        const double positionErrorLOF = (positionLOF.accessCoordinates() - referencePositionArrayLOF[i]).norm();
-        const double velocityErrorLOF = (velocityLOF.accessCoordinates() - referencePositionArrayLOF[i]).norm();
-        const double totalAccelerationErrorGCRF =
-            (totalAccelerationGCRF - referenceTotalAccelerationArrayGCRF[i]).norm();
-        const double massError = std::abs(mass - referenceMassArray[i]);
-
-        // Frame verification
-        ASSERT_EQ(*Frame::GCRF(), *positionGCRF.accessFrame());
-        ASSERT_EQ(*Frame::GCRF(), *velocityGCRF.accessFrame());
-        ASSERT_EQ(*lofSPtr, *positionLOF.accessFrame());
-        ASSERT_EQ(*lofSPtr, *velocityLOF.accessFrame());
-
-        // GCRF Errors
-        // State
-        ASSERT_GT(positionErrorGCRFTolerance, positionErrorGCRF);
-        ASSERT_GT(velocityErrorGCRFTolerance, velocityErrorGCRF);
-        ASSERT_GT(MassErrorTolerance, massError);
-
-        // Accelerations from dynamics
-        ASSERT_GT(1e-8, centralBodyGravityAccelerationContributionErrorGCRF);
-        ASSERT_GT(1e-9, dragAccelerationContributionErrorGCRF);
-        ASSERT_GT(1e-9, maneuverAccelerationContributionErrorGCRF);
-        ASSERT_GT(5e-9, totalAccelerationErrorGCRF);
-
-        // // LOF Errors
-        // // State
-        ASSERT_GT(1e-15, positionErrorLOF);
-        ASSERT_GT(1e-15, velocityErrorLOF);
-
-        // Results console output
-
-        // std::cout << "**************************************" << std::endl;
-        // std::cout.setf(std::ios::scientific,std::ios::floatfield);
-        // std::cout << "Instant is: " << instantArray[i] << std::endl;
-        // // Quaternion quat = gcrfSPtr_->getTransformTo(lofSPtr, instantArray[i]).getOrientation();
-        // // std::cout << lofSPtr->getOriginIn(gcrfSPtr_, instantArray[i]) << std::endl;
-        // // std::cout << quat << std::endl ;
-        // std::cout << "Position OSTk is: " << positionGCRF.accessCoordinates() << "m" << std::endl;
-        // std::cout << "Position Orekit is: " << referencePositionArrayGCRF[i] << "m" << std::endl;
-        // std::cout << "Velocity OSTk is: " << velocityGCRF.accessCoordinates() << "m/s" << std::endl;
-        // std::cout << "Velocity Orekit is: " << referenceVelocityArrayGCRF[i] << "m/s" << std::endl;
-        // std::cout << "Position error GCRF is: " << positionErrorGCRF << "m" << std::endl;
-        // std::cout << "Velocity error GCRF is: " << velocityErrorGCRF << "m/s" << std::endl;
-        // std::cout << "Position OSTk LOF is: " << positionLOF.accessCoordinates() << "m" << std::endl;
-        // std::cout << "Position Orekit LOF is: " << referencePositionArrayLOF[i] << "m" << std::endl;
-        // std::cout << "Velocity OSTk LOF is: " << velocityLOF.accessCoordinates() << "m/s" << std::endl;
-        // std::cout << "Velocity Orekit LOF is: " << referenceVelocityArrayLOF[i] << "m/s" << std::endl;
-        // std::cout << "Position error LOF is: " << positionErrorLOF << "m" << std::endl;
-        // std::cout << "Velocity error LOF is: " << velocityErrorLOF << "m/s" << std::endl;
-        // std::cout << "Mass OSTk is: " << mass << "kg" << std::endl;
-        // std::cout << "Mass Orekit is: " << referenceMassArray[i] << "kg" << std::endl;
-        // std::cout << "Mass error is: " << massError << "kg" << std::endl;
-        // std::cout << "Maneuver acceleration error GCRF X is: " << maneuverContributionGCRF[0] -
-        // referenceManeuverAccelerationArrayGCRF[i][0] << "m/s^2" << std::endl; std::cout << "Maneuver acceleration
-        // error GCRF Y is: " << maneuverContributionGCRF[1] - referenceManeuverAccelerationArrayGCRF[i][1] <<
-        // "m/s^2"
-        // << std::endl; std::cout << "Maneuver acceleration error GCRF Z is: " << maneuverContributionGCRF[2] -
-        // referenceManeuverAccelerationArrayGCRF[i][2] << "m/s^2" << std::endl; std::cout << "Maneuver acceleration
-        // error GCRF is: " << maneuverAccelerationContributionErrorGCRF << "m/s^2" << std::endl;  // Do it in
-        // percentage std::cout << "Central Body Gravity acceleration error GCRF is: " <<
-        // centralBodyGravityAccelerationContributionErrorGCRF << "m/s^2" << std::endl;  // Do it in percentage
-        // std::cout << "Drag acceleration error GCRF is: " << dragAccelerationContributionErrorGCRF << "m/s^2" <<
-        // std::endl;  // Do it in percentage std::cout << "Total acceleration (centralbody + maneuver + drag) error
-        // GCRF is: " << totalAccelerationErrorGCRF << "m/s^2" << std::endl;
-        // std::cout.setf(std::ios::fixed,std::ios::floatfield); std::cout <<
-        // "**************************************"
-        // << std::endl;
-    }
-}
-
-// TBI: Agree on a format to version Orekit validation files
-INSTANTIATE_TEST_SUITE_P(
-    ForceModel_Thrust_Drag_Exponential,
-    OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster_Drag_Exponential,
-    ::testing::Values(
-        // Test Case 0
+            0.0,                                           // Cross section [m^2]
+            0.0,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            5e-9   // Acceleration error LOF tolerance [m/s^2]
+        ),
+        //
+        //
+        // With Atmosphere
+        //
+        //
+        // Test Case 14
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_1.0_"
             "0.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",   // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
             1.0,                                           // Cross section [m^2]
-            2.1,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 1: Start date in 2021
+        // Test Case 15: Start date in 2021
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2021-12-23T11-23-21.235_115.0_0.1_1500.0_3600.0_VNC_1.0_"
             "0.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",   // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
             1.0,                                           // Cross section [m^2]
-            2.1,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 2: QSW LOF
+        // Test Case 16: QSW LOF
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_QSW_0.0_"
             "1.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",   // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::QSW(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({0.0, 1.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
             1.0,                                           // Cross section [m^2]
-            2.1,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 3: Increase spacecraft mass to 1000kg
+        // Test Case 17: Increase spacecraft mass to 1000kg
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2023-01-01T00-00-00.000_1015.0_0.1_1500.0_3600.0_VNC_1."
             "0_0.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",  // Scenario validation data file path
+            true,                                           // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),   // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                      // Thrust direction in Local Orbital Frame
             1000.0,                                         // Satellite dry mass [kg]
             0.1,                                            // Thrust [N]
             1500.0,                                         // Specific impulse [s]
             1.0,                                            // Cross section [m^2]
-            2.1,                                            // Drag coefficient
-            1e-3,                                           // Position error GCRF tolerance [m]
-            1e-6,                                           // Velocity error GCRF tolerance [m/s]
-            1e-9                                            // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                            // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 4: Increase maneuver duration to 2h
+        // Test Case 18: Increase maneuver duration to 2h
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_7200.0_VNC_1.0_"
             "0.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",   // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
             1.0,                                           // Cross section [m^2]
-            2.1,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-4,  // Position error GCRF tolerance [m]
+            8e-7,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-5,  // Position error LOF tolerance [m]
+            8e-8,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 5: Increase maneuver duration to 4h
+        // Test Case 19: Increase maneuver duration to 4h
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_14400.0_VNC_1."
             "0_0.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",  // Scenario validation data file path
+            true,                                           // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),   // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                      // Thrust direction in Local Orbital Frame
             100.0,                                          // Satellite dry mass [kg]
             0.1,                                            // Thrust [N]
             1500.0,                                         // Specific impulse [s]
             1.0,                                            // Cross section [m^2]
-            2.1,                                            // Drag coefficient
-            3e-3,                                           // Position error GCRF tolerance [m]
-            3e-6,                                           // Velocity error GCRF tolerance [m/s]
-            1e-9                                            // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                            // Drag coefficient [-]
+            // Assertion tolerances
+            8e-4,  // Position error GCRF tolerance [m]
+            8e-7,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-5,  // Position error LOF tolerance [m]
+            8e-8,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 6: Increase thrust to 1N, lowering specific impulse to 150.0
+        // Test Case 20: Increase thrust to 1N, lowering specific impulse to 150.0
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_1.0_150.0_3600.0_VNC_1.0_"
             "0.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",   // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             1.0,                                           // Thrust [N]
             150.0,                                         // Specific impulse [s]
             1.0,                                           // Cross section [m^2]
-            2.1,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-4,  // Position error GCRF tolerance [m]
+            8e-7,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-5,  // Position error LOF tolerance [m]
+            8e-8,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 7: Equatorial orbit
+        // Test Case 21: Equatorial orbit
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_0.0_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_1.0_"
             "0.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",   // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
             1.0,                                           // Cross section [m^2]
-            2.1,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 8: Increase spacecraft cross section
+        // Test Case 22: Increase spacecraft cross section
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_1.0_"
             "0.0_0.0_30.0_EXPONENTIAL_25.0_2.1_TRUE.csv",  // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
             25.0,                                          // Cross section [m^2]
-            2.1,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-4,  // Position error GCRF tolerance [m]
+            8e-7,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-5,  // Position error LOF tolerance [m]
+            8e-8,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 9: Increase spacecraft drag coefficient and cross section
+        // Test Case 23: Increase spacecraft drag coefficient and cross section
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7000000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_1.0_"
             "0.0_0.0_30.0_EXPONENTIAL_1.0_4.2_TRUE.csv",   // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
             1.0,                                           // Cross section [m^2]
-            4.2,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            4.2,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-4,  // Position error GCRF tolerance [m]
+            8e-7,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-5,  // Position error LOF tolerance [m]
+            8e-8,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         ),
-        // Test Case 10: Higher initial altitude (~800 km) and increase cross section
+        // Test Case 24: Higher initial altitude (~800 km) and increase cross section
         std::make_tuple(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/"
             "Orekit_ConstantThrustThruster_Drag_7300000.0_98.1_2023-01-01T00-00-00.000_115.0_0.1_1500.0_3600.0_VNC_1.0_"
             "0.0_0.0_30.0_EXPONENTIAL_1.0_2.1_TRUE.csv",   // Scenario validation data file path
+            true,                                          // With atmosphere
             LocalOrbitalFrameFactory::VNC(Frame::GCRF()),  // Local Orbital Frame Factory to express thrust direction
             Vector3d({1.0, 0.0, 0.0}),                     // Thrust direction in Local Orbital Frame
             100.0,                                         // Satellite dry mass [kg]
             0.1,                                           // Thrust [N]
             1500.0,                                        // Specific impulse [s]
             1.0,                                           // Cross section [m^2]
-            2.1,                                           // Drag coefficient
-            1e-3,                                          // Position error GCRF tolerance [m]
-            1e-6,                                          // Velocity error GCRF tolerance [m/s]
-            1e-9                                           // Mass error tolerance [kg]
-            // Acceleration errors
+            2.1,                                           // Drag coefficient [-]
+            // Assertion tolerances
+            8e-5,  // Position error GCRF tolerance [m]
+            8e-8,  // Velocity error GCRF tolerance [m/s]
+            1e-9,  // Acceleration error GCRF tolerance [m/s^2]
+            1e-9,  // Mass error tolerance [kg]
+            8e-6,  // Position error LOF tolerance [m]
+            8e-9,  // Velocity error LOF tolerance [m/s]
+            0.0    // Acceleration error LOF tolerance [m/s^2] Not tested because quantity is not recorded in csv
         )
     )
 );


### PR DESCRIPTION
Part of Maneuver validation effort.

This MR:
- re-adds the validation tests that were commented out (I don't know why they were commented out cause they actually do work) for ConstantThrust and ThrusterDynamics working together