### PR TITLE
feat: add getInterval methods to the Solution classes for Sequence/Solution classes

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -130,6 +130,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
         )
 
         .def(
+            "get_interval",
+            &Segment::Solution::getInterval,
+            R"doc(
+                Get the time interval of the solution.
+
+                Returns:
+                    Interval: The interval.
+
+            )doc"
+        )
+        .def(
             "get_initial_mass",
             &Segment::Solution::getInitialMass,
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -98,6 +98,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
 
             )doc"
         )
+        .def(
+            "get_interval",
+            &Sequence::Solution::getInterval,
+            R"doc(
+                Get the interval.
+
+                Returns:
+                    Interval: The interval.
+
+            )doc"
+        )
 
         .def(
             "get_states",

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -11,8 +11,8 @@ from ostk.physics.time import Duration
 from ostk.physics.coordinate import Frame
 from ostk.physics.environment.object.celestial import Earth
 
-from ostk.astrodynamics.flight import Maneuver
 from ostk.astrodynamics.flight.system import SatelliteSystem
+from ostk.astrodynamics import Dynamics
 from ostk.astrodynamics.dynamics import CentralBodyGravity
 from ostk.astrodynamics.dynamics import PositionDerivative
 from ostk.astrodynamics.dynamics import Thruster
@@ -133,6 +133,64 @@ def thruster_dynamics() -> Thruster:
         satellite_system=SatelliteSystem.default(),
         guidance_law=ConstantThrust.intrack(),
     )
