### PR TITLE
chore: add convenience method for total size of state builder

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
         "StateBuilder",
         R"doc(
             This class makes it convenient to build a `State` object.
-        
+
         )doc"
     )
 
@@ -37,7 +37,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                     coordinate_subsets list[CoordinateSubset]: The coordinate subsets.
 
                 Returns:
-                    StateBuilder 
+                    StateBuilder
 
             )doc"
         )
@@ -68,7 +68,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder: The new `StateBuilder` object.
-                
+
             )doc"
         )
 
@@ -79,7 +79,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     bool: True if the two `StateBuilder` objects are equal, False otherwise.
-            
+
             )doc"
         )
         .def(
@@ -203,6 +203,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                 Returns:
                     Array<Shared<const CoordinateSubset>>: The coordinate subsets of the `StateBuilder`.
 
+            )doc"
+        )
+        .def(
+            "get_size",
+            &StateBuilder::getSize,
+            R"doc(
+                Get the total size of all coordinates from all subsets.
+
+                Returns:
+                    Size: The total size of all coordinates from all subsets.
             )doc"
         )
         .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -21,7 +21,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
         "StateBuilder",
         R"doc(
             This class makes it convenient to build a `State` object.
-
         )doc"
     )
 
@@ -38,7 +37,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder
-
             )doc"
         )
         .def(
@@ -54,7 +52,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder: The new `StateBuilder` object.
-
             )doc"
         )
         .def(
@@ -68,7 +65,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder: The new `StateBuilder` object.
-
             )doc"
         )
 
@@ -79,7 +75,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     bool: True if the two `StateBuilder` objects are equal, False otherwise.
-
             )doc"
         )
         .def(
@@ -89,7 +84,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     bool: True if the two `StateBuilder` objects are not equal, False otherwise.
-
             )doc"
         )
         .def(
@@ -107,7 +101,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder: The `StateBuilder` with the added coordinate subset.
-
             )doc"
         )
         .def(
@@ -125,7 +118,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder: The `StateBuilder` with the removed coordinate subset.
-
             )doc"
         )
 
@@ -140,7 +132,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     bool: True if the `StateBuilder` is defined, False otherwise.
-
             )doc"
         )
 
@@ -158,7 +149,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     State: The `State` object built from the `StateBuilder`.
-
             )doc"
         )
         .def(
@@ -173,7 +163,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder: The `StateBuilder` object reduced from the `State`.
-
             )doc"
         )
         .def(
@@ -190,7 +179,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     StateBuilder: The `StateBuilder` object expanded from the `State`.
-
             )doc"
         )
 
@@ -202,7 +190,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     Array<Shared<const CoordinateSubset>>: The coordinate subsets of the `StateBuilder`.
-
             )doc"
         )
         .def(
@@ -223,7 +210,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     CoordinateBroker: The coordinate broker of the `StateBuilder`.
-
             )doc"
         )
         .def(
@@ -234,7 +220,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Returns:
                     Frame: The reference frame of the `StateBuilder`.
-
             )doc"
         )
 

--- a/bindings/python/test/trajectory/test_state_builder.py
+++ b/bindings/python/test/trajectory/test_state_builder.py
@@ -169,3 +169,4 @@ class TestStateBuilder:
     ):
         assert state_builder.get_frame() == frame
         assert state_builder.get_coordinate_subsets() == coordinate_broker.get_subsets()
+        assert state_builder.get_size() == coordinate_broker.get_number_of_coordinates()

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp
@@ -141,6 +141,11 @@ class StateBuilder
     /// @return The coordinate subsets
     const Array<Shared<const CoordinateSubset>> getCoordinateSubsets() const;
 
+    /// @brief Get the total size of all coordinates from all subsets.
+    ///
+    /// @return The total size of all coordinates from all subsets
+    Size getSize() const;
+
     /// @brief Print the StateBuilder to an output stream.
     ///
     /// @param anOutputStream The output stream to print to

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -258,6 +258,16 @@ const Array<Shared<const CoordinateSubset>> StateBuilder::getCoordinateSubsets()
     return this->coordinatesBrokerSPtr_->getSubsets();
 }
 
+Size StateBuilder::getSize() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("StateBuilder");
+    }
+
+    return this->coordinatesBrokerSPtr_->getNumberOfCoordinates();
+}
+
 void StateBuilder::print(std::ostream& anOutputStream, bool displayDecorator) const
 {
     using ostk::core::type::String;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -611,11 +611,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Getters)
         const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
 
         EXPECT_EQ(stateBuilder.getCoordinateSubsets(), posVelBrokerSPtr->getSubsets());
+        EXPECT_EQ(stateBuilder.getTotalCoordinateSize(), posVelBrokerSPtr->getNumberOfCoordinates());
         EXPECT_EQ(Frame::GCRF(), stateBuilder.getFrame());
     }
 
     {
         EXPECT_ANY_THROW(StateBuilder::Undefined().getCoordinateSubsets());
+        EXPECT_ANY_THROW(StateBuilder::Undefined().getSize());
         EXPECT_ANY_THROW(StateBuilder::Undefined().getFrame());
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.test.cpp
@@ -611,7 +611,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_StateBuilder, Getters)
         const StateBuilder stateBuilder = StateBuilder(Frame::GCRF(), posVelBrokerSPtr);
 
         EXPECT_EQ(stateBuilder.getCoordinateSubsets(), posVelBrokerSPtr->getSubsets());
-        EXPECT_EQ(stateBuilder.getTotalCoordinateSize(), posVelBrokerSPtr->getNumberOfCoordinates());
+        EXPECT_EQ(stateBuilder.getSize(), posVelBrokerSPtr->getNumberOfCoordinates());
         EXPECT_EQ(Frame::GCRF(), stateBuilder.getFrame());
     }
 


### PR DESCRIPTION
Avoids having to loop through all coordinate subsets and accumulate their sizes each time.
It also avoids the necessity of accessing the underlying coordinate broker, since at some point I believe we will remove it from the API and have it just be something intenral.

Example inconvenience that this helps alleviate:
```
Size totalSize = 0;
for (const auto& subset : stateSubsets)
{
    totalSize += subset->getSize();
}
```

or 
```
Size totalSize = stateBuilder.accessCoordinateBroker.getNumerOfCoordinates()
```

I called it `.getSize` because that is what the equivalent method in the `State` class does

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `get_size()` method to `StateBuilder` class to retrieve total coordinate size.

- **Tests**
  - Enhanced test coverage for `StateBuilder` class.
  - Added assertions to validate `get_size()` method functionality.
  - Verified error handling for undefined `StateBuilder` instances.

- **Documentation**
  - Updated method signatures with explicit return type annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->