### PR TITLE
fix: fix off nadir state missing frame transformation

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Data/Provider/OffNadir.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Data/Provider/OffNadir.cpp
@@ -47,21 +47,22 @@ Tuple<Angle, Angle, Angle> ComputeOffNadirAngles(const State& aState, const Posi
     }
 
     const Instant instant = aState.getInstant();
-    const State stateInFrame = aState.inFrame(VVLHFrameFactory->accessParentFrame());
+    const Shared<const Frame> parentFrameSPtr = VVLHFrameFactory->accessParentFrame();
+    const State stateInFrame = aState.inFrame(parentFrameSPtr);
     
     const Shared<const Frame> localOrbitalFrameSPtr = VVLHFrameFactory->generateFrame(
         instant, stateInFrame.getPosition().getCoordinates(), stateInFrame.getVelocity().getCoordinates()
     );
 
-    // Calculate satellite to target direction vector in GCRF frame
+    // Calculate satellite to target direction vector in parent frame
     const Vector3d satelliteToTargetDirection =
-        (aTargetPosition.inFrame(Frame::GCRF(), instant).inMeters().getCoordinates() -
-         aState.inFrame(Frame::GCRF()).getPosition().inMeters().getCoordinates())
+        (aTargetPosition.inFrame(parentFrameSPtr, instant).inMeters().getCoordinates() -
+         aState.inFrame(parentFrameSPtr).getPosition().inMeters().getCoordinates())
             .normalized();
 
     // Transform direction vector to local orbital frame
     const Vector3d localDirection =
-        Frame::GCRF()->getTransformTo(localOrbitalFrameSPtr, instant).applyToVector(satelliteToTargetDirection);
+        parentFrameSPtr->getTransformTo(localOrbitalFrameSPtr, instant).applyToVector(satelliteToTargetDirection);
 
     const double x = localDirection.x();
     const double y = localDirection.y();

--- a/src/OpenSpaceToolkit/Astrodynamics/Data/Provider/OffNadir.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Data/Provider/OffNadir.cpp
@@ -47,9 +47,10 @@ Tuple<Angle, Angle, Angle> ComputeOffNadirAngles(const State& aState, const Posi
     }
 
     const Instant instant = aState.getInstant();
-
+    const State stateInFrame = aState.inFrame(VVLHFrameFactory->accessParentFrame())
+    
     const Shared<const Frame> localOrbitalFrameSPtr = VVLHFrameFactory->generateFrame(
-        instant, aState.getPosition().getCoordinates(), aState.getVelocity().getCoordinates()
+        instant, stateInFrame.getPosition().getCoordinates(), stateInFrame.getVelocity().getCoordinates()
     );
 
     // Calculate satellite to target direction vector in GCRF frame

--- a/src/OpenSpaceToolkit/Astrodynamics/Data/Provider/OffNadir.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Data/Provider/OffNadir.cpp
@@ -47,7 +47,7 @@ Tuple<Angle, Angle, Angle> ComputeOffNadirAngles(const State& aState, const Posi
     }
 
     const Instant instant = aState.getInstant();
-    const State stateInFrame = aState.inFrame(VVLHFrameFactory->accessParentFrame())
+    const State stateInFrame = aState.inFrame(VVLHFrameFactory->accessParentFrame());
     
     const Shared<const Frame> localOrbitalFrameSPtr = VVLHFrameFactory->generateFrame(
         instant, stateInFrame.getPosition().getCoordinates(), stateInFrame.getVelocity().getCoordinates()


### PR DESCRIPTION
**Context:**

Off Nadir data provider assumes that the State frame is given in the VVLH parent frame (GCRF). Whilst this is likely the case most of the time, it cannot be guaranteed. This results in a "wrong" Local Orbital Frame being built if the State's frame is not GCRF.

**This PR:**

This PR ensures that the State is previously transformed to the VVLH parent frame, before its coordinates are extracted in order to construct the Local Orbital Frame.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the logic for off-nadir angle calculations by improving state transformation and frame utilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->