### PR TITLE
build: bump nlopt dep to from 2.5.0 to 2.9.1

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -72,7 +72,7 @@ RUN git clone https://github.com/dnwrnr/sgp4.git /tmp/sgp4 \
 
 ## NLopt
 
-ARG NLOPT_VERSION="2.5.0"
+ARG NLOPT_VERSION="2.9.1"
 
 RUN git clone --branch v${NLOPT_VERSION} --depth 1 https://github.com/stevengj/nlopt.git /tmp/nlopt \
     && cd /tmp/nlopt \


### PR DESCRIPTION
This bumps nlopt dependency, and fixes an issue encountered when building the development image from scratch, I believe due to the fact that python3.12 and python3.13 are installed now in the base image and nlopt tries to set them up somehow to install its python interface?
Anyways this fixes it, as the whole dev image was rebuilt (without being cached)

Logs from the error:
```
3.152 -- Found PythonInterp: /usr/bin/python3.12 (found version "3.12.8") 
3.158 -- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.12.so (found version "3.12.8") 
3.192 Traceback (most recent call last):
3.192   File "<string>", line 1, in <module>
3.192 ModuleNotFoundError: No module named 'distutils'
3.194 CMake Error at CMakeLists.txt:297 (get_filename_component):
3.194   get_filename_component called with incorrect number of arguments
3.194 
3.194 
3.195 -- Configuring incomplete, errors occurred!
------
Dockerfile:77
--------------------
  76 |     
  77 | >>> RUN git clone --branch v${NLOPT_VERSION} --depth 1 https://github.com/stevengj/nlopt.git /tmp/nlopt \
  78 | >>>     && cd /tmp/nlopt \
  79 | >>>     && mkdir build \
  80 | >>>     && cd build \
  81 | >>>     && cmake -DBUILD_SHARED_LIBS=OFF .. \
  82 | >>>     && make \
  83 | >>>     && make install \
  84 | >>>     && rm -rf /tmp/nlopt
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated NLopt library version in development Docker image from 2.5.0 to 2.9.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->