### PR TITLE
feat: make coordinate subsets hashable

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinateSubset.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/CoordinateSubset.cpp
@@ -113,6 +113,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_CoordinateSubset(py
 
         .def("__eq__", &CoordinateSubset::operator==)
         .def("__ne__", &CoordinateSubset::operator!=)
+        .def("__hash__", &CoordinateSubset::hash)
 
         .def(
             "get_id",

--- a/bindings/python/test/trajectory/state/test_coordinate_subset.py
+++ b/bindings/python/test/trajectory/state/test_coordinate_subset.py
@@ -30,6 +30,9 @@ class TestCoordinateSubset:
     def test_ne(self, coordinate_subset: CoordinateSubset):
         assert (coordinate_subset != coordinate_subset) == False
 
+    def test_hash(self, coordinate_subset: CoordinateSubset):
+        assert hash(coordinate_subset) is not None
+
     def test_get_id(self, coordinate_subset: CoordinateSubset):
         assert coordinate_subset.get_id() is not None
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp
@@ -63,6 +63,11 @@ class CoordinateSubset
     /// @return True if CoordinateSubsets are not equal
     bool operator!=(const CoordinateSubset& aCoordinateSubset) const;
 
+    /// @brief Return the hash value of the instance
+    ///
+    /// @return The hash value of the instance
+    Size hash() const;
+
     /// @brief Return the unique identifier of the instance
     ///
     /// @return The unique identifier of the instance

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.cpp
@@ -40,6 +40,11 @@ bool CoordinateSubset::operator!=(const CoordinateSubset& aCoordinateSubset) con
     return !((*this) == aCoordinateSubset);
 }
 
+Size CoordinateSubset::hash() const
+{
+    return std::hash<String>()(id_);
+}
+
 String CoordinateSubset::getId() const
 {
     return id_;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.test.cpp
@@ -75,6 +75,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset, NotEqua
     }
 }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset, Hash)
+{
+    {
+        EXPECT_NO_THROW(defaultCoordinateSubset_.hash());
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset, Getters)
 {
     {


### PR DESCRIPTION
This will allow us to use `CoordinateSubset` as a key in a python dictionary in our services