### PR TITLE
feat: add minimum maneuver duration constraint

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -209,16 +209,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                     const NumericalSolver&,
                     const Array<Shared<Dynamics>>&,
                     const Duration&,
-                    const Size&>(),
+                    const Size&,
+                    const Duration&>(),
                 R"doc(
                     Construct a new `Sequence` object.
 
                     Args:
-                    segments (list[Segment], optional): The segments.
-                    numerical_solver (NumericalSolver, optional): The numerical solver.
-                    dynamics (list[Dynamics], optional): The dynamics.
-                    maximum_propagation_duration (Duration, optional): The maximum propagation duration.
-                    verbosity (int, optional): The verbosity level.
+                    segments (list[Segment], optional): The segments. Defaults to an empty list.
+                    numerical_solver (NumericalSolver, optional): The numerical solver. Defaults to the default conditional numerical solver.
+                    dynamics (list[Dynamics], optional): The dynamics. Defaults to an empty list.
+                    maximum_propagation_duration (Duration, optional): The maximum propagation duration. Defaults to 30 days.
+                    verbosity (int, optional): The verbosity level. Defaults to 1.
+                    minimum_maneuver_duration (Duration, optional): The minimum maneuver duration. Defaults to Undefined.
 
                     Returns:
                         Sequence: The new `Sequence` object.
@@ -230,7 +232,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
                 ),
                 arg_v("dynamics", Array<Shared<Dynamics>>::Empty(), "[]"),
                 arg_v("maximum_propagation_duration", Duration::Days(30.0), "duration.days(30.0)"),
-                arg("verbosity") = 1
+                arg("verbosity") = 1,
+                arg_v("minimum_maneuver_duration", Duration::Undefined(), "duration.undefined()")
             )
 
             .def("__str__", &(shiftToString<Sequence>))
@@ -277,6 +280,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
 
                     Returns:
                         Duration: The maximum propagation duration.
+
+                )doc"
+            )
+            .def(
+                "get_minimum_maneuver_duration",
+                &Sequence::getMinimumManeuverDuration,
+                R"doc(
+                    Get the minimum maneuver duration.
+
+                    Returns:
+                        Duration: The minimum maneuver duration.
 
                 )doc"
             )

--- a/bindings/python/test/trajectory/test_sequence.py
+++ b/bindings/python/test/trajectory/test_sequence.py
@@ -351,6 +351,28 @@ def sequence_solution(
     )
 
 
+@pytest.fixture
+def minimum_maneuver_duration():
+    return Duration.minutes(1.0)
+
+
+@pytest.fixture
+def sequence_with_minimum_maneuver_duration(
+    segments: list[Segment],
+    numerical_solver: NumericalSolver,
+    dynamics: list,
+    maximum_propagation_duration: Duration,
+    minimum_maneuver_duration: Duration,
+):
+    return Sequence(
+        segments=segments,
+        dynamics=dynamics,
+        numerical_solver=numerical_solver,
+        maximum_propagation_duration=maximum_propagation_duration,
+        minimum_maneuver_duration=minimum_maneuver_duration,
+    )
+
+
 class TestSequenceSolution:
     def test_properties(
         self,
@@ -420,6 +442,16 @@ class TestSequence:
         maximum_propagation_duration: Duration,
     ):
         assert sequence.get_maximum_propagation_duration() == maximum_propagation_duration
