### PR TITLE
fix: ground trajectory discontinuities due to finite differencing step size

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -268,7 +268,7 @@ class Trajectory
     static Array<State> computeStates(
         const std::function<physics::coordinate::Position(const Instant&)>& aPositionGenerator,
         const Array<Instant>& anInstantArray,
-        const Duration& aStepSize = Duration::Seconds(1e-6)
+        const Duration& aStepSize = Duration::Seconds(1e-2)
     );
 };
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
@@ -328,7 +328,7 @@ Array<State> Trajectory::computeStates(
 
         const Velocity currentVelocity = Velocity::MetersPerSecond(velocityCoordinates, currentPosition.accessFrame());
 
-        states.add(State(currentInstant, currentPosition, currentVelocity));
+        states.add(State(currentInstant, currentPosition, currentVelocity).inFrame(Frame::GCRF()));
     }
 
     return states;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -762,7 +762,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
         const State trajectoryState = trajectory.getStateAt(instant);
         const State orbitState = orbit.getStateAt(instant);
 
-        // check that the trajectory state is the same as the geodetic nadir coordinate of the orbit
+        // check that the trajectory position is the same as the geodetic nadir coordinate of the orbit
 
         const Vector3d orbitLLACoordinates =
             Position::FromLLA(
@@ -778,7 +778,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
 
         EXPECT_VECTORS_ALMOST_EQUAL(trajectoryLLACoordinates, orbitLLACoordinates, 1e-12);
 
-        // check that the trajectory velocity is the same as the geodetic nadir coordinate of the orbit
+        // check that the trajectory speed is the same as the geodetic nadir coordinate of the orbit
+
         const Duration stepSize = Duration::Seconds(1.0);
         const Instant nextInstant = instant + stepSize;
         const LLA startLLA =
@@ -793,5 +794,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
         const double expectedSpeed = groundDistance.inMeters() / stepSize.inSeconds();
 
         EXPECT_NEAR(trajectoryState.inFrame(Frame::ITRF()).getVelocity().getCoordinates().norm(), expectedSpeed, 1.0);
+
+        // computed with Orekit
+
+        const Vector3d expectedVelocity = {-0.07204923298218091, -956.9095709619337, 6804.692417661864};
+        
+        EXPECT_VECTORS_ALMOST_EQUAL(trajectoryState.getVelocity().getCoordinates(), expectedVelocity, 1e-12);
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -798,7 +798,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
         // computed with Orekit
 
         const Vector3d expectedVelocity = {-0.07204923298218091, -956.9095709619337, 6804.692417661864};
-        
+
         EXPECT_VECTORS_ALMOST_EQUAL(trajectoryState.getVelocity().getCoordinates(), expectedVelocity, 1e-12);
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -799,6 +799,6 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
 
         const Vector3d expectedVelocity = {-0.07204923298218091, -956.9095709619337, 6804.692417661864};
 
-        EXPECT_VECTORS_ALMOST_EQUAL(trajectoryState.getVelocity().getCoordinates(), expectedVelocity, 1e-12);
+        EXPECT_VECTORS_ALMOST_EQUAL(trajectoryState.getVelocity().getCoordinates(), expectedVelocity, 1e-1);
     }
 }


### PR DESCRIPTION
Fixes a bug where there were discontinuities in the velocity due to finite difference step size.
Updated the step size to 1e-2 to align with Orekit.

Will look into using interpolators similar to how Orekit does it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured all computed trajectory states are consistently expressed in the GCRF (Geocentric Celestial Reference Frame).

- **Tests**
  - Expanded and improved tests for ground strip and geodetic nadir trajectory functionalities, including enhanced input validation, velocity checks, and use of realistic orbital models.

- **Refactor**
  - Updated the default step size for internal state computations to improve calculation efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->