### PR TITLE
feat: Trajectory constructor based on a ground strip

### DIFF
--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,4 +3,4 @@
 open-space-toolkit-core~=4.0
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.1
-open-space-toolkit-physics~=9.1
+open-space-toolkit-physics~=9.2

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -23,6 +23,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
     using ostk::physics::coordinate::spherical::LLA;
     using ostk::physics::environment::object::Celestial;
     using ostk::physics::environment::object::celestial::Earth;
+    using ostk::physics::time::Duration;
+    using ostk::physics::unit::Derived;
 
     using ostk::astrodynamics::Trajectory;
     using ostk::astrodynamics::trajectory::State;
@@ -150,9 +152,39 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
         )
         .def_static(
             "ground_strip",
+            overload_cast<const LLA&, const LLA&, const Derived&, const Instant&, const Celestial&, const Duration&>(
+                &Trajectory::GroundStrip
+            ),
+            R"doc(
+                Create a `Trajectory` object representing a ground strip.
+                Computes the duration as the geodetic distance / ground speed.
+                Instants are generated at a 1 second interval.
+
+                Args:
+                    start_lla (LLA): The start LLA.
+                    end_lla (LLA): The end LLA.
+                    ground_speed (Derived): The ground speed.
+                    start_instant (Instant): The start instant.
+                    celestial_object (Celestial): The celestial object. Defaults to Earth.WGS84().
+                    step_size (Duration): The step size. Defaults to 1 second.
+
+                Returns:
+                    Trajectory: The `Trajectory` object representing the ground strip.
+
+            )doc",
+            arg("start_lla"),
+            arg("end_lla"),
+            arg("ground_speed"),
+            arg("start_instant"),
+            arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()"),
+            arg_v("step_size", Duration::Seconds(1.0), "Duration.Seconds(1.0)")
+        )
+        .def_static(
+            "ground_strip",
             overload_cast<const LLA&, const LLA&, const Array<Instant>&, const Celestial&>(&Trajectory::GroundStrip),
             R"doc(
                 Create a `Trajectory` object representing a ground strip.
+                This method computes the duration as the geodetic distance / ground speed.
 
                 Args:
                     start_lla (LLA): The start LLA.
@@ -167,33 +199,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
             arg("start_lla"),
             arg("end_lla"),
             arg("instants"),
-            arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()")
-        )
-        .def_static(
-            "ground_strip",
-            overload_cast<const LLA&, const LLA&, const Real&, const Instant&, const Celestial&>(
-                &Trajectory::GroundStrip
-            ),
-            R"doc(
-                Create a `Trajectory` object representing a ground strip.
-                Computes the duration as the geodetic distance / ground speed.
-                Instants are generated at a 1 second interval.
-
-                Args:
-                    start_lla (LLA): The start LLA.
-                    end_lla (LLA): The end LLA.
-                    ground_speed (float): The ground speed.
-                    start_instant (Instant): The start instant.
-                    celestial_object (Celestial): The celestial object. Defaults to Earth.WGS84().
-
-                Returns:
-                    Trajectory: The `Trajectory` object representing the ground strip.
-
-            )doc",
-            arg("start_lla"),
-            arg("end_lla"),
-            arg("ground_speed"),
-            arg("start_instant"),
             arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()")
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -20,6 +20,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
     using ostk::core::container::Array;
     using ostk::core::type::Shared;
 
+    using ostk::physics::coordinate::spherical::LLA;
+    using ostk::physics::environment::object::Celestial;
+    using ostk::physics::environment::object::celestial::Earth;
+
     using ostk::astrodynamics::Trajectory;
     using ostk::astrodynamics::trajectory::State;
 
@@ -78,6 +82,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
         )
 
         .def(
+            "access_model",
+            &Trajectory::accessModel,
+            return_value_policy::reference_internal,
+            R"doc(
+                Access the model of the trajectory.
+
+                Returns:
+                    Model: The model of the trajectory.
+            )doc"
+        )
+
+        .def(
             "get_state_at",
             &Trajectory::getStateAt,
             R"doc(
@@ -131,6 +147,54 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
                     Trajectory: The `Trajectory` object representing the position.
             )doc",
             arg("position")
