### PR TITLE
chore: update test-unit-python make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ test-unit-cpp-standalone: ## Run C++ unit tests (standalone)
 
 .PHONY: test-unit-cpp-standalone
 
-test-unit-python: build-release-image-python ## Run Python unit tests
+test-unit-python: build-development-image ## Run Python unit tests
 
 	@ $(MAKE) test-unit-python-standalone
 
@@ -532,7 +532,7 @@ test-unit-python-standalone: ## Run Python unit tests (standalone)
 		/bin/bash -c "cmake -DBUILD_PYTHON_BINDINGS=ON -DBUILD_UNIT_TESTS=OFF -DBUILD_VALIDATION_TESTS=OFF -DBUILD_BENCHMARK=OFF .. \
 		&& $(MAKE) -j 4 && python3.11 -m pip install --root-user-action=ignore bindings/python/OpenSpaceToolkit*Py-python-package-3.11 \
 		&& python3.11 -m pip install plotly pandas \
-		&& python3.11 -m pip install git+https://github.com/lucas-bremond/cesiumpy.git#egg=cesiumpy \
+		&& python3.11 -m pip install git+https://github.com/open-space-collective/cesiumpy.git#egg=cesiumpy \
 		&& cd /usr/local/lib/python3.11/site-packages/ostk/$(project_name)/ \
 		&& python3.11 -m pytest -sv ."
 


### PR DESCRIPTION
Having make test-unit-python used the python release image currently prevents you from using it locally since git is not installed in the release image and ostk-data needs git. The make test-unit-cpp and even the make packages targets all use the development images as pre-reqs since they all build the whole project from scratch anyways with cmake and the appropriate flags for each of their specific goals. 

Also cesiumpy changed location and needs to be updated