### PR TITLE
feat: brouwer lyddane mean long condition

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
@@ -8,6 +8,7 @@
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/InstantCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp>
+#include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp>
 
 using namespace pybind11;
 
@@ -289,4 +290,5 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition(pybind11::module& aMo
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_InstantCondition(event_condition);
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(event_condition);
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalCondition(event_condition);
+    OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLongCondition(event_condition);
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
@@ -4,11 +4,11 @@
 
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanCondition.cpp>
+#include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/InstantCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/RealCondition.cpp>
-#include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp>
 
 using namespace pybind11;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp
@@ -4,16 +4,16 @@
 
 using namespace pybind11;
 
-using ostk::core::type::Shared;
 using ostk::core::container::Pair;
+using ostk::core::type::Shared;
 
 using ostk::physics::coordinate::Frame;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Derived;
 
-using ostk::astrodynamics::eventcondition::BrouwerLyddaneMeanLongCondition;
-using ostk::astrodynamics::eventcondition::AngularCondition;
 using ostk::astrodynamics::EventCondition;
+using ostk::astrodynamics::eventcondition::AngularCondition;
+using ostk::astrodynamics::eventcondition::BrouwerLyddaneMeanLongCondition;
 
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLongCondition(pybind11::module& aModule)
 {
@@ -71,9 +71,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
 
             .def_static(
                 "inclination",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &BrouwerLyddaneMeanLongCondition::Inclination
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanLongCondition::Inclination),
                 R"doc(
                     Create a Brouwer-Lyddane Mean Long based on the inclination.
 
@@ -115,9 +117,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
 
             .def_static(
                 "aop",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &BrouwerLyddaneMeanLongCondition::Aop
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanLongCondition::Aop),
                 R"doc(
                     Create a Brouwer-Lyddane Mean Long based on the argument of perigee.
 
@@ -159,9 +163,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
 
             .def_static(
                 "raan",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &BrouwerLyddaneMeanLongCondition::Raan
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanLongCondition::Raan),
                 R"doc(
                     Create a Brouwer-Lyddane Mean Long based on the right ascension of the ascending node.
 
@@ -203,9 +209,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
 
             .def_static(
                 "true_anomaly",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &BrouwerLyddaneMeanLongCondition::TrueAnomaly
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanLongCondition::TrueAnomaly),
                 R"doc(
                     Create a Brouwer-Lyddane Mean Long based on the true anomaly.
 
@@ -247,9 +255,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
 
             .def_static(
                 "mean_anomaly",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &BrouwerLyddaneMeanLongCondition::MeanAnomaly
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanLongCondition::MeanAnomaly),
                 R"doc(
                     Create a Brouwer-Lyddane Mean Long based on the mean anomaly.
 
@@ -291,7 +301,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
 
             .def_static(
                 "eccentric_anomaly",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(&BrouwerLyddaneMeanLongCondition::EccentricAnomaly),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanLongCondition::EccentricAnomaly),
                 R"doc(
                     Create a Brouwer-Lyddane Mean Long based on the eccentric anomaly.
 
@@ -312,7 +326,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
 
             .def_static(
                 "eccentric_anomaly",
-                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(&BrouwerLyddaneMeanLongCondition::EccentricAnomaly),
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanLongCondition::EccentricAnomaly
+                ),
                 R"doc(
                     Create a Brouwer-Lyddane Mean Long based on the eccentric anomaly being within a range.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp
@@ -31,7 +31,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                 "semi_major_axis",
                 &BrouwerLyddaneMeanLongCondition::SemiMajorAxis,
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the semi-major axis.
+                    Create a Brouwer-Lyddane Mean Long condition based on the semi-major axis.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -40,7 +40,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -52,7 +52,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                 "eccentricity",
                 &BrouwerLyddaneMeanLongCondition::Eccentricity,
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the eccentricity.
+                    Create a Brouwer-Lyddane Mean Long condition based on the eccentricity.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -61,7 +61,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -77,7 +77,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     const EventCondition::Target&,
                     const Derived&>(&BrouwerLyddaneMeanLongCondition::Inclination),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the inclination.
+                    Create a Brouwer-Lyddane Mean Long condition based on the inclination.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -86,7 +86,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -100,7 +100,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     &BrouwerLyddaneMeanLongCondition::Inclination
                 ),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the inclination being within a range.
+                    Create a Brouwer-Lyddane Mean Long condition based on the inclination being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -108,7 +108,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -123,7 +123,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     const EventCondition::Target&,
                     const Derived&>(&BrouwerLyddaneMeanLongCondition::Aop),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the argument of perigee.
+                    Create a Brouwer-Lyddane Mean Long condition based on the argument of perigee.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -132,7 +132,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -146,7 +146,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     &BrouwerLyddaneMeanLongCondition::Aop
                 ),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the argument of perigee being within a range.
+                    Create a Brouwer-Lyddane Mean Long condition based on the argument of perigee being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -154,7 +154,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -169,7 +169,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     const EventCondition::Target&,
                     const Derived&>(&BrouwerLyddaneMeanLongCondition::Raan),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the right ascension of the ascending node.
+                    Create a Brouwer-Lyddane Mean Long condition based on the right ascension of the ascending node.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -178,7 +178,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -192,7 +192,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     &BrouwerLyddaneMeanLongCondition::Raan
                 ),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the right ascension of the ascending node being within a range.
+                    Create a Brouwer-Lyddane Mean Long condition based on the right ascension of the ascending node being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -200,7 +200,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -215,7 +215,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     const EventCondition::Target&,
                     const Derived&>(&BrouwerLyddaneMeanLongCondition::TrueAnomaly),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the true anomaly.
+                    Create a Brouwer-Lyddane Mean Long condition based on the true anomaly.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -224,7 +224,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -238,7 +238,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     &BrouwerLyddaneMeanLongCondition::TrueAnomaly
                 ),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the true anomaly being within a range.
+                    Create a Brouwer-Lyddane Mean Long condition based on the true anomaly being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -246,7 +246,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -261,7 +261,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     const EventCondition::Target&,
                     const Derived&>(&BrouwerLyddaneMeanLongCondition::MeanAnomaly),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the mean anomaly.
+                    Create a Brouwer-Lyddane Mean Long condition based on the mean anomaly.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -270,7 +270,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -284,7 +284,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     &BrouwerLyddaneMeanLongCondition::MeanAnomaly
                 ),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the mean anomaly being within a range.
+                    Create a Brouwer-Lyddane Mean Long condition based on the mean anomaly being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -292,7 +292,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -307,7 +307,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     const EventCondition::Target&,
                     const Derived&>(&BrouwerLyddaneMeanLongCondition::EccentricAnomaly),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the eccentric anomaly.
+                    Create a Brouwer-Lyddane Mean Long condition based on the eccentric anomaly.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -316,7 +316,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -330,7 +330,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                     &BrouwerLyddaneMeanLongCondition::EccentricAnomaly
                 ),
                 R"doc(
-                    Create a Brouwer-Lyddane Mean Long based on the eccentric anomaly being within a range.
+                    Create a Brouwer-Lyddane Mean Long condition based on the eccentric anomaly being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -338,7 +338,53 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLon
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The Brouwer-Lyddane Mean Long.
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "argument_of_latitude",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanLongCondition::ArgumentOfLatitude),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Long condition based on the argument of latitude.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        argument_of_latitude (EventConditionTarget): The argument of latitude.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("argument_of_latitude"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "argument_of_latitude",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanLongCondition::ArgumentOfLatitude
+                ),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Long condition based on the argument of latitude being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanLongCondition: The Brouwer-Lyddane Mean Long condition.
                 )doc",
                 arg("frame"),
                 arg("target_range"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp
@@ -1,6 +1,6 @@
 /// Apache License 2.0
 
-#include <OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.hpp>
 
 using namespace pybind11;
 
@@ -11,27 +11,27 @@ using ostk::physics::coordinate::Frame;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Derived;
 
-using ostk::astrodynamics::eventcondition::COECondition;
+using ostk::astrodynamics::eventcondition::BrouwerLyddaneMeanLongCondition;
 using ostk::astrodynamics::eventcondition::AngularCondition;
 using ostk::astrodynamics::EventCondition;
 
-inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11::module& aModule)
+inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLongCondition(pybind11::module& aModule)
 {
     {
-        class_<COECondition>(
+        class_<BrouwerLyddaneMeanLongCondition>(
             aModule,
-            "COECondition",
+            "BrouwerLyddaneMeanLongCondition",
             R"doc(
-                A COE Event Condition.
+                A Brouwer-Lyddane Mean Long Event Condition.
 
             )doc"
         )
 
             .def_static(
                 "semi_major_axis",
-                &COECondition::SemiMajorAxis,
+                &BrouwerLyddaneMeanLongCondition::SemiMajorAxis,
                 R"doc(
-                    Create a COE condition based on the semi-major axis.
+                    Create a Brouwer-Lyddane Mean Long based on the semi-major axis.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -40,7 +40,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -50,9 +50,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "eccentricity",
-                &COECondition::Eccentricity,
+                &BrouwerLyddaneMeanLongCondition::Eccentricity,
                 R"doc(
-                    Create a COE condition based on the eccentricity.
+                    Create a Brouwer-Lyddane Mean Long based on the eccentricity.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -61,7 +61,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -72,10 +72,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "inclination",
                 overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::Inclination
+                    &BrouwerLyddaneMeanLongCondition::Inclination
                 ),
                 R"doc(
-                    Create a COE condition based on the inclination.
+                    Create a Brouwer-Lyddane Mean Long based on the inclination.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -84,7 +84,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -95,10 +95,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "inclination",
                 overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
-                    &COECondition::Inclination
+                    &BrouwerLyddaneMeanLongCondition::Inclination
                 ),
                 R"doc(
-                    Create a COE condition based on the inclination being within a range.
+                    Create a Brouwer-Lyddane Mean Long based on the inclination being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -106,7 +106,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -116,10 +116,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "aop",
                 overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::Aop
+                    &BrouwerLyddaneMeanLongCondition::Aop
                 ),
                 R"doc(
