### PR TITLE
feat: add state from dict ballistic coefficient

### DIFF
--- a/bindings/python/test/trajectory/test_state.py
+++ b/bindings/python/test/trajectory/test_state.py
@@ -458,6 +458,41 @@ class TestState:
         assert isinstance(state, State)
         assert state.get_size() == 6
 
+    def test_from_dict_with_ballistic_coefficient(self):
+        data: dict = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "rx_eci": 7000.0,
+            "ry_eci": 0.0,
+            "rz_eci": 0.0,
+            "vx_eci": 0.0,
+            "vy_eci": 7.5,
+            "vz_eci": 0.0,
+            "ballistic_coefficient": 2.2,
+        }
+
+        state: State = State.from_dict(data)
+
+        assert state is not None
+        assert isinstance(state, State)
+        assert state.get_size() == 7
+
+        data: dict = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "rx_eci": 7000.0,
+            "ry_eci": 0.0,
+            "rz_eci": 0.0,
+            "vx_eci": 0.0,
+            "vy_eci": 7.5,
+            "vz_eci": 0.0,
+            "ballistic_coefficient": None,
+        }
+
+        state: State = State.from_dict(data)
+
+        assert state is not None
+        assert isinstance(state, State)
+        assert state.get_size() == 6
+
     @pytest.mark.parametrize(
         ("data", "expected_length", "expected_frame"),
         [


### PR DESCRIPTION
Adds the ballistic coeff subset for from_dict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional ballistic coefficient attribute when creating a state from a dictionary input.

- **Bug Fixes**
  - Improved handling of state creation to accommodate cases where the ballistic coefficient is provided or omitted.

- **Tests**
  - Added tests to verify correct behavior when the ballistic coefficient is included or set to None during state creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->