### PR TITLE
feat: update velocity computation ground strip

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -201,6 +201,24 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
             arg("instants"),
             arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()")
         )
+        .def_static(
+            "ground_strip_geodetic_nadir",
+            &Trajectory::GroundStripGeodeticNadir,
+            R"doc(
+                Create a `Trajectory` object representing a ground strip that follows the geodetic nadir of the provided orbit.
+
+                Args:
+                    orbit (Orbit): The orbit.
+                    instants (list[Instant]): The instants.
+                    celestial_object (Celestial): The celestial object. Defaults to Earth.WGS84().
+
+                Returns:
+                    Trajectory: The `Trajectory` object representing the ground strip.  
+            )doc",
+            arg("orbit"),
+            arg("instants"),
+            arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()")
+        )
 
         ;
 

--- a/bindings/python/test/test_trajectory.py
+++ b/bindings/python/test/test_trajectory.py
@@ -16,6 +16,7 @@ from ostk.astrodynamics import Trajectory
 from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory import Orbit
 
+
 @pytest.fixture
 def start_lla() -> LLA:
     return LLA.vector([0.0, 0.0, 0.0])
@@ -62,9 +63,15 @@ def states(trajectory: Trajectory) -> list[State]:
         [Instant.J2000(), Instant.J2000() + Duration.seconds(10.0)]
     )
 
+
 @pytest.fixture
 def orbit() -> Orbit:
-    return Orbit.circular(epoch=Instant.J2000(), altitude=Length.meters(545000.0), inclination=Angle.degrees(0.0), celestial_object=Earth.WGS84(),)
+    return Orbit.circular(
+        epoch=Instant.J2000(),
+        altitude=Length.meters(545000.0),
+        inclination=Angle.degrees(0.0),
+        celestial_object=Earth.WGS84(),
+    )
 
 
 class TestTrajectory:
@@ -123,6 +130,16 @@ class TestTrajectory:
         assert Trajectory.ground_strip(start_lla, end_lla, instants, earth) is not None
         assert Trajectory.ground_strip(start_lla, end_lla, instants) is not None
 
-    def test_ground_strip_geodetic_nadir(self, orbit: Orbit, instants: list[Instant], earth: Earth):
-        assert Trajectory.ground_strip_geodetic_nadir(orbit=orbit, instants=instants, celestial_object=earth) is not None
-        assert Trajectory.ground_strip_geodetic_nadir(orbit=orbit, instants=instants) is not None
+    def test_ground_strip_geodetic_nadir(
+        self, orbit: Orbit, instants: list[Instant], earth: Earth
+    ):
+        assert (
+            Trajectory.ground_strip_geodetic_nadir(
+                orbit=orbit, instants=instants, celestial_object=earth
+            )
+            is not None
+        )
+        assert (
+            Trajectory.ground_strip_geodetic_nadir(orbit=orbit, instants=instants)
+            is not None
+        )

--- a/bindings/python/test/test_trajectory.py
+++ b/bindings/python/test/test_trajectory.py
@@ -9,10 +9,12 @@ from ostk.physics.coordinate import Frame
 from ostk.physics.time import Instant
 from ostk.physics.time import Duration
 from ostk.physics.unit import Derived
+from ostk.physics.unit import Length
+from ostk.physics.unit import Angle
 
 from ostk.astrodynamics import Trajectory
 from ostk.astrodynamics.trajectory import State
-
+from ostk.astrodynamics.trajectory import Orbit
 
 @pytest.fixture
 def start_lla() -> LLA:
@@ -59,6 +61,10 @@ def states(trajectory: Trajectory) -> list[State]:
     return trajectory.get_states_at(
         [Instant.J2000(), Instant.J2000() + Duration.seconds(10.0)]
     )
+
+@pytest.fixture
+def orbit() -> Orbit:
+    return Orbit.circular(epoch=Instant.J2000(), altitude=Length.meters(545000.0), inclination=Angle.degrees(0.0), celestial_object=Earth.WGS84(),)
 
 
 class TestTrajectory:
@@ -116,3 +122,7 @@ class TestTrajectory:
 
         assert Trajectory.ground_strip(start_lla, end_lla, instants, earth) is not None
         assert Trajectory.ground_strip(start_lla, end_lla, instants) is not None
+
+    def test_ground_strip_geodetic_nadir(self, orbit: Orbit, instants: list[Instant], earth: Earth):
+        assert Trajectory.ground_strip_geodetic_nadir(orbit=orbit, instants=instants, celestial_object=earth) is not None
+        assert Trajectory.ground_strip_geodetic_nadir(orbit=orbit, instants=instants) is not None

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -235,7 +235,7 @@ class Trajectory
         const Celestial& aCelestial = Earth::WGS84()
     );
 