+        )
+        .def_static(
+            "ground_strip",
+            overload_cast<const LLA&, const LLA&, const Array<Instant>&, const Celestial&>(&Trajectory::GroundStrip),
+            R"doc(
+                Create a `Trajectory` object representing a ground strip.
+
+                Args:
+                    start_lla (LLA): The start LLA.
+                    end_lla (LLA): The end LLA.
+                    instants (list[Instant]): The instants.
+                    celestial_object (Celestial): The celestial object. Defaults to Earth.WGS84().
+
+                Returns:
+                    Trajectory: The `Trajectory` object representing the ground strip.
+
+            )doc",
+            arg("start_lla"),
+            arg("end_lla"),
+            arg("instants"),
+            arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()")
+        )
+        .def_static(
+            "ground_strip",
+            overload_cast<const LLA&, const LLA&, const Real&, const Instant&, const Celestial&>(
+                &Trajectory::GroundStrip
+            ),
+            R"doc(
+                Create a `Trajectory` object representing a ground strip.
+                Computes the duration as the geodetic distance / ground speed.
+                Instants are generated at a 1 second interval.
+
+                Args:
+                    start_lla (LLA): The start LLA.
+                    end_lla (LLA): The end LLA.
+                    ground_speed (float): The ground speed.
+                    start_instant (Instant): The start instant.
+                    celestial_object (Celestial): The celestial object. Defaults to Earth.WGS84().
+
+                Returns:
+                    Trajectory: The `Trajectory` object representing the ground strip.
+
+            )doc",
+            arg("start_lla"),
+            arg("end_lla"),
+            arg("ground_speed"),
+            arg("start_instant"),
+            arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()")
         )
 
         ;

--- a/bindings/python/test/test_trajectory.py
+++ b/bindings/python/test/test_trajectory.py
@@ -8,6 +8,7 @@ from ostk.physics.coordinate import Position
 from ostk.physics.coordinate import Frame
 from ostk.physics.time import Instant
 from ostk.physics.time import Duration
+from ostk.physics.unit import Derived
 
 from ostk.astrodynamics import Trajectory
 from ostk.astrodynamics.trajectory import State
@@ -29,8 +30,8 @@ def start_instant() -> Instant:
 
 
 @pytest.fixture
-def ground_speed() -> float:
-    return 7000.0
+def ground_speed() -> Derived:
+    return Derived(7000.0, Derived.Unit.meter_per_second())
 
 
 @pytest.fixture
@@ -97,7 +98,7 @@ class TestTrajectory:
         self,
         start_lla: LLA,
         end_lla: LLA,
-        ground_speed: float,
+        ground_speed: Derived,
         start_instant: Instant,
         earth: Earth,
         instants: list[Instant],

--- a/bindings/python/test/test_trajectory.py
+++ b/bindings/python/test/test_trajectory.py
@@ -1,40 +1,117 @@
 # Apache License 2.0
 
-import ostk.mathematics as mathematics
+import pytest
 
-import ostk.physics as physics
+from ostk.physics.environment.object.celestial import Earth
+from ostk.physics.coordinate.spherical import LLA
+from ostk.physics.coordinate import Position
+from ostk.physics.coordinate import Frame
+from ostk.physics.time import Instant
+from ostk.physics.time import Duration
 
