### PR TITLE
fix: downgrade physics dep. to 10.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Physics [11.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "11" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "10" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,4 +3,4 @@
 open-space-toolkit-core~=4.1
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3
-open-space-toolkit-physics~=11.1
+open-space-toolkit-physics~=10.1

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -148,7 +148,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG TARGETPLATFORM
-ARG OSTK_PHYSICS_MAJOR="11"
+ARG OSTK_PHYSICS_MAJOR="10"
 
 ## Force an image rebuild when new Physics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR} /tmp/open-space-toolkit-physics/versions.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted version requirements for the Open Space Toolkit Physics package to enhance compatibility.
  
- **Bug Fixes**
	- Downgraded dependency versions for `open-space-toolkit-physics` to ensure stability.

- **Chores**
	- Updated dependency management in the Dockerfile for improved installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->