### PR TITLE
feat: add duration step parameter to Orbit.getPassWithRevolutionNumber

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -20,6 +20,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
     using ostk::physics::environment::object::Celestial;
     using ostk::physics::unit::Angle;
+    using ostk::physics::time::Duration;
 
     using ostk::astrodynamics::trajectory::Orbit;
     using ostk::astrodynamics::trajectory::orbit::model::Kepler;
@@ -219,12 +220,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                     Args:
                         revolution_number (int): The revolution number.
+                        step_size (Duration): The step size of the pass computation algorithm.
 
                     Returns:
                         Pass: The pass.
 
                 )doc",
-                arg("revolution_number")
+                arg("revolution_number"),
+                arg_v("duration", Duration::Minutes(5.0), "Duration.minutes(5.0)")
             )
             .def(
                 "get_orbital_frame",

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -227,7 +227,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                 )doc",
                 arg("revolution_number"),
-                arg_v("duration", Duration::Minutes(5.0), "Duration.minutes(5.0)")
+                arg_v("duration", Duration::Minutes(10.0), "Duration.minutes(10.0)")
             )
             .def(
                 "get_orbital_frame",

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -220,14 +220,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
 
                     Args:
                         revolution_number (int): The revolution number.
-                        step_size (Duration): The step size of the pass computation algorithm.
+                        step_duration (Duration): The initial step duration used for the pass computation algorithm.
 
                     Returns:
                         Pass: The pass.
 
                 )doc",
                 arg("revolution_number"),
