### PR TITLE
fix: missing binding get_provider_type for LocalOrbitalFrameFactory

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/LocalOrbitalFrameFactory.cpp
@@ -51,6 +51,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_LocalOrbitalFrameFactory(
         )
 
         .def(
+            "get_provider_type",
+            &LocalOrbitalFrameFactory::getProviderType,
+            R"doc(
+                Get the provider type.
+
+                Returns:
+                    LocalOrbitalFrameTransformProvider.Type: The provider type.
+            )doc"
+        )
+
+        .def(
             "generate_frame",
             &LocalOrbitalFrameFactory::generateFrame,
             arg("state"),

--- a/bindings/python/test/trajectory/test_local_orbital_frame_factory.py
+++ b/bindings/python/test/trajectory/test_local_orbital_frame_factory.py
@@ -78,6 +78,7 @@ class TestLocalOrbitalFrameFactory:
         local_orbital_frame_factory: LocalOrbitalFrameFactory,
     ):
         assert parent_frame == local_orbital_frame_factory.access_parent_frame()
+        assert local_orbital_frame_factory.get_provider_type() is not None
 
     def test_generate_frame(
         self,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the local orbital frame functionality by adding a method to retrieve provider type information, offering users access to additional details for their orbital frame operations.
  
- **Tests**
  - Improved test coverage to ensure that the new provider type retrieval consistently returns valid information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->