### PR TITLE
refactor!: use state instead of instantposvel

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -53,16 +53,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
         .def(
             "generate_frame",
             &LocalOrbitalFrameFactory::generateFrame,
-            arg("instant"),
-            arg("position_vector"),
-            arg("velocity_vector"),
+            arg("state"),
             R"doc(
                 Generate a local orbital frame.
 
                 Args:
-                    instant (Instant): The instant.
-                    position_vector (numpy.ndarray): The position vector.
-                    velocity_vector (numpy.ndarray): The velocity vector.
+                    state (State): The state.
 
                 Returns:
                     Frame: The local orbital frame.
@@ -185,16 +181,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
         )
         .def_static(
             "construct",
-            overload_cast<
-                const std::function<Transform(const Instant&, const Vector3d&, const Vector3d&)>&,
-                const Shared<const Frame>&>(&LocalOrbitalFrameFactory::Construct),
+            overload_cast<const std::function<Transform(const State&)>&, const Shared<const Frame>&>(
+                &LocalOrbitalFrameFactory::Construct
+            ),
             arg("transform_generator"),
             arg("parent_frame"),
             R"doc(
                 Construct a local orbital frame factory for a custom type, using the provided transform generator.
 
                 Args:
-                    transform_generator (callable[[Instant, np.array, np.array], Transform]): The transform generator.
+                    transform_generator (callable[[State], Transform]): The transform generator.
                     parent_frame (Frame): The parent frame.
 
                 Returns:

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameTransformProvider.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameTransformProvider.cpp
@@ -19,7 +19,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameTransfor
             "LocalOrbitalFrameTransformProvider",
             R"doc(
                 Local orbital frame transform provider, frame provider.
-                Generates a specific transform based on instant, position, velocity and a LOF type.
+                Generates a specific transform based on a State (instant, position, velocity) and a LOF type.
 
             )doc"
         );
@@ -94,17 +94,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameTransfor
 
                 Args:
                     type (LocalOrbitalFrameTransformProvider.Type): The local orbital frame provider type.
-                    instant (Instant): The instant.
-                    position (Vector3d): The position vector.
-                    velocity (Vector3d): The velocity vector.
+                    state (State): The state.
 
                 Returns:
                     LocalOrbitalFrameTransformProvider: The provider.
             )doc",
             arg("type"),
-            arg("instant"),
-            arg("position"),
-            arg("velocity")
+            arg("state")
         )
 
         .def_static(
@@ -117,7 +113,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameTransfor
                     type (LocalOrbitalFrameTransformProvider.Type): The local orbital frame provider type.
 
                 Returns:
-                    callable[[Instant, np.array, np.array], Transform]: The transform generator function.
+                    callable[[State], Transform]: The transform generator function.
             )doc",
             arg("type")
         )

--- a/bindings/python/test/trajectory/test_local_orbital_frame_factory.py
+++ b/bindings/python/test/trajectory/test_local_orbital_frame_factory.py
@@ -7,7 +7,10 @@ from ostk.physics.time import DateTime
 from ostk.physics.time import Scale
 from ostk.physics.coordinate import Frame
 from ostk.physics.coordinate import Transform
+from ostk.physics.coordinate import Position
+from ostk.physics.coordinate import Velocity
 
+from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory import LocalOrbitalFrameFactory
 from ostk.astrodynamics.trajectory import LocalOrbitalFrameTransformProvider
 
@@ -24,7 +27,7 @@ def local_orbital_transform_provider_type() -> LocalOrbitalFrameTransformProvide
 
 @pytest.fixture
 def transform_generator() -> callable:
-    return lambda instant, position, velocity: Transform.identity(Transform.Type.passive)
+    return lambda state: Transform.identity(Transform.Type.passive)
 
 
 @pytest.fixture
@@ -38,13 +41,24 @@ def instant() -> Instant:
 
 
 @pytest.fixture
-def position_vector() -> list:
-    return [7500000.0, 0.0, 0.0]
+def position() -> list:
+    return Position.meters([7500000.0, 0.0, 0.0], Frame.GCRF())
 
 
 @pytest.fixture
