### PR TITLE
fix: remove zero duration access interval padding

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -403,9 +403,9 @@ Array<Access> Generator::computeAccessesForTrajectoryTarget(
     const Array<physics::time::Interval> accessIntervals =
         temporalConditionSolver.solve(this->getConditionFunction(anAccessTarget, aToTrajectory), anInterval);
 
-    const Trajectory& aFromTrajectory = anAccessTarget.accessTrajectory();
+    const Trajectory& fromTrajectory = anAccessTarget.accessTrajectory();
 
-    return generateAccessesFromIntervals(accessIntervals, anInterval, aFromTrajectory, aToTrajectory);
+    return generateAccessesFromIntervals(accessIntervals, anInterval, fromTrajectory, aToTrajectory);
 }
 
 Array<Array<Access>> Generator::computeAccessesForFixedTargets(
@@ -933,18 +933,10 @@ Access Generator::GenerateAccess(
 
     const Instant acquisitionOfSignal = anAccessInterval.getStart();
 
-    ostk::physics::time::Interval accessInterval = anAccessInterval;
-
-    if (anAccessInterval.getDuration() == Duration::Zero())
-    {
-        accessInterval = physics::time::Interval::Closed(
-            anAccessInterval.getStart() - Duration::Seconds(60.0), anAccessInterval.getStart() + Duration::Seconds(60.0)
-        );
-    }
-
     const Instant timeOfClosestApproach =
-        Generator::FindTimeOfClosestApproach(accessInterval, aFromTrajectory, aToTrajectory, aTolerance);
-    const Instant lossOfSignal = accessInterval.getEnd();
+        Generator::FindTimeOfClosestApproach(anAccessInterval, aFromTrajectory, aToTrajectory, aTolerance);
+
+    const Instant lossOfSignal = anAccessInterval.getEnd();
 
     if (!timeOfClosestApproach.isDefined() and type == Access::Type::Complete)
     {

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -943,8 +943,8 @@ Access Generator::GenerateAccess(
     }
 
     const Instant timeOfClosestApproach =
-        Generator::FindTimeOfClosestApproach(anAccessInterval, aFromTrajectory, aToTrajectory, aTolerance);
-    const Instant lossOfSignal = anAccessInterval.getEnd();
+        Generator::FindTimeOfClosestApproach(accessInterval, aFromTrajectory, aToTrajectory, aTolerance);
+    const Instant lossOfSignal = accessInterval.getEnd();
 
     if (!timeOfClosestApproach.isDefined() and type == Access::Type::Complete)
     {


### PR DESCRIPTION
Turns out we don't need to check for a zero interval here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined how access intervals are processed, ensuring more direct and predictable generation of access windows.
  - Enhanced clarity in trajectory input handling for improved maintainability and consistency of results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->