-    /// @brief Constructs a trajectory for the given orbit, with a geodetic nadir pointing attitude law
+    /// @brief Constructs a trajectory representing a ground strip that follows the geodetic nadir of the provided orbit
     ///
     /// @code{.cpp}
     ///             Instant startInstant = Instant::DateTime(DateTime::Parse("2020-01-01 00:00:00"), Scale::UTC);

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -32,6 +32,7 @@ using ostk::core::type::String;
 using ostk::core::type::Unique;
 
 using ostk::physics::coordinate::spherical::LLA;
+using ostk::physics::coordinate::Velocity;
 using ostk::physics::environment::object::Celestial;
 using ostk::physics::environment::object::celestial::Earth;
 using ostk::physics::time::Duration;
@@ -41,6 +42,11 @@ using ostk::physics::unit::Derived;
 
 using ostk::astrodynamics::trajectory::Model;
 using ostk::astrodynamics::trajectory::State;
+
+namespace trajectory
+{
+class Orbit;
+}
 
 /// @brief Path followed by an object through space as a function of time
 ///
@@ -229,10 +235,37 @@ class Trajectory
         const Celestial& aCelestial = Earth::WGS84()
     );
 
+    /// @brief Constructs a trajectory for the given orbit, with a geodetic nadir pointing attitude law
+    ///
+    /// @code{.cpp}
+    ///             Instant startInstant = Instant::DateTime(DateTime::Parse("2020-01-01 00:00:00"), Scale::UTC);
+    ///             Earth earth = Earth::WGS84();
+    ///             Trajectory trajectory = Trajectory::GroundStripGeodeticNadir(anOrbit, anInstantArray, earth);
+    /// @endcode
+    ///
+    /// @param anOrbit An orbit
+    /// @param anInstantArray An array of instants
+    /// @param aCelestial Celestial body
+    /// @return Trajectory
+    static Trajectory GroundStripGeodeticNadir(
+        const trajectory::Orbit& anOrbit,
+        const Array<Instant>& anInstantArray,
+        const Celestial& aCelestial = Earth::WGS84()
+    );
+
    private:
     Unique<Model> modelUPtr_;
 
     Trajectory();
+
+    /// @brief Compute velocities using finite difference from positions and instants
+    ///
+    /// @param aPositionArray An array of positions
+    /// @param anInstantArray An array of instants
+    /// @return Array of velocities
+    static Array<Velocity> computeVelocities(
+        const Array<physics::coordinate::Position>& aPositionArray, const Array<Instant>& anInstantArray
+    );
 };
 
 }  // namespace astrodynamics

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -258,13 +258,17 @@ class Trajectory
 
     Trajectory();
 
-    /// @brief Compute velocities using finite difference from positions and instants
+    /// @brief Compute states using the provided position generator, and finite differenced velocities, at the provided
+    /// instants
     ///
-    /// @param aPositionArray An array of positions
+    /// @param aPositionGenerator A position generator
     /// @param anInstantArray An array of instants
-    /// @return Array of velocities
-    static Array<Velocity> computeVelocities(
-        const Array<physics::coordinate::Position>& aPositionArray, const Array<Instant>& anInstantArray
+    /// @param aStepSize A step size
+    /// @return Array of states
+    static Array<State> computeStates(
+        const std::function<physics::coordinate::Position(const Instant&)>& aPositionGenerator,
+        const Array<Instant>& anInstantArray,
+        const Duration& aStepSize = Duration::Seconds(1e-6)
     );
 };
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
@@ -1,8 +1,8 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Core/Error.hpp>
-#include <OpenSpaceToolkit/Core/Utility.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
+#include <OpenSpaceToolkit/Core/Utility.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
@@ -232,10 +232,8 @@ Trajectory Trajectory::GroundStrip(
             anEndLLA, ratio, aCelestial.getEquatorialRadius(), aCelestial.getFlattening()
         );
 
-        const physics::coordinate::Position position = physics::coordinate::Position::FromLLA(
-            intermediateLLA,
-            celestialSPtr
-        ).inFrame(Frame::GCRF(), instant);
+        const physics::coordinate::Position position =
+            physics::coordinate::Position::FromLLA(intermediateLLA, celestialSPtr).inFrame(Frame::GCRF(), instant);
 
         positions.add(position);
     }
