### PR TITLE
fix: coordinate subset unsafe frame conversion

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.cpp
@@ -85,6 +85,13 @@ VectorXd CoordinateSubset::inFrame(
     const Shared<const CoordinateBroker>& aCoordinateBrokerSPtr
 ) const
 {
+    if (size_ != 1)
+    {
+        throw ostk::core::error::RuntimeError(
+            "Cannot transform a non-scalar coordinate subset. Child classes must implement this method."
+        );
+    }
+
     VectorXd coordinates = aCoordinateBrokerSPtr->extractCoordinate(aFullCoordinatesVector, *this);
 
     return coordinates;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.test.cpp
@@ -132,6 +132,39 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset, InFrame
 
         EXPECT_EQ(expected, actual);
     }
+
+    // Attempt to transform a non-scalar subset without implementing the inFrame method
+    {
+        const Shared<const CoordinateSubset> nonScalarCoordinateSubset = std::make_shared<CoordinateSubset>("NAME", 3);
+        const Shared<const CoordinateBroker> nonScalarCoordinateBroker =
+            std::make_shared<CoordinateBroker>(Array<Shared<const CoordinateSubset>>({nonScalarCoordinateSubset}));
+
+        const Instant instant = Instant::J2000();
+        const Shared<const Frame> fromFrame = Frame::GCRF();
+        const Shared<const Frame> toFrame = Frame::TEME();
+        VectorXd fullCoordinatesVector(3);
+        fullCoordinatesVector << 1.0e7, -1e7, 5e6;
+
+        EXPECT_THROW(
+            {
+                try
+                {
+                    nonScalarCoordinateSubset->inFrame(
+                        instant, fullCoordinatesVector, fromFrame, toFrame, nonScalarCoordinateBroker
+                    );
+                }
+                catch (const ostk::core::error::RuntimeError& e)
+                {
+                    EXPECT_EQ(
+                        "Cannot transform a non-scalar coordinate subset. Child classes must implement this method.",
+                        e.getMessage()
+                    );
+                    throw;
+                }
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset, Mass)


### PR DESCRIPTION
Users can create a `CoordinateSubset`, giving it a specific name and number of coordinates in the subset. However, if they use the `inFrame` conversion method on the `CoordinateSubset` class itself, it doesn't actually do the conversion they want, it just returns the coordinates as they are.

This is fine for scalar subsets, but not fine for vector coordinate subsets because it is a hidden behavior the user may not be aware of. Therefore, if someone tries to do this, I will raise an error.

If the user wants to make their own non-scalar coordinate subset by inheriting from `CoordinateSubset`, then they can get around this error by acutally implementing the `virtual` `inFrame` method and overriding it in their child class.