### PR TITLE
fix: prevent State addition and subtraction based on coordinates broker not being equal

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -19,8 +19,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
     using ostk::core::type::Shared;
 
     using ostk::physics::environment::object::Celestial;
-    using ostk::physics::unit::Angle;
     using ostk::physics::time::Duration;
+    using ostk::physics::unit::Angle;
 
     using ostk::astrodynamics::trajectory::Orbit;
     using ostk::astrodynamics::trajectory::orbit::model::Kepler;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
@@ -43,8 +43,8 @@ using ostk::core::type::Unique;
 
 using ostk::physics::coordinate::Frame;
 using ostk::physics::environment::object::Celestial;
-using ostk::physics::time::Instant;
 using ostk::physics::time::Duration;
+using ostk::physics::time::Instant;
 using ostk::physics::time::Time;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Length;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -230,9 +230,9 @@ State State::operator+(const State& aState) const
         throw ostk::core::error::runtime::Wrong("Frame");
     }
 
-    if (!this->coordinatesBrokerSPtr_ != aState.coordinatesBrokerSPtr_)
+    if (this->coordinatesBrokerSPtr_ != aState.coordinatesBrokerSPtr_)
     {
-        throw ostk::core::error::runtime::Wrong("Coordinates");
+        throw ostk::core::error::runtime::Wrong("Coordinate Subsets");
     }
 
     VectorXd addedCoordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());
@@ -275,9 +275,9 @@ State State::operator-(const State& aState) const
         throw ostk::core::error::runtime::Wrong("Frame");
     }
 
-    if (!this->coordinatesBrokerSPtr_ != aState.coordinatesBrokerSPtr_)
+    if (this->coordinatesBrokerSPtr_ != aState.coordinatesBrokerSPtr_)
     {
-        throw ostk::core::error::runtime::Wrong("Coordinates");
+        throw ostk::core::error::runtime::Wrong("Coordinate Subsets");
     }
 
     VectorXd subtractedCoordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -230,9 +230,9 @@ State State::operator+(const State& aState) const
         throw ostk::core::error::runtime::Wrong("Frame");
     }
 
-    if (this->getSize() != aState.getSize())
+    if (!this->coordinatesBrokerSPtr_ != aState.coordinatesBrokerSPtr_)
     {
-        throw ostk::core::error::runtime::Wrong("Size");
+        throw ostk::core::error::runtime::Wrong("Coordinates");
     }
 
     VectorXd addedCoordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());
@@ -275,9 +275,9 @@ State State::operator-(const State& aState) const
         throw ostk::core::error::runtime::Wrong("Frame");
     }
 
-    if (this->getSize() != aState.getSize())
+    if (!this->coordinatesBrokerSPtr_ != aState.coordinatesBrokerSPtr_)
     {
-        throw ostk::core::error::runtime::Wrong("Size");
+        throw ostk::core::error::runtime::Wrong("Coordinates");
     }
 
     VectorXd subtractedCoordinates = VectorXd(this->coordinatesBrokerSPtr_->getNumberOfCoordinates());

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -837,7 +837,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, AdditionOperator)
     {
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
 
-        VectorXd aCoordinates(3);
+        VectorXd aCoordinates(6);
         aCoordinates << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
         const Shared<const CoordinateBroker> brokerSPtr1 = std::make_shared<CoordinateBroker>(
             CoordinateBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
@@ -958,7 +958,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, SubtractionOperator)
     {
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
 
-        VectorXd aCoordinates(3);
+        VectorXd aCoordinates(6);
         aCoordinates << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
         const Shared<const CoordinateBroker> brokerSPtr1 = std::make_shared<CoordinateBroker>(
             CoordinateBroker({CartesianPosition::Default(), CartesianVelocity::Default()})

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State.test.cpp
@@ -833,6 +833,26 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, AdditionOperator)
 
         EXPECT_ANY_THROW(aState + anotherState);
     }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+        VectorXd aCoordinates(3);
+        aCoordinates << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+        const Shared<const CoordinateBroker> brokerSPtr1 = std::make_shared<CoordinateBroker>(
+            CoordinateBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
+        const State aState = State(instant, aCoordinates, Frame::GCRF(), brokerSPtr1);
+
+        VectorXd anotherCoordinates(6);
+        anotherCoordinates << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+        const Shared<const CoordinateBroker> brokerSPtr2 = std::make_shared<CoordinateBroker>(
+            CoordinateBroker({CartesianVelocity::Default(), CartesianPosition::Default()})
+        );
+        const State anotherState = State(instant, anotherCoordinates, Frame::GCRF(), brokerSPtr2);
+
+        EXPECT_ANY_THROW(aState + anotherState);
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, SubtractionOperator)
@@ -929,6 +949,26 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_State, SubtractionOperator)
         anotherCoordinates << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
         const Shared<const CoordinateBroker> brokerSPtr2 = std::make_shared<CoordinateBroker>(
             CoordinateBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
+        const State anotherState = State(instant, anotherCoordinates, Frame::GCRF(), brokerSPtr2);
+
+        EXPECT_ANY_THROW(aState - anotherState);
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+        VectorXd aCoordinates(3);
+        aCoordinates << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+        const Shared<const CoordinateBroker> brokerSPtr1 = std::make_shared<CoordinateBroker>(
+            CoordinateBroker({CartesianPosition::Default(), CartesianVelocity::Default()})
+        );
+        const State aState = State(instant, aCoordinates, Frame::GCRF(), brokerSPtr1);
+
+        VectorXd anotherCoordinates(6);
+        anotherCoordinates << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+        const Shared<const CoordinateBroker> brokerSPtr2 = std::make_shared<CoordinateBroker>(
+            CoordinateBroker({CartesianVelocity::Default(), CartesianPosition::Default()})
         );
         const State anotherState = State(instant, anotherCoordinates, Frame::GCRF(), brokerSPtr2);
 


### PR DESCRIPTION
We are not performing subset-to-subset +/- operations at the moment whenever a State +/- operation is carried out.

This MR fails when attempting to perform a +/- operations between states where the underlying coordinate subsets are not in the same and in the same order.