### PR TITLE
feat: target velocity profile target type

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -56,6 +56,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
         .value("GeocentricNadir", Profile::TargetType::GeocentricNadir, "Geocentric nadir")
         .value("GeodeticNadir", Profile::TargetType::GeodeticNadir, "Geodetic nadir")
         .value("Trajectory", Profile::TargetType::Trajectory, "Trajectory")
+        .value("TargetPosition", Profile::TargetType::TargetPosition, "Target position")
+        .value("TargetVelocity", Profile::TargetType::TargetVelocity, "Target velocity")
         .value("Sun", Profile::TargetType::Sun, "Sun")
         .value("Moon", Profile::TargetType::Moon, "Moon")
         .value("VelocityECI", Profile::TargetType::VelocityECI, "Velocity in ECI")
@@ -121,10 +123,32 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
             arg("anti_direction") = false
         )
 
+        .def_static(
+            "target_position",
+            &Profile::TrajectoryTarget::TargetPosition,
+            R"doc(
+                Create a target, which produces a vector pointing from the observer to the target position.
+            )doc",
+            arg("trajectory"),
+            arg("axis"),
+            arg("anti_direction") = false
+        )
+
+        .def_static(
+            "target_velocity",
+            &Profile::TrajectoryTarget::TargetVelocity,
+            R"doc(
+                Create a target, which produces a vector pointing along the target velocity.
+            )doc",
+            arg("trajectory"),
+            arg("axis"),
+            arg("anti_direction") = false
+        )
+
         .def_readonly(
             "trajectory",
             &Profile::TrajectoryTarget::trajectory,
-            "The trajectory of the target. Required only if the target type is `Trajectory`."
+            "The trajectory of the target. Used to compute the target position or velocity."
         )
 
         ;
@@ -156,7 +180,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
         .def_readonly(
             "orientation_profile",
             &Profile::OrientationProfileTarget::orientationProfile,
-            "The orientation profile of the target"
+            "The orientation profile of the target."
         )
 
         ;
@@ -188,7 +212,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
         .def_readonly(
             "orientation_generator",
             &Profile::CustomTarget::orientationGenerator,
-            "The orientation generator of the target"
+            "The orientation generator of the target."
         )
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -55,7 +55,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
 
         .value("GeocentricNadir", Profile::TargetType::GeocentricNadir, "Geocentric nadir")
         .value("GeodeticNadir", Profile::TargetType::GeodeticNadir, "Geodetic nadir")
-        .value("Trajectory", Profile::TargetType::Trajectory, "Trajectory")
+        .value("Trajectory", Profile::TargetType::Trajectory, "Trajectory")  // Deprecated in favor of TargetPosition
         .value("TargetPosition", Profile::TargetType::TargetPosition, "Target position")
         .value("TargetVelocity", Profile::TargetType::TargetVelocity, "Target velocity")
         .value("Sun", Profile::TargetType::Sun, "Sun")