-def velocity_vector() -> list:
-    return [0.0, 5335.865450622126, 5335.865450622126]
+def velocity() -> list:
+    return Velocity.meters_per_second(
+        [0.0, 5335.865450622126, 5335.865450622126], Frame.GCRF()
+    )
+
+
+@pytest.fixture
+def state(
+    instant: Instant,
+    position: Position,
+    velocity: Velocity,
+) -> State:
+    return State(instant, position, velocity)
 
 
 class TestLocalOrbitalFrameFactory:
@@ -66,15 +80,9 @@ class TestLocalOrbitalFrameFactory:
     def test_generate_frame(
         self,
         local_orbital_frame_factory: LocalOrbitalFrameFactory,
-        instant: Instant,
-        position_vector: list,
-        velocity_vector: list,
+        state: State,
     ):
-        frame = local_orbital_frame_factory.generate_frame(
-            instant,
-            position_vector,
-            velocity_vector,
-        )
+        frame = local_orbital_frame_factory.generate_frame(state=state)
 
         assert frame is not None
         assert frame.is_defined()

--- a/bindings/python/test/trajectory/test_local_orbital_frame_factory.py
+++ b/bindings/python/test/trajectory/test_local_orbital_frame_factory.py
@@ -41,12 +41,12 @@ def instant() -> Instant:
 
 
 @pytest.fixture
-def position() -> list:
+def position() -> Position:
     return Position.meters([7500000.0, 0.0, 0.0], Frame.GCRF())
 
 
 @pytest.fixture
-def velocity() -> list:
+def velocity() -> Velocity:
     return Velocity.meters_per_second(
         [0.0, 5335.865450622126, 5335.865450622126], Frame.GCRF()
     )

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -183,7 +183,6 @@ class TestSegmentSolution:
     ):
         assert segment_solution.compute_delta_mass() is not None
 
-    @pytest.mark.skip(reason="Not implemented yet")
     def test_extract_maneuvers(
         self,
         segment_solution: Segment.Solution,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.hpp
@@ -37,16 +37,13 @@ using ostk::astrodynamics::trajectory::LocalOrbitalFrameTransformProvider;
 class LocalOrbitalFrameFactory
 {
    public:
-    typedef std::function<Transform(const Instant&, const Vector3d&, const Vector3d&)> TransformGenerator;
+    typedef std::function<Transform(const State&)> TransformGenerator;
     /// @brief Generate a frame shared pointer based on current state input
     ///
-    /// @param anInstant An instant
-    /// @param aPosition A position vector
-    /// @param aVelocity A velocity vector
+    /// @param aState A State
     ///
     /// @return A shared pointer to the frame created
-    Shared<const Frame> generateFrame(const Instant& anInstant, const Vector3d& aPosition, const Vector3d& aVelocity)
-        const;
+    Shared<const Frame> generateFrame(const State& aState) const;
 
     /// @brief Check if local orbital frame factory is defined
     ///
@@ -152,12 +149,10 @@ class LocalOrbitalFrameFactory
 
     /// @brief Generate a frame name based on current state
     ///
-    /// @param anInstant An instant
-    /// @param aPosition A position vector
-    /// @param aVelocity A velocity vector
+    /// @param aState A state
     ///
     /// @return A frame name
-    String generateFrameName(const Instant& anInstant, const Vector3d& aPosition, const Vector3d& aVelocity) const;
+    String generateFrameName(const State& aState) const;
 };
 
 }  // namespace trajectory

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameTransformProvider.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameTransformProvider.hpp
@@ -12,6 +12,8 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+
 namespace ostk
 {
 namespace astrodynamics
@@ -29,6 +31,8 @@ using ostk::physics::coordinate::Transform;
 using ostk::physics::coordinate::Vector3d;
 using ostk::physics::coordinate::Velocity;
 using ostk::physics::time::Instant;
+
+using ostk::astrodynamics::trajectory::State;
 
 /// @brief Local orbital frame transform provider, frame provider
 ///
@@ -83,16 +87,11 @@ class LocalOrbitalFrameTransformProvider : public Provider
     /// @brief Construct a local orbital frame transform provider shared pointer for the provided type
     ///
     /// @param aType A local orbital frame provider type
-    /// @param anInstant An instant
-    /// @param aPosition A position vector
-    /// @param aVelocity A velocity vector
+    /// @param aState A state
     ///
     /// @return The shared pointer to the local orbital frame transform provider constructed
     static Shared<const LocalOrbitalFrameTransformProvider> Construct(
-        const LocalOrbitalFrameTransformProvider::Type& aType,
-        const Instant& anInstant,
-        const Vector3d& aPosition,
-        const Vector3d& aVelocity
+        const LocalOrbitalFrameTransformProvider::Type& aType, const State& aState
     );
 
     /// @brief Get the transform generator function for a given type
@@ -100,7 +99,7 @@ class LocalOrbitalFrameTransformProvider : public Provider
     /// @param aType A local orbital frame provider type
     ///
     /// @return The transform generator function
-    static std::function<Transform(const Instant&, const Vector3d&, const Vector3d&)> GetTransformGenerator(
+    static std::function<Transform(const State&)> GetTransformGenerator(
         const LocalOrbitalFrameTransformProvider::Type& aType
     );
 
@@ -117,17 +116,10 @@ class LocalOrbitalFrameTransformProvider : public Provider
     /// @brief Generate a transform based on current state and LOF type
     ///
     /// @param aType A local orbital frame provider type
-    /// @param anInstant An instant
-    /// @param aPosition A position vector
-    /// @param aVelocity A velocity vector
+    /// @param aState
     ///
     /// @return The transform generated
-    static Transform generateTransform(
-        const LocalOrbitalFrameTransformProvider::Type& aType,
-        const Instant& anInstant,
-        const Vector3d& aPosition,
-        const Vector3d& aVelocity
-    );
+    static Transform GenerateTransform(const LocalOrbitalFrameTransformProvider::Type& aType, const State& aState);
 };
 
 }  // namespace trajectory