-import ostk.astrodynamics as astrodynamics
-
-RealInterval = mathematics.object.RealInterval
-Quaternion = mathematics.geometry.d3.transformation.rotation.Quaternion
-Length = physics.unit.Length
-Angle = physics.unit.Angle
-DateTime = physics.time.DateTime
-Scale = physics.time.Scale
-Duration = physics.time.Duration
-Instant = physics.time.Instant
-Transform = physics.coordinate.Transform
-Frame = physics.coordinate.Frame
-Axes = physics.coordinate.Axes
-DynamicProvider = physics.coordinate.frame.provider.Dynamic
-Environment = physics.Environment
-Earth = physics.environment.object.celestial.Earth
-Trajectory = astrodynamics.Trajectory
-Profile = astrodynamics.flight.Profile
-SatelliteSystem = astrodynamics.flight.system.SatelliteSystem
-Orbit = astrodynamics.trajectory.Orbit
-State = astrodynamics.trajectory.State
-Pass = astrodynamics.trajectory.orbit.Pass
-Kepler = astrodynamics.trajectory.orbit.model.Kepler
-COE = astrodynamics.trajectory.orbit.model.kepler.COE
-SGP4 = astrodynamics.trajectory.orbit.model.sgp4
-Access = astrodynamics.Access
+from ostk.astrodynamics import Trajectory
+from ostk.astrodynamics.trajectory import State
 
 
-def test_trajectory_undefined():
-    trajectory: Trajectory = Trajectory.undefined()
+@pytest.fixture
+def start_lla() -> LLA:
+    return LLA.vector([0.0, 0.0, 0.0])
 
-    assert trajectory is not None
-    assert isinstance(trajectory, Trajectory)
-    assert trajectory.is_defined() is False
+
+@pytest.fixture
+def end_lla() -> LLA:
+    return LLA.vector([1.0, 0.0, 0.0])
+
+
+@pytest.fixture
+def start_instant() -> Instant:
+    return Instant.J2000()
+
+
+@pytest.fixture
+def ground_speed() -> float:
+    return 7000.0
+
+
+@pytest.fixture
+def earth() -> Earth:
+    return Earth.WGS84()
+
+
+@pytest.fixture
+def instants() -> list[Instant]:
+    return [Instant.J2000(), Instant.J2000() + Duration.seconds(10.0)]
+
+
+@pytest.fixture
+def position() -> Position:
+    return Position.meters([0.0, 0.0, 0.0], Frame.ITRF())
+
+
+@pytest.fixture
+def trajectory(position: Position) -> Trajectory:
+    return Trajectory.position(position)
+
+
+@pytest.fixture
+def states(trajectory: Trajectory) -> list[State]:
+    return trajectory.get_states_at(
+        [Instant.J2000(), Instant.J2000() + Duration.seconds(10.0)]
+    )
+
+
+class TestTrajectory:
+    def test_trajectory(self, states: list[State]):
+        assert Trajectory(states) is not None
+
+    def test_is_defined(self, trajectory: Trajectory):
+        assert trajectory.is_defined()
+
+    def test_access_model(self, trajectory: Trajectory):
+        assert trajectory.access_model() is not None
+
+    def test_get_state_at(self, trajectory: Trajectory):
+        assert trajectory.get_state_at(Instant.J2000()) is not None
+
+    def test_get_states_at(self, trajectory: Trajectory):
+        assert (
+            trajectory.get_states_at(
+                [Instant.J2000(), Instant.J2000() + Duration.seconds(10.0)]
+            )
+            is not None
+        )
+
+    def test_trajectory_undefined(self):
+        trajectory: Trajectory = Trajectory.undefined()
+
+        assert trajectory is not None
+        assert isinstance(trajectory, Trajectory)
+        assert trajectory.is_defined() is False
+
+    def test_trajectory_position(self, position: Position):
+        trajectory: Trajectory = Trajectory.position(position)
+
+        assert trajectory is not None
+
+    def test_ground_strip(
+        self,
+        start_lla: LLA,
+        end_lla: LLA,
+        ground_speed: float,
+        start_instant: Instant,
+        earth: Earth,
+        instants: list[Instant],
+    ):
+        assert (
+            Trajectory.ground_strip(
+                start_lla, end_lla, ground_speed, start_instant, earth
+            )
+            is not None
+        )
+        assert (
+            Trajectory.ground_strip(start_lla, end_lla, ground_speed, start_instant)
+            is not None
+        )
+
+        assert Trajectory.ground_strip(start_lla, end_lla, instants, earth) is not None
+        assert Trajectory.ground_strip(start_lla, end_lla, instants) is not None

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -197,7 +197,7 @@ class Trajectory
         const Celestial& aCelestial = Earth::WGS84()
     );
 
