### PR TITLE
style: re-run format with clang 18

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics.cpp
@@ -56,9 +56,8 @@ class PyDynamics : public Dynamics
         );
     }
 
-    VectorXd computeContribution(
-        const Instant& anInstant, const VectorXd& x, const Shared<const Frame>& aFrameSPtr
-    ) const override
+    VectorXd computeContribution(const Instant& anInstant, const VectorXd& x, const Shared<const Frame>& aFrameSPtr)
+        const override
     {
         PYBIND11_OVERRIDE_PURE_NAME(
             VectorXd, Dynamics, "compute_contribution", computeContribution, anInstant, x, aFrameSPtr

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Dynamics/Thruster.cpp
@@ -52,9 +52,8 @@ class PyThruster : public Thruster
         );
     }
 
-    VectorXd computeContribution(
-        const Instant& anInstant, const VectorXd& x, const Shared<const Frame>& aFrameSPtr
-    ) const override
+    VectorXd computeContribution(const Instant& anInstant, const VectorXd& x, const Shared<const Frame>& aFrameSPtr)
+        const override
     {
         PYBIND11_OVERRIDE_PURE_NAME(
             VectorXd, Thruster, "compute_contribution", computeContribution, anInstant, x, aFrameSPtr

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMean.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMean.cpp
@@ -153,10 +153,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_BrouwerLyddan
     // Create "brouwerLyddaneMean" python submodule
     auto brouwerLyddaneMean = aModule.def_submodule("brouwerLyddaneMean");
 
-    OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_BrouwerLyddaneMean_BrouwerLyddaneMeanShort(
-        brouwerLyddaneMean
+    OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_BrouwerLyddaneMean_BrouwerLyddaneMeanShort(brouwerLyddaneMean
     );
-    OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_BrouwerLyddaneMean_BrouwerLyddaneMeanLong(
-        brouwerLyddaneMean
+    OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_BrouwerLyddaneMean_BrouwerLyddaneMeanLong(brouwerLyddaneMean
     );
 }

--- a/include/OpenSpaceToolkit/Astrodynamics/Solver/TemporalConditionSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solver/TemporalConditionSolver.hpp
@@ -78,9 +78,8 @@ class TemporalConditionSolver
     /// @param anInterval A time interval within which to perform the search.
     ///
     /// @return An array of time intervals.
-    Array<Interval> solve(
-        const Array<TemporalConditionSolver::Condition>& aConditionArray, const Interval& anInterval
-    ) const;
+    Array<Interval> solve(const Array<TemporalConditionSolver::Condition>& aConditionArray, const Interval& anInterval)
+        const;
 
    private:
     Duration timeStep_;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMean.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMean.hpp
@@ -95,9 +95,8 @@ class BrouwerLyddaneMean : public COE
     /// @param aGravitationalParameter A gravitational parameter
     /// @param aFrameSPtr A frame
     /// @return Cartesian state
-    COE::CartesianState getCartesianState(
-        const Derived &aGravitationalParameter, const Shared<const Frame> &aFrameSPtr
-    ) const;
+    COE::CartesianState getCartesianState(const Derived &aGravitationalParameter, const Shared<const Frame> &aFrameSPtr)
+        const;
 
     /// @brief Convert to COE
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
@@ -215,9 +215,8 @@ class COE
     /// @param aGravitationalParameter A gravitational parameter
     /// @param aFrameSPtr A frame
     /// @return Cartesian state
-    COE::CartesianState getCartesianState(
-        const Derived& aGravitationalParameter, const Shared<const Frame>& aFrameSPtr
-    ) const;
+    COE::CartesianState getCartesianState(const Derived& aGravitationalParameter, const Shared<const Frame>& aFrameSPtr)
+        const;
 
     /// @brief Get vector of elements in SI units
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -125,9 +125,8 @@ class Segment
         /// @param aNumericalSolver a numerical solver to use for the propagation between states
         /// @param anInstantArray an array of instants
         /// @return States at specified instants
-        Array<State> calculateStatesAt(
-            const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver
-        ) const;
+        Array<State> calculateStatesAt(const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver)
+            const;
 
         /// @brief Get dynamics contribution
         ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
@@ -97,9 +97,8 @@ class Sequence
         /// @param anInstantArray An array of instants.
         /// @param aNumericalSolver A numerical solver to be used for the propagation.
         /// @return Array of states at provided instants.
-        Array<State> calculateStatesAt(
-            const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver
-        ) const;
+        Array<State> calculateStatesAt(const Array<Instant>& anInstantArray, const NumericalSolver& aNumericalSolver)
+            const;
 
         /// @brief Print the sequence solution
         ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -100,11 +100,9 @@ AccessTarget AccessTarget::FromLLA(
     return AccessTarget(
         AccessTarget::Type::Fixed,
         aVisibilityCriterion,
-        Trajectory::Position(
-            Position::Meters(
-                anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()), Frame::ITRF()
-            )
-        )
+        Trajectory::Position(Position::Meters(
+            anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()), Frame::ITRF()
+        ))
     );
 }
 
@@ -474,8 +472,7 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
         }
     );
 