--- a/src/OpenSpaceToolkit/Astrodynamics/Data/Provider/OffNadir.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Data/Provider/OffNadir.cpp
@@ -48,9 +48,7 @@ Tuple<Angle, Angle, Angle> ComputeOffNadirAngles(const State& aState, const Posi
 
     const Instant instant = aState.getInstant();
 
-    const Shared<const Frame> localOrbitalFrameSPtr = VVLHFrameFactory->generateFrame(
-        instant, aState.getPosition().getCoordinates(), aState.getVelocity().getCoordinates()
-    );
+    const Shared<const Frame> localOrbitalFrameSPtr = VVLHFrameFactory->generateFrame(aState);
 
     // Calculate satellite to target direction vector in GCRF frame
     const Vector3d satelliteToTargetDirection =

--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.cpp
@@ -17,6 +17,9 @@ namespace guidancelaw
 
 using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
 
+using ostk::physics::coordinate::Position;
+using ostk::physics::coordinate::Velocity;
+
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameDirection;
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameFactory;
 
@@ -53,10 +56,14 @@ Vector3d ConstantThrust::calculateThrustAccelerationAt(
     const Shared<const Frame>& outputFrameSPtr
 ) const
 {
+    const State state = {
+        anInstant,
+        Position::Meters(aPositionCoordinates, outputFrameSPtr),
+        Velocity::MetersPerSecond(aVelocityCoordinates, outputFrameSPtr),
+    };
+
     const Shared<const Frame> localOrbitalFrameSPtr =
-        this->localOrbitalFrameDirection_.accessLocalOrbitalFrameFactory()->generateFrame(
-            anInstant, aPositionCoordinates, aVelocityCoordinates
-        );
+        this->localOrbitalFrameDirection_.accessLocalOrbitalFrameFactory()->generateFrame(state);
 
     const Quaternion q_requestedFrame_LOF =
         localOrbitalFrameSPtr->getTransformTo(outputFrameSPtr, anInstant).getOrientation().normalize();

--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.cpp
@@ -56,10 +56,13 @@ Vector3d ConstantThrust::calculateThrustAccelerationAt(
     const Shared<const Frame>& outputFrameSPtr
 ) const
 {
+    const Shared<const Frame> parentFrameSPtr =
+        this->localOrbitalFrameDirection_.accessLocalOrbitalFrameFactory()->accessParentFrame();
+
     const State state = {
         anInstant,
-        Position::Meters(aPositionCoordinates, outputFrameSPtr),
-        Velocity::MetersPerSecond(aVelocityCoordinates, outputFrameSPtr),
+        Position::Meters(aPositionCoordinates, parentFrameSPtr),
+        Velocity::MetersPerSecond(aVelocityCoordinates, parentFrameSPtr),
     };
 
     const Shared<const Frame> localOrbitalFrameSPtr =

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -59,7 +59,7 @@ struct SharedFrameEnabler : public Frame
 Shared<const Frame> LocalOrbitalFrameFactory::generateFrame(const State& aState) const
 {
     const StateBuilder positionVelocityStateBuilder =
-        StateBuilder(state.getFrame(), {CartesianPosition::Default(), CartesianVelocity::Default()});
+        StateBuilder(aState.getFrame(), {CartesianPosition::Default(), CartesianVelocity::Default()});
 
     const State positionVelocityStateInParentFrame =
         positionVelocityStateBuilder.reduce(aState).inFrame(parentFrameSPtr_);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -52,7 +52,8 @@ struct SharedFrameEnabler : public Frame
 
 Shared<const Frame> LocalOrbitalFrameFactory::generateFrame(const State& aState) const
 {
-    const State stateInParentFrame = aState.inFrame(parentFrameSPtr_);
+    const StateBuilder posVelStateBuilder = StateBuilder(state.getFrame(), {CartesianPosition::Default(), CartesianVelocity::Default()})
+    const State posVelStateInParentFrame = posVelStateBuilder.reduce(aState).inFrame(parentFrameSPtr_);
 
     const String name = this->generateFrameName(stateInParentFrame);
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -39,8 +39,8 @@ using ostk::physics::coordinate::Velocity;
 
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameTransformProvider;
 using ostk::astrodynamics::trajectory::State;
-using ostk::astrodynamics::trajectory::state::coordinatesubsets::CartesianPosition;
-using ostk::astrodynamics::trajectory::state::coordinatesubsets::CartesianVelocity;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
 struct SharedFrameEnabler : public Frame

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -50,18 +50,18 @@ struct SharedFrameEnabler : public Frame
     }
 };
 
-Shared<const Frame> LocalOrbitalFrameFactory::generateFrame(
-    const Instant& anInstant, const Vector3d& aPosition, const Vector3d& aVelocity
-) const
+Shared<const Frame> LocalOrbitalFrameFactory::generateFrame(const State& aState) const
 {
-    const String name = this->generateFrameName(anInstant, aPosition, aVelocity);
+    const State stateInParentFrame = aState.inFrame(parentFrameSPtr_);
+
+    const String name = this->generateFrameName(stateInParentFrame);
 
     if (const auto frameSPtr = FrameManager::Get().accessFrameWithName(name))
     {
         return frameSPtr;
     }
 
-    const Transform transform = transformGenerator_(anInstant, aPosition, aVelocity);
+    const Transform transform = transformGenerator_(stateInParentFrame);
 
     const Shared<const LocalOrbitalFrameTransformProvider> providerSPtr =
         std::make_shared<const LocalOrbitalFrameTransformProvider>(transform);
@@ -164,12 +164,10 @@ LocalOrbitalFrameFactory::LocalOrbitalFrameFactory(
 {
 }
 
-String LocalOrbitalFrameFactory::generateFrameName(
-    const Instant& anInstant, const Vector3d& aPosition, const Vector3d& aVelocity
-) const
+String LocalOrbitalFrameFactory::generateFrameName(const State& aState) const
 {
-    return LocalOrbitalFrameTransformProvider::StringFromType(type_) + "@" + anInstant.toString() +
-           aPosition.toString() + aVelocity.toString();
+    return LocalOrbitalFrameTransformProvider::StringFromType(type_) + "@" + aState.accessInstant().toString() +
+           aState.getPosition().getCoordinates().toString() + aState.getVelocity().getCoordinates().toString();
 }
 
 }  // namespace trajectory

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -15,6 +15,9 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameFactory.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 namespace ostk
 {
@@ -36,6 +39,9 @@ using ostk::physics::coordinate::Velocity;
 
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameTransformProvider;
 using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::coordinatesubsets::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubsets::CartesianVelocity;
+using ostk::astrodynamics::trajectory::StateBuilder;
 
 struct SharedFrameEnabler : public Frame
 {
@@ -52,17 +58,20 @@ struct SharedFrameEnabler : public Frame
 
 Shared<const Frame> LocalOrbitalFrameFactory::generateFrame(const State& aState) const
 {
-    const StateBuilder posVelStateBuilder = StateBuilder(state.getFrame(), {CartesianPosition::Default(), CartesianVelocity::Default()})
-    const State posVelStateInParentFrame = posVelStateBuilder.reduce(aState).inFrame(parentFrameSPtr_);
+    const StateBuilder positionVelocityStateBuilder =
+        StateBuilder(state.getFrame(), {CartesianPosition::Default(), CartesianVelocity::Default()});
 
-    const String name = this->generateFrameName(stateInParentFrame);
+    const State positionVelocityStateInParentFrame =
+        positionVelocityStateBuilder.reduce(aState).inFrame(parentFrameSPtr_);
+
+    const String name = this->generateFrameName(positionVelocityStateInParentFrame);
 
     if (const auto frameSPtr = FrameManager::Get().accessFrameWithName(name))
     {
         return frameSPtr;
     }
 
-    const Transform transform = transformGenerator_(stateInParentFrame);
+    const Transform transform = transformGenerator_(positionVelocityStateInParentFrame);
 
     const Shared<const LocalOrbitalFrameTransformProvider> providerSPtr =
         std::make_shared<const LocalOrbitalFrameTransformProvider>(transform);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameTransformProvider.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameTransformProvider.cpp
@@ -144,7 +144,6 @@ Transform LocalOrbitalFrameTransformProvider::GenerateTransform(
         {
             // X axis along position vector
             // Z axis along orbital momentum
-            // Y axis toward velocity vector
             const Vector3d transformPosition = -positionCoordinates;
             const Vector3d transformVelocity = -velocityCoordinates;
             const Vector3d xAxis = positionCoordinates.normalized();
@@ -166,8 +165,8 @@ Transform LocalOrbitalFrameTransformProvider::GenerateTransform(
 
         case LocalOrbitalFrameTransformProvider::Type::VVLH:
         {
+            // Z axis along negative position vector
             // Y axis along negative orbital momentum
-            // X axis toward velocity vector
             const Vector3d transformPosition = -positionCoordinates;
             const Vector3d transformVelocity = -velocityCoordinates;
             const Vector3d zAxis = -positionCoordinates.normalized();

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameTransformProvider.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameTransformProvider.test.cpp
@@ -15,13 +15,17 @@ using ostk::core::type::Shared;
 
 using ostk::mathematics::object::Vector3d;
 
+using ostk::physics::coordinate::Frame;
+using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::Transform;
+using ostk::physics::coordinate::Velocity;
 using ostk::physics::time::DateTime;
 using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Scale;
 
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameTransformProvider;
+using ostk::astrodynamics::trajectory::State;
 
 class OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvider : public ::testing::Test
 {
@@ -32,8 +36,14 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvid
     const Vector3d position_ = {7000000.0, 0.0, 0.0};
     const Vector3d velocity_ = {0.0, 5335.865450622126, 5335.865450622126};
 
+    const State state_ = {
+        instant_,
+        Position::Meters(position_, Frame::GCRF()),
+        Velocity::MetersPerSecond(velocity_, Frame::GCRF()),
+    };
+
     const Shared<const LocalOrbitalFrameTransformProvider> localOrbitalFrameTransformProvider_ =
-        LocalOrbitalFrameTransformProvider::Construct(type_, instant_, position_, velocity_);
+        LocalOrbitalFrameTransformProvider::Construct(type_, state_);
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvider, Constructer)
@@ -47,52 +57,50 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
 {
     {
         {
-            EXPECT_NO_THROW(LocalOrbitalFrameTransformProvider::Construct(
-                LocalOrbitalFrameTransformProvider::Type::VNC, instant_, position_, velocity_
-            ));
+            EXPECT_NO_THROW(
+                LocalOrbitalFrameTransformProvider::Construct(LocalOrbitalFrameTransformProvider::Type::VNC, state_)
+            );
         }
 
         {
-            EXPECT_NO_THROW(LocalOrbitalFrameTransformProvider::Construct(
-                LocalOrbitalFrameTransformProvider::Type::NED, instant_, position_, velocity_
-            ));
+            EXPECT_NO_THROW(
+                LocalOrbitalFrameTransformProvider::Construct(LocalOrbitalFrameTransformProvider::Type::NED, state_)
+            );
         }
 
         {
-            EXPECT_NO_THROW(LocalOrbitalFrameTransformProvider::Construct(
-                LocalOrbitalFrameTransformProvider::Type::LVLH, instant_, position_, velocity_
-            ));
+            EXPECT_NO_THROW(
+                LocalOrbitalFrameTransformProvider::Construct(LocalOrbitalFrameTransformProvider::Type::LVLH, state_)
+            );
+        }
+
+        {
+            EXPECT_ANY_THROW(
+                LocalOrbitalFrameTransformProvider::Construct(LocalOrbitalFrameTransformProvider::Type::LVLHGD, state_)
+            );  // ToBeImplemented
+        }
+
+        {
+            EXPECT_NO_THROW(
+                LocalOrbitalFrameTransformProvider::Construct(LocalOrbitalFrameTransformProvider::Type::QSW, state_)
+            );
+        }
+
+        {
+            EXPECT_NO_THROW(
+                LocalOrbitalFrameTransformProvider::Construct(LocalOrbitalFrameTransformProvider::Type::TNW, state_)
+            );
         }
 
         {
             EXPECT_ANY_THROW(LocalOrbitalFrameTransformProvider::Construct(
-                LocalOrbitalFrameTransformProvider::Type::LVLHGD, instant_, position_, velocity_
-            ));  // ToBeImplemented
-        }
-
-        {
-            EXPECT_NO_THROW(LocalOrbitalFrameTransformProvider::Construct(
-                LocalOrbitalFrameTransformProvider::Type::QSW, instant_, position_, velocity_
-            ));
-        }
-
-        {
-            EXPECT_NO_THROW(LocalOrbitalFrameTransformProvider::Construct(
-                LocalOrbitalFrameTransformProvider::Type::TNW, instant_, position_, velocity_
-            ));
-        }
-
-        {
-            EXPECT_ANY_THROW(LocalOrbitalFrameTransformProvider::Construct(
-                LocalOrbitalFrameTransformProvider::Type::Undefined, instant_, position_, velocity_
+                LocalOrbitalFrameTransformProvider::Type::Undefined, state_
             ));
         }
 
         {
             EXPECT_THROW(
-                LocalOrbitalFrameTransformProvider::Construct(
-                    LocalOrbitalFrameTransformProvider::Type::Custom, instant_, position_, velocity_
-                ),
+                LocalOrbitalFrameTransformProvider::Construct(LocalOrbitalFrameTransformProvider::Type::Custom, state_),
                 ostk::core::error::RuntimeError
             );
         }
@@ -125,7 +133,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
                 LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::VNC
                 );
 
-            const Transform transform = transformGenerator(instant_, position_, velocity_);
+            const Transform transform = transformGenerator(state_);
 
             EXPECT_TRUE(transform.isDefined());
         }
@@ -135,7 +143,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
                 LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::NED
                 );
 
-            const Transform transform = transformGenerator(instant_, position_, velocity_);
+            const Transform transform = transformGenerator(state_);
 
             EXPECT_TRUE(transform.isDefined());
         }
@@ -145,7 +153,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
                 LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::LVLH
                 );
 
-            const Transform transform = transformGenerator(instant_, position_, velocity_);
+            const Transform transform = transformGenerator(state_);
 
             EXPECT_TRUE(transform.isDefined());
         }
@@ -155,7 +163,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
                 LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::QSW
                 );
 
-            const Transform transform = transformGenerator(instant_, position_, velocity_);
+            const Transform transform = transformGenerator(state_);
 
             EXPECT_TRUE(transform.isDefined());
         }
@@ -165,7 +173,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
                 LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::TNW
                 );
 
-            const Transform transform = transformGenerator(instant_, position_, velocity_);
+            const Transform transform = transformGenerator(state_);
 
             EXPECT_TRUE(transform.isDefined());
         }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
@@ -841,7 +841,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation_Thruster, Force
 
         // Get LOF
         Shared<const Frame> lofSPtr = param_localOrbitalFrameFactory->generateFrame(
-            instantArray[i], positionGCRF_Thruster.accessCoordinates(), velocityGCRF_Thruster.accessCoordinates()
+            State(instantArray[i], positionGCRF_Thruster, velocityGCRF_Thruster)
         );
 
         // Get LOF State


### PR DESCRIPTION
Closes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `State` object that consolidates instant, position, and velocity parameters across multiple components.

- **Refactor**
  - Streamlined method signatures in trajectory and frame-related classes by replacing multiple parameters with a single `State` object.
  - Updated method calls and test cases to utilize the new `State` object.

- **Documentation**
  - Updated method documentation to reflect changes in parameter types and method signatures.

- **Tests**
  - Modified test cases to accommodate the new `State` object.
  - Removed skipped test methods, indicating readiness for new implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->