-    /// @brief Constructs a trajectory for a given strip, specified ground speed and start instant
+    /// @brief Constructs a trajectory for a given strip, assuming a constant ground speed and start instant
     ///
     /// @code{.cpp}
     ///             LLA startLLA = LLA::FromVector({ 0.0, 0.0, 0.0 });

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -12,8 +12,10 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
@@ -32,8 +34,10 @@ using ostk::core::type::Unique;
 using ostk::physics::coordinate::spherical::LLA;
 using ostk::physics::environment::object::Celestial;
 using ostk::physics::environment::object::celestial::Earth;
+using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Interval;
+using ostk::physics::unit::Derived;
 
 using ostk::astrodynamics::trajectory::Model;
 using ostk::astrodynamics::trajectory::State;
@@ -177,10 +181,12 @@ class Trajectory
     /// @code{.cpp}
     ///             LLA startLLA = { 0.0, 0.0, 0.0 };
     ///             LLA endLLA = { 1.0, 0.0, 0.0 };
-    ///             Real groundSpeed = 1000.0;
+    ///             Derived groundSpeed = Derived(1000.0, Derived::Unit::MeterPerSecond());
     ///             Instant startInstant = Instant::DateTime(DateTime::Parse("2020-01-01 00:00:00"), Scale::UTC);
     ///             Earth earth = Earth::WGS84();
-    ///             Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, groundSpeed, startInstant, earth);
+    ///             Duration stepSize = Duration::Seconds(1.0);
+    ///             Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, groundSpeed, startInstant, earth,
+    ///             duration);
     /// @endcode
     ///
     /// @param aStartLLA A start LLA
@@ -192,9 +198,10 @@ class Trajectory
     static Trajectory GroundStrip(
         const LLA& aStartLLA,
         const LLA& anEndLLA,
-        const Real& aGroundSpeed,
+        const Derived& aGroundSpeed,
         const Instant& aStartInstant,
-        const Celestial& aCelestial = Earth::WGS84()
+        const Celestial& aCelestial = Earth::WGS84(),
+        const Duration& aStepSize = Duration::Seconds(1.0)
     );
 
     /// @brief Constructs a trajectory for a given strip, assuming a constant ground speed and start instant

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -9,6 +9,9 @@
 #include <OpenSpaceToolkit/Core/Type/Unique.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
+#include <OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Object/Celestial.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 
@@ -22,9 +25,13 @@ namespace astrodynamics
 
 using ostk::core::container::Array;
 using ostk::core::type::Index;
+using ostk::core::type::Real;
 using ostk::core::type::String;
 using ostk::core::type::Unique;
 
+using ostk::physics::coordinate::spherical::LLA;
+using ostk::physics::environment::object::Celestial;
+using ostk::physics::environment::object::celestial::Earth;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Interval;
 
@@ -164,6 +171,56 @@ class Trajectory
     /// @param aPosition A position
     /// @return Static trajectory
     static Trajectory Position(const physics::coordinate::Position& aPosition);