-                arg_v("duration", Duration::Minutes(10.0), "Duration.minutes(10.0)")
+                arg_v("step_duration", Duration::Minutes(10.0), "Duration.minutes(10.0)")
             )
             .def(
                 "get_orbital_frame",

--- a/bindings/python/test/trajectory/test_orbit.py
+++ b/bindings/python/test/trajectory/test_orbit.py
@@ -98,6 +98,10 @@ class TestOrbit:
         assert isinstance(pass_, Pass)
         assert pass_.is_defined()
 
+        assert (
+            orbit.get_pass_with_revolution_number(0, Duration.minutes(10.0)) is not None
+        )
+
     def test_undefined(self):
         assert Orbit.undefined().is_defined() is False
 

--- a/bindings/python/test/trajectory/test_orbit.py
+++ b/bindings/python/test/trajectory/test_orbit.py
@@ -98,9 +98,7 @@ class TestOrbit:
         assert isinstance(pass_, Pass)
         assert pass_.is_defined()
 
-        assert (
-            orbit.get_pass_with_revolution_number(0, Duration.minutes(10.0)) is not None
-        )
+        assert orbit.get_pass_with_revolution_number(0, Duration.minutes(5.0)) is not None
 
     def test_undefined(self):
         assert Orbit.undefined().is_defined() is False

--- a/bindings/python/test/trajectory/test_orbit.py
+++ b/bindings/python/test/trajectory/test_orbit.py
@@ -98,7 +98,7 @@ class TestOrbit:
         assert isinstance(pass_, Pass)
         assert pass_.is_defined()
 
-        assert orbit.get_pass_with_revolution_number(2, Duration.minutes(5.0)) is not None
+        assert orbit.get_pass_with_revolution_number(2, Duration.minutes(10.0)) is not None
 
     def test_undefined(self):
         assert Orbit.undefined().is_defined() is False

--- a/bindings/python/test/trajectory/test_orbit.py
+++ b/bindings/python/test/trajectory/test_orbit.py
@@ -98,7 +98,7 @@ class TestOrbit:
         assert isinstance(pass_, Pass)
         assert pass_.is_defined()
 
-        assert orbit.get_pass_with_revolution_number(0, Duration.minutes(5.0)) is not None
+        assert orbit.get_pass_with_revolution_number(2, Duration.minutes(5.0)) is not None
 
     def test_undefined(self):
         assert Orbit.undefined().is_defined() is False

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
@@ -103,7 +103,7 @@ class Orbit : public Trajectory
     Pass getPassAt(const Instant& anInstant) const;
 
     Pass getPassWithRevolutionNumber(
-        const Integer& aRevolutionNumber, const Duration& aStepSize = Duration::Minutes(10.0)
+        const Integer& aRevolutionNumber, const Duration& aStepDuration = Duration::Minutes(10.0)
     ) const;
 
     Shared<const Frame> getOrbitalFrame(const Orbit::FrameType& aFrameType) const;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
@@ -44,6 +44,7 @@ using ostk::core::type::Unique;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::environment::object::Celestial;
 using ostk::physics::time::Instant;
+using ostk::physics::time::Duration;
 using ostk::physics::time::Time;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Length;
@@ -101,7 +102,9 @@ class Orbit : public Trajectory
 
     Pass getPassAt(const Instant& anInstant) const;
 
-    Pass getPassWithRevolutionNumber(const Integer& aRevolutionNumber) const;
+    Pass getPassWithRevolutionNumber(
+        const Integer& aRevolutionNumber, const Duration& aStepSize = Duration::Minutes(10.0)
+    ) const;
 
     Shared<const Frame> getOrbitalFrame(const Orbit::FrameType& aFrameType) const;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -255,12 +255,12 @@ Pass Orbit::getPassWithRevolutionNumber(const Integer& aRevolutionNumber, const 
             if (currentPass.isDefined() && currentPass.isComplete())
             {
                 Array<Duration> durations = {
-                    (currentPass.accessInstantAtNorthPoint() - currentPass.accessInstantAtAscendingNode()) / 10.0,
-                    (currentPass.accessInstantAtDescendingNode() - currentPass.accessInstantAtNorthPoint()) / 10.0,
-                    (currentPass.accessInstantAtSouthPoint() - currentPass.accessInstantAtDescendingNode()) / 10.0,
-                    (currentPass.accessInstantAtPassBreak() - currentPass.accessInstantAtSouthPoint()) / 10.0,
+                    (currentPass.accessInstantAtNorthPoint() - currentPass.accessInstantAtAscendingNode()),
+                    (currentPass.accessInstantAtDescendingNode() - currentPass.accessInstantAtNorthPoint()),
+                    (currentPass.accessInstantAtSouthPoint() - currentPass.accessInstantAtDescendingNode()),
+                    (currentPass.accessInstantAtPassBreak() - currentPass.accessInstantAtSouthPoint()),
                 };
-                stepDuration = *std::min_element(durations.begin(), durations.end());
+                stepDuration = *std::min_element(durations.begin(), durations.end()) / 2.0;
             }
 
             if (currentRevolutionNumber <= aRevolutionNumber)  // Forward propagation

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -248,7 +248,7 @@ Pass Orbit::getPassWithRevolutionNumber(const Integer& aRevolutionNumber, const 
             Integer currentRevolutionNumber = currentPass.isDefined() ? currentPass.getRevolutionNumber()
                                                                       : this->modelPtr_->getRevolutionNumberAtEpoch();
             Instant previousInstant = currentPass.isDefined()
-                                        ? (currentPass.accessInstantAtPassBreak() + Duration::Seconds(10.0))
+                                        ? (currentPass.accessInstantAtPassBreak() + Duration::Microseconds(1.0))
                                         : this->modelPtr_->getEpoch();
 
             Duration stepDuration = aStepDuration;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -763,6 +763,27 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
             );
         }
     }
+
+    {
+        // Environment setup
+
+        const Environment environment = Environment::Default();
+
+        // Orbit setup
+
+        const TLE tle = {
+            "1  7276U 74026A   19177.06815612 -.00000040  00000-0 -59146-3 0  9999",
+            "2  7276  63.5942  41.6062 6850823 289.3685  12.0680  2.45095050222705",
+        };
+
+        const SGP4 sgp4 = SGP4(tle);
+
+        const Orbit orbit = {sgp4, environment.accessCelestialObjectWithName("Earth")};
+
+        const Pass pass = orbit.getPassWithRevolutionNumber(22700, Duration::Minutes(30.0));
+
+        EXPECT_TRUE(pass.isDefined());
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetOrbitalFrame)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -784,12 +784,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         const Pass pass = orbit.getPassWithRevolutionNumber(22273, Duration::Minutes(10.0));
 
         EXPECT_TRUE(pass.isDefined());