@@ -275,7 +273,8 @@ Trajectory Trajectory::GroundStripGeodeticNadir(
     {
         const State state = anOrbit.getStateAt(instant);
 
-        const LLA lla = LLA::FromPosition(state.getPosition().inFrame(Frame::ITRF(), instant), celestialSPtr).onSurface();
+        const LLA lla =
+            LLA::FromPosition(state.getPosition().inFrame(Frame::ITRF(), instant), celestialSPtr).onSurface();
 
         const physics::coordinate::Position position =
             physics::coordinate::Position::FromLLA(lla, celestialSPtr).inFrame(Frame::GCRF(), instant);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -699,7 +699,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
         const State trajectoryState = trajectory.getStateAt(instant);
         const State orbitState = orbit.getStateAt(instant);
 
-        // check that the trahectory state is the same as the geodetic nadir coordinate of the orbit
+        // check that the trajectory state is the same as the geodetic nadir coordinate of the orbit
 
         const Vector3d orbitLLACoordinates =
             Position::FromLLA(

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -2,17 +2,18 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp>
+#include <OpenSpaceToolkit/Physics/Data/Direction.hpp>
+#include <OpenSpaceToolkit/Physics/Data/Provider/Nadir.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
-#include <OpenSpaceToolkit/Physics/Data/Direction.hpp>
-#include <OpenSpaceToolkit/Physics/Data/Provider/Nadir.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
+
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
@@ -21,26 +22,26 @@ using ostk::core::type::Shared;
 
 using ostk::mathematics::object::Vector3d;
 
-using ostk::physics::Environment;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::spherical::LLA;
 using ostk::physics::coordinate::Velocity;
+using ostk::physics::data::Direction;
+using ostk::physics::data::provider::Nadir;
+using ostk::physics::Environment;
 using ostk::physics::environment::object::celestial::Earth;
 using ostk::physics::time::DateTime;
 using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Scale;
+using ostk::physics::unit::Angle;
 using ostk::physics::unit::Derived;
 using ostk::physics::unit::Length;
-using ostk::physics::unit::Angle;
-using ostk::physics::data::Direction;
-using ostk::physics::data::provider::Nadir;
 
 using ostk::astrodynamics::Trajectory;
 using ostk::astrodynamics::trajectory::model::Tabulated;
-using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::Orbit;
+using ostk::astrodynamics::trajectory::State;
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, Constructor)
 {
@@ -677,11 +678,15 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
     const Orbit orbit = Orbit::Circular(Instant::J2000(), Length::Meters(545000.0), Angle::Degrees(0.0), earthSPtr);
 
     {
-        EXPECT_THROW(Trajectory::GroundStripGeodeticNadir(Orbit::Undefined(), instants, earth), ostk::core::error::RuntimeError);
+        EXPECT_THROW(
+            Trajectory::GroundStripGeodeticNadir(Orbit::Undefined(), instants, earth), ostk::core::error::RuntimeError
+        );
     }
 
     {
-        EXPECT_THROW(Trajectory::GroundStripGeodeticNadir(orbit, Array<Instant>::Empty(), earth), ostk::core::error::RuntimeError);
+        EXPECT_THROW(
+            Trajectory::GroundStripGeodeticNadir(orbit, Array<Instant>::Empty(), earth), ostk::core::error::RuntimeError
+        );
     }
 
     {
@@ -696,18 +701,18 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
 
         // check that the trahectory state is the same as the geodetic nadir coordinate of the orbit
 
-        const Vector3d orbitLLACoordinates = Position::FromLLA(
-            LLA::FromPosition(orbitState.inFrame(Frame::ITRF()).getPosition(), earthSPtr).onSurface(),
-            earthSPtr
-        ).getCoordinates();
-        const Vector3d trajectoryLLACoordinates = Position::FromLLA(
-            LLA::FromPosition(trajectoryState.inFrame(Frame::ITRF()).getPosition(), earthSPtr).onSurface(),
-            earthSPtr
-        ).getCoordinates();
+        const Vector3d orbitLLACoordinates =
+            Position::FromLLA(
+                LLA::FromPosition(orbitState.inFrame(Frame::ITRF()).getPosition(), earthSPtr).onSurface(), earthSPtr
+            )
+                .getCoordinates();
+        const Vector3d trajectoryLLACoordinates =
+            Position::FromLLA(
+                LLA::FromPosition(trajectoryState.inFrame(Frame::ITRF()).getPosition(), earthSPtr).onSurface(),
+                earthSPtr
+            )
+                .getCoordinates();
 
         EXPECT_VECTORS_ALMOST_EQUAL(trajectoryLLACoordinates, orbitLLACoordinates, 1e-12);
-
     }
-    
-    
 }


### PR DESCRIPTION
- Previously the velocity was hardcoded to zero, which is incorrect. We now finite difference the velocity based on the provided instants
- Added a method to compute a trajectory that follows the geodetic nadir path of the provided orbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to generate a ground strip trajectory that follows the geodetic nadir of an orbit.
- **Bug Fixes**
  - Improved velocity calculations for ground strip trajectories to ensure accurate velocity estimation along the path.
- **Tests**
  - Introduced new tests for geodetic nadir ground strip trajectories.
  - Updated existing ground strip tests to improve validation of velocity and trajectory accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->