-    const auto computeAer = [&SEZRotations, &fromPositionCoordinates_ITRF](
-                                const Vector3d& aToPositionCoordinates_ITRF
+    const auto computeAer = [&SEZRotations, &fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF
                             ) -> Triple<VectorXd, VectorXd, VectorXd>
     {
         const MatrixXd dx = (-fromPositionCoordinates_ITRF).colwise() + aToPositionCoordinates_ITRF;
@@ -508,8 +505,8 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
         return {azimuth_rad, elevation_rad, range_m};
     };
 
-    const auto computeElevations =
-        [&fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF) -> VectorXd
+    const auto computeElevations = [&fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF
+                                   ) -> VectorXd
     {
         const MatrixXd dx = (-fromPositionCoordinates_ITRF).colwise() + aToPositionCoordinates_ITRF;
         const MatrixXd fromPositionDirection_ITRF = fromPositionCoordinates_ITRF.colwise().normalized();
@@ -748,8 +745,8 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
 
     std::function<bool(const Instant&)> condition;
 
-    const auto computeAER =
-        [&fromPositionCoordinate_ITRF, &SEZRotation, &aToTrajectory](const Instant& instant) -> Triple<Real, Real, Real>
+    const auto computeAER = [&fromPositionCoordinate_ITRF, &SEZRotation, &aToTrajectory](const Instant& instant
+                            ) -> Triple<Real, Real, Real>
     {
         const Vector3d toPositionCoordinates_ITRF =
             aToTrajectory.getStateAt(instant).inFrame(Frame::ITRF()).getPosition().getCoordinates();

--- a/src/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.cpp
@@ -197,8 +197,7 @@ TLESolver::Analysis TLESolver::estimate(
     {
         if (estimateBStar_)
         {
-            throw ostk::core::error::RuntimeError(
-                "Initial guess must be a TLE or (State, B*) when also estimating B*."
+            throw ostk::core::error::RuntimeError("Initial guess must be a TLE or (State, B*) when also estimating B*."
             );
         }
         initialGuessTLEState = CartesianStateAndBStarToTLEState(*state);

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.cpp
@@ -206,11 +206,9 @@ AngularCondition::AngularCondition(
               return (currentValue >= lowerBound) && (currentValue <= upperBound);
           }
       ),
-      targetRange_(
-          std::make_pair(
-              aTargetRange.first.inRadians(0.0, Real::TwoPi()), aTargetRange.second.inRadians(0.0, Real::TwoPi())
-          )
-      )
+      targetRange_(std::make_pair(
+          aTargetRange.first.inRadians(0.0, Real::TwoPi()), aTargetRange.second.inRadians(0.0, Real::TwoPi())
+      ))
 {
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -61,8 +61,7 @@ Maneuver::Maneuver(const Array<State>& aStateArray)
                 }
             ))
         {
-            throw ostk::core::error::RuntimeError(
-                String::Format("{} not found in states.", coordinateSubset->getName())
+            throw ostk::core::error::RuntimeError(String::Format("{} not found in states.", coordinateSubset->getName())
             );
         }
     }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameDirection.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameDirection.cpp
@@ -62,13 +62,12 @@ void LocalOrbitalFrameDirection::print(std::ostream& anOutputStream, bool displa
 
     ostk::core::utils::Print::Line(anOutputStream)
         << "Value:" << (this->getValue().isDefined() ? this->getValue().toString() : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Local Orbital Frame Factory Type:"
-        << (((this->getLocalOrbitalFrameFactory() != nullptr) && (this->getLocalOrbitalFrameFactory()->isDefined()))
-                ? LocalOrbitalFrameTransformProvider::StringFromType(
-                      this->getLocalOrbitalFrameFactory()->getProviderType()
-                  )
-                : "Undefined");
+    ostk::core::utils::Print::Line(anOutputStream
+    ) << "Local Orbital Frame Factory Type:"
+      << (((this->getLocalOrbitalFrameFactory() != nullptr) && (this->getLocalOrbitalFrameFactory()->isDefined()))
+              ? LocalOrbitalFrameTransformProvider::StringFromType(this->getLocalOrbitalFrameFactory()->getProviderType(
+                ))
+              : "Undefined");
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
@@ -138,14 +138,12 @@ State Tabulated::calculateStateAt(const Instant& anInstant) const
 
     if (anInstant < firstState_.accessInstant() || anInstant > lastState_.accessInstant())
     {
-        throw ostk::core::error::RuntimeError(
-            String::Format(
-                "Provided instant [{}] is outside of interpolation range [{}, {}].",
-                anInstant.toString(),
-                firstState_.accessInstant().toString(),
-                lastState_.accessInstant().toString()
-            )
-        );
+        throw ostk::core::error::RuntimeError(String::Format(
+            "Provided instant [{}] is outside of interpolation range [{}, {}].",
+            anInstant.toString(),
+            firstState_.accessInstant().toString(),
+            lastState_.accessInstant().toString()
+        ));
     }
 
     VectorXd interpolatedCoordinates(interpolators_.getSize());

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -991,14 +991,13 @@ Orbit Orbit::SunSynchronous(
 
         // Ecliptic latitude of the Sun
 
-        const Real sunEclipticLatitude_rad = Angle::Degrees(
-                                                 std::fmod(
-                                                     sunMeanLongitude_deg + 1.914666471 * std::sin(sunMeanAnomaly_rad) +
-                                                         0.019994643 * std::sin(2.0 * sunMeanAnomaly_rad),
-                                                     360.0
-                                                 )
-        )
-                                                 .inRadians();
+        const Real sunEclipticLatitude_rad =
+            Angle::Degrees(std::fmod(
+                               sunMeanLongitude_deg + 1.914666471 * std::sin(sunMeanAnomaly_rad) +
+                                   0.019994643 * std::sin(2.0 * sunMeanAnomaly_rad),
+                               360.0
+                           ))
+                .inRadians();
 
         // Compute the equation of time
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -224,13 +224,11 @@ Length COE::getRadialDistance() const
         throw ostk::core::error::runtime::Undefined("COE");
     }
 
-    return Length::Meters(
-        COE::ComputeRadialDistance(
-            semiMajorAxis_.inMeters(),
-            eccentricity_,
-            COE::ConvertAnomaly(anomaly_, eccentricity_, anomalyType_, AnomalyType::True, 1e-12).inRadians()
-        )
-    );
+    return Length::Meters(COE::ComputeRadialDistance(
+        semiMajorAxis_.inMeters(),
+        eccentricity_,
+        COE::ConvertAnomaly(anomaly_, eccentricity_, anomalyType_, AnomalyType::True, 1e-12).inRadians()
+    ));
 }
 
 Derived COE::getAngularMomentum(const Derived& aGravitationalParameter) const
@@ -1197,14 +1195,13 @@ Angle COE::ComputeEquationOfTime(const Instant& anInstant)
     const Real sunMeanAnomaly_rad = Angle::Degrees(std::fmod(357.5291092 + 35999.05034 * T_UT1, 360.0)).inRadians();
 
     // Ecliptic latitude of the Sun
-    const Real sunEclipticLatitude_rad = Angle::Degrees(
-                                             std::fmod(
-                                                 sunMeanLongitude_deg + 1.914666471 * std::sin(sunMeanAnomaly_rad) +
-                                                     0.019994643 * std::sin(2.0 * sunMeanAnomaly_rad),
-                                                 360.0
-                                             )
-    )
-                                             .inRadians();
+    const Real sunEclipticLatitude_rad =
+        Angle::Degrees(std::fmod(
+                           sunMeanLongitude_deg + 1.914666471 * std::sin(sunMeanAnomaly_rad) +
+                               0.019994643 * std::sin(2.0 * sunMeanAnomaly_rad),
+                           360.0
+                       ))
+            .inRadians();
 
     // Compute the equation of time
     const Real equationOfTime_deg =

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -302,12 +302,10 @@ MatrixXd Segment::Solution::getDynamicsContribution(
     {
         if (!dynamicsWriteCoordinateSubsets.contains(aCoordinateSubsetSPtr))
         {
-            throw ostk::core::error::RuntimeError(
-                String::Format(
-                    "Provided coordinate subset [{}] is not part of the dynamics write coordinate subsets.",
-                    aCoordinateSubsetSPtr->getName()
-                )
-            );
+            throw ostk::core::error::RuntimeError(String::Format(
+                "Provided coordinate subset [{}] is not part of the dynamics write coordinate subsets.",
+                aCoordinateSubsetSPtr->getName()
+            ));
         }
     }
 
@@ -365,8 +363,7 @@ MatrixXd Segment::Solution::getDynamicsAccelerationContribution(
     return this->getDynamicsContribution(aDynamicsSPtr, aFrameSPtr, {CartesianVelocity::Default()});
 }
 
-Map<Shared<Dynamics>, MatrixXd> Segment::Solution::getAllDynamicsContributions(
-    const Shared<const Frame>& aFrameSPtr
+Map<Shared<Dynamics>, MatrixXd> Segment::Solution::getAllDynamicsContributions(const Shared<const Frame>& aFrameSPtr
 ) const
 {
     // TBI: Use smart caching for multiple calls in the future

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -1074,12 +1074,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_Generator, ComputeAccesses_5)
             Length::Meters(0.0),
         };
 
-        const Trajectory trajectory = Trajectory::Position(
-            Position::Meters(
-                lla.toCartesian(defaultEarthSPtr_->getEquatorialRadius(), defaultEarthSPtr_->getFlattening()),
-                Frame::ITRF()
-            )
-        );
+        const Trajectory trajectory = Trajectory::Position(Position::Meters(
+            lla.toCartesian(defaultEarthSPtr_->getEquatorialRadius(), defaultEarthSPtr_->getFlattening()), Frame::ITRF()
+        ));
 
         const VisibilityCriterion visibilityCriterion =
             VisibilityCriterion::FromElevationInterval(ostk::mathematics::object::Interval<Real>::Closed(5.0, 90.0));
@@ -1211,9 +1208,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_Generator, AerRanges_1)
 
         // Reference data setup
 
-        const File referenceDataFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Access/Generator/AerRanges/Scenario 1.csv")
-        );
+        const File referenceDataFile =
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Access/Generator/AerRanges/Scenario 1.csv")
+            );
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
@@ -41,10 +41,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, Constructor)
         const Interval<Real> elevationInterval = Interval<Real>::Closed(0.0, 90.0);
         const Interval<Real> rangeInterval = Interval<Real>::Closed(0.0, 1e6);
 
-        EXPECT_NO_THROW(
-            VisibilityCriterion visibilityCriterion =
-                VisibilityCriterion::FromAERInterval(azimuthInterval, elevationInterval, rangeInterval);
-        );
+        EXPECT_NO_THROW(VisibilityCriterion visibilityCriterion =
+                            VisibilityCriterion::FromAERInterval(azimuthInterval, elevationInterval, rangeInterval););
 
         // Undefined
 
@@ -110,10 +108,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, Constructor)
             const Map<Real, Real> azimuthElevationMask = {{0.0, 10.0}, {90.0, 15.0}, {180.0, 20.0}};
             const Interval<Real> rangeInterval = Interval<Real>::Closed(0.0, 1e6);
 
