### PR TITLE
build: add python3.13 support

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -188,7 +188,7 @@ FIND_PACKAGE (pybind11 2.12.0 REQUIRED)
 ### Python
 
 # Python versions to build for and support
-SET (PYTHON_SEARCH_VERSIONS 3.9 3.10 3.11 3.12 CACHE STRING "Versions of Python bindings to build.")
+SET (PYTHON_SEARCH_VERSIONS 3.9 3.10 3.11 3.12 3.13 CACHE STRING "Versions of Python bindings to build.")
 
 MESSAGE (STATUS "Looking for available python versions...")
 FOREACH (PYTHON_VERSION ${PYTHON_SEARCH_VERSIONS})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Python version 3.13 for building bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->