### PR TITLE
refactor: remove extra quaternion conversion methods

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install --quiet "numpy~=2.0" "pandas" "plotly" "ipywidgets>=7.6" "ipympl
 # Install JupyterLab extensions
 
 RUN jupyter labextension install --no-build \
-        @jupyterlab/shortcuts-extension
+ @jupyterlab/shortcuts-extension
 
 COPY ./shortcuts-extension /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/shortcuts-extension
 
@@ -38,6 +38,15 @@ ENV OSTK_PHYSICS_DATA_LOCAL_REPOSITORY="${OSTK_DATA_LOCAL_CACHE}/data"
 RUN git clone --branch v1 --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git ${OSTK_DATA_LOCAL_CACHE} && chmod -R g+w ${OSTK_DATA_LOCAL_CACHE}
 
 RUN chown -R ${NB_UID}:${NB_GID} ${OSTK_DATA_LOCAL_CACHE}
+
+## Install libstdc++ including GLIBCXX_3.4.32 (For OSTk), can be removed when Ubuntu version >= 24.0 or debian >= 13.0
+
+RUN apt-get update \
+ && apt-get install -y software-properties-common \
+ && add-apt-repository ppa:ubuntu-toolchain-r/test \
+ && apt-get update \
+ && apt-get install -y libstdc++6 \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install Open Space Toolkit
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.hpp
@@ -68,20 +68,6 @@ class AttitudeQuaternion : public CoordinateSubset
         const Shared<const CoordinateBroker>& aCoordinateBrokerSPtr
     ) const override;
 
-    /// @brief              Return a Quaternion from coordinates.
-    ///
-    /// @param              [in] coordinates coordinates vector
-    ///
-    /// @return
-    static Quaternion coordinatesToQuaternion(const VectorXd& coordinates);
-
-    /// @brief              Return coordinates from a Quaternion.
-    ///
-    /// @param              [in] quaterion quaternion
-    ///
-    /// @return
-    static VectorXd quaterionToCoordinates(const Quaternion& quaternion);
-
     /// @brief              Return the default instance
     ///
     /// @return             The default instance

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -3,6 +3,8 @@
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
+#include <OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.hpp>
+
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.hpp>
@@ -18,6 +20,8 @@ namespace trajectory
 {
 
 using ostk::core::type::Index;
+
+using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
 
 using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::AngularVelocity;
@@ -135,7 +139,7 @@ State::State(
     VectorXd coordinates(13);
     coordinates.segment(0, 3) = aPosition.inUnit(Position::Unit::Meter).accessCoordinates();
     coordinates.segment(3, 3) = aVelocity.inUnit(Velocity::Unit::MeterPerSecond).accessCoordinates();
-    coordinates.segment(6, 4) = AttitudeQuaternion::quaterionToCoordinates(anAttitude);
+    coordinates.segment(6, 4) = anAttitude.toVector(Quaternion::Format::XYZS);
     coordinates.segment(10, 3) = anAngularVelocity;
 
     static const Shared<CoordinateBroker> coordinatesBrokerSPtr = std::make_shared<CoordinateBroker>(CoordinateBroker(
@@ -403,7 +407,14 @@ Quaternion State::getAttitude() const
         throw ostk::core::error::runtime::Undefined("State");
     }
 
-    return AttitudeQuaternion::coordinatesToQuaternion(this->extractCoordinate(AttitudeQuaternion::Default()));
+    const VectorXd attitudeQuaternionCoordinates = this->extractCoordinate(AttitudeQuaternion::Default());
+
+    return Quaternion::XYZS(
+        attitudeQuaternionCoordinates[0],
+        attitudeQuaternionCoordinates[1],
+        attitudeQuaternionCoordinates[2],
+        attitudeQuaternionCoordinates[3]
+    );
 }
 
 Vector3d State::getAngularVelocity() const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.cpp
@@ -41,8 +41,13 @@ VectorXd AngularVelocity::inFrame(
     const VectorXd attitudeCoordinatesInFrame = this->attitudeQuaternionSPtr_->inFrame(
         anInstant, aFullCoordinatesVector, fromFrame, toFrame, aCoordinateBrokerSPtr
     );
-    const Quaternion quaternionInFrame =
-        AttitudeQuaternion::coordinatesToQuaternion(attitudeCoordinatesInFrame).toNormalized();
+    const Quaternion quaternionInFrame = Quaternion::XYZS(
+                                             attitudeCoordinatesInFrame[0],
+                                             attitudeCoordinatesInFrame[1],
+                                             attitudeCoordinatesInFrame[2],
+                                             attitudeCoordinatesInFrame[3]
+    )
+                                             .toNormalized();
 
     const Transform transform = fromFrame->getTransformTo(toFrame, anInstant);
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.cpp
@@ -36,26 +36,13 @@ VectorXd AttitudeQuaternion::inFrame(
 {
     const VectorXd coordinates = aCoordinateBrokerSPtr->extractCoordinate(aFullCoordinatesVector, *this);
 
-    const Quaternion quaternion = coordinatesToQuaternion(coordinates);
+    const Quaternion quaternion = Quaternion::XYZS(coordinates[0], coordinates[1], coordinates[2], coordinates[3]);
 
     const Transform transform = fromFrame->getTransformTo(toFrame, anInstant);
 
     const Quaternion quaternionInFrame = quaternion * transform.getOrientation().toConjugate();
 
-    return quaterionToCoordinates(quaternionInFrame);
-}
-
-Quaternion AttitudeQuaternion::coordinatesToQuaternion(const VectorXd& coordinates)
-{
-    return {coordinates(0), coordinates(1), coordinates(2), coordinates(3), Quaternion::Format::XYZS};
-}
-
-VectorXd AttitudeQuaternion::quaterionToCoordinates(const Quaternion& quaternion)
-{
-    VectorXd coordinates(4);
-    coordinates << quaternion.x(), quaternion.y(), quaternion.z(), quaternion.s();
-
-    return coordinates;
+    return quaternionInFrame.toVector(Quaternion::Format::XYZS);
 }
 
 Shared<const AttitudeQuaternion> AttitudeQuaternion::Default()

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.test.cpp
@@ -87,22 +87,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset_Attitude
     }
 }
 
-TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset_AttitudeQuaternion, ConversionToAndFromQuaternion
-)
-{
-    {
-        VectorXd coordinates(4);
-        coordinates << 0.0, 0.0, 0.0, 1.0;
-
-        const Quaternion quaternion = AttitudeQuaternion::coordinatesToQuaternion(coordinates);
-
-        const VectorXd roundTripCoordinates = AttitudeQuaternion::quaterionToCoordinates(quaternion);
-
-        EXPECT_EQ(coordinates, roundTripCoordinates);
-    }
-}
-
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset_AttitudeQuaternion, Default)
 {
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced Jupyter environment setup with the installation of the `libstdc++6` library for improved compatibility with the Open Space Toolkit (OSTk).

- **Bug Fixes**
  - Simplified the `AttitudeQuaternion` interface by removing outdated conversion methods, streamlining user interaction with quaternion data.

- **Tests**
  - Removed outdated test case for quaternion conversion, reflecting the removal of related methods in the `AttitudeQuaternion` class. 

These changes improve the functionality and usability of the Open Space Toolkit while maintaining a focus on performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->