-        EXPECT_TRUE(pass.getType() == Pass::Type::Complete);
-        EXPECT_TRUE(pass.getRevolutionNumber() == 22273);
-        EXPECT_TRUE(
-            pass.accessInstantAtAscendingNode() == Instant::Parse("2019-06-26 21:13:14.137.431.793", Scale::UTC)
-        );
-        EXPECT_TRUE(pass.accessInstantAtPassBreak() == Instant::Parse("2019-06-27 07:00:45.686.118.910", Scale::UTC));
+        EXPECT_EQ(pass.getType(), Pass::Type::Complete);
+        EXPECT_EQ(pass.getRevolutionNumber(), 22273);
+        EXPECT_EQ(pass.accessInstantAtAscendingNode(), Instant::Parse("2019-06-26 21:13:14.137.431.788", Scale::UTC));
+        EXPECT_EQ(pass.accessInstantAtPassBreak(), Instant::Parse("2019-06-27 07:00:45.686.118.913", Scale::UTC));
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -781,9 +781,15 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
 
         const Orbit orbit = {sgp4, environment.accessCelestialObjectWithName("Earth")};
 
-        const Pass pass = orbit.getPassWithRevolutionNumber(22273, Duration::Minutes(30.0));
+        const Pass pass = orbit.getPassWithRevolutionNumber(22273, Duration::Minutes(10.0));
 
         EXPECT_TRUE(pass.isDefined());
+        EXPECT_TRUE(pass.getType() == Pass::Type::Complete);
+        EXPECT_TRUE(pass.getRevolutionNumber() == 22273);
+        EXPECT_TRUE(
+            pass.accessInstantAtAscendingNode() == Instant::Parse("2019-06-26 21:13:14.137.431.793", Scale::UTC)
+        );
+        EXPECT_TRUE(pass.accessInstantAtPassBreak() == Instant::Parse("2019-06-27 07:00:45.686.118.910", Scale::UTC));
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -572,197 +572,197 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePasses)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumber)
 {
-    {
-        // Environment setup
+    // {
+    //     // Environment setup
 
-        const Environment environment = Environment::Default();
+    //     const Environment environment = Environment::Default();
 
-        // Orbit setup
+    //     // Orbit setup
 
-        const Length semiMajorAxis = Length::Kilometers(7000.0);
-        const Real eccentricity = 0.0;
-        const Angle inclination = Angle::Degrees(45.0);
-        const Angle raan = Angle::Degrees(0.0);
-        const Angle aop = Angle::Degrees(0.0);
-        const Angle trueAnomaly = Angle::Degrees(0.0);
+    //     const Length semiMajorAxis = Length::Kilometers(7000.0);
+    //     const Real eccentricity = 0.0;
+    //     const Angle inclination = Angle::Degrees(45.0);
+    //     const Angle raan = Angle::Degrees(0.0);
+    //     const Angle aop = Angle::Degrees(0.0);
+    //     const Angle trueAnomaly = Angle::Degrees(0.0);
 
-        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+    //     const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
-        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
-        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
-        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+    //     const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    //     const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+    //     const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+    //     const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+    //     const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
-        const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
-        };
+    //     const Kepler keplerianModel = {
+    //         coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+    //     };
 
-        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+    //     const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-        // Reference data setup
+    //     // Reference data setup
 
-        const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                                   "Satellite Passes.csv")),
-            Table::Format::CSV,
-            true
-        );
+    //     const Table referenceData = Table::Load(
+    //         File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+    //                                "Satellite Passes.csv")),
+    //         Table::Format::CSV,
+    //         true
+    //     );
 
-        // Pass test
+    //     // Pass test
 
