### PR TITLE
refactor!: FiniteDifferenceSolver interface for computeStateTransitionMatrix

### DIFF
--- a/bindings/python/test/solvers/test_finite_difference_solver.py
+++ b/bindings/python/test/solvers/test_finite_difference_solver.py
@@ -84,11 +84,11 @@ def generate_states_coordinates() -> callable:
             x: float = x0 * math.cos(omega * t) + v0 / omega * math.sin(omega * t)
             v: float = -x0 * omega * math.sin(omega * t) + v0 * math.cos(omega * t)
 
-            coordinates: list[float] = [x, v]
+            coordinates: list[float] = np.array([x, v])
 
             states_coordinates.append(coordinates)
 
-        return np.array(states_coordinates)
+        return np.array(states_coordinates).transpose()
 
     return state_fn
 
@@ -133,15 +133,16 @@ class TestFiniteDifferenceSolver:
         instants: list[Instant],
         generate_states_coordinates: callable,
     ):
-        stm = finite_difference_solver.compute_state_transition_matrix(
+        stms: list[np.ndarray] = finite_difference_solver.compute_state_transition_matrix(
             state=state,
             instants=instants,
             generate_states_coordinates=generate_states_coordinates,
-            coordinates_dimension=2,
         )
-        assert isinstance(stm, np.ndarray)
-        assert stm.shape == (
-            len(state.get_coordinates()) * len(instants),
+
+        assert len(stms) == len(instants)
+
+        assert stms[0].shape == (
+            len(state.get_coordinates()),
             len(state.get_coordinates()),
         )
 
@@ -152,11 +153,10 @@ class TestFiniteDifferenceSolver:
         generate_state_coordinates: callable,
         instant: Instant,
     ):
-        stm = finite_difference_solver.compute_state_transition_matrix(
+        stm: np.ndarray = finite_difference_solver.compute_state_transition_matrix(
             state=state,
             instant=instant,
             generate_state_coordinates=generate_state_coordinates,
-            coordinates_dimension=2,
         )
         assert isinstance(stm, np.ndarray)
         assert stm.shape == (

--- a/include/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.hpp
@@ -90,10 +90,10 @@ class FiniteDifferenceSolver
     /// @param aState A state from which to compute the STMs.
     /// @param anInstantArray An array of instants at which to compute the STMs.
     /// @param generateStatesCoordinates Callable to generate coordinates of States at the
-    /// requested Instants.
+    /// requested Instants. The callable should return a MatrixXd where each column is the coordinates at an instant.
     ///
     /// @return The State Transition Matrices (STMs)
-    MatrixXd computeStateTransitionMatrices(
+    Array<MatrixXd> computeStateTransitionMatrix(
         const State& aState,
         const Array<Instant>& anInstantArray,
         const std::function<MatrixXd(const State&, const Array<Instant>&)>& generateStatesCoordinates
@@ -104,7 +104,7 @@ class FiniteDifferenceSolver
     /// @param aState A state.
     /// @param anInstant An instant.
     /// @param generateStateCoordinates Callable to generate coordinates of a State at the
-    /// requested Instant.
+    /// requested Instant. Must be a column vector.
     /// @return The State Transition Matrix (STM)
     MatrixXd computeStateTransitionMatrix(
         const State& aState,

--- a/include/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.hpp
@@ -64,9 +64,11 @@ class FiniteDifferenceSolver
     /// @brief Output stream operator.
     ///
     /// @param anOutputStream An output stream.
-    /// @param aFiniteDifference A finite difference solver.
+    /// @param aFiniteDifferenceSolver A finite difference solver.
     /// @return An output stream.
-    friend std::ostream& operator<<(std::ostream& anOutputStream, const FiniteDifferenceSolver& aFiniteDifference);
+    friend std::ostream& operator<<(
+        std::ostream& anOutputStream, const FiniteDifferenceSolver& aFiniteDifferenceSolver
+    );
 
     /// @brief Get the Type.
     ///
@@ -83,21 +85,18 @@ class FiniteDifferenceSolver
     /// @return The step duration.
     Duration getStepDuration() const;
 
-    /// @brief Compute the State Transition Matrix (STM) by perturbing the coordinates
+    /// @brief Compute the State Transition Matrices (STMs) by perturbing the coordinates
     ///
-    /// @param aState A state.
-    /// @param anInstantArray An array of instants.
-    /// @param generateStateCoordinates Callable to generate coordinates of States at the
+    /// @param aState A state from which to compute the STMs.
+    /// @param anInstantArray An array of instants at which to compute the STMs.
+    /// @param generateStatesCoordinates Callable to generate coordinates of States at the
     /// requested Instants.
-    /// @param aCoordinatesDimension The dimension of the coordinates produced by
-    /// `generateStateCoordinates`.
     ///
-    /// @return The State Transition Matrix (STM)
-    MatrixXd computeStateTransitionMatrix(
+    /// @return The State Transition Matrices (STMs)
+    MatrixXd computeStateTransitionMatrices(
         const State& aState,
         const Array<Instant>& anInstantArray,
-        const std::function<MatrixXd(const State&, const Array<Instant>&)>& generateStateCoordinates,
-        const Size& aCoordinatesDimension
+        const std::function<MatrixXd(const State&, const Array<Instant>&)>& generateStatesCoordinates
     ) const;
 
     /// @brief Compute the State Transition Matrix (STM) by perturbing the coordinates
@@ -106,14 +105,11 @@ class FiniteDifferenceSolver
     /// @param anInstant An instant.
     /// @param generateStateCoordinates Callable to generate coordinates of a State at the
     /// requested Instant.
-    /// @param aCoordinatesDimension The dimension of the coordinates produced by
-    /// `generateStateCoordinates`.
     /// @return The State Transition Matrix (STM)
     MatrixXd computeStateTransitionMatrix(
         const State& aState,
         const Instant& anInstant,
-        const std::function<VectorXd(const State&, const Instant&)>& generateStateCoordinates,
-        const Size& aCoordinatesDimension
+        const std::function<VectorXd(const State&, const Instant&)>& generateStateCoordinates
     ) const;
 
     /// @brief Compute the gradient.
@@ -130,11 +126,11 @@ class FiniteDifferenceSolver
     /// @brief Compute the Jacobian.
     ///
     /// @param aState The state to compute the Jacobian of.
-    /// @param generateStateDerivatives Callable to generate derivatives of the State.
+    /// @param generateStateCoordinates Callable to generate coordinates of the State.
     ///
     /// @return The Jacobian.
     MatrixXd computeJacobian(
-        const State& aState, const std::function<VectorXd(const State&, const Instant&)>& generateStateDerivatives
+        const State& aState, const std::function<VectorXd(const State&, const Instant&)>& generateStateCoordinates
     ) const;
 
     /// @brief Print the solver.

--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
@@ -659,7 +659,7 @@ Vector5d QLaw::computeNumerical_dQ_dOE(const Vector5d& aCOEVector, const double&
 
     const Vector5d jacobian = Eigen::Map<Vector5d>(
         finiteDifferenceSolver_
-            .computeStateTransitionMatrix(stateBuilder_.build(Instant::J2000(), aCOEVector), Instant::J2000(), getQ, 1)
+            .computeStateTransitionMatrix(stateBuilder_.build(Instant::J2000(), aCOEVector), Instant::J2000(), getQ)
             .data(),
         5
     );

--- a/src/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.cpp
@@ -113,11 +113,7 @@ Array<MatrixXd> FiniteDifferenceSolver::computeStateTransitionMatrix(
                 const MatrixXd backwardCoordinates =
                     generateStatesCoordinates(stateBuilder.build(anInstant, aCoordinateVector), anInstantArray);
 
-                // TBR: returning (forwardCoordinates - backwardCoordinates) / (2.0 * aStepSize) in the lambda returns a
-                // matrix of zeros
-                const MatrixXd differencedCoordinates = (forwardCoordinates - backwardCoordinates) / (2.0 * aStepSize);
-
-                return differencedCoordinates;
+                return (forwardCoordinates - backwardCoordinates) / (2.0 * aStepSize);
             };
             break;
 
@@ -129,8 +125,6 @@ Array<MatrixXd> FiniteDifferenceSolver::computeStateTransitionMatrix(
 
     const Size coordinateDimension = matrixResult.rows();
 
-    MatrixXd A = MatrixXd::Zero(coordinateDimension * numberOfInstants, stateVectorDimension);
-
     Array<MatrixXd> stateTransitionMatrices(
         numberOfInstants, MatrixXd::Zero(coordinateDimension, stateVectorDimension)
     );
@@ -141,15 +135,11 @@ Array<MatrixXd> FiniteDifferenceSolver::computeStateTransitionMatrix(
                                 ? aState.accessCoordinates()(i) * stepPercentage_
                                 : stepPercentage_;
 
-        MatrixXd differencedCoordinates = computeBlock(stepSize, aState.accessCoordinates(), i);
-
-        const VectorXd columnStackedCoordinates =
-            Eigen::Map<VectorXd>(differencedCoordinates.data(), differencedCoordinates.size());
+        const MatrixXd differencedCoordinates = computeBlock(stepSize, aState.accessCoordinates(), i);
 
         for (Index k = 0; k < numberOfInstants; ++k)
         {
-            stateTransitionMatrices[k].col(i) =
-                columnStackedCoordinates.segment(k * coordinateDimension, coordinateDimension);
+            stateTransitionMatrices[k].col(i) = differencedCoordinates.col(k);
         }
     }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.test.cpp
@@ -144,7 +144,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, Getters)
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeStateTransitionMatrices)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeStateTransitionMatrix_MultipleInstants)
 {
     {
         const Array<Instant> instants = {
@@ -153,11 +153,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
             Instant::J2000() + Duration::Seconds(300.0),
         };
 
-        MatrixXd expectedStateTransitionMatrix(2 * instants.getSize(), 2);
+        Array<MatrixXd> expectedStateTransitionMatrices = Array<MatrixXd>::Empty();
+        for (const auto& instant : instants)
+        {
+            const Real t = (instant - Instant::J2000()).inSeconds();
 
-        expectedStateTransitionMatrix << std::cos(100.0), std::sin(100.0), std::sin(-100.0), std::cos(100.0),
-            std::cos(200.0), std::sin(200.0), std::sin(-200.0), std::cos(200.0), std::cos(300.0), std::sin(300.0),
-            std::sin(-300.0), std::cos(300.0);
+            MatrixXd expectedStateTransitionMatrix(2, 2);
+            expectedStateTransitionMatrix << std::cos(t), std::sin(t), std::sin(-t), std::cos(t);
+
+            expectedStateTransitionMatrices.add(expectedStateTransitionMatrix);
+        }
 
         {
             const FiniteDifferenceSolver solver = {
@@ -165,10 +170,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
                 defaultStepPercentage_,
                 defaultStepDuration_,
             };
-            const MatrixXd jacobian =
-                solver.computeStateTransitionMatrix(initialState_, instants, generateStatesCoordinates_, 2);
+            const Array<MatrixXd> stationTransitionMatrices =
+                solver.computeStateTransitionMatrix(initialState_, instants, generateStatesCoordinates_);
 
-            EXPECT_TRUE(jacobian.isApprox(expectedStateTransitionMatrix, 1e-12));
+            EXPECT_EQ(stationTransitionMatrices.getSize(), instants.getSize());
+            for (Size i = 0; i < instants.getSize(); ++i)
+            {
+                EXPECT_TRUE(stationTransitionMatrices[i].isApprox(expectedStateTransitionMatrices[i], 1e-12));
+            }
         }
 
         {
@@ -177,9 +186,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
                 defaultStepPercentage_,
                 defaultStepDuration_,
             };
-            const MatrixXd jacobian =
-                solver.computeStateTransitionMatrix(initialState_, instants, generateStatesCoordinates_, 2);
-            EXPECT_TRUE(jacobian.isApprox(expectedStateTransitionMatrix, 1e-12));
+            const Array<MatrixXd> stationTransitionMatrices =
+                solver.computeStateTransitionMatrix(initialState_, instants, generateStatesCoordinates_);
+
+            EXPECT_EQ(stationTransitionMatrices.getSize(), instants.getSize());
+            for (Size i = 0; i < instants.getSize(); ++i)
+            {
+                EXPECT_TRUE(stationTransitionMatrices[i].isApprox(expectedStateTransitionMatrices[i], 1e-12));
+            }
         }
 
         {
@@ -188,9 +202,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
                 defaultStepPercentage_,
                 defaultStepDuration_,
             };
-            const MatrixXd jacobian =
-                solver.computeStateTransitionMatrix(initialState_, instants, generateStatesCoordinates_, 2);
-            EXPECT_TRUE(jacobian.isApprox(expectedStateTransitionMatrix, 1e-12));
+            const Array<MatrixXd> stationTransitionMatrices =
+                solver.computeStateTransitionMatrix(initialState_, instants, generateStatesCoordinates_);
+
+            EXPECT_EQ(stationTransitionMatrices.getSize(), instants.getSize());
+            for (Size i = 0; i < instants.getSize(); ++i)
+            {
+                EXPECT_TRUE(stationTransitionMatrices[i].isApprox(expectedStateTransitionMatrices[i], 1e-12));
+            }
         }
     }
 }
@@ -198,10 +217,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
 TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeStateTransitionMatrix)
 {
     {
-        const Instant instant = Instant::J2000() + Duration::Seconds(100.0);
+        const Real t = 100.0;
+        const Instant instant = Instant::J2000() + Duration::Seconds(t);
 
         MatrixXd expectedStateTransitionMatrix(2, 2);
-        expectedStateTransitionMatrix << std::cos(100.0), std::sin(100.0), std::sin(-100.0), std::cos(100.0);
+        expectedStateTransitionMatrix << std::cos(t), std::sin(t), std::sin(-t), std::cos(t);
 
         {
             const FiniteDifferenceSolver solver = {
@@ -210,7 +230,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
                 defaultStepDuration_,
             };
             const MatrixXd stateTransitionMatrix =
-                solver.computeStateTransitionMatrix(initialState_, instant, generateStateCoordinates_, 2);
+                solver.computeStateTransitionMatrix(initialState_, instant, generateStateCoordinates_);
 
             EXPECT_TRUE(stateTransitionMatrix.isApprox(expectedStateTransitionMatrix, 1e-12));
         }
@@ -222,7 +242,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
                 defaultStepDuration_,
             };
             const MatrixXd stateTransitionMatrix =
-                solver.computeStateTransitionMatrix(initialState_, instant, generateStateCoordinates_, 2);
+                solver.computeStateTransitionMatrix(initialState_, instant, generateStateCoordinates_);
 
             EXPECT_TRUE(stateTransitionMatrix.isApprox(expectedStateTransitionMatrix, 1e-12));
         }
@@ -234,7 +254,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
                 defaultStepDuration_,
             };
             const MatrixXd stateTransitionMatrix =
-                solver.computeStateTransitionMatrix(initialState_, instant, generateStateCoordinates_, 2);
+                solver.computeStateTransitionMatrix(initialState_, instant, generateStateCoordinates_);
 
             EXPECT_TRUE(stateTransitionMatrix.isApprox(expectedStateTransitionMatrix, 1e-12));
         }

--- a/test/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.test.cpp
@@ -144,7 +144,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, Getters)
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeStateTransitionMatrix)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeStateTransitionMatrices)
 {
     {
         const Array<Instant> instants = {
@@ -193,7 +193,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeSta
             EXPECT_TRUE(jacobian.isApprox(expectedStateTransitionMatrix, 1e-12));
         }
     }
+}
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, computeStateTransitionMatrix)
+{
     {
         const Instant instant = Instant::J2000() + Duration::Seconds(100.0);
 
@@ -357,30 +360,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, ComputeGra
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, Print)
-{
-    {
-        testing::internal::CaptureStdout();
-
-        EXPECT_NO_THROW(defaultSolver_.print(std::cout, true));
-        EXPECT_NO_THROW(defaultSolver_.print(std::cout, false));
-
-        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
-    }
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, StringFromType)
-{
-    EXPECT_EQ("Central", FiniteDifferenceSolver::StringFromType(FiniteDifferenceSolver::Type::Central));
-    EXPECT_EQ("Forward", FiniteDifferenceSolver::StringFromType(FiniteDifferenceSolver::Type::Forward));
-    EXPECT_EQ("Backward", FiniteDifferenceSolver::StringFromType(FiniteDifferenceSolver::Type::Backward));
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, Default)
-{
-    EXPECT_NO_THROW(FiniteDifferenceSolver::Default());
-}
-
 TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, ComputeJacobian)
 {
     const State state = {
@@ -520,4 +499,28 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, ComputeJac
 
         EXPECT_TRUE(jacobian.isApprox(expectedJacobian, 1e-3));
     }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, Print)