--- a/bindings/python/test/flight/test_profile.py
+++ b/bindings/python/test/flight/test_profile.py
@@ -97,7 +97,11 @@ def profile(request) -> Profile:
 @pytest.fixture(
     params=[
         Profile.Target(Profile.TargetType.GeocentricNadir, Profile.Axis.X),
-        Profile.TrajectoryTarget(
+        Profile.TrajectoryTarget.target_position(
+            Trajectory.position(Position.meters((0.0, 0.0, 0.0), Frame.ITRF())),
+            Profile.Axis.X,
+        ),
+        Profile.TrajectoryTarget.target_velocity(
             Trajectory.position(Position.meters((0.0, 0.0, 0.0), Frame.ITRF())),
             Profile.Axis.X,
         ),

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -129,6 +129,7 @@ class Profile
         /// @param aTrajectory The trajectory to point towards.
         /// @param anAxis The axis of the target.
         /// @param isAntiDirection Whether the target is in the anti-direction.
+        [[deprecated("Use TrajectoryTarget::TargetPosition instead.")]]
         TrajectoryTarget(
             const ostk::astrodynamics::Trajectory& aTrajectory, const Axis& anAxis, const bool& isAntiDirection = false
         );

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -65,7 +65,6 @@ using ostk::physics::time::Interval;
 using ostk::physics::unit::Angle;
 
 using ostk::astrodynamics::flight::profile::Model;
-using ostk::astrodynamics::Trajectory;
 using ostk::astrodynamics::trajectory::State;
 
 /// @brief Spacecraft flight profile
@@ -94,6 +93,8 @@ class Profile
         GeocentricNadir,     /// Negative of the position vector of the satellite in the ECI frame
         GeodeticNadir,       /// Negative of the geodetic normal of the satellite in the ECI frame
         Trajectory,          /// Points towards the provided trajectory, eg. Ground Station in ECEF
+        TargetPosition,      /// Points towards the provided target position
+        TargetVelocity,      /// Points along the target velocity vector
         Sun,                 /// The position of the Sun
         Moon,                /// The position of the Moon
         VelocityECI,         /// The velocity vector in the ECI frame
@@ -128,9 +129,43 @@ class Profile
         /// @param aTrajectory The trajectory to point towards.
         /// @param anAxis The axis of the target.
         /// @param isAntiDirection Whether the target is in the anti-direction.
-        TrajectoryTarget(const Trajectory& aTrajectory, const Axis& anAxis, const bool& isAntiDirection = false);
+        TrajectoryTarget(
+            const ostk::astrodynamics::Trajectory& aTrajectory, const Axis& anAxis, const bool& isAntiDirection = false
+        );
 
-        Trajectory trajectory;  ///< The trajectory to point towards.
+        /// @brief Constructs a TrajectoryTarget object of type Trajectory, pointing towards a specific position.
+        ///
+        /// @param aTrajectory The trajectory to point towards.
+        /// @param anAxis The axis of the target.
+        /// @param isAntiDirection Whether the target is in the anti-direction.
+        static TrajectoryTarget TargetPosition(
+            const ostk::astrodynamics::Trajectory& aTrajectory, const Axis& anAxis, const bool& isAntiDirection = false
+        );
+
+        /// @brief Constructs a TrajectoryTarget object of type TargetVelocity, pointing along the scan direction.
+        ///
+        /// @param aTrajectory The trajectory to point towards.
+        /// @param anAxis The axis of the target.
+        /// @param isAntiDirection Whether the target is in the anti-direction.
+        static TrajectoryTarget TargetVelocity(
+            const ostk::astrodynamics::Trajectory& aTrajectory, const Axis& anAxis, const bool& isAntiDirection = false
+        );
+
+        ostk::astrodynamics::Trajectory trajectory;  ///< The trajectory to point towards.
+
+       private:
+        /// @brief Constructs a TrajectoryTarget object.
+        ///
+        /// @param aType The type of the target.
+        /// @param aTrajectory The trajectory to point towards.
+        /// @param anAxis The axis of the target.
+        /// @param isAntiDirection Whether the target is in the anti-direction.
+        TrajectoryTarget(
+            const TargetType& aType,
+            const ostk::astrodynamics::Trajectory& aTrajectory,
+            const Axis& anAxis,
+            const bool& isAntiDirection = false
+        );
     };
 
     /// @brief Represents a target that points towards a profile of orientations.
@@ -285,7 +320,7 @@ class Profile
     /// @param aTrajectory A trajectory
     /// @param aQuaternion A pointing in GCRF
     /// @return Flight profile
-    static Profile InertialPointing(const Trajectory& aTrajectory, const Quaternion& aQuaternion);
+    static Profile InertialPointing(const ostk::astrodynamics::Trajectory& aTrajectory, const Quaternion& aQuaternion);
 
     /// @brief Constructs a flight profile with local orbital frame pointing
     ///
@@ -340,7 +375,9 @@ class Profile
 
     static Vector3d ComputeGeodeticNadirDirectionVector(const State& aState);
 
-    static Vector3d ComputeTargetDirectionVector(const State& aState, const Trajectory& aTrajectory);
+    static Vector3d ComputeTargetDirectionVector(
+        const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory
+    );
 
     static Vector3d ComputeCelestialDirectionVector(const State& aState, const Celestial& aCelestial);
 
@@ -349,6 +386,10 @@ class Profile
     static Vector3d ComputeVelocityDirectionVector_ECEF(const State& aState);
 
     static Vector3d ComputeOrbitalMomentumDirectionVector(const State& aState);
+
+    static Vector3d ComputeTargetVelocityVector(
+        const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory
+    );
 
     static Vector3d ComputeClockingAxisVector(const Vector3d& anAlignmentAxisVector, const Vector3d& aClockingVector);
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
@@ -48,10 +48,6 @@ Profile::TrajectoryTarget::TrajectoryTarget(
     {
         throw ostk::core::error::runtime::Undefined("Trajectory");
     }
-
-    std::cout << "Deprecation warning: TrajectoryTarget constructor is deprecated. Use "
-                 "TrajectoryTarget::TargetPosition or TrajectoryTarget::TargetVelocity instead as appropriate."
-              << std::endl;
 }
 
 Profile::TrajectoryTarget Profile::TrajectoryTarget::TargetPosition(
@@ -468,11 +464,6 @@ Vector3d Profile::ComputeGeodeticNadirDirectionVector(const State& aState)
 
 Vector3d Profile::ComputeTargetDirectionVector(const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory)
 {
-    if (!aTrajectory.isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Trajectory");
-    }
-
     const Vector3d targetPositionCoordinates =
         aTrajectory.getStateAt(aState.accessInstant()).inFrame(Frame::GCRF()).getPosition().accessCoordinates();
     const Vector3d satellitePositionCoordinates = aState.getPosition().accessCoordinates();
@@ -482,11 +473,6 @@ Vector3d Profile::ComputeTargetDirectionVector(const State& aState, const ostk::
 
 Vector3d Profile::ComputeTargetVelocityVector(const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory)
 {
-    if (!aTrajectory.isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Trajectory");
-    }
-
     const Transform ITRF_GCRF_transform = Frame::ITRF()->getTransformTo(Frame::GCRF(), aState.accessInstant());
 
     const State slidingTargetState_GCRF = aTrajectory.getStateAt(aState.accessInstant());

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
@@ -294,8 +294,8 @@ Array<State> Trajectory::computeStates(
     Vector3d velocityCoordinates = Vector3d::Zero();
     for (Size i = 0; i < anInstantArray.getSize(); i++)
     {
-        physics::coordinate::Position currentPosition = aPositionFunction(anInstantArray.at(i));
         const Instant currentInstant = anInstantArray.at(i);
+        physics::coordinate::Position currentPosition = aPositionFunction(currentInstant);
 
         if (i == 0)
         {

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -844,6 +844,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, TrajectoryTarget)
         const Trajectory trajectory = Trajectory::Position(Position::Meters({0.0, 0.0, 0.0}, Frame::ITRF()));
         EXPECT_NO_THROW(Profile::TrajectoryTarget(trajectory, Profile::Axis::X));
         EXPECT_NO_THROW(Profile::TrajectoryTarget(trajectory, Profile::Axis::X, true));
+
+        // Testing static factory methods
+        EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetPosition(trajectory, Profile::Axis::X));
+        EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetPosition(trajectory, Profile::Axis::X, true));
+        EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetVelocity(trajectory, Profile::Axis::X));
+        EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetVelocity(trajectory, Profile::Axis::X, true));
     }
 }
 
@@ -881,6 +887,68 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, OrientationProfileTarget)
         };
         EXPECT_NO_THROW(Profile::OrientationProfileTarget(orientationProfile, Profile::Axis::X));
     }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, YawCompensation)