+
+    /// @brief Constructs a trajectory for a given strip, specified ground speed and start instant
+    ///
+    /// @code{.cpp}
+    ///             LLA startLLA = { 0.0, 0.0, 0.0 };
+    ///             LLA endLLA = { 1.0, 0.0, 0.0 };
+    ///             Real groundSpeed = 1000.0;
+    ///             Instant startInstant = Instant::DateTime(DateTime::Parse("2020-01-01 00:00:00"), Scale::UTC);
+    ///             Earth earth = Earth::WGS84();
+    ///             Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, groundSpeed, startInstant, earth);
+    /// @endcode
+    ///
+    /// @param aStartLLA A start LLA
+    /// @param anEndLLA An end LLA
+    /// @param aGroundSpeed A ground speed
+    /// @param aStartInstant A start instant
+    /// @param aCelestial Celestial body
+    /// @return GroundStrip trajectory
+    static Trajectory GroundStrip(
+        const LLA& aStartLLA,
+        const LLA& anEndLLA,
+        const Real& aGroundSpeed,
+        const Instant& aStartInstant,
+        const Celestial& aCelestial = Earth::WGS84()
+    );
+
+    /// @brief Constructs a trajectory for a given strip, specified ground speed and start instant
+    ///
+    /// @code{.cpp}
+    ///             LLA startLLA = LLA::FromVector({ 0.0, 0.0, 0.0 });
+    ///             LLA endLLA = LLA::FromVector({ 1.0, 0.0, 0.0 });
+    ///             Instant startInstant = Instant::DateTime(DateTime::Parse("2020-01-01 00:00:00"), Scale::UTC);
+    ///             Instant endInstant = Instant::DateTime(DateTime::Parse("2020-01-01 00:10:00"), Scale::UTC);
+    ///             Interval interval = Interval::Closed(startInstant, endInstant);
+    ///             Array<Instant> instants = interval.generateGrid(Duration::Seconds(1.0));
+    ///             Earth earth = Earth::WGS84();
+    ///             Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, instants, earth);
+    /// @endcode
+    ///
+    /// @param aStartLLA A start LLA
+    /// @param anEndLLA An end LLA
+    /// @param anInstantArray An array of instants
+    /// @param aCelestial Celestial body
+    /// @return GroundStrip trajectory
+    static Trajectory GroundStrip(
+        const LLA& aStartLLA,
+        const LLA& anEndLLA,
+        const Array<Instant>& anInstantArray,
+        const Celestial& aCelestial = Earth::WGS84()
+    );
 
    private:
     Unique<Model> modelUPtr_;

--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
@@ -109,7 +109,7 @@ QLaw::QLaw(
 )
     : GuidanceLaw("Q-Law"),
       parameters_(aParameterSet),
