### PR TITLE
build!: update physics to 11.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Physics [11.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "10" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "11" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,4 +3,4 @@
 open-space-toolkit-core~=4.1
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3
-open-space-toolkit-physics~=10.1
+open-space-toolkit-physics~=11.1

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -148,7 +148,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG TARGETPLATFORM
-ARG OSTK_PHYSICS_MAJOR="10"
+ARG OSTK_PHYSICS_MAJOR="11"
 
 ## Force an image rebuild when new Physics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR} /tmp/open-space-toolkit-physics/versions.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated dependencies to require the latest version of OpenSpaceToolkitPhysics (version 11).
  
- **Chores**
	- Adjusted version specifications in the Python requirements.
	- Enhanced Dockerfile for improved installation processes and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->