### PR TITLE
chore: package stubs in whl

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -157,6 +157,9 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/requirements.txt"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
+                            COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/py.typed" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/py.typed"
+                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m pip install .
+                            COMMAND python${PYTHON_VERSION} -m "pybind11_stubgen" -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" # generate stubs in same dir as binaries
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m build --no-isolation -w
                             COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/dist"
                             COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/dist/*" "${CMAKE_CURRENT_BINARY_DIR}/dist"

--- a/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
@@ -21,7 +21,6 @@ from ostk.astrodynamics.trajectory.state.coordinate_subset import (
 CANONICAL_FORMAT: str = r"(r|v)_(.*?)_(x|y|z)"
 
 
-@staticmethod
 def custom_class_generator(frame: Frame, coordinate_subsets: list) -> type:
     """
     Emit a custom class type for States. This is meta-programming syntactic sugar on top of the StateBuilder class.
@@ -44,7 +43,6 @@ def custom_class_generator(frame: Frame, coordinate_subsets: list) -> type:
     return StateTemplateType
 
 
-@staticmethod
 def from_dict(data: dict) -> State:
     """
     Create a State from a dictionary.
@@ -247,5 +245,5 @@ def from_dict(data: dict) -> State:
     )
 
 
-State.from_dict = from_dict
-State.template = custom_class_generator
+State.from_dict = staticmethod(from_dict)
+State.template = staticmethod(custom_class_generator)


### PR DESCRIPTION
Adds automated stub generation and bundling into the wheels. Requires [open-space-toolkit >= 0.8.3](https://github.com/open-space-collective/open-space-toolkit/releases/tag/0.8.3) due to the apt-installed numpy being incompatible with pybind11-stubgen.

Additionally, changed the `staticmethod` markers from decorators to functions. This is because in Python 3.9, pybind11-stubgen will throw the following error: 
<details><summary>Traceback</summary>

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/__main__.py", line 4, in <module>
    main()
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/__init__.py", line 319, in main
    run(
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/__init__.py", line 357, in run
    module = parser.handle_module(
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/error_handlers.py", line 45, in handle_module
    return super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 207, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 223, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 128, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 451, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/parse.py", line 90, in handle_module
    obj = self.handle_module_member(
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/filter.py", line 119, in handle_module_member
    return super().handle_module_member(path, module, obj)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/filter.py", line 136, in handle_module_member
    result = super().handle_module_member(path, module, obj)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/parse.py", line 135, in handle_module_member
    return self.handle_module(path, member)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/error_handlers.py", line 45, in handle_module
    return super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 207, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 223, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 128, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 451, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/parse.py", line 90, in handle_module
    obj = self.handle_module_member(
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/filter.py", line 119, in handle_module_member
    return super().handle_module_member(path, module, obj)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/filter.py", line 136, in handle_module_member
    result = super().handle_module_member(path, module, obj)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/parse.py", line 135, in handle_module_member
    return self.handle_module(path, member)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/error_handlers.py", line 45, in handle_module
    return super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 207, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 223, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 128, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 451, in handle_module
    result = super().handle_module(path, module)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/parse.py", line 90, in handle_module
    obj = self.handle_module_member(
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/filter.py", line 119, in handle_module_member
    return super().handle_module_member(path, module, obj)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/filter.py", line 136, in handle_module_member
    result = super().handle_module_member(path, module, obj)
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/parse.py", line 128, in handle_module_member
    if self._is_alias(path, member):
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/parse.py", line 150, in _is_alias
    ] != member.__name__:
AttributeError: 'staticmethod' object has no attribute '__name__'
```
</details> 

I believe this is due to stubgen trying to look up some inherited properties that were only implemented in the `@staticmethod` decorator in [Python 3.10](https://github.com/python/cpython/issues/87848#issuecomment-1093908549)