-        for (const auto &referenceRow : referenceData)
-        {
-            const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
-            const Instant referencePassStartInstant =
-                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-            const Instant referencePassEndInstant =
-                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+    //     for (const auto &referenceRow : referenceData)
+    //     {
+    //         const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
+    //         const Instant referencePassStartInstant =
+    //             Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+    //         const Instant referencePassEndInstant =
+    //             Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
 
-            const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
+    //         const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
 
-            EXPECT_TRUE(pass.isDefined());
+    //         EXPECT_TRUE(pass.isDefined());
 
-            EXPECT_EQ(Pass::Type::Complete, pass.getType());
+    //         EXPECT_EQ(Pass::Type::Complete, pass.getType());
 
-            EXPECT_GT(
-                Duration::Microseconds(1.0),
-                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
-            );
-            EXPECT_GT(
-                Duration::Microseconds(1.0),
-                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
-            );
-        }
-    }
+    //         EXPECT_GT(
+    //             Duration::Microseconds(1.0),
+    //             Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
+    //         );
+    //         EXPECT_GT(
+    //             Duration::Microseconds(1.0),
+    //             Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
+    //         );
+    //     }
+    // }
 
-    {
-        // Environment setup
+    // {
+    //     // Environment setup
 
-        const Environment environment = Environment::Default();
+    //     const Environment environment = Environment::Default();
 
-        // Orbit setup
+    //     // Orbit setup
 
-        const Length semiMajorAxis = Length::Kilometers(7000.0);
-        const Real eccentricity = 0.0;
-        const Angle inclination = Angle::Degrees(45.0);
-        const Angle raan = Angle::Degrees(0.0);
-        const Angle aop = Angle::Degrees(0.0);
-        const Angle trueAnomaly = Angle::Degrees(0.0);
+    //     const Length semiMajorAxis = Length::Kilometers(7000.0);
+    //     const Real eccentricity = 0.0;
+    //     const Angle inclination = Angle::Degrees(45.0);
+    //     const Angle raan = Angle::Degrees(0.0);
+    //     const Angle aop = Angle::Degrees(0.0);
+    //     const Angle trueAnomaly = Angle::Degrees(0.0);
 
-        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+    //     const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
-        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
-        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
-        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+    //     const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    //     const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+    //     const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+    //     const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+    //     const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
-        const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
-        };
+    //     const Kepler keplerianModel = {
+    //         coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
+    //     };
 
-        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+    //     const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-        // Reference data setup
+    //     // Reference data setup
 
-        const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
-                                   "Satellite Passes.csv")),
-            Table::Format::CSV,
-            true
-        );
+    //     const Table referenceData = Table::Load(
+    //         File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
+    //                                "Satellite Passes.csv")),
+    //         Table::Format::CSV,
+    //         true
+    //     );
 
-        // Pass test
+    //     // Pass test
 
-        for (const auto &referenceRow : referenceData)
-        {
-            const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
-            const Instant referencePassStartInstant =
-                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-            const Instant referencePassEndInstant =
-                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+    //     for (const auto &referenceRow : referenceData)
+    //     {
+    //         const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
+    //         const Instant referencePassStartInstant =
+    //             Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+    //         const Instant referencePassEndInstant =
+    //             Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
 
-            const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
+    //         const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
 
-            EXPECT_TRUE(pass.isDefined());
+    //         EXPECT_TRUE(pass.isDefined());
 
-            EXPECT_EQ(Pass::Type::Complete, pass.getType());
+    //         EXPECT_EQ(Pass::Type::Complete, pass.getType());
 
-            EXPECT_GT(
-                Duration::Milliseconds(1.0),
-                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
-            );
-            EXPECT_GT(
-                Duration::Milliseconds(1.0),
-                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
-            );
-        }
-    }
+    //         EXPECT_GT(
+    //             Duration::Milliseconds(1.0),
+    //             Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
+    //         );
+    //         EXPECT_GT(
+    //             Duration::Milliseconds(1.0),
+    //             Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
+    //         );
+    //     }
+    // }
 