-      mu_(aGravitationalParameter.in(aGravitationalParameter.getUnit())),
+      mu_(aGravitationalParameter.in(Derived::Unit::MeterCubedPerSecondSquared())),
       targetCOEVector_(aCOE.getSIVector(COE::AnomalyType::True)),
       gravitationalParameter_(aGravitationalParameter),
       gradientStrategy_(aGradientStrategy),

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
@@ -3,6 +3,8 @@
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
+#include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
+
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
@@ -11,6 +13,11 @@ namespace ostk
 {
 namespace astrodynamics
 {
+
+using ostk::physics::coordinate::Frame;
+using ostk::physics::coordinate::Velocity;
+using ostk::physics::time::Duration;
+using ostk::physics::unit::Length;
 
 using ostk::astrodynamics::trajectory::model::Tabulated;
 
@@ -127,6 +134,103 @@ Trajectory Trajectory::Position(const physics::coordinate::Position& aPosition)
     }
 
     return Trajectory(Static(aPosition));
+}
+
+Trajectory Trajectory::GroundStrip(
+    const LLA& aStartLLA,
+    const LLA& anEndLLA,
+    const Real& aGroundSpeed,
+    const Instant& aStartInstant,
+    const Celestial& aCelestial
+)
+{
+    if (!aStartLLA.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Start LLA");
+    }
+
+    if (!anEndLLA.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("End LLA");
+    }
+
+    if (!aGroundSpeed.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Ground speed");
+    }
+
+    if (!aStartInstant.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Start instant");
+    }
+
+    if ((aStartLLA.getAltitude().inMeters() > Real::Epsilon()) || (anEndLLA.getAltitude().inMeters() > Real::Epsilon()))
+    {
+        throw ostk::core::error::RuntimeError("LLA altitude must be zero.");
+    }
+
+    const Length distance =
+        aStartLLA.calculateDistanceTo(anEndLLA, aCelestial.getEquatorialRadius(), aCelestial.getFlattening());
+
+    const Duration duration = Duration::Seconds(distance.inMeters() / aGroundSpeed);
+
+    const Instant endInstant = aStartInstant + duration;
+
+    const Interval interval = Interval::Closed(aStartInstant, endInstant);
+
+    const Array<Instant> instants = interval.generateGrid(Duration::Seconds(1.0));  // TBI: Make a param?
+
+    return GroundStrip(aStartLLA, anEndLLA, instants, aCelestial);
+}
+
+Trajectory Trajectory::GroundStrip(
+    const LLA& aStartLLA, const LLA& anEndLLA, const Array<Instant>& anInstantArray, const Celestial& aCelestial
+)
+{
+    if (!aStartLLA.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Start LLA");
+    }
+
+    if (!anEndLLA.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("End LLA");
+    }
+
+    if (anInstantArray.getSize() < 2)
+    {
+        throw ostk::core::error::RuntimeError("Atleast 2 instants must be provided.");
+    }
+
+    if ((aStartLLA.getAltitude().inMeters() > Real::Epsilon()) || (anEndLLA.getAltitude().inMeters() > Real::Epsilon()))
+    {
+        throw ostk::core::error::RuntimeError("LLA altitude must be zero.");
+    }
+
+    const Velocity velocity = Velocity::MetersPerSecond({0.0, 0.0, 0.0}, Frame::ITRF());
+
+    Array<State> states = Array<State>::Empty();
+
+    const Duration duration = anInstantArray.accessLast() - anInstantArray.accessFirst();
+
+    for (const auto& instant : anInstantArray)
+    {
+        const Real ratio = (instant - anInstantArray.accessFirst()).inSeconds() / duration.inSeconds();
+
+        const LLA intermediateLLA = aStartLLA.calculateIntermediateTo(
+            anEndLLA, ratio, aCelestial.getEquatorialRadius(), aCelestial.getFlattening()
+        );
+
+        const physics::coordinate::Position position = physics::coordinate::Position::Meters(
+            intermediateLLA.toCartesian(aCelestial.getEquatorialRadius(), aCelestial.getFlattening()), Frame::ITRF()
+        );
+
+        const State state = State(instant, position, velocity).inFrame(Frame::GCRF());
+
+        states.add(state);
+    }
+
+    return Trajectory(states);
 }
 
 Trajectory::Trajectory()

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -43,10 +43,8 @@ using TimeUnit = ostk::physics::unit::Time;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
 
 static const Real Tolerance = 1e-30;
-static const Derived::Unit GravitationalParameterSIUnit =
-    Derived::Unit::GravitationalParameter(Length::Unit::Meter, TimeUnit::Unit::Second);
-static const Derived::Unit angularVelocitySIUnit =
-    Derived::Unit::AngularVelocity(Angle::Unit::Radian, TimeUnit::Unit::Second);
+static const Derived::Unit GravitationalParameterSIUnit = Derived::Unit::MeterCubedPerSecondSquared();
+static const Derived::Unit angularVelocitySIUnit = Derived::Unit::RadianPerSecond();
 static const Derived::Unit AngularMomentumSIUnit = {
     Length::Unit::Meter,
     {2},

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
@@ -158,8 +158,7 @@ class OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw : public
         Angle::Degrees(0.0),
     };
 
-    const Derived gravitationalParameter_ =
-        Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit());
+    const Derived gravitationalParameter_ = Derived(398600.49 * 1e9, Derived::Unit::MeterCubedPerSecondSquared());
 
     const Real thrustAcceleration_ = 1.0 / 300.0;
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -8,12 +8,16 @@
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
+using ostk::core::type::Real;
 using ostk::core::type::Shared;
 
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
+using ostk::physics::coordinate::spherical::LLA;
 using ostk::physics::coordinate::Velocity;
+using ostk::physics::environment::object::celestial::Earth;
 using ostk::physics::time::DateTime;
