### PR TITLE
fix: skip importing coordinates that are none in State.from_dict

### DIFF
--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -180,7 +180,7 @@ class TestState:
         assert custom_state is not state
 
     def test_from_dict_with_eci_coordinates(self):
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc),
             "rx_eci": 7000.0,
             "ry_eci": 0.0,
@@ -198,7 +198,7 @@ class TestState:
         assert state.get_size() == 6
 
     def test_from_dict_with_ecef_coordinates(self):
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx_ecef": 7000.0,
             "ry_ecef": 0.0,
@@ -216,7 +216,7 @@ class TestState:
         assert state.get_size() == 6
 
     def test_from_dict_with_generic_coordinates(self):
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx": 7000.0,
             "ry": 0.0,
@@ -237,7 +237,7 @@ class TestState:
         with pytest.raises(
             ValueError, match="Frame must be provided for generic columns."
         ):
-            data = {
+            data: dict = {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "rx": 7000.0,
                 "ry": 0.0,
@@ -250,7 +250,7 @@ class TestState:
             State.from_dict(data)
 
         with pytest.raises(ValueError, match="No frame exists with name \\[RANDOM\\]."):
-            data = {
+            data: dict = {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "rx": 7000.0,
                 "ry": 0.0,
@@ -264,7 +264,7 @@ class TestState:
             State.from_dict(data)
 
         with pytest.raises(ValueError, match="Invalid frame data \\[123\\]"):
-            data = {
+            data: dict = {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "rx": 7000.0,
                 "ry": 0.0,
@@ -278,7 +278,7 @@ class TestState:
             State.from_dict(data)
 
     def test_from_dict_with_attitude_quaternion(self):
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx_eci": 7000.0,
             "ry_eci": 0.0,
@@ -300,7 +300,7 @@ class TestState:
         assert state.get_size() == 10
 
     def test_from_dict_with_angular_velocity(self):
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx_eci": 7000.0,
             "ry_eci": 0.0,
@@ -320,7 +320,7 @@ class TestState:
         assert state.get_size() == 9
 
     def test_from_dict_with_drag_coefficient(self):
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx_eci": 7000.0,
             "ry_eci": 0.0,
@@ -337,7 +337,7 @@ class TestState:
         assert isinstance(state, State)
         assert state.get_size() == 7
 
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx_eci": 7000.0,
             "ry_eci": 0.0,
@@ -354,8 +354,25 @@ class TestState:
         assert isinstance(state, State)
         assert state.get_size() == 7
 
+        data: dict = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "rx_eci": 7000.0,
+            "ry_eci": 0.0,
+            "rz_eci": 0.0,
+            "vx_eci": 0.0,
+            "vy_eci": 7.5,
+            "vz_eci": 0.0,
+            "drag_coefficient": None,
+        }
+
+        state: State = State.from_dict(data)
+
+        assert state is not None
+        assert isinstance(state, State)
+        assert state.get_size() == 6
+
     def test_from_dict_with_surface_area(self):
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx_eci": 7000.0,
             "ry_eci": 0.0,
@@ -372,7 +389,7 @@ class TestState:
         assert isinstance(state, State)
         assert state.get_size() == 7
 
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx_eci": 7000.0,
             "ry_eci": 0.0,
@@ -389,8 +406,25 @@ class TestState:
         assert isinstance(state, State)
         assert state.get_size() == 7
 
+        data: dict = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "rx_eci": 7000.0,
+            "ry_eci": 0.0,
+            "rz_eci": 0.0,
+            "vx_eci": 0.0,
+            "vy_eci": 7.5,
+            "vz_eci": 0.0,
+            "cross_sectional_area": None,
+        }
+
+        state: State = State.from_dict(data)
+
+        assert state is not None
+        assert isinstance(state, State)
+        assert state.get_size() == 6
+
     def test_from_dict_with_mass(self):
-        data = {
+        data: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "rx_eci": 7000.0,
             "ry_eci": 0.0,
@@ -406,6 +440,23 @@ class TestState:
         assert state is not None
         assert isinstance(state, State)
         assert state.get_size() == 7
+
+        data: dict = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "rx_eci": 7000.0,
+            "ry_eci": 0.0,
+            "rz_eci": 0.0,
+            "vx_eci": 0.0,
+            "vy_eci": 7.5,
+            "vz_eci": 0.0,
+            "mass": None,
+        }
+
+        state: State = State.from_dict(data)
+
+        assert state is not None
+        assert isinstance(state, State)
+        assert state.get_size() == 6
 
     @pytest.mark.parametrize(
         ("data", "expected_length", "expected_frame"),

--- a/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/pytrajectory/pystate.py
@@ -216,21 +216,23 @@ def from_dict(data: dict) -> State:
             ],
         )
 
-    if "drag_coefficient" in data or "cd" in data:
+    if (data.get("drag_coefficient") is not None) or (data.get("cd") is not None):
         coordinate_subsets.append(CoordinateSubset.drag_coefficient())
         coordinates = np.append(
             coordinates,
             data.get("drag_coefficient", data.get("cd")),
         )
 
-    if "cross_sectional_area" in data or "surface_area" in data:
+    if (data.get("cross_sectional_area") is not None) or (
+        data.get("surface_area") is not None
+    ):
         coordinate_subsets.append(CoordinateSubset.surface_area())
         coordinates = np.append(
             coordinates,
             data.get("cross_sectional_area", data.get("surface_area")),
         )
 
-    if "mass" in data:
+    if data.get("mass") is not None:
         coordinate_subsets.append(CoordinateSubset.mass())
         coordinates = np.append(
             coordinates,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the processing of optional input data to ensure more robust and consistent state creation.
  
- **Tests**
  - Expanded test coverage, including new scenarios when certain optional parameters are absent, to validate accurate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->