### PR TITLE
fix: within range angular condition, wrapping boundaries

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.cpp
@@ -203,6 +203,13 @@ AngularCondition::AngularCondition(
               const Real& currentValue, [[maybe_unused]] const Real& previousValue, [[maybe_unused]] const Real& aTarget
           ) -> bool
           {
+              // For ranges that wrap around 0/360 (when lowerBound > upperBound)
+              if (lowerBound > upperBound)
+              {
+                  return (currentValue >= lowerBound) || (currentValue <= upperBound);
+              }
+
+              // Normal range check
               return (currentValue >= lowerBound) && (currentValue <= upperBound);
           }
       ),

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.test.cpp
@@ -309,6 +309,69 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_AngularCondition, isSatisfi
             }
         }
     }
+
+    // Within Range
+    {
+        // Regular range (no boundary crossing)
+        {
+            const Pair<Angle, Angle> targetRange = {Angle::Degrees(30.0), Angle::Degrees(60.0)};
+
+            AngularCondition condition = AngularCondition::WithinRange(
+                "RegularRange",
+                defaultEvaluator_,
+                targetRange
+            );
+
+            // Inside range
+            {
+                const State state = generateState(Angle::Degrees(45.0).inRadians());
+                EXPECT_TRUE(condition.isSatisfied(state, state));
+            }
+
+            // Outside range
+            {
+                const State state = generateState(Angle::Degrees(20.0).inRadians());
+                EXPECT_FALSE(condition.isSatisfied(state, state));
+            }
+        }
+
+        // Boundary crossing range (-30 to 30 degrees, which normalizes to 330-30 degrees)
+        {
+            const Pair<Angle, Angle> boundaryCrossingRange = {Angle::Degrees(-30.0), Angle::Degrees(30.0)};
+
+            AngularCondition condition = AngularCondition::WithinRange(
+                "BoundaryCrossingRange",
+                defaultEvaluator_,
+                boundaryCrossingRange
+            );
+
+            // Inside range (positive side)
+            {
+                const State state = generateState(Angle::Degrees(15.0).inRadians());
+                EXPECT_TRUE(condition.isSatisfied(state, state));
+            }
+
+            // Inside range (negative side - will be normalized to 345 degrees)
+            {
+                const State state = generateState(Angle::Degrees(-15.0).inRadians());
+                EXPECT_TRUE(condition.isSatisfied(state, state));
+            }
+
+            // Inside range (exactly at boundary)
+            {
+                const State lowerState = generateState(Angle::Degrees(-30.0).inRadians());
+                const State upperState = generateState(Angle::Degrees(30.0).inRadians());
+                EXPECT_TRUE(condition.isSatisfied(lowerState, lowerState));
+                EXPECT_TRUE(condition.isSatisfied(upperState, upperState));
+            }
+
+            // Outside range
+            {
+                const State state = generateState(Angle::Degrees(45.0).inRadians());
+                EXPECT_FALSE(condition.isSatisfied(state, state));
+            }
+        }
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_AngularCondition, Clone)

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.test.cpp
@@ -316,11 +316,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_AngularCondition, isSatisfi
         {
             const Pair<Angle, Angle> targetRange = {Angle::Degrees(30.0), Angle::Degrees(60.0)};
 
-            AngularCondition condition = AngularCondition::WithinRange(
-                "RegularRange",
-                defaultEvaluator_,
-                targetRange
-            );
+            AngularCondition condition = AngularCondition::WithinRange("RegularRange", defaultEvaluator_, targetRange);
 
             // Inside range
             {
@@ -339,11 +335,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_AngularCondition, isSatisfi
         {
             const Pair<Angle, Angle> boundaryCrossingRange = {Angle::Degrees(-30.0), Angle::Degrees(30.0)};
 
-            AngularCondition condition = AngularCondition::WithinRange(
-                "BoundaryCrossingRange",
-                defaultEvaluator_,
-                boundaryCrossingRange
-            );
+            AngularCondition condition =
+                AngularCondition::WithinRange("BoundaryCrossingRange", defaultEvaluator_, boundaryCrossingRange);
 
             // Inside range (positive side)
             {


### PR DESCRIPTION
This MR addresses an issue in the AngularCondition::WithinRange criterion when the angular range wraps across a boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of angular ranges that cross the 0/360-degree boundary, ensuring accurate evaluation of values within these ranges.

- **Tests**
	- Added new test cases to verify correct behavior for both standard and boundary-crossing angular ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->