+using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Scale;
 
@@ -474,5 +478,188 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, Position)
         const Trajectory trajectory = Trajectory::Position(Position::Meters({2.0, 0.0, 0.0}, Frame::ITRF()));
         const State state = trajectory.getStateAt(Instant::J2000());
         EXPECT_TRUE(state.accessFrame() == Frame::GCRF());
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStrip)
+{
+    const Earth earth = Earth::WGS84();
+    const LLA startLLA = LLA::Vector({0.0, 0.0, 0.0});
+    const LLA endLLA = LLA::Vector({1.0, 0.0, 0.0});
+
+    {
+        const Array<Instant> instants = {Instant::J2000(), Instant::J2000() + Duration::Seconds(10.0)};
+
+        {
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(LLA::Undefined(), endLLA, instants, earth), ostk::core::error::RuntimeError
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(startLLA, LLA::Undefined(), instants, earth),
+                    ostk::core::error::RuntimeError
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(LLA::Vector({0.0, 0.0, 1e-1}), endLLA, instants, earth),
+                    ostk::core::error::RuntimeError
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(startLLA, LLA::Vector({0.0, 0.0, 1e-1}), instants, earth),
+                    ostk::core::error::RuntimeError
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(startLLA, endLLA, {Instant::J2000()}, earth),
+                    ostk::core::error::RuntimeError
+                );
+            }
+        }
+
+        {
+            {
+                const Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, instants, earth);
+
+                EXPECT_TRUE(trajectory.isDefined());
+            }
+
+            {
+                const Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, instants);
+
+                EXPECT_TRUE(trajectory.isDefined());
+            }
+        }
+
+        {
+            const Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, instants, earth);
+
+            {
+                const State state = trajectory.getStateAt(instants.accessFirst()).inFrame(Frame::ITRF());
+
+                EXPECT_TRUE(state.getVelocity().getCoordinates().isNear({0.0, 0.0, 0.0}, 1e-12));
+
+                EXPECT_TRUE(LLA::Cartesian(
+                                state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
+                )
+                                .toVector()
+                                .isNear(startLLA.toVector(), 1e-12));
+            }
+
+            {
+                const State state = trajectory.getStateAt(instants.accessLast()).inFrame(Frame::ITRF());
+
+                EXPECT_TRUE(state.getVelocity().getCoordinates().isNear({0.0, 0.0, 0.0}, 1e-12));
+
+                EXPECT_TRUE(LLA::Cartesian(
+                                state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
+                )
+                                .toVector()
+                                .isNear(endLLA.toVector(), 1e-12));
+            }
+        }
+    }
+
+    {
+        const Real groundSpeed = 7000.0;
+        const Instant startInstant = Instant::J2000();
+
+        {
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(LLA::Undefined(), endLLA, groundSpeed, startInstant, earth),
+                    ostk::core::error::RuntimeError
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(startLLA, LLA::Undefined(), groundSpeed, startInstant, earth),
+                    ostk::core::error::RuntimeError
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(LLA::Vector({0.0, 0.0, 1e-1}), endLLA, groundSpeed, startInstant, earth),
+                    ostk::core::error::RuntimeError
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(startLLA, LLA::Vector({0.0, 0.0, 1e-1}), groundSpeed, startInstant, earth),
+                    ostk::core::error::RuntimeError
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(startLLA, endLLA, Real::Undefined(), startInstant, earth),
+                    ostk::core::error::runtime::Undefined
+                );
+            }
+
+            {
+                EXPECT_THROW(
+                    Trajectory::GroundStrip(startLLA, endLLA, groundSpeed, Instant::Undefined(), earth),
+                    ostk::core::error::runtime::Undefined
+                );
+            }
+        }
+
+        {
+            {
+                const Trajectory trajectory =
+                    Trajectory::GroundStrip(startLLA, endLLA, groundSpeed, startInstant, earth);
+
+                EXPECT_TRUE(trajectory.isDefined());
+            }
+
+            {
+                const Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, groundSpeed, startInstant);
+
+                EXPECT_TRUE(trajectory.isDefined());
+            }
+        }
+
+        {
+            const Trajectory trajectory = Trajectory::GroundStrip(startLLA, endLLA, groundSpeed, startInstant, earth);
+
+            {
+                const State state = trajectory.getStateAt(startInstant).inFrame(Frame::ITRF());
+
+                EXPECT_TRUE(state.getVelocity().getCoordinates().isNear({0.0, 0.0, 0.0}, 1e-13));
+
+                EXPECT_TRUE(LLA::Cartesian(
+                                state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
+                )
+                                .toVector()
+                                .isNear(startLLA.toVector(), 1e-12));
+            }
+
+            {
+                const Duration duration =
+                    Duration::Seconds(15.796341222542683);  // computed from ground speed and distance
+                const State state = trajectory.getStateAt(startInstant + duration).inFrame(Frame::ITRF());
+
+                EXPECT_TRUE(state.getVelocity().getCoordinates().isNear({0.0, 0.0, 0.0}, 1e-13));
+
+                EXPECT_TRUE(LLA::Cartesian(
+                                state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
+                )
+                                .toVector()
+                                .isNear(endLLA.toVector(), 1e-8));
+            }
+        }
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -282,7 +282,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetAngu
 
         EXPECT_DOUBLE_EQ(
             std::sqrt(
-                Earth::EGM2008.gravitationalParameter_.in(Earth::EGM2008.gravitationalParameter_.getUnit()) *
+                Earth::EGM2008.gravitationalParameter_.in(Derived::Unit::MeterCubedPerSecondSquared()) *
                 coe_.getSemiLatusRectum().inMeters()
             ),
             angularMomentum.in(angularMomentum.getUnit())
@@ -430,7 +430,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetNoda
             Earth::EGM2008.gravitationalParameter_, Length::Meters(6.378137e6), 1.08262668e-3
         );
 