+
+
+@pytest.fixture
+def segment_solution(dynamics: list[Dynamics], state: State) -> Segment.Solution:
+    return Segment.Solution(
+        name="A Segment",
+        dynamics=dynamics,
+        states=[
+            state,
+        ],
+        condition_is_satisfied=True,
+        segment_type=Segment.Type.Coast,
+    )
+
+
+class TestSegmentSolution:
+    def test_constructors(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert segment_solution is not None
+        assert segment_solution.name is not None
+        assert segment_solution.dynamics is not None
+        assert segment_solution.states is not None
+        assert segment_solution.condition_is_satisfied is not None
+        assert segment_solution.segment_type is not None
+
+    def test_accessors(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert segment_solution.access_start_instant() is not None
+        assert segment_solution.access_end_instant() is not None
+        assert segment_solution.get_interval() is not None
+        assert segment_solution.get_initial_mass() is not None
+        assert segment_solution.get_final_mass() is not None
+        assert segment_solution.get_propagation_duration() is not None
+
+    def test_compute_delta_v(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert segment_solution.compute_delta_v(1500.0) is not None
+
+    def test_compute_delta_mass(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert segment_solution.compute_delta_mass() is not None
+
+    # def test_extract_maneuvers(
+    #     self,
+    #     dynamics: list,
+    #     state: State,
+    # ):
+    #     segment_solution: Segment.Solution = Segment.Solution(
+    #         name="A Segment",
+    #         dynamics=dynamics,
 
 
 class TestSegment:

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -160,7 +160,7 @@ class TestSegmentSolution:
         assert segment_solution.condition_is_satisfied is not None
         assert segment_solution.segment_type is not None
 
-    def test_accessors(
+    def test_getters_and_accessors(
         self,
         segment_solution: Segment.Solution,
     ):

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -183,14 +183,54 @@ class TestSegmentSolution:
     ):
         assert segment_solution.compute_delta_mass() is not None
 
-    # def test_extract_maneuvers(
-    #     self,
-    #     dynamics: list,
-    #     state: State,
-    # ):
-    #     segment_solution: Segment.Solution = Segment.Solution(
-    #         name="A Segment",
-    #         dynamics=dynamics,
+    @pytest.mark.skip(reason="Not implemented yet")
+    def test_extract_maneuvers(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert segment_solution.extract_maneuvers(Frame.GCRF()) is not None
+
+    def test_calculate_states_at(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert (
+            segment_solution.calculate_states_at(
+                [
+                    segment_solution.states[0].get_instant(),
+                ],
+                NumericalSolver.default_conditional(),
+            )
+            is not None
+        )
+
+    def get_dynamics_contribution(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert (
+            segment_solution.get_dynamics_contribution(
+                segment_solution.dynamics[0], Frame.GCRF()
+            )
+            is not None
+        )
+
+    def get_dynamics_acceleration_contribution(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert (
+            segment_solution.get_dynamics_acceleration_contribution(
+                segment_solution.dynamics[0], Frame.GCRF()
+            )
+            is not None
+        )
+
+    def get_all_dynamics_contributions(
+        self,
+        segment_solution: Segment.Solution,
+    ):
+        assert segment_solution.get_all_dynamics_contributions(Frame.GCRF()) is not None
 
 
 class TestSegment:

--- a/bindings/python/test/trajectory/test_sequence.py
+++ b/bindings/python/test/trajectory/test_sequence.py
@@ -360,7 +360,7 @@ class TestSequenceSolution:
         assert len(sequence_solution.segment_solutions) == 1
         assert sequence_solution.execution_is_complete
 
-    def test_getters(
+    def test_getters_and_accessors(
         self,
         sequence_solution: Sequence.Solution,
     ):

--- a/bindings/python/test/trajectory/test_sequence.py
+++ b/bindings/python/test/trajectory/test_sequence.py
@@ -339,6 +339,59 @@ def instants(state: State) -> list[Instant]:
     return [state.get_instant(), state.get_instant() + Duration.minutes(1.0)]
 
 
+@pytest.fixture
+def sequence_solution(
+    segment_solution: Segment.Solution,
+):
+    return Sequence.Solution(
+        segment_solutions=[
+            segment_solution,
+        ],
+        execution_is_complete=True,
+    )
+
+
+class TestSequenceSolution:
+    def test_properties(
+        self,
+        sequence_solution: Sequence.Solution,
+    ):
+        assert sequence_solution is not None
+        assert len(sequence_solution.segment_solutions) == 1
+        assert sequence_solution.execution_is_complete
+
+    def test_getters(
+        self,
+        sequence_solution: Sequence.Solution,
+    ):
+        assert sequence_solution.access_start_instant() is not None
+        assert sequence_solution.access_end_instant() is not None
+
+        assert sequence_solution.get_states() is not None
+        assert sequence_solution.get_initial_mass() is not None
+        assert sequence_solution.get_final_mass() is not None
+        assert sequence_solution.get_propagation_duration() is not None
+
+        assert sequence_solution.compute_delta_mass() is not None
+        assert sequence_solution.compute_delta_v(1500.0) is not None
+
+    def test_calculate_states_at(
+        self,
+        sequence_solution: Sequence.Solution,
+        numerical_solver: NumericalSolver,
+    ):
+        instants: list[Instant] = sequence_solution.get_interval().generate_grid(
+            Duration.seconds(10.0)
+        )
+        states: list[State] = sequence_solution.calculate_states_at(
+            instants,
+            numerical_solver,
+        )
+
+        assert states is not None
+        assert len(states) == len(instants)
+
+
 class TestSequence:
     def test_get_segments(
         self,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -13,6 +13,7 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics.hpp>
@@ -39,6 +40,7 @@ using ostk::mathematics::object::MatrixXd;
 
 using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
+using ostk::physics::time::Interval;
 using ostk::physics::unit::Mass;
 
 using ostk::astrodynamics::Dynamics;
@@ -85,6 +87,10 @@ class Segment
         /// @brief Access end instant
         /// @return End Instant
         const Instant& accessEndInstant() const;
+
+        /// @brief Get interval
+        /// @return Interval
+        Interval getInterval() const;
 
         /// @brief Get initial mass
         /// @return Initial mass

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
@@ -9,6 +9,7 @@
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.hpp>
@@ -28,6 +29,7 @@ using ostk::core::type::Real;
 using ostk::core::type::Size;
 
 using ostk::physics::Environment;
+using ostk::physics::time::Interval;
 using ostk::physics::unit::Mass;
 
 using ostk::astrodynamics::dynamics::Thruster;
@@ -59,6 +61,10 @@ class Sequence
         /// @brief Access end instant
         /// @return End Instant
         const Instant& accessEndInstant() const;
+
+        /// @brief Get interval
+        /// @return Interval
+        Interval getInterval() const;
 
         /// @brief Get all states (at variable intervals) that were computed when solving the sequence.
         /// @return Array of states.

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -63,6 +63,16 @@ const Instant& Segment::Solution::accessEndInstant() const
     return this->states.accessLast().accessInstant();
 }
 
+Interval Segment::Solution::getInterval() const
+{
+    if (this->states.isEmpty())
+    {
+        throw ostk::core::error::RuntimeError("No solution available.");
+    }
+
+    return Interval::Closed(accessStartInstant(), accessEndInstant());
+}
+
 Mass Segment::Solution::getInitialMass() const
 {
     if (this->states.isEmpty())

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.cpp
@@ -33,6 +33,11 @@ const Instant& Sequence::Solution::accessEndInstant() const
     return this->segmentSolutions.accessLast().accessEndInstant();
 }
 
+Interval Sequence::Solution::getInterval() const
+{
+    return Interval::Closed(this->accessStartInstant(), this->accessEndInstant());
+}
+
 Array<State> Sequence::Solution::getStates() const
 {
     if (this->segmentSolutions.isEmpty())

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -20,6 +20,7 @@
 #include <OpenSpaceToolkit/Physics/Time/DateTime.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
@@ -73,6 +74,7 @@ using ostk::physics::environment::object::celestial::Earth;
 using ostk::physics::time::DateTime;
 using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
+using ostk::physics::time::Interval;
 using ostk::physics::time::Scale;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Length;
@@ -217,6 +219,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Getter
         EXPECT_THROW(segmentSolution.getInitialMass(), ostk::core::error::RuntimeError);
         EXPECT_THROW(segmentSolution.getFinalMass(), ostk::core::error::RuntimeError);
         EXPECT_THROW(segmentSolution.getPropagationDuration(), ostk::core::error::RuntimeError);
+        EXPECT_THROW(segmentSolution.getInterval(), ostk::core::error::RuntimeError);
     }
 
     {
@@ -227,6 +230,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Getter
         EXPECT_DOUBLE_EQ(200.0, segmentSolution.getInitialMass().inKilograms());
         EXPECT_DOUBLE_EQ(199.999592114, segmentSolution.getFinalMass().inKilograms());
         EXPECT_DOUBLE_EQ(60.0, segmentSolution.getPropagationDuration().inSeconds());
+        EXPECT_EQ(
+            Interval::Closed(initialStateWithMass_.accessInstant(), finalStateWithMass_.accessInstant()),
+            segmentSolution.getInterval()
+        );
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `get_interval` method in both `Segment::Solution` and `Sequence::Solution` classes, allowing users to retrieve the time interval associated with segment and sequence solutions.

- **Bug Fixes**
	- Enhanced error handling in the new `get_interval` methods to manage empty states.

- **Tests**
	- Added new test classes and fixtures for `Segment.Solution` and `Sequence.Solution` to validate the functionality of the new interval retrieval methods, ensuring comprehensive coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->