-    {
-        // Environment setup
+    // {
+    //     // Environment setup
 
-        const Environment environment = Environment::Default();
+    //     const Environment environment = Environment::Default();
 
-        // Orbit setup
+    //     // Orbit setup
 
-        const Length semiMajorAxis = Length::Kilometers(7000.0);
-        const Real eccentricity = 0.0;
-        const Angle inclination = Angle::Degrees(45.0);
-        const Angle raan = Angle::Degrees(0.0);
-        const Angle aop = Angle::Degrees(0.0);
-        const Angle trueAnomaly = Angle::Degrees(0.0);
+    //     const Length semiMajorAxis = Length::Kilometers(7000.0);
+    //     const Real eccentricity = 0.0;
+    //     const Angle inclination = Angle::Degrees(45.0);
+    //     const Angle raan = Angle::Degrees(0.0);
+    //     const Angle aop = Angle::Degrees(0.0);
+    //     const Angle trueAnomaly = Angle::Degrees(0.0);
 
-        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+    //     const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-        const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
-        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
-        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
-        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+    //     const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    //     const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+    //     const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+    //     const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+    //     const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
-        const Kepler keplerianModel = {
-            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4
-        };
+    //     const Kepler keplerianModel = {
+    //         coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4
+    //     };
 
-        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+    //     const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-        // Reference data setup
+    //     // Reference data setup
 
-        const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
-                                   "Satellite Passes.csv")),
-            Table::Format::CSV,
-            true
-        );
+    //     const Table referenceData = Table::Load(
+    //         File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
+    //                                "Satellite Passes.csv")),
+    //         Table::Format::CSV,
+    //         true
+    //     );
 
-        // Pass test
+    //     // Pass test
 
-        for (const auto &referenceRow : referenceData)
-        {
-            const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
-            const Instant referencePassStartInstant =
-                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-            const Instant referencePassEndInstant =
-                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+    //     for (const auto &referenceRow : referenceData)
+    //     {
+    //         const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
+    //         const Instant referencePassStartInstant =
+    //             Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+    //         const Instant referencePassEndInstant =
+    //             Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
 
-            const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
+    //         const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
 
-            EXPECT_TRUE(pass.isDefined());
+    //         EXPECT_TRUE(pass.isDefined());
 
-            EXPECT_EQ(Pass::Type::Complete, pass.getType());
+    //         EXPECT_EQ(Pass::Type::Complete, pass.getType());
 
-            EXPECT_GT(
-                Duration::Milliseconds(2.0),
-                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
-            );
-            EXPECT_GT(
-                Duration::Milliseconds(2.0),
-                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
-            );
-        }
-    }
+    //         EXPECT_GT(
+    //             Duration::Milliseconds(2.0),
+    //             Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
+    //         );
+    //         EXPECT_GT(
+    //             Duration::Milliseconds(2.0),
+    //             Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
+    //         );
+    //     }
+    // }
 
     {
         // Environment setup
@@ -780,7 +780,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
 
         const Orbit orbit = {sgp4, environment.accessCelestialObjectWithName("Earth")};
 
-        const Pass pass = orbit.getPassWithRevolutionNumber(22700, Duration::Minutes(30.0));
+        const Pass pass = orbit.getPassWithRevolutionNumber(22273, Duration::Minutes(30.0));
 
         EXPECT_TRUE(pass.isDefined());
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -572,198 +572,199 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePasses)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumber)
 {
-    // {
-    //     // Environment setup
+    {
+        // Environment setup
 
-    //     const Environment environment = Environment::Default();
+        const Environment environment = Environment::Default();
 
-    //     // Orbit setup
+        // Orbit setup
 
-    //     const Length semiMajorAxis = Length::Kilometers(7000.0);
-    //     const Real eccentricity = 0.0;
-    //     const Angle inclination = Angle::Degrees(45.0);
-    //     const Angle raan = Angle::Degrees(0.0);
-    //     const Angle aop = Angle::Degrees(0.0);
-    //     const Angle trueAnomaly = Angle::Degrees(0.0);
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(45.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
 
-    //     const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-    //     const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-    //     const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
-    //     const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
-    //     const Real J2 = EarthGravitationalModel::EGM2008.J2_;
-    //     const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+        const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
-    //     const Kepler keplerianModel = {
-    //         coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
-    //     };
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
 
-    //     const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-    //     // Reference data setup
+        // Reference data setup
 
-    //     const Table referenceData = Table::Load(
-    //         File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-    //                                "Satellite Passes.csv")),
-    //         Table::Format::CSV,
-    //         true
-    //     );
+        const Table referenceData = Table::Load(
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                   "Satellite Passes.csv")),
+            Table::Format::CSV,
+            true
+        );
 
-    //     // Pass test
+        // Pass test
 
-    //     for (const auto &referenceRow : referenceData)
-    //     {
-    //         const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
-    //         const Instant referencePassStartInstant =
-    //             Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-    //         const Instant referencePassEndInstant =
-    //             Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+        for (const auto &referenceRow : referenceData)
+        {
+            const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
+            const Instant referencePassStartInstant =
+                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+            const Instant referencePassEndInstant =
+                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
 
-    //         const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
+            const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
 
-    //         EXPECT_TRUE(pass.isDefined());
+            EXPECT_TRUE(pass.isDefined());
 
-    //         EXPECT_EQ(Pass::Type::Complete, pass.getType());
+            EXPECT_EQ(Pass::Type::Complete, pass.getType());
 
-    //         EXPECT_GT(
-    //             Duration::Microseconds(1.0),
-    //             Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
-    //         );
-    //         EXPECT_GT(
-    //             Duration::Microseconds(1.0),
-    //             Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
-    //         );
-    //     }
-    // }
+            EXPECT_GT(
+                Duration::Microseconds(1.0),
+                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
+            );
+            EXPECT_GT(
+                Duration::Microseconds(1.0),
+                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
+            );
+        }
+    }
 
