### PR TITLE
feat: argument of latitude computation

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -714,5 +714,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
             arg("element")
         )
 
+        .def(
+            "get_argument_of_latitude",
+            &COE::getArgumentOfLatitude,
+            R"doc(
+                Get the argument of latitude of the COE.
+
+                Returns:
+                    Angle: The argument of latitude (sum of argument of periapsis and true anomaly).
+            )doc"
+        )
+
         ;
 }

--- a/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
+++ b/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
@@ -118,6 +118,7 @@ class TestCOE:
         assert coe.get_raan() == raan
         assert coe.get_aop() == aop
         assert coe.get_true_anomaly() == true_anomaly
+        assert coe.get_argument_of_latitude() == aop + true_anomaly
         assert coe.get_mean_anomaly() is not None
         assert coe.get_eccentric_anomaly() is not None
         assert coe.get_mean_motion(Earth.EGM2008.gravitational_parameter) is not None

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
@@ -147,6 +147,11 @@ class COE
     /// @return Argument of periapsis
     Angle getAop() const;
 
+    /// @brief Get Argument of latitude
+    ///
+    /// @return Argument of latitude
+    Angle getArgumentOfLatitude() const;
+
     /// @brief Get True anomaly
     ///
     /// @return True anomaly

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -1096,6 +1096,16 @@ String COE::StringFromElement(const COE::Element& anElement)
     throw ostk::core::error::runtime::Wrong("Element");
 }
 
+Angle COE::getArgumentOfLatitude() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("COE");
+    }
+
+    return aop_ + getTrueAnomaly();
+}
+
 COE::COE(
     const Length& aSemiMajorAxis,
     const Real& anEccentricity,

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -167,6 +167,16 @@ Angle COE::getTrueAnomaly() const
     return anomaly_;
 }
 
+Angle COE::getArgumentOfLatitude() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("COE");
+    }
+
+    return aop_ + anomaly_;
+}
+
 Angle COE::getMeanAnomaly() const
 {
     if (!this->isDefined())
@@ -1094,16 +1104,6 @@ String COE::StringFromElement(const COE::Element& anElement)
     }
 
     throw ostk::core::error::runtime::Wrong("Element");
-}
-
-Angle COE::getArgumentOfLatitude() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("COE");
-    }
-
-    return aop_ + getTrueAnomaly();
 }
 
 COE::COE(

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -418,6 +418,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, Compute
 
 // }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetArgumentOfLatitude)
+{
+    {
+        EXPECT_EQ(defaultAop_ + defaultTrueAnomaly_, coe_.getArgumentOfLatitude());
+    }
+
+    {
+        EXPECT_ANY_THROW(COE::Undefined().getArgumentOfLatitude());
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetNodalPrecessionRate)
 {
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to retrieve the argument of latitude for orbital elements, enhancing access to this key orbital parameter.
  
- **Tests**
  - Expanded test coverage to ensure the new functionality returns correct values and properly handles cases where the orbital data is undefined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->