+{
+    const Environment environment = Environment::Default();
+
+    const Length semiMajorAxis = Length::Kilometers(7000.0);
+    const Real eccentricity = 0.0;
+    const Angle inclination = Angle::Degrees(98.0);
+    const Angle raan = Angle::Degrees(0.0);
+    const Angle aop = Angle::Degrees(0.0);
+    const Angle trueAnomaly = Angle::Degrees(0.0);
+
+    const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+
+    const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+    const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+    const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+    const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+
+    const Kepler keplerianModel = {
+        coe, instant, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+    };
+
+    const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+    const State state = orbit.getStateAt(instant);
+
+    const Array<Instant> instants =
+        Interval::Closed(instant, instant + Duration::Seconds(2.0)).generateGrid(Duration::Seconds(1.0));
+
+    const Trajectory trajectory = Trajectory::GroundStripGeodeticNadir(orbit, instants, Earth::WGS84());
+
+    const Profile compensatedProfile = Profile::CustomPointing(
+        orbit,
+        std::make_shared<const Profile::TrajectoryTarget>(
+            Profile::TrajectoryTarget::TargetPosition(trajectory, Profile::Axis::Z)
+        ),
+        std::make_shared<const Profile::TrajectoryTarget>(
+            Profile::TrajectoryTarget::TargetVelocity(trajectory, Profile::Axis::X)
+        )
+    );
+
+    const Profile uncompensatedProfile = Profile::CustomPointing(
+        orbit,
+        std::make_shared<const Profile::TrajectoryTarget>(
+            Profile::TrajectoryTarget::TargetPosition(trajectory, Profile::Axis::Z)
+        ),
+        std::make_shared<const Profile::Target>(Profile::TargetType::VelocityECI, Profile::Axis::X)
+    );
+
+    const State compensatedState = compensatedProfile.getStateAt(instant);
+    const State uncompensatedState = uncompensatedProfile.getStateAt(instant);
+
+    // Values taken from Orekit for unit test
+
+    EXPECT_NEAR(
+        compensatedState.getAttitude().angularDifferenceWith(uncompensatedState.getAttitude()).inDegrees(),
+        3.803545407107513,
+        1e-4
+    );
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, AlignAndConstrain)


### PR DESCRIPTION
- Non breaking change, add TargetPosition enum type (to replace the Trajectory enum in a future release).
- Add TargetVelocity enum type, which generates a direction vector aligned with the velocity of the target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for targeting both position and velocity in trajectory-based pointing profiles, allowing more flexible orientation options.
- **Bug Fixes**
  - Improved clarity and accuracy of documentation strings for trajectory target attributes.
- **Tests**
  - Expanded test coverage for new target types and added validation for yaw compensation in attitude profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->