-        EXPECT_NEAR(nodalPrecessionRate.in(nodalPrecessionRate.getUnit()), -7.44e-7, 1e-6);
+        EXPECT_NEAR(nodalPrecessionRate.in(Derived::Unit::RadianPerSecond()), -7.44e-7, 1e-6);
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/QLaw.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/QLaw.validation.cpp
@@ -202,8 +202,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_QLawValidation, QLaw_Paper_Case
         Length::Kilometers(6578.0)
     };
 
-    const Derived gravitationalParameter =
-        Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit());
+    const Derived gravitationalParameter = Derived(398600.49 * 1e9, Derived::Unit::MeterCubedPerSecondSquared());
 
     const Shared<QLaw> qlaw =
         std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
@@ -299,8 +298,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_QLawValidation, QLaw_Paper_Case
         },
     };
 
-    const Derived gravitationalParameter =
-        Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit());
+    const Derived gravitationalParameter = Derived(398600.49 * 1e9, Derived::Unit::MeterCubedPerSecondSquared());
 
     const Shared<QLaw> qlaw =
         std::make_shared<QLaw>(QLaw(targetCOE, gravitationalParameter, parameters, gradientStrategy));
@@ -385,8 +383,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_QLawValidation, SSO_targeting)
         Instant::J2000(), Length::Meters(585.0e3), Time(10, 0, 0), std::make_shared<Earth>(Earth::Default())
     );
 
-    const Derived gravitationalParameter =
-        Derived(398600.49 * 1e9, EarthGravitationalModel::EGM2008.gravitationalParameter_.getUnit());
+    const Derived gravitationalParameter = Derived(398600.49 * 1e9, Derived::Unit::MeterCubedPerSecondSquared());
 
     const State currentState = orbit.getStateAt(Instant::J2000());
     const COE currentCOE =


### PR DESCRIPTION
This MR adds a static constructor for the Trajectory class for a ground strip. This is useful in conjunction with the Profile::TrajectoryTarget object where we want to create a Profile during a ground strip is tracked, in Earth observation applications.