### PR TITLE
chore: rename groundTarget to accessTarget

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -336,9 +336,7 @@ Array<Array<Access>> Generator::computeAccesses(
 
         for (const auto& accessTarget : someAccessTargets)
         {
-            accessesPerTarget.add(
-                this->computeAccessesForTrajectoryTarget(anInterval, accessTarget, aToTrajectory)
-            );
+            accessesPerTarget.add(this->computeAccessesForTrajectoryTarget(anInterval, accessTarget, aToTrajectory));
         }
 
         return accessesPerTarget;

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -334,10 +334,10 @@ Array<Array<Access>> Generator::computeAccesses(
         Array<Array<Access>> accessesPerTarget;
         accessesPerTarget.reserve(someAccessTargets.getSize());
 
-        for (const auto& groundTargetConfiguration : someAccessTargets)
+        for (const auto& accessTarget : someAccessTargets)
         {
             accessesPerTarget.add(
-                this->computeAccessesForTrajectoryTarget(anInterval, groundTargetConfiguration, aToTrajectory)
+                this->computeAccessesForTrajectoryTarget(anInterval, accessTarget, aToTrajectory)
             );
         }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -962,7 +962,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses)
                 const AccessTarget accessTarget = accessTargets.at(i);
 
                 const Array<Access> expectedAccesses =
-                    defaultGenerator_.computeAccesses(interval, accessTarget, aToTrajectory);
+                    defaultGenerator_.computeAccesses(interval, accessTarget, toTrajectory);
 
                 ASSERT_EQ(accesses.getSize(), expectedAccesses.getSize());
 
@@ -1016,7 +1016,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses)
                 const AccessTarget accessTarget = accessTargets.at(i);
 
                 const Array<Access> expectedAccesses =
-                    defaultGenerator_.computeAccesses(interval, accessTarget, aToTrajectory);
+                    defaultGenerator_.computeAccesses(interval, accessTarget, toTrajectory);
 
                 ASSERT_EQ(accesses.getSize(), expectedAccesses.getSize());
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -959,10 +959,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses)
             for (Index i = 0; i < accessesPerTarget.getSize(); ++i)
             {
                 const Array<Access> accesses = accessesPerTarget.at(i);
-                const AccessTarget groundTarget = accessTargets.at(i);
+                const AccessTarget accessTarget = accessTargets.at(i);
 
                 const Array<Access> expectedAccesses =
-                    defaultGenerator_.computeAccesses(interval, groundTarget, toTrajectory);
+                    defaultGenerator_.computeAccesses(interval, accessTarget, aToTrajectory);
 
                 ASSERT_EQ(accesses.getSize(), expectedAccesses.getSize());
 
@@ -1013,10 +1013,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses)
             for (Index i = 0; i < accessesPerTarget.getSize(); ++i)
             {
                 const Array<Access> accesses = accessesPerTarget.at(i);
-                const AccessTarget groundTarget = accessTargets.at(i);
+                const AccessTarget accessTarget = accessTargets.at(i);
 
                 const Array<Access> expectedAccesses =
-                    defaultGenerator_.computeAccesses(interval, groundTarget, toTrajectory);
+                    defaultGenerator_.computeAccesses(interval, accessTarget, aToTrajectory);
 
                 ASSERT_EQ(accesses.getSize(), expectedAccesses.getSize());
 


### PR DESCRIPTION
Small variable rename, because `groundTarget` was a) probably a holdover from the previous version of this code and b) is confusing, especially in the generator.cpp because it is actually referring to a trajectory target which aren't on the ground

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal variable naming for enhanced clarity and consistency across the system and its tests. These cosmetic improvements do not affect functionality or the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->