-    // {
-    //     // Environment setup
+    {
+        // Environment setup
 
-    //     const Environment environment = Environment::Default();
+        const Environment environment = Environment::Default();
 
-    //     // Orbit setup
+        // Orbit setup
 
-    //     const Length semiMajorAxis = Length::Kilometers(7000.0);
-    //     const Real eccentricity = 0.0;
-    //     const Angle inclination = Angle::Degrees(45.0);
-    //     const Angle raan = Angle::Degrees(0.0);
-    //     const Angle aop = Angle::Degrees(0.0);
-    //     const Angle trueAnomaly = Angle::Degrees(0.0);
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(45.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
 
-    //     const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-    //     const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-    //     const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
-    //     const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
-    //     const Real J2 = EarthGravitationalModel::EGM2008.J2_;
-    //     const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+        const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
-    //     const Kepler keplerianModel = {
-    //         coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
-    //     };
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J2
+        };
 
-    //     const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-    //     // Reference data setup
+        // Reference data setup
 
-    //     const Table referenceData = Table::Load(
-    //         File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
-    //                                "Satellite Passes.csv")),
-    //         Table::Format::CSV,
-    //         true
-    //     );
+        const Table referenceData = Table::Load(
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
+                                   "Satellite Passes.csv")),
+            Table::Format::CSV,
+            true
+        );
 
-    //     // Pass test
+        // Pass test
 
-    //     for (const auto &referenceRow : referenceData)
-    //     {
-    //         const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
-    //         const Instant referencePassStartInstant =
-    //             Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-    //         const Instant referencePassEndInstant =
-    //             Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+        for (const auto &referenceRow : referenceData)
+        {
+            const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
+            const Instant referencePassStartInstant =
+                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+            const Instant referencePassEndInstant =
+                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
 
-    //         const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
+            const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
 
-    //         EXPECT_TRUE(pass.isDefined());
+            EXPECT_TRUE(pass.isDefined());
 
-    //         EXPECT_EQ(Pass::Type::Complete, pass.getType());
+            EXPECT_EQ(Pass::Type::Complete, pass.getType());
 
-    //         EXPECT_GT(
-    //             Duration::Milliseconds(1.0),
-    //             Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
-    //         );
-    //         EXPECT_GT(
-    //             Duration::Milliseconds(1.0),
-    //             Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
-    //         );
-    //     }
-    // }
+            EXPECT_GT(
+                Duration::Milliseconds(1.0),
+                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
+            );
+            EXPECT_GT(
+                Duration::Milliseconds(1.0),
+                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
+            );
+        }
+    }
 
