### PR TITLE
build: loosen boost req to 1.82, bump physics to 12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,9 +335,9 @@ IF (NOT OpenSpaceToolkitMathematics_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Physics [11.x.y]
+### Open Space Toolkit ▸ Physics [12.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "11" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "12" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ ENDFOREACH ()
 
 ## Dependencies
 
-### Boost [1.87.0]
+### Boost [1.82.0]
 
 IF (BUILD_WITH_BOOST_STATIC)
     SET (Boost_USE_STATIC_LIBS ON)
@@ -248,7 +248,7 @@ ENDIF ()
 
 SET (Boost_USE_MULTITHREADED ON)
 
-FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS log log_setup thread)
+FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS log log_setup thread)
 
 IF (BUILD_WITH_BOOST_STACKTRACE)
 ## Stacktrace definitions

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,4 +3,4 @@
 open-space-toolkit-core~=5.0
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3
-open-space-toolkit-physics~=11.2
+open-space-toolkit-physics~=12.0

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -148,7 +148,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG TARGETPLATFORM
-ARG OSTK_PHYSICS_MAJOR="11"
+ARG OSTK_PHYSICS_MAJOR="12"
 
 ## Force an image rebuild when new Physics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR} /tmp/open-space-toolkit-physics/versions.json


### PR DESCRIPTION
See https://github.com/open-space-collective/open-space-toolkit-core/pull/187

Also bumps Physics dependency to v12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated Boost library version from 1.87.0 to 1.82.0
	- Updated Open Space Toolkit Physics dependency to version 12.x.y across multiple configuration files
	- Modified Python requirements to use the new physics toolkit version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->