### PR TITLE
fix: elevation interval was missing in trajectory based access computation

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/VisibilityCriterion.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/VisibilityCriterion.cpp
@@ -18,12 +18,16 @@ void OpenSpaceToolkitAstrodynamicsPy_Access_VisibilityCriterion(pybind11::module
 {
     using namespace pybind11;
 
-    using ostk::astrodynamics::access::VisibilityCriterion;
     using ostk::core::container::Map;
     using ostk::core::type::Real;
+
     using ostk::mathematics::object::Interval;
+
     using ostk::physics::coordinate::spherical::AER;
     using ostk::physics::Environment;
+    using ostk::physics::unit::Angle;
+
+    using ostk::astrodynamics::access::VisibilityCriterion;
 
     class_<VisibilityCriterion> visibilityCriterionClass(
         aModule,
@@ -250,13 +254,27 @@ void OpenSpaceToolkitAstrodynamicsPy_Access_VisibilityCriterion(pybind11::module
         )
         .def(
             "is_satisfied",
-            &VisibilityCriterion::ElevationInterval::isSatisfied,
+            overload_cast<const Real&>(&VisibilityCriterion::ElevationInterval::isSatisfied, const_),
             arg("elevation"),
             R"doc(
                 Checks if the given elevation angle satisfies the criterion.
 
                 Args:
                     elevation (float): Elevation angle in radians.
+
+                Returns:
+                    bool: True if the criterion is satisfied, False otherwise.
+            )doc"
+        )
+        .def(
+            "is_satisfied",
+            overload_cast<const Angle&>(&VisibilityCriterion::ElevationInterval::isSatisfied, const_),
+            arg("elevation"),
+            R"doc(
+                Checks if the given elevation angle satisfies the criterion.
+
+                Args:
+                    elevation (Angle): Elevation angle.
 
                 Returns:
                     bool: True if the criterion is satisfied, False otherwise.

--- a/bindings/python/test/access/test_visibility_criterion.py
+++ b/bindings/python/test/access/test_visibility_criterion.py
@@ -9,6 +9,7 @@ from ostk.physics import Environment
 from ostk.physics.time import Instant
 from ostk.physics.time import DateTime
 from ostk.physics.time import Scale
+from ostk.physics.unit import Angle
 
 from ostk.astrodynamics.access import VisibilityCriterion
 
@@ -152,9 +153,11 @@ class TestVisibilityCriterion:
         elevation_criterion = VisibilityCriterion.ElevationInterval(elevation_interval)
         elevation_valid = np.pi / 8  # 22.5 degrees
         assert elevation_criterion.is_satisfied(elevation_valid) is True
+        assert elevation_criterion.is_satisfied(Angle.radians(elevation_valid)) is True
 
         elevation_invalid = np.pi / 2  # 90 degrees
         assert elevation_criterion.is_satisfied(elevation_invalid) is False
+        assert elevation_criterion.is_satisfied(Angle.radians(elevation_invalid)) is False
 
     def test_line_of_sight_is_satisfied(
         self,

--- a/include/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.hpp
@@ -16,6 +16,7 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Spherical/AER.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
 
 namespace ostk
 {
@@ -33,6 +34,7 @@ using ostk::mathematics::object::Vector3d;
 using ostk::physics::coordinate::spherical::AER;
 using ostk::physics::Environment;
 using ostk::physics::time::Instant;
+using ostk::physics::unit::Angle;
 
 /// @brief Represents a visibility criterion for accesses between objects.
 class VisibilityCriterion
@@ -160,6 +162,12 @@ class VisibilityCriterion
         ///
         /// @param anElevationInterval The elevation interval.
         ElevationInterval(const Interval<Real>& anElevationInterval);
+
+        /// @brief Checks if the given elevation angle satisfies the criterion.
+        ///
+        /// @param anElevationAngle The elevation angle.
+        /// @return True if the criterion is satisfied.
+        bool isSatisfied(const Angle& anElevationAngle) const;
 
         /// @brief Checks if the given elevation angle satisfies the criterion.
         ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -252,6 +252,13 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
             return visibilityCriterion.as<VisibilityCriterion::AERInterval>().value().isSatisfied(aer);
         }
 
+        if (visibilityCriterion.is<VisibilityCriterion::ElevationInterval>())
+        {
+            return visibilityCriterion.as<VisibilityCriterion::ElevationInterval>().value().isSatisfied(
+                aer.getElevation()
+            );
+        }
+
         return false;
     };
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/ElevationInterval.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/ElevationInterval.cpp
@@ -28,6 +28,11 @@ VisibilityCriterion::ElevationInterval::ElevationInterval(const Interval<Real>& 
     );
 }
 
+bool VisibilityCriterion::ElevationInterval::isSatisfied(const Angle& anElevationAngle) const
+{
+    return this->elevation.contains(anElevationAngle.inRadians());
+}
+
 bool VisibilityCriterion::ElevationInterval::isSatisfied(const Real& anElevation) const
 {
     return this->elevation.contains(anElevation);

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
@@ -472,20 +472,38 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, LineOfSightIsS
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, ElevationIntervalIsSatisfied)
 {
+    const Interval<Real> elevationInterval = Interval<Real>::Closed(10.0, 80.0);
+
+    const VisibilityCriterion visibilityCriterion = VisibilityCriterion::FromElevationInterval(elevationInterval);
+
+    const auto elevationIntervalCriterion = visibilityCriterion.as<VisibilityCriterion::ElevationInterval>();
+    ASSERT_TRUE(elevationIntervalCriterion.has_value());
+
     {
-        const Interval<Real> elevationInterval = Interval<Real>::Closed(10.0, 80.0);
+        {
+            const Real elevation = 45.0 * deg2rad;
 
-        const VisibilityCriterion visibilityCriterion = VisibilityCriterion::FromElevationInterval(elevationInterval);
+            EXPECT_TRUE(elevationIntervalCriterion.value().isSatisfied(elevation));
+        }
 
-        const auto elevationIntervalCriterion = visibilityCriterion.as<VisibilityCriterion::ElevationInterval>();
-        ASSERT_TRUE(elevationIntervalCriterion.has_value());
+        {
+            const Real elevationOutside = 5.0 * deg2rad;
 
-        const Real elevation = 45.0 * deg2rad;
+            EXPECT_FALSE(elevationIntervalCriterion.value().isSatisfied(elevationOutside));
+        }
+    }
 
-        EXPECT_TRUE(elevationIntervalCriterion.value().isSatisfied(elevation));
+    {
+        {
+            const Angle elevation = Angle::Degrees(45.0);
 
-        const Real elevationOutside = 5.0 * deg2rad;
+            EXPECT_TRUE(elevationIntervalCriterion.value().isSatisfied(elevation));
+        }
 
-        EXPECT_FALSE(elevationIntervalCriterion.value().isSatisfied(elevationOutside));
+        {
+            const Angle elevationOutside = Angle::Degrees(5.0);
+
+            EXPECT_FALSE(elevationIntervalCriterion.value().isSatisfied(elevationOutside));
+        }
     }
 }


### PR DESCRIPTION
Stumbled across this bug when doing some testing in python. The `ElevationInterval` based check was missing if the access computation was for a Trajectory typed target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Extended elevation interval functionality to directly evaluate elevation using angle measurements.
	- Enhanced access condition logic by incorporating elevation-based visibility criteria.

- **Bug Fixes**
	- Resolved a regression where accesses for fixed targets were miscomputed when elevation intervals were applied.

- **Tests**
	- Added and refined test cases to validate the improved elevation interval handling with clearer and more intuitive unit representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->