-    // {
-    //     // Environment setup
+    {
+        // Environment setup
 
-    //     const Environment environment = Environment::Default();
+        const Environment environment = Environment::Default();
 
-    //     // Orbit setup
+        // Orbit setup
 
-    //     const Length semiMajorAxis = Length::Kilometers(7000.0);
-    //     const Real eccentricity = 0.0;
-    //     const Angle inclination = Angle::Degrees(45.0);
-    //     const Angle raan = Angle::Degrees(0.0);
-    //     const Angle aop = Angle::Degrees(0.0);
-    //     const Angle trueAnomaly = Angle::Degrees(0.0);
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(45.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
 
-    //     const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
 
-    //     const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-    //     const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
-    //     const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
-    //     const Real J2 = EarthGravitationalModel::EGM2008.J2_;
-    //     const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+        const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
 
-    //     const Kepler keplerianModel = {
-    //         coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4
-    //     };
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::J4
+        };
 
-    //     const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-    //     // Reference data setup
+        // Reference data setup
 
-    //     const Table referenceData = Table::Load(
-    //         File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
-    //                                "Satellite Passes.csv")),
-    //         Table::Format::CSV,
-    //         true
-    //     );
+        const Table referenceData = Table::Load(
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
+                                   "Satellite Passes.csv")),
+            Table::Format::CSV,
+            true
+        );
 
-    //     // Pass test
+        // Pass test
 
-    //     for (const auto &referenceRow : referenceData)
-    //     {
-    //         const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
-    //         const Instant referencePassStartInstant =
-    //             Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
-    //         const Instant referencePassEndInstant =
-    //             Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
+        for (const auto &referenceRow : referenceData)
+        {
+            const Integer referenceRevolutionNumber = referenceRow[0].accessInteger();
+            const Instant referencePassStartInstant =
+                Instant::DateTime(DateTime::Parse(referenceRow[1].accessString()), Scale::UTC);
+            const Instant referencePassEndInstant =
+                Instant::DateTime(DateTime::Parse(referenceRow[2].accessString()), Scale::UTC);
 
-    //         const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
+            const Pass pass = orbit.getPassWithRevolutionNumber(referenceRevolutionNumber);
 
-    //         EXPECT_TRUE(pass.isDefined());
+            EXPECT_TRUE(pass.isDefined());
 
-    //         EXPECT_EQ(Pass::Type::Complete, pass.getType());
+            EXPECT_EQ(Pass::Type::Complete, pass.getType());
 
-    //         EXPECT_GT(
-    //             Duration::Milliseconds(2.0),
-    //             Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
-    //         );
-    //         EXPECT_GT(
-    //             Duration::Milliseconds(2.0),
-    //             Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
-    //         );
-    //     }
-    // }
+            EXPECT_GT(
+                Duration::Milliseconds(2.0),
+                Duration::Between(referencePassStartInstant, pass.accessInstantAtAscendingNode()).getAbsolute()
+            );
+            EXPECT_GT(
+                Duration::Milliseconds(2.0),
+                Duration::Between(referencePassEndInstant, pass.accessInstantAtPassBreak()).getAbsolute()
+            );
+        }
+    }
 
+    // Regression test to ensure we can calculate passes for elliptical orbits
     {
         // Environment setup
 


### PR DESCRIPTION
Parametrize the step size when computing passes.
As mentioned in the comments this was a [TBM].
The duration based step size was too big for long orbits and was causing revolutions to get skipped.