+
+    def test_get_minimum_maneuver_duration(
+        self,
+        sequence_with_minimum_maneuver_duration: Sequence,
+        minimum_maneuver_duration: Duration,
+    ):
+        assert (
+            sequence_with_minimum_maneuver_duration.get_minimum_maneuver_duration()
+            == minimum_maneuver_duration
+        )
 
     def test_add_segment(
         self,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -68,14 +68,14 @@ class Segment
         ///
         /// @param aName Name of the segment
         /// @param aDynamicsArray Array of dynamics
-        /// @param aStates Array of states for the segment
+        /// @param aStateArray Array of states for the segment
         /// @param aConditionIsSatisfied True if the event condition is satisfied
         /// @param aSegmentType Type of segment
         /// @return An instance of Solution
         Solution(
             const String& aName,
             const Array<Shared<Dynamics>>& aDynamicsArray,
-            const Array<State>& aStates,
+            const Array<State>& aStateArray,
             const bool& aConditionIsSatisfied,
             const Segment::Type& aSegmentType
         );

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
@@ -135,15 +135,17 @@ class Sequence
     /// @param aSegmentArray An array of segments. Defaults to empty.
     /// @param aNumericalSolver A Numerical Solver. Defaults to Undefined.
     /// @param aDynamicsArray An array of shared dynamics. Defaults to empty.
-    /// @param segmentPropagationDurationLimit Maximum duration for propagation. Defaults to 7.0
+    /// @param aSegmentPropagationDurationLimit Maximum duration for propagation. Defaults to 7.0
     /// days.
-    /// @param verbosity Verbosity level for the solver [0 (low) - 5 (high)]. Defaults to 0.
+    /// @param aVerbosityLevel Verbosity level for the solver [0 (low) - 5 (high)]. Defaults to 0.
+    /// @param aMinimumManeuverDuration Minimum duration for maneuver. Defaults to Undefined.
     Sequence(
         const Array<Segment>& aSegmentArray = Array<Segment>::Empty(),
         const NumericalSolver& aNumericalSolver = NumericalSolver::Undefined(),
         const Array<Shared<Dynamics>>& aDynamicsArray = Array<Shared<Dynamics>>::Empty(),
-        const Duration& segmentPropagationDurationLimit = Duration::Days(7.0),
-        const Size& verbosity = 0
+        const Duration& aSegmentPropagationDurationLimit = Duration::Days(7.0),
+        const Size& aVerbosityLevel = 0,
+        const Duration& aMinimumManeuverDuration = Duration::Undefined()
     );
 
     /// @brief Output stream operator.
@@ -172,6 +174,11 @@ class Sequence
     ///
     /// @return Maximum propagation duration.
     Duration getMaximumPropagationDuration() const;
+
+    /// @brief Get minimum maneuver duration.
+    ///
+    /// @return Minimum maneuver duration.
+    Duration getMinimumManeuverDuration() const;
 
     /// @brief Add a trajectory segment.
     ///
@@ -224,6 +231,7 @@ class Sequence
     NumericalSolver numericalSolver_;
     Array<Shared<Dynamics>> dynamics_;
     Duration segmentPropagationDurationLimit_;
+    Duration minimumManeuverDuration_;
 };
 
 }  // namespace trajectory

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -35,13 +35,13 @@ using ostk::astrodynamics::trajectory::StateBuilder;
 Segment::Solution::Solution(
     const String& aName,
     const Array<Shared<Dynamics>>& aDynamicsArray,
-    const Array<State>& aStates,
+    const Array<State>& aStateArray,
     const bool& aConditionIsSatisfied,
     const Segment::Type& aSegmentType
 )
     : name(aName),
       dynamics(aDynamicsArray),
-      states(aStates),
+      states(aStateArray),
       conditionIsSatisfied(aConditionIsSatisfied),
       segmentType(aSegmentType)
 {
@@ -505,10 +505,19 @@ Segment::Solution Segment::solve(const State& aState, const Duration& maximumPro
         aState, aState.accessInstant() + maximumPropagationDuration, *eventCondition_
     );
 
+    // Expand states based on input state
+    const StateBuilder stateBuilder = {aState};
+
+    Array<State> states = Array<State>::Empty();
+    for (const State& state : propagator.accessNumericalSolver().accessObservedStates())
+    {
+        states.add(stateBuilder.expand(state.inFrame(aState.accessFrame()), aState));
+    }
+
     return {
         name_,
         dynamics_,
-        propagator.accessNumericalSolver().accessObservedStates(),
+        states,
         conditionSolution.conditionIsSatisfied,
         type_,
     };


### PR DESCRIPTION
- add a minimum maneuver duration parameter to the Sequence object
- fix a bug in the sequence solution states where they were not properly expanded with the input state