-                    Create a COE condition based on the argument of perigee.
+                    Create a Brouwer-Lyddane Mean Long based on the argument of perigee.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -128,7 +128,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -139,10 +139,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "aop",
                 overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
-                    &COECondition::Aop
+                    &BrouwerLyddaneMeanLongCondition::Aop
                 ),
                 R"doc(
-                    Create a COE condition based on the argument of perigee being within a range.
+                    Create a Brouwer-Lyddane Mean Long based on the argument of perigee being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -150,7 +150,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -160,10 +160,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "raan",
                 overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::Raan
+                    &BrouwerLyddaneMeanLongCondition::Raan
                 ),
                 R"doc(
-                    Create a COE condition based on the right ascension of the ascending node.
+                    Create a Brouwer-Lyddane Mean Long based on the right ascension of the ascending node.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -172,7 +172,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -183,10 +183,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "raan",
                 overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
-                    &COECondition::Raan
+                    &BrouwerLyddaneMeanLongCondition::Raan
                 ),
                 R"doc(
-                    Create a COE condition based on the right ascension of the ascending node being within a range.
+                    Create a Brouwer-Lyddane Mean Long based on the right ascension of the ascending node being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -194,7 +194,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -204,10 +204,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "true_anomaly",
                 overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::TrueAnomaly
+                    &BrouwerLyddaneMeanLongCondition::TrueAnomaly
                 ),
                 R"doc(
-                    Create a COE condition based on the true anomaly.
+                    Create a Brouwer-Lyddane Mean Long based on the true anomaly.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -216,7 +216,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -227,10 +227,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "true_anomaly",
                 overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
-                    &COECondition::TrueAnomaly
+                    &BrouwerLyddaneMeanLongCondition::TrueAnomaly
                 ),
                 R"doc(
-                    Create a COE condition based on the true anomaly being within a range.
+                    Create a Brouwer-Lyddane Mean Long based on the true anomaly being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -238,7 +238,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -248,10 +248,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "mean_anomaly",
                 overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::MeanAnomaly
+                    &BrouwerLyddaneMeanLongCondition::MeanAnomaly
                 ),
                 R"doc(
-                    Create a COE condition based on the mean anomaly.
+                    Create a Brouwer-Lyddane Mean Long based on the mean anomaly.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -260,7 +260,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -271,10 +271,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
             .def_static(
                 "mean_anomaly",
                 overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
-                    &COECondition::MeanAnomaly
+                    &BrouwerLyddaneMeanLongCondition::MeanAnomaly
                 ),
                 R"doc(
-                    Create a COE condition based on the mean anomaly being within a range.
+                    Create a Brouwer-Lyddane Mean Long based on the mean anomaly being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -282,7 +282,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("frame"),
                 arg("target_range"),
@@ -291,9 +291,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "eccentric_anomaly",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(&COECondition::EccentricAnomaly),
+                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(&BrouwerLyddaneMeanLongCondition::EccentricAnomaly),
                 R"doc(
-                    Create a COE condition based on the eccentric anomaly.
+                    Create a Brouwer-Lyddane Mean Long based on the eccentric anomaly.
 
                     Args:
                         criterion (Criterion): The criterion.
@@ -302,7 +302,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("criterion"),
                 arg("frame"),
@@ -312,9 +312,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "eccentric_anomaly",
-                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(&COECondition::EccentricAnomaly),
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(&BrouwerLyddaneMeanLongCondition::EccentricAnomaly),
                 R"doc(
-                    Create a COE condition based on the eccentric anomaly being within a range.
+                    Create a Brouwer-Lyddane Mean Long based on the eccentric anomaly being within a range.
 
                     Args:
                         frame (Frame): The reference frame.
@@ -322,7 +322,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                         gravitational_parameter (Derived): The gravitational parameter.
 
                     Returns:
-                        COECondition: The COE condition.
+                        COECondition: The Brouwer-Lyddane Mean Long.
                 )doc",
                 arg("frame"),
                 arg("target_range"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
@@ -343,6 +343,52 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
                 arg("gravitational_parameter")
             )
 
+            .def_static(
+                "argument_of_latitude",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&COECondition::ArgumentOfLatitude),
+                R"doc(
+                    Create a COE condition based on the argument of latitude.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        argument_of_latitude (EventConditionTarget): The argument of latitude.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("argument_of_latitude"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "argument_of_latitude",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &COECondition::ArgumentOfLatitude
+                ),
+                R"doc(
+                    Create a COE condition based on the argument of latitude being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        COECondition: The COE condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
             ;
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp
@@ -4,16 +4,16 @@
 
 using namespace pybind11;
 
-using ostk::core::type::Shared;
 using ostk::core::container::Pair;
+using ostk::core::type::Shared;
 
 using ostk::physics::coordinate::Frame;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Derived;
 
-using ostk::astrodynamics::eventcondition::COECondition;
-using ostk::astrodynamics::eventcondition::AngularCondition;
 using ostk::astrodynamics::EventCondition;
+using ostk::astrodynamics::eventcondition::AngularCondition;
+using ostk::astrodynamics::eventcondition::COECondition;
 
 inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11::module& aModule)
 {
@@ -71,9 +71,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "inclination",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::Inclination
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&COECondition::Inclination),
                 R"doc(
                     Create a COE condition based on the inclination.
 
@@ -115,9 +117,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "aop",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::Aop
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&COECondition::Aop),
                 R"doc(
                     Create a COE condition based on the argument of perigee.
 
@@ -138,8 +142,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "aop",
-                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
-                    &COECondition::Aop
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(&COECondition::Aop
                 ),
                 R"doc(
                     Create a COE condition based on the argument of perigee being within a range.
@@ -159,9 +162,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "raan",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::Raan
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&COECondition::Raan),
                 R"doc(
                     Create a COE condition based on the right ascension of the ascending node.
 
@@ -182,8 +187,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "raan",
-                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
-                    &COECondition::Raan
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(&COECondition::Raan
                 ),
                 R"doc(
                     Create a COE condition based on the right ascension of the ascending node being within a range.
@@ -203,9 +207,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "true_anomaly",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::TrueAnomaly
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&COECondition::TrueAnomaly),
                 R"doc(
                     Create a COE condition based on the true anomaly.
 
@@ -247,9 +253,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "mean_anomaly",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(
-                    &COECondition::MeanAnomaly
-                ),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&COECondition::MeanAnomaly),
                 R"doc(
                     Create a COE condition based on the mean anomaly.
 
@@ -291,7 +299,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "eccentric_anomaly",
-                overload_cast<const AngularCondition::Criterion&, const Shared<const Frame>&, const EventCondition::Target&, const Derived&>(&COECondition::EccentricAnomaly),
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&COECondition::EccentricAnomaly),
                 R"doc(
                     Create a COE condition based on the eccentric anomaly.
 
@@ -312,7 +324,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(pybind11
 
             .def_static(
                 "eccentric_anomaly",
-                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(&COECondition::EccentricAnomaly),
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &COECondition::EccentricAnomaly
+                ),
                 R"doc(
                     Create a COE condition based on the eccentric anomaly being within a range.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -57,6 +57,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
         .value("TrueAnomaly", COE::Element::TrueAnomaly, "True Anomaly")
         .value("MeanAnomaly", COE::Element::MeanAnomaly, "Mean Anomaly")
         .value("EccentricAnomaly", COE::Element::EccentricAnomaly, "Eccentric Anomaly")
+        .value("ArgumentOfLatitude", COE::Element::ArgumentOfLatitude, "Argument of Latitude")
 
         ;
 

--- a/bindings/python/test/event_condition/test_brouwer_lyddane_mean_long_condition.py
+++ b/bindings/python/test/event_condition/test_brouwer_lyddane_mean_long_condition.py
@@ -85,32 +85,32 @@ class TestBrouwerLyddaneMeanLongCondition:
     ):
         condition = static_constructor(criterion, frame, target, gravitational_parameter)
         assert condition is not None
-    
+
     @pytest.mark.parametrize(
         "static_constructor,target_range",
         (
             (
-                BrouwerLyddaneMeanLongCondition.inclination_within_range,
+                BrouwerLyddaneMeanLongCondition.inclination,
                 (Angle.degrees(10.0), Angle.degrees(20.0)),
             ),
             (
-                BrouwerLyddaneMeanLongCondition.aop_within_range,
+                BrouwerLyddaneMeanLongCondition.aop,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                BrouwerLyddaneMeanLongCondition.raan_within_range,
+                BrouwerLyddaneMeanLongCondition.raan,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                BrouwerLyddaneMeanLongCondition.true_anomaly_within_range,
+                BrouwerLyddaneMeanLongCondition.true_anomaly,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                BrouwerLyddaneMeanLongCondition.mean_anomaly_within_range,
+                BrouwerLyddaneMeanLongCondition.mean_anomaly,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                BrouwerLyddaneMeanLongCondition.eccentric_anomaly_within_range,
+                BrouwerLyddaneMeanLongCondition.eccentric_anomaly,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
         ),

--- a/bindings/python/test/event_condition/test_brouwer_lyddane_mean_long_condition.py
+++ b/bindings/python/test/event_condition/test_brouwer_lyddane_mean_long_condition.py
@@ -73,6 +73,11 @@ class TestBrouwerLyddaneMeanLongCondition:
                 EventCondition.Target(Angle.degrees(0.0)),
                 AngularCondition.Criterion.PositiveCrossing,
             ),
+            (
+                BrouwerLyddaneMeanLongCondition.argument_of_latitude,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
         ),
     )
     def test_static_constructors(
@@ -111,6 +116,10 @@ class TestBrouwerLyddaneMeanLongCondition:
             ),
             (
                 BrouwerLyddaneMeanLongCondition.eccentric_anomaly,
+                (Angle.degrees(0.0), Angle.degrees(90.0)),
+            ),
+            (
+                BrouwerLyddaneMeanLongCondition.argument_of_latitude,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
         ),