-            EXPECT_NO_THROW(
-                VisibilityCriterion visibilityCriterion =
-                    VisibilityCriterion::FromAERMask(azimuthElevationMask, rangeInterval);
-            );
+            EXPECT_NO_THROW(VisibilityCriterion visibilityCriterion =
+                                VisibilityCriterion::FromAERMask(azimuthElevationMask, rangeInterval););
         }
 
         // Incorrect bounds
@@ -168,24 +164,21 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, Constructor)
 
     // FromLineOfSight
     {
-        EXPECT_NO_THROW(
-            VisibilityCriterion visibilityCriterion = VisibilityCriterion::FromLineOfSight(defaultEnvironment_);
-        );
+        EXPECT_NO_THROW(VisibilityCriterion visibilityCriterion =
+                            VisibilityCriterion::FromLineOfSight(defaultEnvironment_););
     }
 
     // FromElevationInterval
     {
         const Interval<Real> elevationInterval = Interval<Real>::Closed(0.0, 90.0);
 
-        EXPECT_NO_THROW(
-            VisibilityCriterion visibilityCriterion = VisibilityCriterion::FromElevationInterval(elevationInterval);
-        );
+        EXPECT_NO_THROW(VisibilityCriterion visibilityCriterion =
+                            VisibilityCriterion::FromElevationInterval(elevationInterval););
 
         // Incorrect bounds
         {
             EXPECT_THROW(
-                VisibilityCriterion::FromElevationInterval(
-                    ostk::mathematics::object::Interval<Real>::Closed(-91.0, 0.0)
+                VisibilityCriterion::FromElevationInterval(ostk::mathematics::object::Interval<Real>::Closed(-91.0, 0.0)
                 ),
                 ostk::core::error::RuntimeError
             );

--- a/test/OpenSpaceToolkit/Astrodynamics/Estimator/OrbitDeterminationSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Estimator/OrbitDeterminationSolver.test.cpp
@@ -132,11 +132,9 @@ class OpenSpaceToolkit_Astrodynamics_Solver_OrbitDeterminationSolver : public ::
     void SetUp() override
     {
         const Table observationData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Estimator/OrbitDeterminationSolverData/gnss_data.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Estimator/OrbitDeterminationSolverData/gnss_data.csv"
+            )),
             Table::Format::CSV,
             true
         );

--- a/test/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.test.cpp
@@ -62,11 +62,9 @@ Array<State> loadData(const String& aFileName)
     Array<State> observations;
 
     const Table observationData = Table::Load(
-        File::Path(
-            Path::Parse(
-                String::Format("/app/test/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolverData/{}.csv", aFileName)
-            )
-        ),
+        File::Path(Path::Parse(
+            String::Format("/app/test/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolverData/{}.csv", aFileName)
+        )),
         Table::Format::CSV,
         true
     );

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -245,12 +245,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, GetStatesAt)
     }
 
     {
-        EXPECT_ANY_THROW(
-            Profile::Undefined().getStatesAt(
-                {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
-                 Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC)}
-            )
-        );
+        EXPECT_ANY_THROW(Profile::Undefined().getStatesAt(
+            {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
+             Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC)}
+        ));
     }
 }
 