+{
+    {
+        testing::internal::CaptureStdout();
+
+        EXPECT_NO_THROW(defaultSolver_.print(std::cout, true));
+        EXPECT_NO_THROW(defaultSolver_.print(std::cout, false));
+
+        EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, StringFromType)
+{
+    EXPECT_EQ("Central", FiniteDifferenceSolver::StringFromType(FiniteDifferenceSolver::Type::Central));
+    EXPECT_EQ("Forward", FiniteDifferenceSolver::StringFromType(FiniteDifferenceSolver::Type::Forward));
+    EXPECT_EQ("Backward", FiniteDifferenceSolver::StringFromType(FiniteDifferenceSolver::Type::Backward));
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, Default)
+{
+    EXPECT_NO_THROW(FiniteDifferenceSolver::Default());
 }


### PR DESCRIPTION
- return an array of STMs rather than one big matrix, more intuitive interface
- fix jacobian/STM typos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `FiniteDifferenceSolver` to compute multiple state transition matrices across different instants.
  - Improved computational capabilities for numerical derivatives and Jacobian calculations.

- **Documentation**
  - Updated class and method documentation for `FiniteDifferenceSolver`.
  - Clarified parameter descriptions and method behaviors.

- **Bug Fixes**
  - Refined method signatures to improve clarity and usability.
  - Simplified computational logic for state transition matrix calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->