--- a/bindings/python/test/event_condition/test_brouwer_lyddane_mean_long_condition.py
+++ b/bindings/python/test/event_condition/test_brouwer_lyddane_mean_long_condition.py
@@ -8,7 +8,7 @@ from ostk.physics.coordinate import Frame
 
 from ostk.astrodynamics import EventCondition
 from ostk.astrodynamics.event_condition import (
-    COECondition,
+    BrouwerLyddaneMeanLongCondition,
     AngularCondition,
     RealCondition,
 )
@@ -29,47 +29,47 @@ def frame() -> Frame:
     return Frame.GCRF()
 
 
-class TestCOECondition:
+class TestBrouwerLyddaneMeanLongCondition:
     @pytest.mark.parametrize(
         "static_constructor,target,criterion",
         (
             (
-                COECondition.semi_major_axis,
+                BrouwerLyddaneMeanLongCondition.semi_major_axis,
                 EventCondition.Target(Length.meters(7e6)),
                 RealCondition.Criterion.PositiveCrossing,
             ),
             (
-                COECondition.eccentricity,
+                BrouwerLyddaneMeanLongCondition.eccentricity,
                 EventCondition.Target(0.1),
                 RealCondition.Criterion.PositiveCrossing,
             ),
             (
-                COECondition.inclination,
+                BrouwerLyddaneMeanLongCondition.inclination,
                 EventCondition.Target(Angle.degrees(0.0)),
                 AngularCondition.Criterion.PositiveCrossing,
             ),
             (
-                COECondition.aop,
+                BrouwerLyddaneMeanLongCondition.aop,
                 EventCondition.Target(Angle.degrees(0.0)),
                 AngularCondition.Criterion.PositiveCrossing,
             ),
             (
-                COECondition.raan,
+                BrouwerLyddaneMeanLongCondition.raan,
                 EventCondition.Target(Angle.degrees(0.0)),
                 AngularCondition.Criterion.PositiveCrossing,
             ),
             (
-                COECondition.true_anomaly,
+                BrouwerLyddaneMeanLongCondition.true_anomaly,
                 EventCondition.Target(Angle.degrees(0.0)),
                 AngularCondition.Criterion.PositiveCrossing,
             ),
             (
-                COECondition.mean_anomaly,
+                BrouwerLyddaneMeanLongCondition.mean_anomaly,
                 EventCondition.Target(Angle.degrees(0.0)),
                 AngularCondition.Criterion.PositiveCrossing,
             ),
             (
-                COECondition.eccentric_anomaly,
+                BrouwerLyddaneMeanLongCondition.eccentric_anomaly,
                 EventCondition.Target(Angle.degrees(0.0)),
                 AngularCondition.Criterion.PositiveCrossing,
             ),
@@ -90,27 +90,27 @@ class TestCOECondition:
         "static_constructor,target_range",
         (
             (
-                COECondition.inclination_within_range,
+                BrouwerLyddaneMeanLongCondition.inclination_within_range,
                 (Angle.degrees(10.0), Angle.degrees(20.0)),
             ),
             (
-                COECondition.aop_within_range,
+                BrouwerLyddaneMeanLongCondition.aop_within_range,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                COECondition.raan_within_range,
+                BrouwerLyddaneMeanLongCondition.raan_within_range,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                COECondition.true_anomaly_within_range,
+                BrouwerLyddaneMeanLongCondition.true_anomaly_within_range,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                COECondition.mean_anomaly_within_range,
+                BrouwerLyddaneMeanLongCondition.mean_anomaly_within_range,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                COECondition.eccentric_anomaly_within_range,
+                BrouwerLyddaneMeanLongCondition.eccentric_anomaly_within_range,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
         ),

--- a/bindings/python/test/event_condition/test_coe_condition.py
+++ b/bindings/python/test/event_condition/test_coe_condition.py
@@ -85,32 +85,32 @@ class TestCOECondition:
     ):
         condition = static_constructor(criterion, frame, target, gravitational_parameter)
         assert condition is not None
-    
+
     @pytest.mark.parametrize(
         "static_constructor,target_range",
         (
             (
-                COECondition.inclination_within_range,
+                COECondition.inclination,
                 (Angle.degrees(10.0), Angle.degrees(20.0)),
             ),
             (
-                COECondition.aop_within_range,
+                COECondition.aop,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                COECondition.raan_within_range,
+                COECondition.raan,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                COECondition.true_anomaly_within_range,
+                COECondition.true_anomaly,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                COECondition.mean_anomaly_within_range,
+                COECondition.mean_anomaly,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
             (
-                COECondition.eccentric_anomaly_within_range,
+                COECondition.eccentric_anomaly,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
         ),

--- a/bindings/python/test/event_condition/test_coe_condition.py
+++ b/bindings/python/test/event_condition/test_coe_condition.py
@@ -73,6 +73,11 @@ class TestCOECondition:
                 EventCondition.Target(Angle.degrees(0.0)),
                 AngularCondition.Criterion.PositiveCrossing,
             ),
+            (
+                COECondition.argument_of_latitude,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
         ),
     )
     def test_static_constructors(
@@ -111,6 +116,10 @@ class TestCOECondition:
             ),
             (
                 COECondition.eccentric_anomaly,
+                (Angle.degrees(0.0), Angle.degrees(90.0)),
+            ),
+            (
+                COECondition.argument_of_latitude,
                 (Angle.degrees(0.0), Angle.degrees(90.0)),
             ),
         ),

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.hpp
@@ -1,7 +1,7 @@
 /// Apache License 2.0
 
-#ifndef __OpenSpaceToolkit_Astrodynamics_EventConditions_COECondition__
-#define __OpenSpaceToolkit_Astrodynamics_EventConditions_COECondition__
+#ifndef __OpenSpaceToolkit_Astrodynamics_EventConditions_BrouwerLyddaneMeanLongCondition__
+#define __OpenSpaceToolkit_Astrodynamics_EventConditions_BLMCondition__
 
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
@@ -13,7 +13,8 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMeanLong.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMeanShort.hpp>
 
 namespace ostk
 {
@@ -36,11 +37,12 @@ using ostk::physics::unit::Length;
 using ostk::astrodynamics::EventCondition;
 using ostk::astrodynamics::eventcondition::AngularCondition;
 using ostk::astrodynamics::eventcondition::RealCondition;
+using ostk::astrodynamics::trajectory::orbit::model::blm::BrouwerLyddaneMeanLong;
 using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::State;
 
-/// @brief A Classical Orbital Element based event condition
-class COECondition
+/// @brief A Brouwer-Lyddane Long Mean orbital elements based event condition
+class BrouwerLyddaneMeanLongCondition
 {
    public:
     /// @brief Semi-Major Axis based constructor
@@ -50,7 +52,7 @@ class COECondition
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static RealCondition SemiMajorAxis(
         const RealCondition::Criterion& aCriterion,
         const Shared<const Frame>& aFrameSPtr,
@@ -65,7 +67,7 @@ class COECondition
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static RealCondition Eccentricity(
         const RealCondition::Criterion& aCriterion,
         const Shared<const Frame>& aFrameSPtr,
@@ -80,7 +82,7 @@ class COECondition
     /// @param aTarget A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition Inclination(
         const AngularCondition::Criterion& aCriterion,
         const Shared<const Frame>& aFrameSPtr,
@@ -94,7 +96,7 @@ class COECondition
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition Inclination(
         const Shared<const Frame>& aFrameSPtr,
         const Pair<Angle, Angle>& aTargetRange,
@@ -108,7 +110,7 @@ class COECondition
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition Aop(
         const AngularCondition::Criterion& aCriterion,
         const Shared<const Frame>& aFrameSPtr,
@@ -122,7 +124,7 @@ class COECondition
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition Aop(
         const Shared<const Frame>& aFrameSPtr,
         const Pair<Angle, Angle>& aTargetRange,
@@ -136,7 +138,7 @@ class COECondition
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition Raan(
         const AngularCondition::Criterion& aCriterion,
         const Shared<const Frame>& aFrameSPtr,
@@ -150,7 +152,7 @@ class COECondition
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition Raan(
         const Shared<const Frame>& aFrameSPtr,
         const Pair<Angle, Angle>& aTargetRange,
@@ -164,7 +166,7 @@ class COECondition
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition TrueAnomaly(
         const AngularCondition::Criterion& aCriterion,
         const Shared<const Frame>& aFrameSPtr,
@@ -178,7 +180,7 @@ class COECondition
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition TrueAnomaly(
         const Shared<const Frame>& aFrameSPtr,
         const Pair<Angle, Angle>& aTargetRange,
@@ -192,7 +194,7 @@ class COECondition
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition MeanAnomaly(
         const AngularCondition::Criterion& aCriterion,
         const Shared<const Frame>& aFrameSPtr,
@@ -206,7 +208,7 @@ class COECondition
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition MeanAnomaly(
         const Shared<const Frame>& aFrameSPtr,
         const Pair<Angle, Angle>& aTargetRange,
@@ -220,7 +222,7 @@ class COECondition
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition EccentricAnomaly(
         const AngularCondition::Criterion& aCriterion,
         const Shared<const Frame>& aFrameSPtr,
@@ -234,7 +236,7 @@ class COECondition
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
-    /// @return COECondition object
+    /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition EccentricAnomaly(
         const Shared<const Frame>& aFrameSPtr,
         const Pair<Angle, Angle>& aTargetRange,

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.hpp
@@ -1,7 +1,7 @@
 /// Apache License 2.0
 
 #ifndef __OpenSpaceToolkit_Astrodynamics_EventConditions_BrouwerLyddaneMeanLongCondition__
-#define __OpenSpaceToolkit_Astrodynamics_EventConditions_BLMCondition__
+#define __OpenSpaceToolkit_Astrodynamics_EventConditions_BrouwerLyddaneMeanLongCondition__
 
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
@@ -9,12 +9,12 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMeanLong.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMeanShort.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 
 namespace ostk
 {
@@ -23,16 +23,14 @@ namespace astrodynamics
 namespace eventcondition
 {
 
+using ostk::core::container::Pair;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
 using ostk::core::type::String;
 
-using ostk::mathematics::object::Vector3d;
-
 using ostk::physics::coordinate::Frame;
 using ostk::physics::unit::Angle;
 using ostk::physics::unit::Derived;
-using ostk::physics::unit::Length;
 
 using ostk::astrodynamics::EventCondition;
 using ostk::astrodynamics::eventcondition::AngularCondition;
@@ -47,8 +45,8 @@ class BrouwerLyddaneMeanLongCondition
    public:
     /// @brief Semi-Major Axis based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -62,8 +60,8 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Eccentricity based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -77,8 +75,8 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Inclination based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -92,7 +90,7 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Inclination based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -105,8 +103,8 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Argument of Periapsis based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -120,7 +118,7 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Argument of Periapsis based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -133,8 +131,8 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Right Ascension of Ascending Node based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -148,7 +146,7 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Right Ascension of Ascending Node based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -161,8 +159,8 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief True Anomaly based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -176,7 +174,7 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief True Anomaly based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -189,8 +187,8 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Mean Anomaly based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -204,7 +202,7 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Mean Anomaly based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -217,8 +215,8 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Eccentric Anomaly based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -232,12 +230,40 @@ class BrouwerLyddaneMeanLongCondition
 
     /// @brief Eccentric Anomaly based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
     /// @return BrouwerLyddaneMeanLongCondition object
     static AngularCondition EccentricAnomaly(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Argument of Latitude based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanLongCondition object
+    static AngularCondition ArgumentOfLatitude(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Argument of Latitude based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanLongCondition object
+    static AngularCondition ArgumentOfLatitude(
         const Shared<const Frame>& aFrameSPtr,
         const Pair<Angle, Angle>& aTargetRange,
         const Derived& aGravitationalParameter

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp
@@ -45,8 +45,8 @@ class COECondition
    public:
     /// @brief Semi-Major Axis based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -60,8 +60,8 @@ class COECondition
 
     /// @brief Eccentricity based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -75,9 +75,9 @@ class COECondition
 
     /// @brief Inclination based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
-    /// @param aTarget A Target Range
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
     /// @return COECondition object
@@ -90,7 +90,7 @@ class COECondition
 
     /// @brief Inclination based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -103,8 +103,8 @@ class COECondition
 
     /// @brief Argument of Periapsis based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -118,7 +118,7 @@ class COECondition
 
     /// @brief Argument of Periapsis based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -131,8 +131,8 @@ class COECondition
 
     /// @brief Right Ascension of Ascending Node based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -146,7 +146,7 @@ class COECondition
 
     /// @brief Right Ascension of Ascending Node based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -159,8 +159,8 @@ class COECondition
 
     /// @brief True Anomaly based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -174,7 +174,7 @@ class COECondition
 
     /// @brief True Anomaly based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -187,8 +187,8 @@ class COECondition
 
     /// @brief Mean Anomaly based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -202,7 +202,7 @@ class COECondition
 
     /// @brief Mean Anomaly based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -215,8 +215,8 @@ class COECondition
 
     /// @brief Eccentric Anomaly based constructor
     ///
-    /// @param aCriterion An enum indicating the criterion used to determine the Event Condition
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTarget A Target
     /// @param aGravitationalParameter A gravitational parameter
     ///
@@ -230,12 +230,40 @@ class COECondition
 
     /// @brief Eccentric Anomaly based constructor
     ///
-    /// @param aFrameSPtr A frame in which the Element is to be computed
+    /// @param aFrameSPtr A frame in which the element is to be computed
     /// @param aTargetRange A Target Range
     /// @param aGravitationalParameter A gravitational parameter
     ///
     /// @return COECondition object
     static AngularCondition EccentricAnomaly(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Argument of Latitude based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return COECondition object
+    static AngularCondition ArgumentOfLatitude(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Argument of Latitude based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return COECondition object
+    static AngularCondition ArgumentOfLatitude(
         const Shared<const Frame>& aFrameSPtr,
         const Pair<Angle, Angle>& aTargetRange,
         const Derived& aGravitationalParameter

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
@@ -67,7 +67,8 @@ class COE
         Aop,
         TrueAnomaly,
         MeanAnomaly,
-        EccentricAnomaly
+        EccentricAnomaly,
+        ArgumentOfLatitude
     };
 
     enum class AnomalyType

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLydanneMeanLongCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLydanneMeanLongCondition.cpp
@@ -12,8 +12,6 @@ namespace astrodynamics
 namespace eventcondition
 {
 
-
-
 RealCondition BrouwerLyddaneMeanLongCondition::SemiMajorAxis(
     const RealCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
@@ -66,9 +64,7 @@ AngularCondition BrouwerLyddaneMeanLongCondition::Inclination(
 )
 {
     return AngularCondition::WithinRange(
-        "Inclination",
-        GenerateEvaluator(COE::Element::Inclination, aFrameSPtr, aGravitationalParameter),
-        aTargetRange
+        "Inclination", GenerateEvaluator(COE::Element::Inclination, aFrameSPtr, aGravitationalParameter), aTargetRange
     );
 }
 
@@ -94,9 +90,7 @@ AngularCondition BrouwerLyddaneMeanLongCondition::Aop(
 )
 {
     return AngularCondition::WithinRange(
-        "Argument of Periapsis",
-        GenerateEvaluator(COE::Element::Aop, aFrameSPtr, aGravitationalParameter),
-        aTargetRange
+        "Argument of Periapsis", GenerateEvaluator(COE::Element::Aop, aFrameSPtr, aGravitationalParameter), aTargetRange
     );
 }
 
@@ -150,9 +144,7 @@ AngularCondition BrouwerLyddaneMeanLongCondition::TrueAnomaly(
 )
 {
     return AngularCondition::WithinRange(
-        "True Anomaly",
-        GenerateEvaluator(COE::Element::TrueAnomaly, aFrameSPtr, aGravitationalParameter),
-        aTargetRange
+        "True Anomaly", GenerateEvaluator(COE::Element::TrueAnomaly, aFrameSPtr, aGravitationalParameter), aTargetRange
     );
 }
 
@@ -178,9 +170,7 @@ AngularCondition BrouwerLyddaneMeanLongCondition::MeanAnomaly(
 )
 {
     return AngularCondition::WithinRange(
-        "Mean Anomaly",
-        GenerateEvaluator(COE::Element::MeanAnomaly, aFrameSPtr, aGravitationalParameter),
-        aTargetRange
+        "Mean Anomaly", GenerateEvaluator(COE::Element::MeanAnomaly, aFrameSPtr, aGravitationalParameter), aTargetRange
     );
 }
 
@@ -213,9 +203,7 @@ AngularCondition BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
 }
 
 std::function<Real(const State&)> BrouwerLyddaneMeanLongCondition::GenerateEvaluator(
-    const COE::Element& anElement, 
-    const Shared<const Frame>& aFrameSPtr, 
-    const Derived& aGravitationalParameter
+    const COE::Element& anElement, const Shared<const Frame>& aFrameSPtr, const Derived& aGravitationalParameter
 )
 {
     return [anElement, aFrameSPtr, aGravitationalParameter](const State& aState) -> Real
@@ -226,7 +214,9 @@ std::function<Real(const State&)> BrouwerLyddaneMeanLongCondition::GenerateEvalu
             const State stateInTargetFrame = aState.inFrame(aFrameSPtr);
 
             // Compute the COE set from the position and velocity
-            const BrouwerLyddaneMeanLong orbitalElements = BrouwerLyddaneMeanLong::Cartesian({stateInTargetFrame.getPosition(), stateInTargetFrame.getVelocity()}, aGravitationalParameter);
+            const BrouwerLyddaneMeanLong orbitalElements = BrouwerLyddaneMeanLong::Cartesian(
+                {stateInTargetFrame.getPosition(), stateInTargetFrame.getVelocity()}, aGravitationalParameter
+            );
 
             // Return the requested element value
             switch (anElement)
@@ -236,19 +226,19 @@ std::function<Real(const State&)> BrouwerLyddaneMeanLongCondition::GenerateEvalu
                 case COE::Element::Eccentricity:
                     return orbitalElements.getEccentricity();
                 case COE::Element::Inclination:
-                    return orbitalElements.getInclination().inRadians();
+                    return orbitalElements.getInclination().inRadians(0.0, Real::TwoPi());
                 case COE::Element::Aop:
-                    return orbitalElements.getAop().inRadians();
+                    return orbitalElements.getAop().inRadians(0.0, Real::TwoPi());
                 case COE::Element::Raan:
-                    return orbitalElements.getRaan().inRadians();
+                    return orbitalElements.getRaan().inRadians(0.0, Real::TwoPi());
                 case COE::Element::TrueAnomaly:
-                    return orbitalElements.getTrueAnomaly().inRadians();
+                    return orbitalElements.getTrueAnomaly().inRadians(0.0, Real::TwoPi());
                 case COE::Element::MeanAnomaly:
-                    return orbitalElements.getMeanAnomaly().inRadians();
+                    return orbitalElements.getMeanAnomaly().inRadians(0.0, Real::TwoPi());
                 case COE::Element::EccentricAnomaly:
-                    return orbitalElements.getEccentricAnomaly().inRadians();
+                    return orbitalElements.getEccentricAnomaly().inRadians(0.0, Real::TwoPi());
                 case COE::Element::ArgumentOfLatitude:
-                    return orbitalElements.getArgumentOfLatitude().inRadians();
+                    return orbitalElements.getArgumentOfLatitude().inRadians(0.0, Real::TwoPi());
                 default:
                     throw ostk::core::error::runtime::Wrong("Element");
             }

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLydanneMeanLongCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLydanneMeanLongCondition.cpp
@@ -49,12 +49,12 @@ AngularCondition BrouwerLyddaneMeanLongCondition::Inclination(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Inclination",
         aCriterion,
         GenerateEvaluator(COE::Element::Inclination, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition BrouwerLyddaneMeanLongCondition::Inclination(
@@ -75,12 +75,12 @@ AngularCondition BrouwerLyddaneMeanLongCondition::Aop(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Argument of Periapsis",
         aCriterion,
         GenerateEvaluator(COE::Element::Aop, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition BrouwerLyddaneMeanLongCondition::Aop(
@@ -101,12 +101,12 @@ AngularCondition BrouwerLyddaneMeanLongCondition::Raan(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Right Ascension of Ascending Node",
         aCriterion,
         GenerateEvaluator(COE::Element::Raan, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition BrouwerLyddaneMeanLongCondition::Raan(
@@ -129,12 +129,12 @@ AngularCondition BrouwerLyddaneMeanLongCondition::TrueAnomaly(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "True Anomaly",
         aCriterion,
         GenerateEvaluator(COE::Element::TrueAnomaly, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition BrouwerLyddaneMeanLongCondition::TrueAnomaly(
@@ -155,12 +155,12 @@ AngularCondition BrouwerLyddaneMeanLongCondition::MeanAnomaly(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Mean Anomaly",
         aCriterion,
         GenerateEvaluator(COE::Element::MeanAnomaly, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition BrouwerLyddaneMeanLongCondition::MeanAnomaly(
@@ -181,12 +181,12 @@ AngularCondition BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Eccentric Anomaly",
         aCriterion,
         GenerateEvaluator(COE::Element::EccentricAnomaly, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
@@ -198,6 +198,34 @@ AngularCondition BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
     return AngularCondition::WithinRange(
         "Eccentric Anomaly",
         GenerateEvaluator(COE::Element::EccentricAnomaly, aFrameSPtr, aGravitationalParameter),
+        aTargetRange
+    );
+}
+
+AngularCondition BrouwerLyddaneMeanLongCondition::ArgumentOfLatitude(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "Argument of Latitude",
+        aCriterion,
+        GenerateEvaluator(COE::Element::ArgumentOfLatitude, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition BrouwerLyddaneMeanLongCondition::ArgumentOfLatitude(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "Argument of Latitude",
+        GenerateEvaluator(COE::Element::ArgumentOfLatitude, aFrameSPtr, aGravitationalParameter),
         aTargetRange
     );
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLydanneMeanLongCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLydanneMeanLongCondition.cpp
@@ -3,7 +3,7 @@
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.hpp>
 
 namespace ostk
 {
@@ -12,7 +12,9 @@ namespace astrodynamics
 namespace eventcondition
 {
 
-RealCondition COECondition::SemiMajorAxis(
+
+
+RealCondition BrouwerLyddaneMeanLongCondition::SemiMajorAxis(
     const RealCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
     const EventCondition::Target& aTarget,
@@ -27,7 +29,7 @@ RealCondition COECondition::SemiMajorAxis(
     );
 }
 
-RealCondition COECondition::Eccentricity(
+RealCondition BrouwerLyddaneMeanLongCondition::Eccentricity(
     const RealCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
     const EventCondition::Target& aTarget,
@@ -42,7 +44,7 @@ RealCondition COECondition::Eccentricity(
     );
 }
 
-AngularCondition COECondition::Inclination(
+AngularCondition BrouwerLyddaneMeanLongCondition::Inclination(
     const AngularCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
     const EventCondition::Target& aTarget,
@@ -57,7 +59,7 @@ AngularCondition COECondition::Inclination(
     );
 }
 
-AngularCondition COECondition::Inclination(
+AngularCondition BrouwerLyddaneMeanLongCondition::Inclination(
     const Shared<const Frame>& aFrameSPtr,
     const Pair<Angle, Angle>& aTargetRange,
     const Derived& aGravitationalParameter
@@ -70,7 +72,7 @@ AngularCondition COECondition::Inclination(
     );
 }
 
-AngularCondition COECondition::Aop(
+AngularCondition BrouwerLyddaneMeanLongCondition::Aop(
     const AngularCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
     const EventCondition::Target& aTarget,
@@ -85,7 +87,7 @@ AngularCondition COECondition::Aop(
     );
 }
 
-AngularCondition COECondition::Aop(
+AngularCondition BrouwerLyddaneMeanLongCondition::Aop(
     const Shared<const Frame>& aFrameSPtr,
     const Pair<Angle, Angle>& aTargetRange,
     const Derived& aGravitationalParameter
@@ -98,7 +100,7 @@ AngularCondition COECondition::Aop(
     );
 }
 
-AngularCondition COECondition::Raan(
+AngularCondition BrouwerLyddaneMeanLongCondition::Raan(
     const AngularCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
     const EventCondition::Target& aTarget,
@@ -113,7 +115,7 @@ AngularCondition COECondition::Raan(
     );
 }
 
-AngularCondition COECondition::Raan(
+AngularCondition BrouwerLyddaneMeanLongCondition::Raan(
     const Shared<const Frame>& aFrameSPtr,
     const Pair<Angle, Angle>& aTargetRange,
     const Derived& aGravitationalParameter
@@ -126,7 +128,7 @@ AngularCondition COECondition::Raan(
     );
 }
 
-AngularCondition COECondition::TrueAnomaly(
+AngularCondition BrouwerLyddaneMeanLongCondition::TrueAnomaly(
     const AngularCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
     const EventCondition::Target& aTarget,
@@ -141,7 +143,7 @@ AngularCondition COECondition::TrueAnomaly(
     );
 }
 
-AngularCondition COECondition::TrueAnomaly(
+AngularCondition BrouwerLyddaneMeanLongCondition::TrueAnomaly(
     const Shared<const Frame>& aFrameSPtr,
     const Pair<Angle, Angle>& aTargetRange,
     const Derived& aGravitationalParameter
@@ -154,7 +156,7 @@ AngularCondition COECondition::TrueAnomaly(
     );
 }
 
-AngularCondition COECondition::MeanAnomaly(
+AngularCondition BrouwerLyddaneMeanLongCondition::MeanAnomaly(
     const AngularCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
     const EventCondition::Target& aTarget,
@@ -169,7 +171,7 @@ AngularCondition COECondition::MeanAnomaly(
     );
 }
 
-AngularCondition COECondition::MeanAnomaly(
+AngularCondition BrouwerLyddaneMeanLongCondition::MeanAnomaly(
     const Shared<const Frame>& aFrameSPtr,
     const Pair<Angle, Angle>& aTargetRange,
     const Derived& aGravitationalParameter
@@ -182,7 +184,7 @@ AngularCondition COECondition::MeanAnomaly(
     );
 }
 
-AngularCondition COECondition::EccentricAnomaly(
+AngularCondition BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
     const AngularCondition::Criterion& aCriterion,
     const Shared<const Frame>& aFrameSPtr,
     const EventCondition::Target& aTarget,
@@ -197,7 +199,7 @@ AngularCondition COECondition::EccentricAnomaly(
     );
 }
 
-AngularCondition COECondition::EccentricAnomaly(
+AngularCondition BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
     const Shared<const Frame>& aFrameSPtr,
     const Pair<Angle, Angle>& aTargetRange,
     const Derived& aGravitationalParameter
@@ -210,7 +212,7 @@ AngularCondition COECondition::EccentricAnomaly(
     );
 }
 
-std::function<Real(const State&)> COECondition::GenerateEvaluator(
+std::function<Real(const State&)> BrouwerLyddaneMeanLongCondition::GenerateEvaluator(
     const COE::Element& anElement, 
     const Shared<const Frame>& aFrameSPtr, 
     const Derived& aGravitationalParameter
@@ -224,36 +226,36 @@ std::function<Real(const State&)> COECondition::GenerateEvaluator(
             const State stateInTargetFrame = aState.inFrame(aFrameSPtr);
 
             // Compute the COE set from the position and velocity
-            const COE coe = COE::Cartesian({stateInTargetFrame.getPosition(), stateInTargetFrame.getVelocity()}, aGravitationalParameter);
+            const BrouwerLyddaneMeanLong orbitalElements = BrouwerLyddaneMeanLong::Cartesian({stateInTargetFrame.getPosition(), stateInTargetFrame.getVelocity()}, aGravitationalParameter);
 
             // Return the requested element value
             switch (anElement)
             {
                 case COE::Element::SemiMajorAxis:
-                    return coe.getSemiMajorAxis().inMeters();
+                    return orbitalElements.getSemiMajorAxis().inMeters();
                 case COE::Element::Eccentricity:
-                    return coe.getEccentricity();
+                    return orbitalElements.getEccentricity();
                 case COE::Element::Inclination:
-                    return coe.getInclination().inRadians();
+                    return orbitalElements.getInclination().inRadians();
                 case COE::Element::Aop:
-                    return coe.getAop().inRadians();
+                    return orbitalElements.getAop().inRadians();
                 case COE::Element::Raan:
-                    return coe.getRaan().inRadians();
+                    return orbitalElements.getRaan().inRadians();
                 case COE::Element::TrueAnomaly:
-                    return coe.getTrueAnomaly().inRadians();
+                    return orbitalElements.getTrueAnomaly().inRadians();
                 case COE::Element::MeanAnomaly:
-                    return coe.getMeanAnomaly().inRadians();
+                    return orbitalElements.getMeanAnomaly().inRadians();
                 case COE::Element::EccentricAnomaly:
-                    return coe.getEccentricAnomaly().inRadians();
+                    return orbitalElements.getEccentricAnomaly().inRadians();
                 case COE::Element::ArgumentOfLatitude:
-                    return coe.getArgumentOfLatitude().inRadians();
+                    return orbitalElements.getArgumentOfLatitude().inRadians();
                 default:
                     throw ostk::core::error::runtime::Wrong("Element");
             }
         }
         catch (const std::exception& e)
         {
-            throw ostk::core::error::RuntimeError("Cannot evaluate COE: [{}].", e.what());
+            throw ostk::core::error::RuntimeError("Cannot evaluate Brouwer-Lyddane Mean Long: [{}].", e.what());
         }
     };
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
@@ -49,12 +49,12 @@ AngularCondition COECondition::Inclination(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Inclination",
         aCriterion,
         GenerateEvaluator(COE::Element::Inclination, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition COECondition::Inclination(
@@ -75,12 +75,12 @@ AngularCondition COECondition::Aop(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Argument of Periapsis",
         aCriterion,
         GenerateEvaluator(COE::Element::Aop, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition COECondition::Aop(
@@ -101,12 +101,12 @@ AngularCondition COECondition::Raan(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Right Ascension of Ascending Node",
         aCriterion,
         GenerateEvaluator(COE::Element::Raan, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition COECondition::Raan(
@@ -129,12 +129,12 @@ AngularCondition COECondition::TrueAnomaly(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "True Anomaly",
         aCriterion,
         GenerateEvaluator(COE::Element::TrueAnomaly, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition COECondition::TrueAnomaly(
@@ -155,12 +155,12 @@ AngularCondition COECondition::MeanAnomaly(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Mean Anomaly",
         aCriterion,
         GenerateEvaluator(COE::Element::MeanAnomaly, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition COECondition::MeanAnomaly(
@@ -181,12 +181,12 @@ AngularCondition COECondition::EccentricAnomaly(
     const Derived& aGravitationalParameter
 )
 {
-    return AngularCondition(
+    return {
         "Eccentric Anomaly",
         aCriterion,
         GenerateEvaluator(COE::Element::EccentricAnomaly, aFrameSPtr, aGravitationalParameter),
         aTarget
-    );
+    };
 }
 
 AngularCondition COECondition::EccentricAnomaly(
@@ -198,6 +198,34 @@ AngularCondition COECondition::EccentricAnomaly(
     return AngularCondition::WithinRange(
         "Eccentric Anomaly",
         GenerateEvaluator(COE::Element::EccentricAnomaly, aFrameSPtr, aGravitationalParameter),
+        aTargetRange
+    );
+}
+
+AngularCondition COECondition::ArgumentOfLatitude(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "Argument of Latitude",
+        aCriterion,
+        GenerateEvaluator(COE::Element::ArgumentOfLatitude, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition COECondition::ArgumentOfLatitude(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "Argument of Latitude",
+        GenerateEvaluator(COE::Element::ArgumentOfLatitude, aFrameSPtr, aGravitationalParameter),
         aTargetRange
     );
 }
@@ -226,19 +254,19 @@ std::function<Real(const State&)> COECondition::GenerateEvaluator(
                 case COE::Element::Eccentricity:
                     return coe.getEccentricity();
                 case COE::Element::Inclination:
-                    return coe.getInclination().inRadians();
+                    return coe.getInclination().inRadians(0.0, Real::TwoPi());
                 case COE::Element::Aop:
-                    return coe.getAop().inRadians();
+                    return coe.getAop().inRadians(0.0, Real::TwoPi());
                 case COE::Element::Raan:
-                    return coe.getRaan().inRadians();
+                    return coe.getRaan().inRadians(0.0, Real::TwoPi());
                 case COE::Element::TrueAnomaly:
-                    return coe.getTrueAnomaly().inRadians();
+                    return coe.getTrueAnomaly().inRadians(0.0, Real::TwoPi());
                 case COE::Element::MeanAnomaly:
-                    return coe.getMeanAnomaly().inRadians();
+                    return coe.getMeanAnomaly().inRadians(0.0, Real::TwoPi());
                 case COE::Element::EccentricAnomaly:
-                    return coe.getEccentricAnomaly().inRadians();
+                    return coe.getEccentricAnomaly().inRadians(0.0, Real::TwoPi());
                 case COE::Element::ArgumentOfLatitude:
-                    return coe.getArgumentOfLatitude().inRadians();
+                    return coe.getArgumentOfLatitude().inRadians(0.0, Real::TwoPi());
                 default:
                     throw ostk::core::error::runtime::Wrong("Element");
             }

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.cpp
@@ -64,9 +64,7 @@ AngularCondition COECondition::Inclination(
 )
 {
     return AngularCondition::WithinRange(
-        "Inclination",
-        GenerateEvaluator(COE::Element::Inclination, aFrameSPtr, aGravitationalParameter),
-        aTargetRange
+        "Inclination", GenerateEvaluator(COE::Element::Inclination, aFrameSPtr, aGravitationalParameter), aTargetRange
     );
 }
 
@@ -92,9 +90,7 @@ AngularCondition COECondition::Aop(
 )
 {
     return AngularCondition::WithinRange(
-        "Argument of Periapsis",
-        GenerateEvaluator(COE::Element::Aop, aFrameSPtr, aGravitationalParameter),
-        aTargetRange
+        "Argument of Periapsis", GenerateEvaluator(COE::Element::Aop, aFrameSPtr, aGravitationalParameter), aTargetRange
     );
 }
 
@@ -148,9 +144,7 @@ AngularCondition COECondition::TrueAnomaly(
 )
 {
     return AngularCondition::WithinRange(
-        "True Anomaly",
-        GenerateEvaluator(COE::Element::TrueAnomaly, aFrameSPtr, aGravitationalParameter),
-        aTargetRange
+        "True Anomaly", GenerateEvaluator(COE::Element::TrueAnomaly, aFrameSPtr, aGravitationalParameter), aTargetRange
     );
 }
 
@@ -176,9 +170,7 @@ AngularCondition COECondition::MeanAnomaly(
 )
 {
     return AngularCondition::WithinRange(
-        "Mean Anomaly",
-        GenerateEvaluator(COE::Element::MeanAnomaly, aFrameSPtr, aGravitationalParameter),
-        aTargetRange
+        "Mean Anomaly", GenerateEvaluator(COE::Element::MeanAnomaly, aFrameSPtr, aGravitationalParameter), aTargetRange
     );
 }
 
@@ -211,9 +203,7 @@ AngularCondition COECondition::EccentricAnomaly(
 }
 
 std::function<Real(const State&)> COECondition::GenerateEvaluator(
-    const COE::Element& anElement, 
-    const Shared<const Frame>& aFrameSPtr, 
-    const Derived& aGravitationalParameter
+    const COE::Element& anElement, const Shared<const Frame>& aFrameSPtr, const Derived& aGravitationalParameter
 )
 {
     return [anElement, aFrameSPtr, aGravitationalParameter](const State& aState) -> Real
@@ -224,7 +214,9 @@ std::function<Real(const State&)> COECondition::GenerateEvaluator(
             const State stateInTargetFrame = aState.inFrame(aFrameSPtr);
 
             // Compute the COE set from the position and velocity
-            const COE coe = COE::Cartesian({stateInTargetFrame.getPosition(), stateInTargetFrame.getVelocity()}, aGravitationalParameter);
+            const COE coe = COE::Cartesian(
+                {stateInTargetFrame.getPosition(), stateInTargetFrame.getVelocity()}, aGravitationalParameter
+            );
 
             // Return the requested element value
             switch (anElement)

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -1101,6 +1101,8 @@ String COE::StringFromElement(const COE::Element& anElement)
             return "MeanAnomaly";
         case COE::Element::EccentricAnomaly:
             return "EccentricAnomaly";
+        case COE::Element::ArgumentOfLatitude:
+            return "ArgumentOfLatitude";
     }
 
     throw ostk::core::error::runtime::Wrong("Element");

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.test.cpp
@@ -22,11 +22,11 @@
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
+using ostk::core::container::Pair;
 using ostk::core::container::Tuple;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
 using ostk::core::type::String;
-using ostk::core::container::Pair;
 
 using ostk::mathematics::object::VectorXd;
 
@@ -43,8 +43,8 @@ using ostk::astrodynamics::EventCondition;
 using ostk::astrodynamics::eventcondition::AngularCondition;
 using ostk::astrodynamics::eventcondition::BrouwerLyddaneMeanLongCondition;
 using ostk::astrodynamics::eventcondition::RealCondition;
+using ostk::astrodynamics::trajectory::orbit::model::blm::BrouwerLyddaneMeanLong;
 using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
-using ostk::astrodynamics::trajectory::orbit::model::blm::BrouwerLyddaneMeanLong; 
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::state::CoordinateBroker;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
@@ -61,21 +61,25 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondit
         Velocity previousVelocity = Velocity::Undefined();
 
         std::tie(currentPosition, currentVelocity) =
-            BrouwerLyddaneMeanLong(Length::Kilometers(551.0) + Earth::EGM2008.equatorialRadius_,
+            BrouwerLyddaneMeanLong(
+                Length::Kilometers(551.0) + Earth::EGM2008.equatorialRadius_,
                 0.00021,
                 Angle::Degrees(16.0),
                 Angle::Degrees(1.0),
                 Angle::Degrees(1.0),
-                Angle::Degrees(1.0))
+                Angle::Degrees(1.0)
+            )
                 .getCartesianState(Earth::EGM2008.gravitationalParameter_, defaultFrame_);
 
         std::tie(previousPosition, previousVelocity) =
-            BrouwerLyddaneMeanLong(Length::Kilometers(549.0) + Earth::EGM2008.equatorialRadius_,
+            BrouwerLyddaneMeanLong(
+                Length::Kilometers(549.0) + Earth::EGM2008.equatorialRadius_,
                 0.00019,
                 Angle::Degrees(15.0),
                 Angle::Degrees(359.0),
                 Angle::Degrees(359.0),
-                Angle::Degrees(359.0))
+                Angle::Degrees(359.0)
+            )
                 .getCartesianState(Earth::EGM2008.gravitationalParameter_, defaultFrame_);
 
         currentState_ = {defaultInstant_, currentPosition, currentVelocity};
@@ -85,7 +89,7 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondit
    protected:
     const Derived gravitationalParameter_ = Earth::Spherical.gravitationalParameter_;
     const Instant defaultInstant_ = Instant::J2000();
-    const Shared<const Frame> defaultFrame_ = Frame::TEME();
+    const Shared<const Frame> defaultFrame_ = Frame::GCRF();
     State currentState_ = State::Undefined();
     State previousState_ = State::Undefined();
 };
@@ -165,20 +169,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondi
     }
 
     {
-    // Range that includes the current state's inclination (16 deg) but not the previous state's (15 deg)
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(15.5), Angle::Degrees(17.0)};
+        // Range that includes the current state's inclination (16 deg) but not the previous state's (15 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(15.5), Angle::Degrees(17.0)};
 
-    AngularCondition condition = BrouwerLyddaneMeanLongCondition::Inclination(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition =
+            BrouwerLyddaneMeanLongCondition::Inclination(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, Aop)
 {
@@ -212,20 +212,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondi
     }
 
     {
-    // Range that includes the current state's AoP (1 deg) but not the previous state's (359 deg)
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's AoP (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = BrouwerLyddaneMeanLongCondition::Aop(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition =
+            BrouwerLyddaneMeanLongCondition::Aop(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, Raan)
 {
@@ -259,21 +255,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondi
     }
 
     {
-    // Range that includes the current state's RAAN (1 deg) but not the previous state's (359 deg)
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's RAAN (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = BrouwerLyddaneMeanLongCondition::Raan(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition =
+            BrouwerLyddaneMeanLongCondition::Raan(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, TrueAnomaly)
 {
@@ -307,20 +298,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondi
     }
 
     {
-    // Range that includes the current state's true anomaly (1 deg) but not the previous state's (359 deg)
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's true anomaly (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = BrouwerLyddaneMeanLongCondition::TrueAnomaly(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition =
+            BrouwerLyddaneMeanLongCondition::TrueAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, MeanAnomaly)
 {
@@ -354,21 +341,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondi
     }
 
     {
-    // Range that includes the current state's mean anomaly (approximately 1 deg) but not the previous state's
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's mean anomaly (approximately 1 deg) but not the previous state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = BrouwerLyddaneMeanLongCondition::MeanAnomaly(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition =
+            BrouwerLyddaneMeanLongCondition::MeanAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, EccentricAnomaly)
 {
@@ -402,16 +384,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondi
     }
 
     {
-    // Range that includes the current state's eccentric anomaly (approximately 1 deg) but not the previous state's
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's eccentric anomaly (approximately 1 deg) but not the previous state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition =
+            BrouwerLyddaneMeanLongCondition::EccentricAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
-}
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.test.cpp
@@ -13,7 +13,7 @@
 #include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateBroker.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
@@ -41,15 +41,16 @@ using ostk::physics::unit::Length;
 
 using ostk::astrodynamics::EventCondition;
 using ostk::astrodynamics::eventcondition::AngularCondition;
-using ostk::astrodynamics::eventcondition::COECondition;
+using ostk::astrodynamics::eventcondition::BrouwerLyddaneMeanLongCondition;
 using ostk::astrodynamics::eventcondition::RealCondition;
 using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
+using ostk::astrodynamics::trajectory::orbit::model::blm::BrouwerLyddaneMeanLong; 
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::state::CoordinateBroker;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
-class OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition
+class OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition
     : public ::testing::TestWithParam<Tuple<COE::Element, Real, Real>>
 {
     void SetUp() override
@@ -60,7 +61,7 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition
         Velocity previousVelocity = Velocity::Undefined();
 
         std::tie(currentPosition, currentVelocity) =
-            COE(Length::Kilometers(551.0) + Earth::EGM2008.equatorialRadius_,
+            BrouwerLyddaneMeanLong(Length::Kilometers(551.0) + Earth::EGM2008.equatorialRadius_,
                 0.00021,
                 Angle::Degrees(16.0),
                 Angle::Degrees(1.0),
@@ -69,7 +70,7 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition
                 .getCartesianState(Earth::EGM2008.gravitationalParameter_, defaultFrame_);
 
         std::tie(previousPosition, previousVelocity) =
-            COE(Length::Kilometers(549.0) + Earth::EGM2008.equatorialRadius_,
+            BrouwerLyddaneMeanLong(Length::Kilometers(549.0) + Earth::EGM2008.equatorialRadius_,
                 0.00019,
                 Angle::Degrees(15.0),
                 Angle::Degrees(359.0),
@@ -89,9 +90,9 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition
     State previousState_ = State::Undefined();
 };
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, SemiMajorAxis)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, SemiMajorAxis)
 {
-    RealCondition condition = COECondition::SemiMajorAxis(
+    RealCondition condition = BrouwerLyddaneMeanLongCondition::SemiMajorAxis(
         RealCondition::Criterion::PositiveCrossing,
         defaultFrame_,
         Length::Meters(550000.0) + Earth::EGM2008.equatorialRadius_,
@@ -101,12 +102,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, SemiMajorAxis
     EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Eccentricity)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, Eccentricity)
 {
     const Real target = 0.0002;
 
     {
-        RealCondition condition = COECondition::Eccentricity(
+        RealCondition condition = BrouwerLyddaneMeanLongCondition::Eccentricity(
             RealCondition::Criterion::PositiveCrossing, defaultFrame_, target, gravitationalParameter_
         );
 
@@ -115,7 +116,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Eccentricity)
     }
 
     {
-        RealCondition condition = COECondition::Eccentricity(
+        RealCondition condition = BrouwerLyddaneMeanLongCondition::Eccentricity(
             RealCondition::Criterion::NegativeCrossing, defaultFrame_, target, gravitationalParameter_
         );
 
@@ -124,7 +125,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Eccentricity)
     }
 
     {
-        RealCondition condition = COECondition::Eccentricity(
+        RealCondition condition = BrouwerLyddaneMeanLongCondition::Eccentricity(
             RealCondition::Criterion::AnyCrossing, defaultFrame_, target, gravitationalParameter_
         );
 
@@ -133,11 +134,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Eccentricity)
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Inclination)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, Inclination)
 {
     const Angle targetAngle = Angle::Degrees(15.5);
     {
-        AngularCondition condition = COECondition::Inclination(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Inclination(
             AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -146,7 +147,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Inclination)
     }
 
     {
-        AngularCondition condition = COECondition::Inclination(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Inclination(
             AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -155,7 +156,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Inclination)
     }
 
     {
-        AngularCondition condition = COECondition::Inclination(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Inclination(
             AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -167,7 +168,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Inclination)
     // Range that includes the current state's inclination (16 deg) but not the previous state's (15 deg)
     const Pair<Angle, Angle> targetRange = {Angle::Degrees(15.5), Angle::Degrees(17.0)};
 
-    AngularCondition condition = COECondition::Inclination(
+    AngularCondition condition = BrouwerLyddaneMeanLongCondition::Inclination(
         defaultFrame_,
         targetRange,
         gravitationalParameter_
@@ -179,12 +180,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Inclination)
 }
 
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Aop)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, Aop)
 {
     const Angle targetAngle = Angle::Degrees(0.0);
 
     {
-        AngularCondition condition = COECondition::Aop(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Aop(
             AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -193,7 +194,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Aop)
     }
 
     {
-        AngularCondition condition = COECondition::Aop(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Aop(
             AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -202,7 +203,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Aop)
     }
 
     {
-        AngularCondition condition = COECondition::Aop(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Aop(
             AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -214,7 +215,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Aop)
     // Range that includes the current state's AoP (1 deg) but not the previous state's (359 deg)
     const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::Aop(
+    AngularCondition condition = BrouwerLyddaneMeanLongCondition::Aop(
         defaultFrame_,
         targetRange,
         gravitationalParameter_
@@ -226,12 +227,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Aop)
 }
 
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Raan)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, Raan)
 {
     const Angle targetAngle = Angle::Degrees(0.0);
 
     {
-        AngularCondition condition = COECondition::Raan(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Raan(
             AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -240,7 +241,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Raan)
     }
 
     {
-        AngularCondition condition = COECondition::Raan(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Raan(
             AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -249,7 +250,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Raan)
     }
 
     {
-        AngularCondition condition = COECondition::Raan(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::Raan(
             AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -261,7 +262,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Raan)
     // Range that includes the current state's RAAN (1 deg) but not the previous state's (359 deg)
     const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::Raan(
+    AngularCondition condition = BrouwerLyddaneMeanLongCondition::Raan(
         defaultFrame_,
         targetRange,
         gravitationalParameter_
@@ -274,12 +275,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Raan)
 
 
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, TrueAnomaly)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, TrueAnomaly)
 {
     const Angle targetAngle = Angle::Degrees(0.0);
 
     {
-        AngularCondition condition = COECondition::TrueAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::TrueAnomaly(
             AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -288,7 +289,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, TrueAnomaly)
     }
 
     {
-        AngularCondition condition = COECondition::TrueAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::TrueAnomaly(
             AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -297,7 +298,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, TrueAnomaly)
     }
 
     {
-        AngularCondition condition = COECondition::TrueAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::TrueAnomaly(
             AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -309,7 +310,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, TrueAnomaly)
     // Range that includes the current state's true anomaly (1 deg) but not the previous state's (359 deg)
     const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::TrueAnomaly(
+    AngularCondition condition = BrouwerLyddaneMeanLongCondition::TrueAnomaly(
         defaultFrame_,
         targetRange,
         gravitationalParameter_
@@ -321,12 +322,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, TrueAnomaly)
 }
 
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, MeanAnomaly)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, MeanAnomaly)
 {
     const Angle targetAngle = Angle::Degrees(0.0);
 
     {
-        AngularCondition condition = COECondition::MeanAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::MeanAnomaly(
             AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -335,7 +336,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, MeanAnomaly)
     }
 
     {
-        AngularCondition condition = COECondition::MeanAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::MeanAnomaly(
             AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -344,7 +345,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, MeanAnomaly)
     }
 
     {
-        AngularCondition condition = COECondition::MeanAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::MeanAnomaly(
             AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -356,7 +357,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, MeanAnomaly)
     // Range that includes the current state's mean anomaly (approximately 1 deg) but not the previous state's
     const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::MeanAnomaly(
+    AngularCondition condition = BrouwerLyddaneMeanLongCondition::MeanAnomaly(
         defaultFrame_,
         targetRange,
         gravitationalParameter_
@@ -369,12 +370,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, MeanAnomaly)
 
 
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, EccentricAnomaly)
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, EccentricAnomaly)
 {
     const Angle targetAngle = Angle::Degrees(0.0);
 
     {
-        AngularCondition condition = COECondition::EccentricAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
             AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -383,7 +384,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, EccentricAnom
     }
 
     {
-        AngularCondition condition = COECondition::EccentricAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
             AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -392,7 +393,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, EccentricAnom
     }
 
     {
-        AngularCondition condition = COECondition::EccentricAnomaly(
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
             AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
         );
 
@@ -404,7 +405,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, EccentricAnom
     // Range that includes the current state's eccentric anomaly (approximately 1 deg) but not the previous state's
     const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::EccentricAnomaly(
+    AngularCondition condition = BrouwerLyddaneMeanLongCondition::EccentricAnomaly(
         defaultFrame_,
         targetRange,
         gravitationalParameter_

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanLongCondition.test.cpp
@@ -394,3 +394,47 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondi
         EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
     }
 }
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanLongCondition, ArgumentOfLatitude)
+{
+    const Angle targetAngle = Angle::Degrees(0.0);
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanLongCondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's argument of latitude (approximately 1 deg) but not the previous
+        // state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+
+        AngularCondition condition =
+            BrouwerLyddaneMeanLongCondition::ArgumentOfLatitude(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
@@ -72,9 +72,9 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition
             COE(Length::Kilometers(549.0) + Earth::EGM2008.equatorialRadius_,
                 0.00019,
                 Angle::Degrees(15.0),
-                Angle::Degrees(359.0),
-                Angle::Degrees(359.0),
-                Angle::Degrees(359.0))
+                Angle::Degrees(358.0),
+                Angle::Degrees(358.0),
+                Angle::Degrees(358.0))
                 .getCartesianState(Earth::EGM2008.gravitationalParameter_, defaultFrame_);
 
         currentState_ = {defaultInstant_, currentPosition, currentVelocity};
@@ -379,6 +379,50 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, EccentricAnom
 
         AngularCondition condition =
             COECondition::EccentricAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, ArgumentOfLatitude)
+{
+    const Angle targetAngle = Angle::Degrees(0.0);
+
+    {
+        AngularCondition condition = COECondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = COECondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = COECondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's argument of latitude (approximately 1 deg) but not the previous
+        // state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+
+        AngularCondition condition =
+            COECondition::ArgumentOfLatitude(defaultFrame_, targetRange, gravitationalParameter_);
 
         EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
         EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
@@ -22,11 +22,11 @@
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
+using ostk::core::container::Pair;
 using ostk::core::container::Tuple;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
 using ostk::core::type::String;
-using ostk::core::container::Pair;
 
 using ostk::mathematics::object::VectorXd;
 
@@ -164,20 +164,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Inclination)
     }
 
     {
-    // Range that includes the current state's inclination (16 deg) but not the previous state's (15 deg)
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(15.5), Angle::Degrees(17.0)};
+        // Range that includes the current state's inclination (16 deg) but not the previous state's (15 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(15.5), Angle::Degrees(17.0)};
 
-    AngularCondition condition = COECondition::Inclination(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition = COECondition::Inclination(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Aop)
 {
@@ -211,20 +206,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Aop)
     }
 
     {
-    // Range that includes the current state's AoP (1 deg) but not the previous state's (359 deg)
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's AoP (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::Aop(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition = COECondition::Aop(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Raan)
 {
@@ -258,21 +248,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, Raan)
     }
 
     {
-    // Range that includes the current state's RAAN (1 deg) but not the previous state's (359 deg)
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's RAAN (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::Raan(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition = COECondition::Raan(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, TrueAnomaly)
 {
@@ -306,20 +290,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, TrueAnomaly)
     }
 
     {
-    // Range that includes the current state's true anomaly (1 deg) but not the previous state's (359 deg)
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's true anomaly (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::TrueAnomaly(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition = COECondition::TrueAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, MeanAnomaly)
 {
@@ -353,21 +332,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, MeanAnomaly)
     }
 
     {
-    // Range that includes the current state's mean anomaly (approximately 1 deg) but not the previous state's
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's mean anomaly (approximately 1 deg) but not the previous state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::MeanAnomaly(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition = COECondition::MeanAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }
-}
-
-
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, EccentricAnomaly)
 {
@@ -401,16 +374,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition, EccentricAnom
     }
 
     {
-    // Range that includes the current state's eccentric anomaly (approximately 1 deg) but not the previous state's
-    const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+        // Range that includes the current state's eccentric anomaly (approximately 1 deg) but not the previous state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
 
-    AngularCondition condition = COECondition::EccentricAnomaly(
-        defaultFrame_,
-        targetRange,
-        gravitationalParameter_
-    );
+        AngularCondition condition =
+            COECondition::EccentricAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
 
-    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
-    EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
-}
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -1018,6 +1018,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, StringF
         {COE::Element::TrueAnomaly, "TrueAnomaly"},
         {COE::Element::MeanAnomaly, "MeanAnomaly"},
         {COE::Element::EccentricAnomaly, "EccentricAnomaly"},
+        {COE::Element::ArgumentOfLatitude, "ArgumentOfLatitude"},
     };
 
     for (const auto& testCase : testCases)


### PR DESCRIPTION
- Add an event condition for BrouwerLyddaneMean
- Add COE Element for Arugment of Latitude
- Add within range overloads for the COECondition class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced event condition support for Brouwer-Lyddane mean longitude orbital elements, enabling detection of events based on these elements.
  - Added the ability to define event conditions for the argument of latitude in both classical and Brouwer-Lyddane orbital element models.
  - Enhanced event condition constructors to allow specifying angular ranges for orbital elements.

- **Bug Fixes**
  - Improved error handling and consistency in event condition evaluation for orbital elements.

- **Tests**
  - Added comprehensive tests for Brouwer-Lyddane mean longitude event conditions and for range-based angular event conditions.
  - Extended test coverage for the argument of latitude and for new constructor overloads accepting angular ranges.

- **Documentation**
  - Updated and clarified method documentation for new and existing event condition interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->