@@ -307,12 +305,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, InertialPointing)
 
         // Reference data setup
 
-        const File referenceDataFile = File::Path(
-            Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/InertialPointing/Satellite "
-                "t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"
-            )
-        );
+        const File referenceDataFile =
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/InertialPointing/Satellite "
+                                   "t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"));
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
 
@@ -425,10 +420,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, LocalOrbitalFramePointing_
         // Reference data setup
 
         const File referenceDataFile = File::Path(
-            Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
-                "Satellite_1 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"
-            )
+            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
+                        "Satellite_1 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv")
         );
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
@@ -538,10 +531,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, LocalOrbitalFramePointing_
         // Reference data setup
 
         const File referenceDataFile = File::Path(
-            Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
-                "Satellite_2 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"
-            )
+            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
+                        "Satellite_2 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv")
         );
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
@@ -651,10 +642,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, LocalOrbitalFramePointing_
         // Reference data setup
 
         const File referenceDataFile = File::Path(
-            Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
-                "Satellite_3 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"
-            )
+            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
+                        "Satellite_3 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv")
         );
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/System/SatelliteSystem.test.cpp
@@ -85,16 +85,14 @@ class OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem : public ::te
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_System_SatelliteSystem, Constructor)
 {
     {
-        EXPECT_NO_THROW(
-            SatelliteSystem satelliteSystem(
-                mass_,
-                satelliteGeometry_,
-                satelliteInertiaTensor_,
-                crossSectionalSurfaceArea_,
-                dragCoefficient_,
-                propulsionSystem_
-            )
-        );
+        EXPECT_NO_THROW(SatelliteSystem satelliteSystem(
+            mass_,
+            satelliteGeometry_,
+            satelliteInertiaTensor_,
+            crossSectionalSurfaceArea_,
+            dragCoefficient_,
+            propulsionSystem_
+        ));
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/ConstantThrust.test.cpp
@@ -194,8 +194,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust, calculateThrus
 
             // Reference data setup
             const Table referenceData = Table::Load(
-                File::Path(
-                    Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/" + referenceDataFileName)
+                File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/" + referenceDataFileName)
                 ),
                 Table::Format::CSV,
                 true
@@ -210,11 +209,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_GuidanceLaw_ConstantThrust, calculateThrus
 
             for (const auto& referenceRow : referenceData)
             {
-                instantArray.add(
-                    Instant::DateTime(
-                        DateTime::Parse(referenceRow[0].accessString(), DateTime::Format::ISO8601), Scale::UTC
-                    )
-                );
+                instantArray.add(Instant::DateTime(
+                    DateTime::Parse(referenceRow[0].accessString(), DateTime::Format::ISO8601), Scale::UTC
+                ));
                 referencePositionArrayGCRF.add(
                     Vector3d(referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal())
                 );

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -317,9 +317,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GetStateAt)
     }
 
     {
-        EXPECT_ANY_THROW(
-            Trajectory::Undefined().getStateAt(Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC))
-        );
+        EXPECT_ANY_THROW(Trajectory::Undefined().getStateAt(Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC)
+        ));
     }
 }
 
@@ -422,12 +421,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GetStatesAt)
     }
 
     {
-        EXPECT_ANY_THROW(
-            Trajectory::Undefined().getStatesAt(
-                {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
-                 Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC)}
-            )
-        );
+        EXPECT_ANY_THROW(Trajectory::Undefined().getStatesAt(
+            {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
+             Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC)}
+        ));
     }
 }
 
@@ -553,13 +550,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStrip)
 
                 EXPECT_TRUE(state.getVelocity().getCoordinates().isNear({0.0, 0.0, 0.0}, 1e-12));
 
-                EXPECT_TRUE(
-                    LLA::Cartesian(
-                        state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
-                    )
-                        .toVector()
-                        .isNear(startLLA.toVector(), 1e-12)
-                );
+                EXPECT_TRUE(LLA::Cartesian(
+                                state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
+                )
+                                .toVector()
+                                .isNear(startLLA.toVector(), 1e-12));
             }
 
             {
@@ -567,13 +562,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStrip)
 
                 EXPECT_TRUE(state.getVelocity().getCoordinates().isNear({0.0, 0.0, 0.0}, 1e-12));
 
-                EXPECT_TRUE(
-                    LLA::Cartesian(
-                        state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
-                    )
-                        .toVector()
-                        .isNear(endLLA.toVector(), 1e-12)
-                );
+                EXPECT_TRUE(LLA::Cartesian(
+                                state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
+                )
+                                .toVector()
+                                .isNear(endLLA.toVector(), 1e-12));
             }
         }
     }
@@ -656,13 +649,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStrip)
 
                 EXPECT_TRUE(state.getVelocity().getCoordinates().isNear({0.0, 0.0, 0.0}, 1e-13));
 
-                EXPECT_TRUE(
-                    LLA::Cartesian(
-                        state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
-                    )
-                        .toVector()
-                        .isNear(startLLA.toVector(), 1e-12)
-                );
+                EXPECT_TRUE(LLA::Cartesian(
+                                state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
+                )
+                                .toVector()
+                                .isNear(startLLA.toVector(), 1e-12));
             }
 
             {
@@ -674,13 +665,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStrip)
 
                 EXPECT_TRUE(state.getVelocity().getCoordinates().isNear({0.0, 0.0, 0.0}, 1e-13));
 
