### PR TITLE
fix: use rgb convention for xyz axis in viewer

### DIFF
--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -205,14 +205,14 @@ class Viewer:
                         direction=(0.0, +1.0, 0.0),
                         half_angle=Angle.degrees(1.0),
                         length=Length.meters(2.0),
-                        color="blue",
+                        color="green",
                     ),
                     ConicSensor(
                         name="z_axis",
                         direction=(0.0, 0.0, +1.0),
                         half_angle=Angle.degrees(1.0),
                         length=Length.meters(2.0),
-                        color="green",
+                        color="blue",
                     ),
                 ]
             )


### PR DESCRIPTION
Changed the Viewer configuration to match the RGB color convention for the XYZ axes:

![image](https://github.com/user-attachments/assets/64ba63d9-5a05-4ffb-9b4b-ebdd44a19824)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the viewer’s sensor color scheme for improved visual clarity, swapping colors to enhance sensor distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->