### PR TITLE
feat: add profile access_model, repr and missing bindings

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -221,6 +221,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
         )
 
         .def(
+            "access_model",
+            &Profile::accessModel,
+            return_value_policy::reference_internal,
+            R"doc(
+                Access the profile model.
+
+                Returns:
+                    Model: The profile model.
+            )doc"
+        )
+
+        .def(
             "get_state_at",
             &Profile::getStateAt,
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model.cpp
@@ -50,6 +50,60 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model(pybind11::modul
         )
 
         .def(
+            "is_tabulated",
+            +[](const Model &aModel) -> bool
+            {
+                return aModel.is<ostk::astrodynamics::flight::profile::model::Tabulated>();
+            },
+            R"doc(
+                Check if the model is a tabulated model.
+
+                Returns:
+                    bool: True if the model is a tabulated model, False otherwise.
+            )doc"
+        )
+        .def(
+            "is_transform",
+            +[](const Model &aModel) -> bool
+            {
+                return aModel.is<ostk::astrodynamics::flight::profile::model::Transform>();
+            },
+            R"doc(
+                Check if the model is a transform model.
+
+                Returns:
+                    bool: True if the model is a transform model, False otherwise.
+            )doc"
+        )
+
+        .def(
+            "as_tabulated",
+            +[](const Model &aModel) -> const ostk::astrodynamics::flight::profile::model::Tabulated &
+            {
+                return aModel.as<ostk::astrodynamics::flight::profile::model::Tabulated>();
+            },
+            R"doc(
+                Cast the model to a tabulated model.
+
+                Returns:
+                    Tabulated: The tabulated model.
+            )doc"
+        )
+        .def(
+            "as_transform",
+            +[](const Model &aModel) -> const ostk::astrodynamics::flight::profile::model::Transform &
+            {
+                return aModel.as<ostk::astrodynamics::flight::profile::model::Transform>();
+            },
+            R"doc(
+                Cast the model to a transform model.
+
+                Returns:
+                    Transform: The transform model.
+            )doc"
+        )
+
+        .def(
             "calculate_state_at",
             &Model::calculateStateAt,
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model/Tabulated.cpp
@@ -34,7 +34,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model_Tabulated(pybin
 
         .def(
             "__str__",
-            &(shiftToString<State>),
+            &(shiftToString<Tabulated>),
             R"doc(
                 Convert the model to a string.
 
@@ -45,7 +45,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model_Tabulated(pybin
 
         .def(
             "__repr__",
-            &(shiftToString<State>),
+            &(shiftToString<Tabulated>),
             R"doc(
                 Convert the model to a string.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model/Transform.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model/Transform.cpp
@@ -39,8 +39,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model_Transform(pybin
             arg("frame")
         )
 
-        .def("__str__", &(shiftToString<State>))
-        .def("__repr__", &(shiftToString<State>))
+        .def("__str__", &(shiftToString<Transform>))
+        .def("__repr__", &(shiftToString<Transform>))
 
         .def(
             "is_defined",

--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -134,6 +134,21 @@ class TestProfile:
         assert alignment_target is not None
         assert isinstance(alignment_target, Profile.Target)
 
+    def test_access_model(self, profile: Profile):
+        model = profile.access_model()
+
+        assert model is not None
+
+        import IPython
+
+        IPython.embed()
+
+        if model.is_transform():
+            assert model.as_transform() is not None
+
+        if model.is_tabulated():
+            assert model.as_tabulated() is not None
+
     def test_get_state_at(self, profile: Profile, instant: Instant):
         state: State = profile.get_state_at(instant)
 

--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -139,7 +139,6 @@ class TestProfile:
 
         assert model is not None
 
-
         if model.is_transform():
             assert model.as_transform() is not None
 

--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -139,9 +139,6 @@ class TestProfile:
 
         assert model is not None
 
-        import IPython
-
-        IPython.embed()
 
         if model.is_transform():
             assert model.as_transform() is not None

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -208,6 +208,16 @@ class Profile
     /// @return True if profile is defined
     bool isDefined() const;
 
+    /// @brief Access profile model
+    ///
+    /// @code{.cpp}
+    ///              Profile profile = { ... };
+    ///              const Unique<Model>& model = profile.accessModel();
+    /// @endcode
+    ///
+    /// @return Reference to the profile model
+    const Model& accessModel() const;
+
     /// @brief Get state at a given instant
     ///
     /// @code{.cpp}

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -215,7 +215,7 @@ class Profile
     ///              const Model& model = profile.accessModel();
     /// @endcode
     ///
-    /// @return Reference to the profile model
+    /// @return Const reference to the profile model
     const Model& accessModel() const;
 
     /// @brief Get state at a given instant

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -212,7 +212,7 @@ class Profile
     ///
     /// @code{.cpp}
     ///              Profile profile = { ... };
-    ///              const Unique<Model>& model = profile.accessModel();
+    ///              const Model& model = profile.accessModel();
     /// @endcode
     ///
     /// @return Reference to the profile model

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
@@ -135,6 +135,16 @@ bool Profile::isDefined() const
     return (this->modelUPtr_ != nullptr) && this->modelUPtr_->isDefined();
 }
 
+const Model& Profile::accessModel() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Profile");
+    }
+
+    return *modelUPtr_;
+}
+
 State Profile::getStateAt(const Instant& anInstant) const
 {
     if (!this->isDefined())

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Transform.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Transform.cpp
@@ -27,6 +27,13 @@ Transform* Transform::clone() const
     return new Transform(*this);
 }
 
+std::ostream& operator<<(std::ostream& anOutputStream, const Transform& aTransformModel)
+{
+    aTransformModel.print(anOutputStream, true);
+
+    return anOutputStream;
+}
+
 bool Transform::isDefined() const
 {
     return this->transformProvider_.isDefined() && (this->frameSPtr_ != nullptr) && this->frameSPtr_->isDefined();

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -161,6 +161,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, IsDefined)
     }
 }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, AccessModel)