-                EXPECT_TRUE(
-                    LLA::Cartesian(
-                        state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
-                    )
-                        .toVector()
-                        .isNear(endLLA.toVector(), 1e-8)
-                );
+                EXPECT_TRUE(LLA::Cartesian(
+                                state.getPosition().getCoordinates(), earth.getEquatorialRadius(), earth.getFlattening()
+                )
+                                .toVector()
+                                .isNear(endLLA.toVector(), 1e-8));
             }
         }
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameTransformProvider.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/LocalOrbitalFrameTransformProvider.test.cpp
@@ -93,11 +93,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
         }
 
         {
-            EXPECT_ANY_THROW(
-                LocalOrbitalFrameTransformProvider::Construct(
-                    LocalOrbitalFrameTransformProvider::Type::Undefined, state_
-                )
-            );
+            EXPECT_ANY_THROW(LocalOrbitalFrameTransformProvider::Construct(
+                LocalOrbitalFrameTransformProvider::Type::Undefined, state_
+            ));
         }
 
         {
@@ -131,9 +129,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
 {
     {
         {
-            const auto transformGenerator = LocalOrbitalFrameTransformProvider::GetTransformGenerator(
-                LocalOrbitalFrameTransformProvider::Type::VNC
-            );
+            const auto transformGenerator =
+                LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::VNC
+                );
 
             const Transform transform = transformGenerator(state_);
 
@@ -141,9 +139,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
         }
 
         {
-            const auto transformGenerator = LocalOrbitalFrameTransformProvider::GetTransformGenerator(
-                LocalOrbitalFrameTransformProvider::Type::NED
-            );
+            const auto transformGenerator =
+                LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::NED
+                );
 
             const Transform transform = transformGenerator(state_);
 
@@ -151,9 +149,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
         }
 
         {
-            const auto transformGenerator = LocalOrbitalFrameTransformProvider::GetTransformGenerator(
-                LocalOrbitalFrameTransformProvider::Type::LVLH
-            );
+            const auto transformGenerator =
+                LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::LVLH
+                );
 
             const Transform transform = transformGenerator(state_);
 
@@ -161,9 +159,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
         }
 
         {
-            const auto transformGenerator = LocalOrbitalFrameTransformProvider::GetTransformGenerator(
-                LocalOrbitalFrameTransformProvider::Type::QSW
-            );
+            const auto transformGenerator =
+                LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::QSW
+                );
 
             const Transform transform = transformGenerator(state_);
 
@@ -171,9 +169,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_LocalOrbitalFrameTransformProvi
         }
 
         {
-            const auto transformGenerator = LocalOrbitalFrameTransformProvider::GetTransformGenerator(
-                LocalOrbitalFrameTransformProvider::Type::TNW
-            );
+            const auto transformGenerator =
+                LocalOrbitalFrameTransformProvider::GetTransformGenerator(LocalOrbitalFrameTransformProvider::Type::TNW
+                );
 
             const Transform transform = transformGenerator(state_);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -270,11 +270,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetRevolutionNumberAt)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -330,11 +328,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassAt)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -482,12 +478,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePasses)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
@@ -674,12 +666,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePassesWithModel)
             // Reference data setup
 
             const Table referenceData = Table::Load(
-                File::Path(
-                    Path::Parse(
-                        "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                        "Satellite Passes.csv"
-                    )
-                ),
+                File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                       "Satellite Passes.csv")),
                 Table::Format::CSV,
                 true
             );
@@ -878,12 +866,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
@@ -946,12 +930,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
@@ -1014,12 +994,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
@@ -1225,35 +1201,27 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassesWithinInterval)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
 
         // Pass test
 
-        const Array<Pass> passes = orbit.getPassesWithinInterval(
-            Interval::Closed(
-                Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
-                Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
-            )
-        );
+        const Array<Pass> passes = orbit.getPassesWithinInterval(Interval::Closed(
+            Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
+            Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
+        ));
 
         EXPECT_TRUE(passes.getSize() > 0);
         EXPECT_EQ(passes.getSize() - 1, referenceData.getRowCount());
 
         // Test regenerating with cached passes
-        EXPECT_NO_THROW(orbit.getPassesWithinInterval(
-            Interval::Closed(
-                Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
-                Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
-            )
-        ));
+        EXPECT_NO_THROW(orbit.getPassesWithinInterval(Interval::Closed(
+            Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
+            Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
+        )));
 
         for (const auto &referenceRow : referenceData)
         {
@@ -1444,14 +1412,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetOrbitalFrame)
             const Angle angularTolerance = std::get<1>(testCase);
             const Angle angularVelocityTolerance = std::get<2>(testCase);
 
-            const File referenceDataFile = File::Path(
-                Path::Parse(
-                    String::Format(
-                        "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/GetOrbitalFrame/{}_GCRF.csv",
-                        Orbit::StringFromFrameType(frameType)
-                    )
-                )
-            );
+            const File referenceDataFile = File::Path(Path::Parse(String::Format(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/GetOrbitalFrame/{}_GCRF.csv",
+                Orbit::StringFromFrameType(frameType)
+            )));
 
             const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
 
@@ -1588,8 +1552,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(0.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 1.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 1.csv")
              ),
              1e-3,
              1e-6,
@@ -1599,8 +1562,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(45.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 2.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 2.csv")
              ),
              1e-3,
              1e-6,
@@ -1610,8 +1572,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(90.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 3.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 3.csv")
              ),
              1e-3,
              1e-6,
@@ -1621,8 +1582,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(135.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 4.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 4.csv")
              ),
              1e-3,
              1e-6,
@@ -1632,8 +1592,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(180.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 5.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 5.csv")
              ),
              1e-3,
              1e-6,
@@ -1643,8 +1602,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(0.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 6.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 6.csv")
              ),
              1e-3,
              1e-6,
@@ -1654,8 +1612,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(45.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 7.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 7.csv")
              ),
              1e-3,
              1e-6,
@@ -1665,8 +1622,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(90.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 8.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 8.csv")
              ),
              1e-3,
              1e-6,
@@ -1676,8 +1632,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(135.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 9.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 9.csv")
              ),
              1e-3,
              1e-6,
@@ -1687,9 +1642,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(180.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 10.csv")
-             ),
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 10.csv"
+             )),
              1e-3,
              1e-6,
              1e-1,
