### PR TITLE
fix: dangling references when custom pointing

### DIFF
--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -125,28 +125,6 @@ def clocking_target() -> Profile.Target:
     return Profile.Target(Profile.TargetType.VelocityECI, Profile.Axis.Y)
 
 
-# This profile is defined with an orbit that is instantiated within the method
-# Regression test for issue where CustomPointing method was passing the orbit as a reference
-# causing the orbit to be deallocated before the profile was used
-@pytest.fixture
-def dangling_profile(
-    instant: Instant,
-    environment: Environment,
-    alignment_target: Profile.Target,
-    clocking_target: Profile.Target,
-) -> Profile:
-    return Profile.custom_pointing(
-        orbit=Orbit.sun_synchronous(
-            epoch=instant,
-            altitude=Length.kilometers(500.0),
-            local_time_at_descending_node=Time(14, 0, 0),
-            celestial_object=environment.access_celestial_object_with_name("Earth"),
-        ),
-        alignment_target=alignment_target,
-        clocking_target=clocking_target,
-    )
-
-
 class TestProfile:
     def test_constructors(self, profile: Profile):
         assert profile is not None
@@ -275,11 +253,3 @@ class TestProfile:
 
         assert profile is not None
         assert profile.is_defined()
-
-    # Regression test for issue where CustomPointing method was passing the orbit as a reference
-    # causing the orbit to be deallocated before the profile was used
-    def test_custom_pointing_dangling_orbit(
-        self,
-        dangling_profile: Profile,
-    ):
-        assert dangling_profile.get_state_at(Instant.J2000()) is not None

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
@@ -240,8 +240,8 @@ Profile Profile::CustomPointing(
     const trajectory::Orbit& anOrbit, const std::function<Quaternion(const State&)>& anOrientationGenerator
 )
 {
-    // Copy the orientation generator to avoid dangling references.
-    auto dynamicProviderGenerator = [&anOrbit, anOrientationGenerator](const Instant& anInstant) -> Transform
+    // Copy the orbit and orientation generator to avoid dangling references.
+    auto dynamicProviderGenerator = [anOrbit, anOrientationGenerator](const Instant& anInstant) -> Transform
     {
         const State state = anOrbit.getStateAt(anInstant);
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -1032,6 +1032,18 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, CustomPointing)
             EXPECT_TRUE(calculatedState.getAttitude().isNear(expectedState.getAttitude(), Angle::Arcseconds(1e-15)));
         }
     }
+
+    // Regression test for dangling orbit reference when a custom pointing profile
+    {
+        Profile profile = Profile::Undefined();
+        {
+            const Orbit anotherOrbit = Orbit::SunSynchronous(epoch, Length::Kilometers(500.0), Time(6, 0, 0), earthSPtr);
+            
+            profile = Profile::CustomPointing(anotherOrbit, alignmentTargetSPtr, clockingTargetSPtr);
+        }
+
+        EXPECT_NO_THROW(profile.getStateAt(epoch));
+    }
 }
 
 class OpenSpaceToolkit_Astrodynamics_Flight_Profile_Parametrized

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -1037,8 +1037,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, CustomPointing)
     {
         Profile profile = Profile::Undefined();
         {
-            const Orbit anotherOrbit = Orbit::SunSynchronous(epoch, Length::Kilometers(500.0), Time(6, 0, 0), earthSPtr);
-            
+            const Orbit anotherOrbit =
+                Orbit::SunSynchronous(epoch, Length::Kilometers(500.0), Time(6, 0, 0), earthSPtr);
+
             profile = Profile::CustomPointing(anotherOrbit, alignmentTargetSPtr, clockingTargetSPtr);
         }
 


### PR DESCRIPTION
This would cause dangling references if the orbit was created inside a method, along with the profile and then the profile was returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the stability of the flight profile’s pointing functionality to prevent potential runtime issues related to dangling references.

- **Tests**
  - Added regression testing to confirm robust behavior under edge-case conditions, specifically addressing potential dangling references in the pointing profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->