+{
+    {
+        EXPECT_TRUE(profile_.accessModel().isDefined());
+    }
+
+    {
+        EXPECT_THROW(Profile::Undefined().accessModel(), ostk::core::error::runtime::Undefined);
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, GetStateAt)
 {
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -381,6 +381,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, InertialPointing)
     }
 }
 
+// TBI: Should move these tests to the Transform test suite and only test interface here
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, NadirPointing_VVLH)
 {
     // VVLH #1

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Transform.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Transform.test.cpp
@@ -1,0 +1,215 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
+#include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
+#include <OpenSpaceToolkit/Physics/Environment.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
+#include <OpenSpaceToolkit/Physics/Time/DateTime.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Transform.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::type::Real;
+using ostk::core::type::Shared;
+using ostk::core::type::String;
+
+using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
+using ostk::mathematics::object::Vector3d;
+
+using ostk::physics::coordinate::Axes;
+using ostk::physics::coordinate::Frame;
+using ostk::physics::coordinate::Position;
+using ostk::physics::coordinate::Velocity;
+using ostk::physics::Environment;
+using ostk::physics::time::DateTime;
+using ostk::physics::time::Instant;
+using ostk::physics::time::Scale;
+using ostk::physics::unit::Angle;
+using ostk::physics::unit::Derived;
+using ostk::physics::unit::Length;
+using CoordinateTransform = ostk::physics::coordinate::Transform;
+using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
+using DynamicProvider = ostk::physics::coordinate::frame::provider::Dynamic;
+
+using ostk::astrodynamics::flight::profile::model::Transform;
+using ostk::astrodynamics::trajectory::Orbit;
+using ostk::astrodynamics::trajectory::orbit::model::Kepler;
+using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
+using ostk::astrodynamics::trajectory::State;
+
+class OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform : public ::testing::Test
+{
+   protected:
+    void SetUp() override
+    {
+        const Environment environment = Environment::Default();
+
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(0.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
+
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+
+        const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
+
+        this->orbit_ = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        this->transform_ = Transform::NadirPointing(this->orbit_, Orbit::FrameType::VVLH);
+    }
+
+    Orbit orbit_ = Orbit::Undefined();
+    Transform transform_ = Transform::Undefined();
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, Constructor)
+{
+    const auto dynamicProviderGenerator = [&](const Instant& anInstant) -> CoordinateTransform
+    {
+        const State state = this->orbit_.getStateAt(anInstant);
+
+        const Position position_GCRF = state.getPosition();
+        const Velocity velocity_GCRF = state.getVelocity();
+
+        return CoordinateTransform::Active(
+            anInstant,
+            -position_GCRF.accessCoordinates(),
+            -velocity_GCRF.accessCoordinates(),
+            Quaternion::Unit(),
+            Vector3d(0.0, 0.0, 0.0)  // TBM: Artificially set to 0 for now.
+        );
+    };
+
+    const Transform transform = Transform(DynamicProvider(dynamicProviderGenerator), Frame::GCRF());
+    EXPECT_TRUE(transform.isDefined());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, StreamOperator)
+{
+    {
+        testing::internal::CaptureStdout();
+
+        EXPECT_NO_THROW(std::cout << transform_ << std::endl);
+
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, Print)
+{
+    testing::internal::CaptureStdout();
+
+    EXPECT_NO_THROW(transform_.print(std::cout, true));
+    EXPECT_NO_THROW(transform_.print(std::cout, false));
+
+    EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, IsDefined)
+{
+    {
+        EXPECT_TRUE(transform_.isDefined());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, CalculateStateAt)
+{
+    {
+        const Instant instant = Instant::DateTime(DateTime(2024, 1, 29, 0, 0, 15), Scale::UTC);
+
+        const State state = transform_.calculateStateAt(instant);
+
+        EXPECT_EQ(state.getInstant(), instant);
+
+        EXPECT_TRUE(state.accessFrame() == Frame::GCRF());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, GetAxesAt)
+{
+    // undefined
+    {
+        const Instant instant = Instant::J2000();
+        const Transform undefinedTransform = Transform::Undefined();
+        EXPECT_THROW(undefinedTransform.getAxesAt(instant), ostk::core::error::runtime::Undefined);
+    }
+
+    // instant undefined
+    {
+        const Instant instant = Instant::Undefined();
+        EXPECT_THROW(transform_.getAxesAt(instant), ostk::core::error::runtime::Undefined);
+    }
+
+    {
+        const Instant instant = Instant::DateTime(DateTime(2024, 1, 29, 0, 0, 15), Scale::UTC);
+        const Axes axes = transform_.getAxesAt(instant);
+        const State state = transform_.calculateStateAt(instant);
+        const Quaternion q_B_GCRF = state.getAttitude();
+        EXPECT_VECTORS_ALMOST_EQUAL(q_B_GCRF * axes.x(), Vector3d::X(), 1e-15);
+        EXPECT_VECTORS_ALMOST_EQUAL(q_B_GCRF * axes.y(), Vector3d::Y(), 1e-15);
+        EXPECT_VECTORS_ALMOST_EQUAL(q_B_GCRF * axes.z(), Vector3d::Z(), 1e-15);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, GetBodyFrame)
+{
+    // name undefined
+    {
+        const String frameName = String::Empty();
+        EXPECT_THROW(transform_.getBodyFrame(frameName), ostk::core::error::runtime::Undefined);
+    }
+
+    // undefined model
+    {
+        const Transform undefinedTransform = Transform::Undefined();
+        const String frameName = "test";
+        EXPECT_THROW(undefinedTransform.getBodyFrame(frameName), ostk::core::error::runtime::Undefined);
+    }
+
+    {
+        const Shared<const Frame> bodyFrame = transform_.getBodyFrame("test");
+        EXPECT_EQ(bodyFrame->getName(), "test");
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, Undefined)
+{
+    {
+        EXPECT_FALSE(Transform::Undefined().isDefined());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, InertialPointing)
+{
+    {
+        EXPECT_TRUE(Transform::InertialPointing(orbit_, Quaternion::Unit()).isDefined());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, NadirPointing)
+{
+    {
+        EXPECT_TRUE(Transform::NadirPointing(orbit_, Orbit::FrameType::VVLH).isDefined());
+    }
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Transform.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Transform.test.cpp
@@ -180,16 +180,19 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, GetBodyFr
         EXPECT_THROW(transform_.getBodyFrame(frameName), ostk::core::error::runtime::Undefined);
     }
 
-    // undefined model
     {
-        const Transform undefinedTransform = Transform::Undefined();
-        const String frameName = "test";
-        EXPECT_THROW(undefinedTransform.getBodyFrame(frameName), ostk::core::error::runtime::Undefined);
-    }
+        const String frameName = "OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform.GetBodyFrame";
 
-    {
-        const Shared<const Frame> bodyFrame = transform_.getBodyFrame("test");
-        EXPECT_EQ(bodyFrame->getName(), "test");
+        // undefined model
+        {
+            const Transform undefinedTransform = Transform::Undefined();
+            EXPECT_THROW(undefinedTransform.getBodyFrame(frameName), ostk::core::error::runtime::Undefined);
+        }
+
+        {
+            const Shared<const Frame> bodyFrame = transform_.getBodyFrame(frameName);
+            EXPECT_EQ(bodyFrame->getName(), frameName);
+        }
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Transform.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Transform.test.cpp
@@ -101,8 +101,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, Construct
         );
     };
 
-    const Transform transform = Transform(DynamicProvider(dynamicProviderGenerator), Frame::GCRF());
-    EXPECT_TRUE(transform.isDefined());
+    EXPECT_NO_THROW(Transform transform_ (DynamicProvider(dynamicProviderGenerator), Frame::GCRF()));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Transform, StreamOperator)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `access_model` method in the `Profile` class, allowing users to access the profile model.
  - Added new methods in the `Model` class for type checking and casting: `is_tabulated`, `is_transform`, `as_tabulated`, and `as_transform`.
  - Enhanced string representation for `Tabulated` and `Transform` classes.
  - Added a new test suite for the `Transform` class, covering various functionalities.

- **Bug Fixes**
  - Improved error handling in the `Profile` class to ensure safe access to the model.

- **Tests**
  - Added tests for the `access_model` method to verify functionality and error handling.
  - Expanded test coverage for the `Transform` class with multiple new test cases.

- **Documentation**
  - Updated method documentation for clarity on new functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->