@@ -1882,11 +1836,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, CircularEquatorial)
             {"Scenario 1",
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
-             File::Path(
-                 Path::Parse(
-                     "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/CircularEquatorial/Scenario 1.csv"
-                 )
-             ),
+             File::Path(Path::Parse(
+                 "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/CircularEquatorial/Scenario 1.csv"
+             )),
              1e-3,
              1e-6,
              1e-1,

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Message/SpaceX/OPM.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Message/SpaceX/OPM.test.cpp
@@ -254,11 +254,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Message_SpaceX_OPM, Load)
     using ostk::core::filesystem::Path;
 
     {
-        const OPM opm = OPM::Load(
-            File::Path(
-                Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Message/SpaceX/OPM/opm_1.yaml")
-            )
-        );
+        const OPM opm = OPM::Load(File::Path(
+            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Message/SpaceX/OPM/opm_1.yaml")
+        ));
 
         EXPECT_EQ(Instant::DateTime(DateTime(2020, 1, 1, 12, 34, 56, 789), Scale::UTC), opm.getHeader().generationDate);
         EXPECT_EQ(Instant::DateTime(DateTime(2020, 1, 2, 12, 34, 56, 789), Scale::UTC), opm.getHeader().launchDate);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.test.cpp
@@ -181,11 +181,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, Test_1)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -294,11 +292,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, Test_2)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -414,11 +410,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, Test_3)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_3/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_3/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -523,11 +517,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, Test_4)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -632,11 +624,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, Test_5)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_5/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_5/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -741,11 +731,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, Test_6)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_6/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_6/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMeanLong.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMeanLong.test.cpp
@@ -150,12 +150,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddane
             Angle::Degrees(291.4817543658902),
         };
 
-        EXPECT_ANY_THROW(
-            BrouwerLyddaneMeanLong::Cartesian(
-                coe.getCartesianState(EarthGravitationalModel::EGM2008.gravitationalParameter_, Frame::GCRF()),
-                EarthGravitationalModel::EGM2008.gravitationalParameter_
-            )
-        );
+        EXPECT_ANY_THROW(BrouwerLyddaneMeanLong::Cartesian(
+            coe.getCartesianState(EarthGravitationalModel::EGM2008.gravitationalParameter_, Frame::GCRF()),
+            EarthGravitationalModel::EGM2008.gravitationalParameter_
+        ));
     }
 
     {
@@ -168,12 +166,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddane
             Angle::Degrees(291.4817543658902),
         };
 
-        EXPECT_ANY_THROW(
-            BrouwerLyddaneMeanLong::Cartesian(
-                coe.getCartesianState(EarthGravitationalModel::EGM2008.gravitationalParameter_, Frame::GCRF()),
-                EarthGravitationalModel::EGM2008.gravitationalParameter_
-            )
-        );
+        EXPECT_ANY_THROW(BrouwerLyddaneMeanLong::Cartesian(
+            coe.getCartesianState(EarthGravitationalModel::EGM2008.gravitationalParameter_, Frame::GCRF()),
+            EarthGravitationalModel::EGM2008.gravitationalParameter_
+        ));
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMeanShort.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMeanShort.test.cpp
@@ -83,20 +83,18 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddan
 INSTANTIATE_TEST_SUITE_P(
     Cartesian,
     OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddaneMeanShort_Parametrized,
-    ::testing::Values(
-        std::make_tuple(
-            Position::Meters({6596065.624114551, 2282234.953292401, -18030.93992064121}, Frame::GCRF()),
-            Velocity::MetersPerSecond({345.4716519563907, -967.0404288726759, 7488.686029827369}, Frame::GCRF()),
-            Vector6d {
-                6973743.736075629,
-                0.001202049190851806,
-                1.7071571281899047,
-                0.3327524364104959,
-                1.568634993642334,
-                4.7143446820819745,
-            }
-        )
-    )
+    ::testing::Values(std::make_tuple(
+        Position::Meters({6596065.624114551, 2282234.953292401, -18030.93992064121}, Frame::GCRF()),
+        Velocity::MetersPerSecond({345.4716519563907, -967.0404288726759, 7488.686029827369}, Frame::GCRF()),
+        Vector6d {
+            6973743.736075629,
+            0.001202049190851806,
+            1.7071571281899047,
+            0.3327524364104959,
+            1.568634993642334,
+            4.7143446820819745,
+        }
+    ))
 );
 
 TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddaneMeanShort_Parametrized, Cartesian)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -640,12 +640,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, Cartesi
     }
 
     {
-        EXPECT_ANY_THROW(
-            COE::Cartesian(
-                COE::CartesianState({Position::Undefined(), Velocity::Undefined()}),
-                Earth::EGM2008.gravitationalParameter_
-            )
-        );
+        EXPECT_ANY_THROW(COE::Cartesian(
+            COE::CartesianState({Position::Undefined(), Velocity::Undefined()}), Earth::EGM2008.gravitationalParameter_
+        ));
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
@@ -318,12 +318,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
 {
     // Reference data setup
     const Table referenceData = Table::Load(
-        File::Path(
-            Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                "Propagated/CalculateStatesAt_StateValidation.csv"
-            )
-        ),
+        File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                               "Propagated/CalculateStatesAt_StateValidation.csv")),
         Table::Format::CSV,
         true
     );
@@ -348,8 +344,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
         });
     }
 
-    const auto getState =
-        [&instantArray, &referencePositionArray, &referenceVelocityArray, this](const Size& index) -> State
+    const auto getState = [&instantArray, &referencePositionArray, &referenceVelocityArray, this](const Size& index
+                          ) -> State
     {
         const Instant startInstant = instantArray[index];
         return {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
@@ -65,11 +65,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
 
         // Orbital model setup
 
-        const TLE tle = TLE::Load(
-            File::Path(
-                Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite.tle")
-            )
-        );
+        const TLE tle = TLE::Load(File::Path(
+            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite.tle")
+        ));
 
         const SGP4 sgp4Model = {tle};
 
@@ -80,11 +78,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.test.cpp
@@ -772,40 +772,28 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4_TLE, CanParse)
 
     {
         EXPECT_TRUE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537")
         );
         EXPECT_TRUE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537")
         );
         EXPECT_TRUE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537\n"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537\n")
         );
         EXPECT_TRUE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537\n\n"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537\n\n")
         );
         EXPECT_TRUE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537\r\n"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537\r\n")
         );
         EXPECT_TRUE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537\r\n\r\n"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537\r\n\r\n")
         );
     }
 
@@ -813,46 +801,32 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4_TLE, CanParse)
         EXPECT_FALSE(TLE::CanParse(""));
         EXPECT_FALSE(TLE::CanParse("abc"));
         EXPECT_FALSE(
-            TLE::CanParse(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            )
+            TLE::CanParse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         );
         EXPECT_FALSE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537")
         );
         EXPECT_FALSE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2928\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2928\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537")
         );
         EXPECT_FALSE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563536"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563536")
         );
         EXPECT_FALSE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  292\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  292\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.72125391563537")
         );
         EXPECT_FALSE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.7212539156353"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.7212539156353")
         );
         EXPECT_FALSE(
-            TLE::CanParse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  292a\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.7212539156353b"
-            )
+            TLE::CanParse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  292a\n2 25544  51.6416 "
+                          "247.4627 0006703 130.5360 325.0288 15.7212539156353b")
         );
     }
 
@@ -885,9 +859,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4_TLE, CanParse)
     }
 
     {
-        const File activeTlesFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE/active.txt")
-        );
+        const File activeTlesFile =
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE/active.txt"
+            ));
 
         const String allTles = activeTlesFile.getContents();
 
@@ -1035,23 +1009,19 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4_TLE, Parse)
         EXPECT_ANY_THROW(TLE::Parse(""));
         EXPECT_ANY_THROW(TLE::Parse("Hello World!"));
         EXPECT_ANY_THROW(
-            TLE::Parse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2926\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563537"
-            )
+            TLE::Parse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2926\n2 25544  51.6416 "
+                       "247.4627 0006703 130.5360 325.0288 15.72125391563537")
         );
         EXPECT_ANY_THROW(
-            TLE::Parse(
-                "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
-                "247.4627 0006703 130.5360 325.0288 15.72125391563538"
-            )
+            TLE::Parse("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n2 25544  51.6416 "
+                       "247.4627 0006703 130.5360 325.0288 15.72125391563538")
         );
     }
 
     {
-        const File activeTlesFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE/active.txt")
-        );
+        const File activeTlesFile =
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE/active.txt"
+            ));
 
         const String allTles = activeTlesFile.getContents();
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
@@ -63,11 +63,9 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated : public :
         referenceStates_.clear();
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -898,12 +898,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Calcula
     /// Test full state results against reference trajectory
     // Reference data setup
     const Table referenceData = Table::Load(
-        File::Path(
-            Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                "Propagated/CalculateStatesAt_StateValidation.csv"
-            )
-        ),
+        File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                               "Propagated/CalculateStatesAt_StateValidation.csv")),
         Table::Format::CSV,
         true
     );
@@ -1347,16 +1343,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Validat
         // Wrong number of AtmosphericDrags
         {
             Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
-            propagator.addDynamics(
-                std::make_shared<AtmosphericDrag>(std::make_shared<Celestial>(Earth::AtmosphericOnly(
-                    std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
-                )))
-            );
-            propagator.addDynamics(
-                std::make_shared<AtmosphericDrag>(std::make_shared<Celestial>(Earth::AtmosphericOnly(
-                    std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
-                )))
-            );
+            propagator.addDynamics(std::make_shared<AtmosphericDrag>(std::make_shared<Celestial>(Earth::AtmosphericOnly(
+                std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
+            ))));
+            propagator.addDynamics(std::make_shared<AtmosphericDrag>(std::make_shared<Celestial>(Earth::AtmosphericOnly(
+                std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
+            ))));
 
             EXPECT_THROW(
                 {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -872,15 +872,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Coast)
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Maneuver)
 {
     {
-        EXPECT_NO_THROW(
-            Segment::Maneuver(
-                defaultName_,
-                defaultInstantCondition_,
-                defaultThrusterDynamicsSPtr_,
-                defaultDynamics_,
-                defaultNumericalSolver_
-            )
-        );
+        EXPECT_NO_THROW(Segment::Maneuver(
+            defaultName_,
+            defaultInstantCondition_,
+            defaultThrusterDynamicsSPtr_,
+            defaultDynamics_,
+            defaultNumericalSolver_
+        ));
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
@@ -339,26 +339,22 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, Constructor)
     }
 
     {
-        EXPECT_NO_THROW(
-            Sequence sequence(
-                defaultSegments_, defaultNumericalSolver_, defaultDynamics_, defaultMaximumPropagationDuration_
-            )
-        );
+        EXPECT_NO_THROW(Sequence sequence(
+            defaultSegments_, defaultNumericalSolver_, defaultDynamics_, defaultMaximumPropagationDuration_
+        ));
     }
 
     {
         {
             for (Size verbosity = 0; verbosity <= 5; ++verbosity)
             {
-                EXPECT_NO_THROW(
-                    Sequence sequence(
-                        defaultSegments_,
-                        defaultNumericalSolver_,
-                        defaultDynamics_,
-                        defaultMaximumPropagationDuration_,
-                        verbosity
-                    )
-                );
+                EXPECT_NO_THROW(Sequence sequence(
+                    defaultSegments_,
+                    defaultNumericalSolver_,
+                    defaultDynamics_,
+                    defaultMaximumPropagationDuration_,
+                    verbosity
+                ));
             }
         }
 
@@ -420,14 +416,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, AddCoastSegment)
     {
         const Size segmentsCount = defaultSequence_.getSegments().getSize();
 
-        defaultSequence_.addCoastSegment(
-            std::make_shared<RealCondition>(COECondition::SemiMajorAxis(
-                RealCondition::Criterion::AnyCrossing,
-                Frame::GCRF(),
-                Length::Kilometers(6999.5),
-                EarthGravitationalModel::EGM2008.gravitationalParameter_
-            ))
-        );
+        defaultSequence_.addCoastSegment(std::make_shared<RealCondition>(COECondition::SemiMajorAxis(
+            RealCondition::Criterion::AnyCrossing,
+            Frame::GCRF(),
+            Length::Kilometers(6999.5),
+            EarthGravitationalModel::EGM2008.gravitationalParameter_
+        )));
 
         EXPECT_TRUE(defaultSequence_.getSegments().getSize() == segmentsCount + 1);
     }
@@ -632,14 +626,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, Solve_2)
         defaultMaximumPropagationDuration_,
     };
 
-    sequence.addCoastSegment(
-        std::make_shared<RealCondition>(COECondition::SemiMajorAxis(
-            RealCondition::Criterion::AnyCrossing,
-            Frame::GCRF(),
-            Length::Kilometers(6999.5),
-            EarthGravitationalModel::EGM2008.gravitationalParameter_
-        ))
-    );
+    sequence.addCoastSegment(std::make_shared<RealCondition>(COECondition::SemiMajorAxis(
+        RealCondition::Criterion::AnyCrossing,
+        Frame::GCRF(),
+        Length::Kilometers(6999.5),
+        EarthGravitationalModel::EGM2008.gravitationalParameter_
+    )));
 
     sequence.addManeuverSegment(
         std::make_shared<RealCondition>(COECondition::SemiMajorAxis(
@@ -817,14 +809,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, Print)
             defaultMaximumPropagationDuration_,
         };
 
-        sequence.addCoastSegment(
-            std::make_shared<RealCondition>(COECondition::SemiMajorAxis(
-                RealCondition::Criterion::AnyCrossing,
-                Frame::GCRF(),
-                Length::Kilometers(6999.5),
-                EarthGravitationalModel::EGM2008.gravitationalParameter_
-            ))
-        );
+        sequence.addCoastSegment(std::make_shared<RealCondition>(COECondition::SemiMajorAxis(
+            RealCondition::Criterion::AnyCrossing,
+            Frame::GCRF(),
+            Length::Kilometers(6999.5),
+            EarthGravitationalModel::EGM2008.gravitationalParameter_
+        )));
 
         sequence.addManeuverSegment(
             std::make_shared<RealCondition>(COECondition::SemiMajorAxis(

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/NRLMSIS00.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/NRLMSIS00.validation.cpp
@@ -167,22 +167,21 @@ class OpenSpaceToolkit_Astrodynamics_Validation_NRLMSIS00Validation_Data_Success
 INSTANTIATE_TEST_SUITE_P(
     Input_Data_Spans_Valid,
     OpenSpaceToolkit_Astrodynamics_Validation_NRLMSIS00Validation_Data_Success,
-    testing::Values(
-        std::make_tuple(
-            Instant::Now() - Duration::Weeks(52 * 5),
-            Instant::Now() - Duration::Weeks(52 * 4.9),
-            Duration::Days(7),
-            "NRLMSISE Past Data limit pass"
-        )
-        // [TBI]: This test case fails sporadically because the actual data files are never updated based on
-        // age, meaning they can get stale.
+    testing::Values(std::make_tuple(
+        Instant::Now() - Duration::Weeks(52 * 5),
+        Instant::Now() - Duration::Weeks(52 * 4.9),
+        Duration::Days(7),
+        "NRLMSISE Past Data limit pass"
+    )
+                    // [TBI]: This test case fails sporadically because the actual data files are never updated based on
+                    // age, meaning they can get stale.
 
-        // std::make_tuple(
-        //     Instant::Now() + Duration::Weeks(52 * 0.9),
-        //     Instant::Now() + Duration::Weeks(52 * 1.0),
-        //     Duration::Days(7),
-        //     "IERS Finals2000A Future Data limit pass"
-        // )
+                    // std::make_tuple(
+                    //     Instant::Now() + Duration::Weeks(52 * 0.9),
+                    //     Instant::Now() + Duration::Weeks(52 * 1.0),
+                    //     Duration::Days(7),
+                    //     "IERS Finals2000A Future Data limit pass"
+                    // )
     )
 );
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
@@ -191,11 +191,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_Two
     {
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/STK_TwoBody_2hr_run.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/STK_TwoBody_2hr_run.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -307,12 +305,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_EGM
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                    "Propagated/STK_EGM2008_100x100_2hr_run.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                                   "Propagated/STK_EGM2008_100x100_2hr_run.csv")),
             Table::Format::CSV,
             true
         );
@@ -390,12 +384,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_WGS
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                    "Propagated/STK_WGS84EGM96_70x70_2hr_run.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                                   "Propagated/STK_WGS84EGM96_70x70_2hr_run.csv")),
             Table::Format::CSV,
             true
         );
@@ -473,12 +463,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_EGM
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                    "Propagated/STK_WGS84_70x70_2hr_run.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                                   "Propagated/STK_WGS84_70x70_2hr_run.csv")),
             Table::Format::CSV,
             true
         );

--- a/validation/OpenSpaceToolkit/Astrodynamics/MissionSequence.test.cpp
+++ b/validation/OpenSpaceToolkit/Astrodynamics/MissionSequence.test.cpp
@@ -41,9 +41,8 @@ class OpenSpaceToolkit_Astrodynamics_Validation_MissionSequence : public ::testi
    protected:
     const Dictionary defaultTree_ =
         CntrObject::Load(
-            File::Path(
-                Path::Parse("/app/validation/OpenSpaceToolkit/Astrodynamics/data/test/test_mission_sequence.yaml")
-            ),
+            File::Path(Path::Parse("/app/validation/OpenSpaceToolkit/Astrodynamics/data/test/test_mission_sequence.yaml"
+            )),
             CntrObject::Format::YAML
         )
             .accessDictionary();

--- a/validation/OpenSpaceToolkit/Astrodynamics/Parser.cpp
+++ b/validation/OpenSpaceToolkit/Astrodynamics/Parser.cpp
@@ -177,18 +177,16 @@ Environment Parser::CreateEnvironment(const Dictionary& aDictionary)
         }
     }
 
-    celestials.add(
-        std::make_shared<const Earth>(Earth::FromModels(
-            std::make_shared<EarthGravitationalModel>(
-                earthGravitationalModelType,
-                Directory::Undefined(),
-                earthGravitationalModelDegree,
-                earthGravitationalModelOrder
-            ),
-            std::make_shared<EarthMagneticModel>(earthMagneticModelType),
-            std::make_shared<EarthAtmosphericModel>(earthAtmosphericModelType)
-        ))
-    );
+    celestials.add(std::make_shared<const Earth>(Earth::FromModels(
+        std::make_shared<EarthGravitationalModel>(
+            earthGravitationalModelType,
+            Directory::Undefined(),
+            earthGravitationalModelDegree,
+            earthGravitationalModelOrder
+        ),
+        std::make_shared<EarthMagneticModel>(earthMagneticModelType),
+        std::make_shared<EarthAtmosphericModel>(earthAtmosphericModelType)
+    )));
 
     return Environment(Instant::J2000(), celestials);
 }


### PR DESCRIPTION
[This PR](https://github.com/open-space-collective/open-space-toolkit/pull/169) freezes the `clang` version to 18, which is the latest stable version. This repo had been previously formatted with v20, so I'm re-running `ostk-format-cpp` with v18. 

Contains no changes to business logic. 