### PR TITLE
feat: nadir trajectory model

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -219,20 +219,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
             arg("instants"),
             arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()")
         )
-        .def_static(
-            "geodetic_nadir_ground_track",
-            &Trajectory::GeodeticNadirGroundTrack,
-            R"doc(
-                Create a `Trajectory` object representing a geodetic nadir ground track.
-
-                Args:
-                    orbit (Orbit): The orbit.
-
-                Returns:
-                    Trajectory: The `Trajectory` object representing the geodetic nadir ground track.
-            )doc",
-            arg("orbit")
-        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory.cpp
@@ -219,6 +219,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory(pybind11::module& aModule
             arg("instants"),
             arg_v("celestial_object", Earth::WGS84(), "Earth.WGS84()")
         )
+        .def_static(
+            "geodetic_nadir_ground_track",
+            &Trajectory::GeodeticNadirGroundTrack,
+            R"doc(
+                Create a `Trajectory` object representing a geodetic nadir ground track.
+
+                Args:
+                    orbit (Orbit): The orbit.
+
+                Returns:
+                    Trajectory: The `Trajectory` object representing the geodetic nadir ground track.
+            )doc",
+            arg("orbit")
+        )
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model.cpp
@@ -2,6 +2,8 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model.hpp>
 
+#include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp>
+
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model(pybind11::module &aModule)
 {
     using namespace pybind11;
@@ -12,7 +14,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model(pybind11::module &a
         aModule,
         "Model",
         R"doc(
-            Orbital model.
+            Trajectory model.
 
         )doc"
     )
@@ -77,4 +79,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model(pybind11::module &a
         )
 
         ;
+
+    // Create "model" python submodule
+    auto model = aModule.def_submodule("model");
+
+    OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Nadir(model);
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp
@@ -68,6 +68,26 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Nadir(pybind11::mod
             )doc",
             arg("instant")
         )
+        .def(
+            "get_orbit",
+            &Nadir::getOrbit,
+            R"doc(
+                Get the orbit of the nadir model.
+
+                Returns:
+                    Orbit: The orbit of the nadir model.
+            )doc"
+        )
+        .def(
+            "get_step_size",
+            &Nadir::getStepSize,
+            R"doc(
+                Get the step size of the nadir model.
+
+                Returns:
+                    Duration: The step size of the nadir model.
+            )doc"
+        )
 
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp
@@ -1,0 +1,73 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp>
+
+inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Nadir(pybind11::module& aModule)
+{
+    using namespace pybind11;
+
+    using ostk::core::type::Shared;
+
+    using ostk::physics::time::Instant;
+
+    using ostk::astrodynamics::trajectory::model::Nadir;
+    using ostk::astrodynamics::trajectory::Orbit;
+    using ostk::astrodynamics::trajectory::State;
+
+    class_<Nadir, ostk::astrodynamics::trajectory::Model>(
+        aModule,
+        "Nadir",
+        R"doc(
+            Nadir trajectory model.
+
+            This model represents a trajectory that follows the nadir direction of an orbit.
+        )doc"
+    )
+
+        .def(
+            init<const Orbit&>(),
+            R"doc(
+                Construct a `Nadir` object from an orbit.
+
+                Args:
+                    orbit (Orbit): The orbit.
+
+                Returns:
+                    Nadir: The `Nadir` object.
+            )doc",
+            arg("orbit")
+        )
+
+        .def(self == self)
+        .def(self != self)
+
+        .def("__str__", &(shiftToString<Nadir>))
+        .def("__repr__", &(shiftToString<Nadir>))
+
+        .def(
+            "is_defined",
+            &Nadir::isDefined,
+            R"doc(
+                Check if the model is defined.
+
+                Returns:
+                    bool: True if the model is defined, False otherwise.
+            )doc"
+        )
+        .def(
+            "calculate_state_at",
+            &Nadir::calculateStateAt,
+            R"doc(
+                Calculate the state at a given instant.
+
+                Args:
+                    instant (Instant): The instant.
+
+                Returns:
+                    State: The state at the given instant.
+            )doc",
+            arg("instant")
+        )
+
+        ;
+}

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp
@@ -9,6 +9,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Nadir(pybind11::mod
     using ostk::core::type::Shared;
 
     using ostk::physics::time::Instant;
+    using ostk::physics::time::Duration;
 
     using ostk::astrodynamics::trajectory::model::Nadir;
     using ostk::astrodynamics::trajectory::Orbit;
@@ -25,17 +26,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Nadir(pybind11::mod
     )
 
         .def(
-            init<const Orbit&>(),
+            init<const Orbit&, const Duration&>(),
             R"doc(
                 Construct a `Nadir` object from an orbit.
 
                 Args:
                     orbit (Orbit): The orbit.
+                    step_size (Duration): The step size for the trajectory. Defaults to 1e-2 seconds.
 
                 Returns:
                     Nadir: The `Nadir` object.
             )doc",
-            arg("orbit")
+            arg("orbit"),
+            arg("step_size") = Duration::Seconds(1e-2)
         )
 
         .def(self == self)

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Nadir.cpp
@@ -8,8 +8,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Nadir(pybind11::mod
 
     using ostk::core::type::Shared;
 
-    using ostk::physics::time::Instant;
     using ostk::physics::time::Duration;
+    using ostk::physics::time::Instant;
 
     using ostk::astrodynamics::trajectory::model::Nadir;
     using ostk::astrodynamics::trajectory::Orbit;

--- a/bindings/python/test/Trajectory/Model/test_nadir.py
+++ b/bindings/python/test/Trajectory/Model/test_nadir.py
@@ -10,6 +10,7 @@ from ostk.physics.unit import Length
 from ostk.physics.unit import Angle
 
 from ostk.astrodynamics.trajectory import Orbit
+from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory.model import Nadir
 from ostk.astrodynamics.trajectory.orbit.model import Kepler
 from ostk.astrodynamics.trajectory.orbit.model.kepler import COE
@@ -44,17 +45,43 @@ def nadir(orbit: Orbit) -> Nadir:
 
 
 class TestNadir:
-    def test_constructor(self, nadir: Nadir):
+    def test_constructor(
+        self,
+        nadir: Nadir,
+    ):
         assert nadir.is_defined()
 
-    def test_calculate_state_at(self, nadir: Nadir):
-        instant = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
-        state = nadir.calculate_state_at(instant)
+    def test_calculate_state_at(
+        self,
+        nadir: Nadir,
+    ):
+        instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
+
+        state: State = nadir.calculate_state_at(instant)
+
         assert state is not None
 
-    def test_equality_operator(self, nadir: Nadir):
+    def test_equality_operator(
+        self,
+        nadir: Nadir,
+    ):
         assert nadir == nadir
 
-    def test_inequality_operator(self, nadir: Nadir):
+    def test_inequality_operator(
+        self,
+        nadir: Nadir,
+    ):
         nadir2 = Nadir(Orbit.undefined())
         assert nadir != nadir2
+
+    def test_get_orbit(
+        self,
+        nadir: Nadir,
+    ):
+        assert nadir.get_orbit() is not None
+
+    def test_get_step_size(
+        self,
+        nadir: Nadir,
+    ):
+        assert nadir.get_step_size() is not None

--- a/bindings/python/test/Trajectory/Model/test_nadir.py
+++ b/bindings/python/test/Trajectory/Model/test_nadir.py
@@ -1,0 +1,60 @@
+# Apache License 2.0
+
+import pytest
+
+from ostk.physics.environment.object.celestial import Earth
+from ostk.physics.time import Instant
+from ostk.physics.time import DateTime
+from ostk.physics.time import Scale
+from ostk.physics.unit import Length
+from ostk.physics.unit import Angle
+
+from ostk.astrodynamics.trajectory import Orbit
+from ostk.astrodynamics.trajectory.model import Nadir
+from ostk.astrodynamics.trajectory.orbit.model import Kepler
+from ostk.astrodynamics.trajectory.orbit.model.kepler import COE
+
+
+@pytest.fixture
+def orbit() -> Orbit:
+    earth = Earth.WGS84()
+    coe = COE(
+        semi_major_axis=Length.kilometers(7000.0),
+        eccentricity=0.0,
+        inclination=Angle.degrees(98.0),
+        raan=Angle.degrees(0.0),
+        aop=Angle.degrees(0.0),
+        true_anomaly=Angle.degrees(0.0),
+    )
+    keplerian_model = Kepler(
+        coe=coe,
+        epoch=Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC),
+        gravitational_parameter=earth.get_gravitational_parameter(),
+        equatorial_radius=earth.get_equatorial_radius(),
+        j2=earth.get_j2(),
+        j4=earth.get_j4(),
+        perturbation_type=Kepler.PerturbationType.No,
+    )
+    return Orbit(keplerian_model, earth)
+
+
+@pytest.fixture
+def nadir(orbit: Orbit) -> Nadir:
+    return Nadir(orbit)
+
+
+class TestNadir:
+    def test_constructor(self, nadir: Nadir):
+        assert nadir.is_defined()
+
+    def test_calculate_state_at(self, nadir: Nadir):
+        instant = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
+        state = nadir.calculate_state_at(instant)
+        assert state is not None
+
+    def test_equality_operator(self, nadir: Nadir):
+        assert nadir == nadir
+
+    def test_inequality_operator(self, nadir: Nadir):
+        nadir2 = Nadir(Orbit.undefined())
+        assert nadir != nadir2

--- a/bindings/python/test/test_trajectory.py
+++ b/bindings/python/test/test_trajectory.py
@@ -75,19 +75,34 @@ def orbit() -> Orbit:
 
 
 class TestTrajectory:
-    def test_trajectory(self, states: list[State]):
+    def test_trajectory(
+        self,
+        states: list[State],
+    ):
         assert Trajectory(states) is not None
 
-    def test_is_defined(self, trajectory: Trajectory):
+    def test_is_defined(
+        self,
+        trajectory: Trajectory,
+    ):
         assert trajectory.is_defined()
 
-    def test_access_model(self, trajectory: Trajectory):
+    def test_access_model(
+        self,
+        trajectory: Trajectory,
+    ):
         assert trajectory.access_model() is not None
 
-    def test_get_state_at(self, trajectory: Trajectory):
+    def test_get_state_at(
+        self,
+        trajectory: Trajectory,
+    ):
         assert trajectory.get_state_at(Instant.J2000()) is not None
 
-    def test_get_states_at(self, trajectory: Trajectory):
+    def test_get_states_at(
+        self,
+        trajectory: Trajectory,
+    ):
         assert (
             trajectory.get_states_at(
                 [Instant.J2000(), Instant.J2000() + Duration.seconds(10.0)]
@@ -102,7 +117,10 @@ class TestTrajectory:
         assert isinstance(trajectory, Trajectory)
         assert trajectory.is_defined() is False
 
-    def test_trajectory_position(self, position: Position):
+    def test_trajectory_position(
+        self,
+        position: Position,
+    ):
         trajectory: Trajectory = Trajectory.position(position)
 
         assert trajectory is not None
@@ -131,7 +149,10 @@ class TestTrajectory:
         assert Trajectory.ground_strip(start_lla, end_lla, instants) is not None
 
     def test_ground_strip_geodetic_nadir(
-        self, orbit: Orbit, instants: list[Instant], earth: Earth
+        self,
+        orbit: Orbit,
+        instants: list[Instant],
+        earth: Earth,
     ):
         assert (
             Trajectory.ground_strip_geodetic_nadir(
@@ -141,16 +162,5 @@ class TestTrajectory:
         )
         assert (
             Trajectory.ground_strip_geodetic_nadir(orbit=orbit, instants=instants)
-            is not None
-        )
-
-    def test_geodetic_nadir_ground_track(
-        self,
-        orbit: Orbit,
-    ):
-        assert (
-            Trajectory.geodetic_nadir_ground_track(
-                orbit=orbit,
-            )
             is not None
         )

--- a/bindings/python/test/test_trajectory.py
+++ b/bindings/python/test/test_trajectory.py
@@ -143,3 +143,14 @@ class TestTrajectory:
             Trajectory.ground_strip_geodetic_nadir(orbit=orbit, instants=instants)
             is not None
         )
+
+    def test_geodetic_nadir_ground_track(
+        self,
+        orbit: Orbit,
+    ):
+        assert (
+            Trajectory.geodetic_nadir_ground_track(
+                orbit=orbit,
+            )
+            is not None
+        )

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -243,6 +243,7 @@ class Trajectory
     ///             Trajectory trajectory = Trajectory::GroundStripGeodeticNadir(anOrbit, anInstantArray, earth);
     /// @endcode
     ///
+    /// @deprecated Use Trajectory::GeodeticNadirGroundTrack instead.
     /// @param anOrbit An orbit
     /// @param anInstantArray An array of instants
     /// @param aCelestial Celestial body
@@ -257,7 +258,7 @@ class Trajectory
     /// @brief Constructs a trajectory representing a ground track that follows the geodetic nadir of the provided orbit
     ///
     /// @code{.cpp}
-    ///             Trajectory trajectory = Trajectory::GroundStripGeodeticNadir(anOrbit);
+    ///             Trajectory trajectory = Trajectory::GeodeticNadirGroundTrack(anOrbit);
     /// @endcode
     ///
     /// @param anOrbit An orbit

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -243,27 +243,17 @@ class Trajectory
     ///             Trajectory trajectory = Trajectory::GroundStripGeodeticNadir(anOrbit, anInstantArray, earth);
     /// @endcode
     ///
-    /// @deprecated Use Trajectory::GeodeticNadirGroundTrack instead.
+    /// @deprecated Use Trajectory(Nadir(...)) instead.
     /// @param anOrbit An orbit
     /// @param anInstantArray An array of instants
     /// @param aCelestial Celestial body
     /// @return Trajectory
-    [[deprecated("Use Trajectory::GeodeticNadirGroundTrack instead.")]]
+    [[deprecated("Use Trajectory(Nadir(...)) instead.")]]
     static Trajectory GroundStripGeodeticNadir(
         const trajectory::Orbit& anOrbit,
         const Array<Instant>& anInstantArray,
         const Celestial& aCelestial = Earth::WGS84()
     );
-
-    /// @brief Constructs a trajectory representing a ground track that follows the geodetic nadir of the provided orbit
-    ///
-    /// @code{.cpp}
-    ///             Trajectory trajectory = Trajectory::GeodeticNadirGroundTrack(anOrbit);
-    /// @endcode
-    ///
-    /// @param anOrbit An orbit
-    /// @return Trajectory
-    static Trajectory GeodeticNadirGroundTrack(const trajectory::Orbit& anOrbit);
 
    private:
     Unique<Model> modelUPtr_;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory.hpp
@@ -247,11 +247,22 @@ class Trajectory
     /// @param anInstantArray An array of instants
     /// @param aCelestial Celestial body
     /// @return Trajectory
+    [[deprecated("Use Trajectory::GeodeticNadirGroundTrack instead.")]]
     static Trajectory GroundStripGeodeticNadir(
         const trajectory::Orbit& anOrbit,
         const Array<Instant>& anInstantArray,
         const Celestial& aCelestial = Earth::WGS84()
     );
+
+    /// @brief Constructs a trajectory representing a ground track that follows the geodetic nadir of the provided orbit
+    ///
+    /// @code{.cpp}
+    ///             Trajectory trajectory = Trajectory::GroundStripGeodeticNadir(anOrbit);
+    /// @endcode
+    ///
+    /// @param anOrbit An orbit
+    /// @return Trajectory
+    static Trajectory GeodeticNadirGroundTrack(const trajectory::Orbit& anOrbit);
 
    private:
     Unique<Model> modelUPtr_;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
@@ -26,8 +26,6 @@ using ostk::physics::time::Interval;
 using ostk::astrodynamics::trajectory::Model;
 using ostk::astrodynamics::trajectory::State;
 
-#define DEFAULT_NADIR_STEP_SIZE Duration::Seconds(1e-2)
-
 /// @brief Nadir pointing trajectory model to represent the geodetic nadir position of an orbit on the surface of the
 /// earth
 class Nadir : public virtual Model
@@ -43,7 +41,7 @@ class Nadir : public virtual Model
     /// @param anOrbit The orbit of the nadir model
     /// @param aStepSize The step size for the nadir model. Defaults to 1e-2 seconds
     /// @return A nadir model
-    Nadir(const Orbit& anOrbit, const Duration& aStepSize = DEFAULT_NADIR_STEP_SIZE);
+    Nadir(const Orbit& anOrbit, const Duration& aStepSize = Duration::Seconds(1e-2));
 
     /// @brief Clone the nadir model
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
@@ -38,17 +38,17 @@ class Nadir : public virtual Model
     ///              Nadir nadirModel(orbit);
     /// @endcode
     ///
-    /// @param aPosition The position of the static model. Must be provided in the ITRF frame.
-    Nadir(const Orbit& orbit);
+    /// @param anOrbit The orbit of the nadir model.
+    Nadir(const Orbit& anOrbit);
 
-    /// @brief Clone the static model
+    /// @brief Clone the nadir model
     ///
     /// @code{.cpp}
     ///              Nadir nadirModel = { ... };
     ///              Nadir* clonedModel = nadirModel.clone();
     /// @endcode
     ///
-    /// @return A pointer to the cloned static model
+    /// @return A pointer to the cloned nadir model
     virtual Nadir* clone() const override;
 
     /// @brief Equality operator
@@ -59,7 +59,7 @@ class Nadir : public virtual Model
     ///              bool isEqual = (nadirModel1 == nadirModel2);
     /// @endcode
     ///
-    /// @param aNadirModel The static model to compare with
+    /// @param aNadirModel The nadir model to compare with
     /// @return True if the models are equal, false otherwise
     bool operator==(const Nadir& aNadirModel) const;
 
@@ -71,7 +71,7 @@ class Nadir : public virtual Model
     ///              bool isNotEqual = (nadirModel1 != nadirModel2);
     /// @endcode
     ///
-    /// @param aNadirModel The static model to compare with
+    /// @param aNadirModel The nadir model to compare with
     /// @return True if the models are not equal, false otherwise
     bool operator!=(const Nadir& aNadirModel) const;
 
@@ -83,11 +83,11 @@ class Nadir : public virtual Model
     /// @endcode
     ///
     /// @param anOutputStream The output stream
-    /// @param aNadirModel The static model to output
+    /// @param aNadirModel The nadir model to output
     /// @return The output stream
     friend std::ostream& operator<<(std::ostream& anOutputStream, const Nadir& aNadirModel);
 
-    /// @brief Check if the static model is defined
+    /// @brief Check if the nadir model is defined
     ///
     /// @code{.cpp}
     ///              Nadir nadirModel = { ... };
@@ -109,7 +109,7 @@ class Nadir : public virtual Model
     /// @return The state at the given instant
     virtual State calculateStateAt(const Instant& anInstant) const override;
 
-    /// @brief Print the static model to an output stream
+    /// @brief Print the nadir model to an output stream
     ///
     /// @code{.cpp}
     ///              Nadir nadirModel = { ... };

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
@@ -27,14 +27,14 @@ using ostk::astrodynamics::trajectory::Model;
 using ostk::astrodynamics::trajectory::State;
 
 /// @brief Nadir pointing trajectory model to represent the geodetic nadir position of an orbit on the surface of the
-/// earth
+/// celestial body
 class Nadir : public virtual Model
 {
    public:
     /// @brief Constructor
     ///
     /// @code{.cpp}
-    ///              Nadir nadir = { ... };
+    ///              Orbit orbit = { ... };
     ///              Nadir nadirModel(orbit);
     /// @endcode
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
@@ -1,0 +1,157 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir__
+#define __OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir__
+
+#include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+
+namespace ostk
+{
+namespace astrodynamics
+{
+namespace trajectory
+{
+namespace model
+{
+
+using ostk::physics::coordinate::Position;
+using ostk::physics::time::Instant;
+using ostk::physics::time::Interval;
+
+using ostk::astrodynamics::trajectory::Model;
+using ostk::astrodynamics::trajectory::State;
+
+/// @brief Nadir pointing trajectory model to represent the geodetic nadir position of an orbit on the surface of the
+/// earth
+class Nadir : public virtual Model
+{
+   public:
+    /// @brief Constructor
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadir = { ... };
+    ///              Nadir nadirModel(orbit);
+    /// @endcode
+    ///
+    /// @param aPosition The position of the static model. Must be provided in the ITRF frame.
+    Nadir(const Orbit& orbit);
+
+    /// @brief Clone the static model
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              Nadir* clonedModel = nadirModel.clone();
+    /// @endcode
+    ///
+    /// @return A pointer to the cloned static model
+    virtual Nadir* clone() const override;
+
+    /// @brief Equality operator
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel1 = { ... };
+    ///              Nadir nadirModel2 = { ... };
+    ///              bool isEqual = (nadirModel1 == nadirModel2);
+    /// @endcode
+    ///
+    /// @param aNadirModel The static model to compare with
+    /// @return True if the models are equal, false otherwise
+    bool operator==(const Nadir& aNadirModel) const;
+
+    /// @brief Inequality operator
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel1 = { ... };
+    ///              Nadir nadirModel2 = { ... };
+    ///              bool isNotEqual = (nadirModel1 != nadirModel2);
+    /// @endcode
+    ///
+    /// @param aNadirModel The static model to compare with
+    /// @return True if the models are not equal, false otherwise
+    bool operator!=(const Nadir& aNadirModel) const;
+
+    /// @brief Output stream operator
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              std::cout << nadirModel;
+    /// @endcode
+    ///
+    /// @param anOutputStream The output stream
+    /// @param aNadirModel The static model to output
+    /// @return The output stream
+    friend std::ostream& operator<<(std::ostream& anOutputStream, const Nadir& aNadirModel);
+
+    /// @brief Check if the static model is defined
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              bool isDefined = nadirModel.isDefined();
+    /// @endcode
+    ///
+    /// @return True if the model is defined, false otherwise
+    virtual bool isDefined() const override;
+
+    /// @brief Calculate the state at a given instant
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              Instant instant = { ... };
+    ///              State state = nadirModel.calculateStateAt(instant);
+    /// @endcode
+    ///
+    /// @param anInstant The instant at which to calculate the state
+    /// @return The state at the given instant
+    virtual State calculateStateAt(const Instant& anInstant) const override;
+
+    /// @brief Print the static model to an output stream
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              nadirModel.print(std::cout, true);
+    /// @endcode
+    ///
+    /// @param anOutputStream The output stream
+    /// @param displayDecorator If true, display decorator
+    virtual void print(std::ostream& anOutputStream, bool displayDecorator = true) const override;
+
+   protected:
+    /// @brief Equality operator for Model base class
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              Model model = { ... };
+    ///              bool isEqual = (nadirModel == model);
+    /// @endcode
+    ///
+    /// @param aModel The model to compare with
+    /// @return True if the models are equal, false otherwise
+    virtual bool operator==(const Model& aModel) const override;
+
+    /// @brief Inequality operator for Model base class
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              Model model = { ... };
+    ///              bool isNotEqual = (nadirModel != model);
+    /// @endcode
+    ///
+    /// @param aModel The model to compare with
+    /// @return True if the models are not equal, false otherwise
+    virtual bool operator!=(const Model& aModel) const override;
+
+   private:
+    Orbit orbit_;
+};
+
+}  // namespace model
+}  // namespace trajectory
+}  // namespace astrodynamics
+}  // namespace ostk
+
+#endif

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp
@@ -26,6 +26,8 @@ using ostk::physics::time::Interval;
 using ostk::astrodynamics::trajectory::Model;
 using ostk::astrodynamics::trajectory::State;
 
+#define DEFAULT_NADIR_STEP_SIZE Duration::Seconds(1e-2)
+
 /// @brief Nadir pointing trajectory model to represent the geodetic nadir position of an orbit on the surface of the
 /// earth
 class Nadir : public virtual Model
@@ -38,8 +40,10 @@ class Nadir : public virtual Model
     ///              Nadir nadirModel(orbit);
     /// @endcode
     ///
-    /// @param anOrbit The orbit of the nadir model.
-    Nadir(const Orbit& anOrbit);
+    /// @param anOrbit The orbit of the nadir model
+    /// @param aStepSize The step size for the nadir model. Defaults to 1e-2 seconds
+    /// @return A nadir model
+    Nadir(const Orbit& anOrbit, const Duration& aStepSize = DEFAULT_NADIR_STEP_SIZE);
 
     /// @brief Clone the nadir model
     ///
@@ -50,6 +54,26 @@ class Nadir : public virtual Model
     ///
     /// @return A pointer to the cloned nadir model
     virtual Nadir* clone() const override;
+
+    /// @brief Get the orbit of the nadir model
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              Orbit orbit = nadirModel.getOrbit();
+    /// @endcode
+    ///
+    /// @return The orbit of the nadir model
+    Orbit getOrbit() const;
+
+    /// @brief Get the step size of the nadir model
+    ///
+    /// @code{.cpp}
+    ///              Nadir nadirModel = { ... };
+    ///              Duration stepSize = nadirModel.getStepSize();
+    /// @endcode
+    ///
+    /// @return The step size of the nadir model
+    Duration getStepSize() const;
 
     /// @brief Equality operator
     ///
@@ -147,6 +171,7 @@ class Nadir : public virtual Model
 
    private:
     Orbit orbit_;
+    Duration stepSize_;
 };
 
 }  // namespace model

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
@@ -128,6 +128,11 @@ class Orbit : public Trajectory
     /// @return True if the Orbit is defined, false otherwise.
     bool isDefined() const;
 
+    /// @brief Access the celestial object.
+    ///
+    /// @return Shared pointer to the celestial object.
+    const Shared<const Celestial> accessCelestialObject() const;
+
     /// @brief Get the revolution number at a given instant.
     ///
     /// @param anInstant Instant to get the revolution number at.

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
@@ -251,8 +251,7 @@ Trajectory Trajectory::GroundStripGeodeticNadir(
     [[maybe_unused]] const Celestial& aCelestial
 )
 {
-    [[deprecated("Use Trajectory::GeodeticNadirGroundTrack instead.")]]
-    return GeodeticNadirGroundTrack(anOrbit);
+    [[deprecated("Use Trajectory::GeodeticNadirGroundTrack instead.")]] return GeodeticNadirGroundTrack(anOrbit);
 }
 
 Trajectory Trajectory::GeodeticNadirGroundTrack(const trajectory::Orbit& anOrbit)

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
@@ -10,8 +10,8 @@
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
 
@@ -30,9 +30,9 @@ using ostk::physics::coordinate::Velocity;
 using ostk::physics::time::Duration;
 using ostk::physics::unit::Length;
 
+using ostk::astrodynamics::trajectory::model::Nadir;
 using ostk::astrodynamics::trajectory::model::Tabulated;
 using ostk::astrodynamics::trajectory::Orbit;
-using ostk::astrodynamics::trajectory::model::Nadir;
 
 Trajectory::Trajectory(const Model& aModel)
     : modelUPtr_(aModel.clone())
@@ -246,7 +246,9 @@ Trajectory Trajectory::GroundStrip(
 }
 
 Trajectory Trajectory::GroundStripGeodeticNadir(
-    const trajectory::Orbit& anOrbit, [[maybe_unused]] const Array<Instant>& anInstantArray, [[maybe_unused]] const Celestial& aCelestial
+    const trajectory::Orbit& anOrbit,
+    [[maybe_unused]] const Array<Instant>& anInstantArray,
+    [[maybe_unused]] const Celestial& aCelestial
 )
 {
     return GeodeticNadirGroundTrack(anOrbit);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
@@ -251,17 +251,7 @@ Trajectory Trajectory::GroundStripGeodeticNadir(
     [[maybe_unused]] const Celestial& aCelestial
 )
 {
-    [[deprecated("Use Trajectory::GeodeticNadirGroundTrack instead.")]] return GeodeticNadirGroundTrack(anOrbit);
-}
-
-Trajectory Trajectory::GeodeticNadirGroundTrack(const trajectory::Orbit& anOrbit)
-{
-    if (!anOrbit.isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Orbit");
-    }
-
-    return Trajectory(Nadir(anOrbit));
+    [[deprecated("Use Trajectory::GeodeticNadirGroundTrack instead.")]] return Trajectory(Nadir(anOrbit));
 }
 
 Trajectory::Trajectory()

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory.cpp
@@ -251,6 +251,7 @@ Trajectory Trajectory::GroundStripGeodeticNadir(
     [[maybe_unused]] const Celestial& aCelestial
 )
 {
+    [[deprecated("Use Trajectory::GeodeticNadirGroundTrack instead.")]]
     return GeodeticNadirGroundTrack(anOrbit);
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.cpp
@@ -1,0 +1,161 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Utility.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp>
+#include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp>
+
+namespace ostk
+{
+namespace astrodynamics
+{
+namespace trajectory
+{
+namespace model
+{
+
+using ostk::mathematics::curvefitting::Interpolator;
+using ostk::mathematics::object::MatrixXd;
+using ostk::mathematics::object::Vector3d;
+using ostk::mathematics::object::VectorXd;
+
+Nadir::Nadir(const Orbit& anOrbit)
+    : Model(),
+      orbit_(anOrbit)
+{
+}
+
+Nadir* Nadir::clone() const
+{
+    return new Nadir(*this);
+}
+
+bool Nadir::operator==(const Nadir& aNadirModel) const
+{
+    if ((!this->isDefined()) || (!aNadirModel.isDefined()))
+    {
+        return false;
+    }
+
+    return orbit_ == aNadirModel.orbit_;
+}
+
+bool Nadir::operator!=(const Nadir& aNadirModel) const
+{
+    return !((*this) == aNadirModel);
+}
+
+std::ostream& operator<<(std::ostream& anOutputStream, const Nadir& aNadirModel)
+{
+    aNadirModel.print(anOutputStream);
+
+    return anOutputStream;
+}
+
+bool Nadir::isDefined() const
+{
+    return orbit_.isDefined();
+}
+
+State Nadir::calculateStateAt(const Instant& anInstant) const
+{
+    using ostk::physics::coordinate::Position;
+
+    if (!anInstant.isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Instant");
+    }
+
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Nadir");
+    }
+
+    // interpolate the velocity using polynomial interpolation
+
+    static const Duration stepSize = Duration::Seconds(1e-2);
+
+    const Array<Instant> instants = {
+        anInstant - stepSize * 2,
+        anInstant - stepSize,
+        anInstant,
+        anInstant + stepSize,
+        anInstant + stepSize * 2,
+    };
+
+    VectorXd times(instants.getSize());
+    MatrixXd positionCoordinates(3, instants.getSize());
+
+    Position position = Position::Undefined();
+
+    Size i = 0;
+    for (const auto& instant : instants)
+    {
+        times(i) = (instant - anInstant).inSeconds();
+
+        const State state = orbit_.getStateAt(instant);
+
+        const LLA lla =
+            LLA::FromPosition(state.getPosition().inFrame(Frame::ITRF(), instant), orbit_.accessCelestialObject())
+                .onSurface();
+
+        const physics::coordinate::Position positionAtInstant =
+            physics::coordinate::Position::FromLLA(lla, orbit_.accessCelestialObject()).inFrame(Frame::GCRF(), instant);
+
+        if (instant == anInstant)
+        {
+            position = positionAtInstant;
+        }
+
+        positionCoordinates.col(i) = positionAtInstant.getCoordinates();
+
+        ++i;
+    }
+
+    Array<Shared<const Interpolator>> interpolators = {
+        Interpolator::GenerateInterpolator(Interpolator::Type::CubicSpline, times, positionCoordinates.row(0)),
+        Interpolator::GenerateInterpolator(Interpolator::Type::CubicSpline, times, positionCoordinates.row(1)),
+        Interpolator::GenerateInterpolator(Interpolator::Type::CubicSpline, times, positionCoordinates.row(2)),
+    };
+
+    const Vector3d velocityCoordinates = {
+        interpolators[0]->computeDerivative(0.0),
+        interpolators[1]->computeDerivative(0.0),
+        interpolators[2]->computeDerivative(0.0),
+    };
+
+    const Velocity velocity = Velocity::MetersPerSecond(velocityCoordinates, Frame::GCRF());
+
+    return State(anInstant, position, velocity);
+}
+
+void Nadir::print(std::ostream& anOutputStream, bool displayDecorator) const
+{
+    using ostk::core::type::String;
+
+    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Nadir") : void();
+
+    orbit_.print(anOutputStream, false);
+
+    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+}
+
+bool Nadir::operator==(const Model& aModel) const
+{
+    const Nadir* staticModelPtr = dynamic_cast<const Nadir*>(&aModel);
+
+    return (staticModelPtr != nullptr) && this->operator==(*staticModelPtr);
+}
+
+bool Nadir::operator!=(const Model& aModel) const
+{
+    return !((*this) == aModel);
+}
+
+}  // namespace model
+}  // namespace trajectory
+}  // namespace astrodynamics
+}  // namespace ostk

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.cpp
@@ -17,6 +17,10 @@ namespace trajectory
 namespace model
 {
 
+using ostk::core::type::String;
+
+using ostk::physics::coordinate::Position;
+
 using ostk::mathematics::curvefitting::Interpolator;
 using ostk::mathematics::object::MatrixXd;
 using ostk::mathematics::object::Vector3d;
@@ -62,8 +66,6 @@ bool Nadir::isDefined() const
 
 State Nadir::calculateStateAt(const Instant& anInstant) const
 {
-    using ostk::physics::coordinate::Position;
-
     if (!anInstant.isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Instant");
@@ -115,7 +117,7 @@ State Nadir::calculateStateAt(const Instant& anInstant) const
         ++i;
     }
 
-    Array<Shared<const Interpolator>> interpolators = {
+    const Array<Shared<const Interpolator>> interpolators = {
         Interpolator::GenerateInterpolator(Interpolator::Type::CubicSpline, times, positionCoordinates.row(0)),
         Interpolator::GenerateInterpolator(Interpolator::Type::CubicSpline, times, positionCoordinates.row(1)),
         Interpolator::GenerateInterpolator(Interpolator::Type::CubicSpline, times, positionCoordinates.row(2)),
@@ -134,8 +136,6 @@ State Nadir::calculateStateAt(const Instant& anInstant) const
 
 void Nadir::print(std::ostream& anOutputStream, bool displayDecorator) const
 {
-    using ostk::core::type::String;
-
     displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Nadir") : void();
 
     orbit_.print(anOutputStream, false);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -152,6 +152,16 @@ bool Orbit::isDefined() const
            this->celestialObjectSPtr_->isDefined();
 }
 
+const Shared<const Celestial> Orbit::accessCelestialObject() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Orbit");
+    }
+
+    return this->celestialObjectSPtr_;
+}
+
 Integer Orbit::getRevolutionNumberAt(const Instant& anInstant) const
 {
     if (!this->isDefined())

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -13,9 +13,6 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 
 #include <Global.test.hpp>
 
@@ -45,9 +42,6 @@ using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth
 
 using ostk::astrodynamics::Trajectory;
 using ostk::astrodynamics::trajectory::model::Tabulated;
-using ostk::astrodynamics::trajectory::Orbit;
-using ostk::astrodynamics::trajectory::orbit::model::Kepler;
-using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::State;
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, Constructor)
@@ -707,24 +701,5 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStrip)
             const Vector3d velocity = state.getVelocity().getCoordinates();
             EXPECT_NEAR(velocity.norm(), 970.3, 1.0);
         }
-    }
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GeodeticNadirGroundTrack)
-{
-    {
-        EXPECT_THROW(Trajectory::GeodeticNadirGroundTrack(Orbit::Undefined()), ostk::core::error::RuntimeError);
-    }
-
-    {
-        const Earth earth = Earth::WGS84();
-
-        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-
-        const Shared<Earth> earthSPtr = std::make_shared<Earth>(earth);
-
-        const Orbit orbit = Orbit::Circular(instant, Length::Kilometers(550.0), Angle::Degrees(0.0), earthSPtr);
-
-        EXPECT_NO_THROW(Trajectory::GeodeticNadirGroundTrack(orbit));
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -713,9 +713,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStrip)
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GeodeticNadirGroundTrack)
 {
     {
-        EXPECT_THROW(
-            Trajectory::GeodeticNadirGroundTrack(Orbit::Undefined()), ostk::core::error::RuntimeError
-        );
+        EXPECT_THROW(Trajectory::GeodeticNadirGroundTrack(Orbit::Undefined()), ostk::core::error::RuntimeError);
     }
 
     {
@@ -723,32 +721,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GeodeticNadirGroundTrack)
 
         const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
 
-        const Environment environment = Environment::Default(true);
-    
         const Shared<Earth> earthSPtr = std::make_shared<Earth>(earth);
-    
-        const Length semiMajorAxis = Length::Kilometers(7000.0);
-        const Real eccentricity = 0.0;
-        const Angle inclination = Angle::Degrees(98.0);
-        const Angle raan = Angle::Degrees(0.0);
-        const Angle aop = Angle::Degrees(0.0);
-        const Angle trueAnomaly = Angle::Degrees(0.0);
-    
-        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
-    
-        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
-        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
-        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
-        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
-    
-        const Kepler keplerianModel = {
-            coe, instant, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
-        };
-    
-        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-        EXPECT_NO_THROW(
-            Trajectory::GeodeticNadirGroundTrack(orbit)
-        );
+        const Orbit orbit = Orbit::Circular(instant, Length::Kilometers(550.0), Angle::Degrees(0.0), earthSPtr);
+
+        EXPECT_NO_THROW(Trajectory::GeodeticNadirGroundTrack(orbit));
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory.test.cpp
@@ -710,95 +710,45 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStrip)
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GroundStripGeodeticNadir)
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory, GeodeticNadirGroundTrack)
 {
-    const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-
-    const Array<Instant> instants = {instant, instant + Duration::Seconds(10.0)};
-
-    const Earth earth = Earth::WGS84();
-
-    const Environment environment = Environment::Default(true);
-
-    const Shared<Earth> earthSPtr = std::make_shared<Earth>(earth);
-
-    const Length semiMajorAxis = Length::Kilometers(7000.0);
-    const Real eccentricity = 0.0;
-    const Angle inclination = Angle::Degrees(98.0);
-    const Angle raan = Angle::Degrees(0.0);
-    const Angle aop = Angle::Degrees(0.0);
-    const Angle trueAnomaly = Angle::Degrees(0.0);
-
-    const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
-
-    const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
-    const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
-    const Real J2 = EarthGravitationalModel::EGM2008.J2_;
-    const Real J4 = EarthGravitationalModel::EGM2008.J4_;
-
-    const Kepler keplerianModel = {
-        coe, instant, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
-    };
-
-    const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
-
     {
         EXPECT_THROW(
-            Trajectory::GroundStripGeodeticNadir(Orbit::Undefined(), instants, earth), ostk::core::error::RuntimeError
+            Trajectory::GeodeticNadirGroundTrack(Orbit::Undefined()), ostk::core::error::RuntimeError
         );
     }
 
     {
-        EXPECT_THROW(
-            Trajectory::GroundStripGeodeticNadir(orbit, Array<Instant>::Empty(), earth), ostk::core::error::RuntimeError
+        const Earth earth = Earth::WGS84();
+
+        const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+        const Environment environment = Environment::Default(true);
+    
+        const Shared<Earth> earthSPtr = std::make_shared<Earth>(earth);
+    
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(98.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
+    
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+    
+        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+    
+        const Kepler keplerianModel = {
+            coe, instant, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
+    
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        EXPECT_NO_THROW(
+            Trajectory::GeodeticNadirGroundTrack(orbit)
         );
-    }
-
-    {
-        const Trajectory trajectory = Trajectory::GroundStripGeodeticNadir(orbit, instants, earth);
-
-        EXPECT_TRUE(trajectory.isDefined());
-
-        const State trajectoryState = trajectory.getStateAt(instant);
-        const State orbitState = orbit.getStateAt(instant);
-
-        // check that the trajectory position is the same as the geodetic nadir coordinate of the orbit
-
-        const Vector3d orbitLLACoordinates =
-            Position::FromLLA(
-                LLA::FromPosition(orbitState.inFrame(Frame::ITRF()).getPosition(), earthSPtr).onSurface(), earthSPtr
-            )
-                .getCoordinates();
-        const Vector3d trajectoryLLACoordinates =
-            Position::FromLLA(
-                LLA::FromPosition(trajectoryState.inFrame(Frame::ITRF()).getPosition(), earthSPtr).onSurface(),
-                earthSPtr
-            )
-                .getCoordinates();
-
-        EXPECT_VECTORS_ALMOST_EQUAL(trajectoryLLACoordinates, orbitLLACoordinates, 1e-12);
-
-        // check that the trajectory speed is the same as the geodetic nadir coordinate of the orbit
-
-        const Duration stepSize = Duration::Seconds(1.0);
-        const Instant nextInstant = instant + stepSize;
-        const LLA startLLA =
-            LLA::FromPosition(trajectoryState.inFrame(Frame::ITRF()).getPosition(), earthSPtr).onSurface();
-        const LLA endLLA =
-            LLA::FromPosition(trajectory.getStateAt(nextInstant).inFrame(Frame::ITRF()).getPosition(), earthSPtr)
-                .onSurface();
-
-        const Length groundDistance =
-            startLLA.calculateDistanceTo(endLLA, earthSPtr->getEquatorialRadius(), earthSPtr->getFlattening());
-
-        const double expectedSpeed = groundDistance.inMeters() / stepSize.inSeconds();
-
-        EXPECT_NEAR(trajectoryState.inFrame(Frame::ITRF()).getVelocity().getCoordinates().norm(), expectedSpeed, 1.0);
-
-        // computed with Orekit
-
-        const Vector3d expectedVelocity = {-0.07204923298218091, -956.9095709619337, 6804.692417661864};
-
-        EXPECT_VECTORS_ALMOST_EQUAL(trajectoryState.getVelocity().getCoordinates(), expectedVelocity, 1e-1);
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
@@ -72,12 +72,14 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir : public ::testing::
     }
 
     const Instant epoch_ = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    const Duration stepSize_ = Duration::Seconds(1e-2);
     Orbit orbit_ = Orbit::Undefined();
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, Constructor)
 {
     EXPECT_NO_THROW(Nadir nadirModel(orbit_));
+    EXPECT_NO_THROW(Nadir nadirModel(orbit_, stepSize_));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, IsDefined)
@@ -199,10 +201,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, GetOrbit)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, GetStepSize)
 {
-    const Duration stepSize = Duration::Seconds(0.1);
-    const Nadir nadirModel(orbit_, stepSize);
+    const Nadir nadirModel(orbit_, stepSize_);
 
-    EXPECT_EQ(nadirModel.getStepSize(), stepSize);
+    EXPECT_EQ(nadirModel.getStepSize(), stepSize_);
 
     const Nadir undefinedNadirModel(Orbit::Undefined());
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
@@ -185,3 +185,26 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, InequalityOperator
 
     EXPECT_TRUE(nadirModel1 != nadirModel3);
 }
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, GetOrbit)
+{
+    const Nadir nadirModel(orbit_);
+
+    EXPECT_TRUE(nadirModel.getOrbit() == orbit_);
+
+    const Nadir undefinedNadirModel(Orbit::Undefined());
+
+    EXPECT_THROW(undefinedNadirModel.getOrbit(), ostk::core::error::runtime::Undefined);
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, GetStepSize)
+{
+    const Duration stepSize = Duration::Seconds(0.1);
+    const Nadir nadirModel(orbit_, stepSize);
+
+    EXPECT_EQ(nadirModel.getStepSize(), stepSize);
+
+    const Nadir undefinedNadirModel(Orbit::Undefined());
+
+    EXPECT_THROW(undefinedNadirModel.getStepSize(), ostk::core::error::runtime::Undefined);
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
@@ -1,0 +1,170 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
+#include <OpenSpaceToolkit/Physics/Time/DateTime.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::type::Shared;
+
+using ostk::mathematics::object::Vector6d;
+using ostk::mathematics::object::VectorXd;
+
+using ostk::physics::coordinate::Frame;
+using ostk::physics::coordinate::spherical::LLA;
+using ostk::physics::environment::object::Celestial;
+using ostk::physics::environment::object::celestial::Earth;
+using ostk::physics::time::DateTime;
+using ostk::physics::time::Duration;
+using ostk::physics::time::Instant;
+using ostk::physics::time::Scale;
+using ostk::physics::unit::Angle;
+using ostk::physics::unit::Length;
+using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
+
+using ostk::astrodynamics::trajectory::model::Nadir;
+using ostk::astrodynamics::trajectory::Orbit;
+using ostk::astrodynamics::trajectory::orbit::model::Kepler;
+using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
+using ostk::astrodynamics::trajectory::State;
+
+class OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir : public ::testing::Test
+{
+   protected:
+    void SetUp() override
+    {
+        const Earth earth = Earth::WGS84();
+        const Shared<const Frame> gcrfSPtr = Frame::GCRF();
+
+        const COE coe = {
+            Length::Kilometers(7000.0),  // Semi-major axis
+            0.0,                         // Eccentricity
+            Angle::Degrees(98.0),        // Inclination
+            Angle::Degrees(0.0),         // RAAN
+            Angle::Degrees(0.0),         // AOP
+            Angle::Degrees(0.0)          // True anomaly
+        };
+
+        const Kepler keplerianModel = {
+            coe,
+            epoch_,
+            EarthGravitationalModel::EGM2008.gravitationalParameter_,
+            EarthGravitationalModel::EGM2008.equatorialRadius_,
+            EarthGravitationalModel::EGM2008.J2_,
+            EarthGravitationalModel::EGM2008.J4_,
+            Kepler::PerturbationType::None
+        };
+
+        orbit_ = {keplerianModel, std::make_shared<Earth>(earth)};
+    }
+
+    const Instant epoch_ = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+    Orbit orbit_ = Orbit::Undefined();
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, Constructor)
+{
+    EXPECT_NO_THROW(Nadir nadirModel(orbit_));
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, IsDefined)
+{
+    const Nadir nadirModel(orbit_);
+
+    EXPECT_TRUE(nadirModel.isDefined());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, CalculateStateAt)
+{
+    const Nadir nadirModel(orbit_);
+
+    const State state = nadirModel.calculateStateAt(epoch_);
+
+    const VectorXd coordinates = state.getCoordinates();
+
+    // Value obtained from Orekit
+
+    const Vector6d expectedCoordinates = {
+        6378136.936099239,
+        2.6122573763132095E-4,
+        -6.584354159011127,
+        -0.07204923298218091,
+        -956.9095709619337,
+        6804.692417661864,
+    };
+
+    EXPECT_VECTORS_ALMOST_EQUAL(coordinates, expectedCoordinates, 1e-5);
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, Clone)
+{
+    const Nadir nadirModel(orbit_);
+
+    Nadir* clonedModel = nadirModel.clone();
+
+    EXPECT_TRUE(clonedModel != nullptr);
+    EXPECT_TRUE(*clonedModel == nadirModel);
+
+    delete clonedModel;
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, Print)
+{
+    const Nadir nadirModel(orbit_);
+
+    testing::internal::CaptureStdout();
+
+    EXPECT_NO_THROW(nadirModel.print(std::cout, true));
+    EXPECT_NO_THROW(nadirModel.print(std::cout, false));
+
+    const std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_FALSE(output.empty());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, StreamOperator)
+{
+    const Nadir nadirModel(orbit_);
+
+    testing::internal::CaptureStdout();
+
+    EXPECT_NO_THROW(std::cout << nadirModel);
+
+    const std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_FALSE(output.empty());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, EqualityOperator)
+{
+    const Nadir nadirModel1(orbit_);
+    const Nadir nadirModel2(orbit_);
+
+    EXPECT_TRUE(nadirModel1 == nadirModel2);
+
+    const Orbit differentOrbit = Orbit::Undefined();
+    const Nadir nadirModel3(differentOrbit);
+
+    EXPECT_FALSE(nadirModel1 == nadirModel3);
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, InequalityOperator)
+{
+    const Nadir nadirModel1(orbit_);
+    const Nadir nadirModel2(orbit_);
+
+    EXPECT_FALSE(nadirModel1 != nadirModel2);
+
+    const Orbit differentOrbit = Orbit::Undefined();
+    const Nadir nadirModel3(differentOrbit);
+
+    EXPECT_TRUE(nadirModel1 != nadirModel3);
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
@@ -9,10 +9,10 @@
 #include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.hpp>
 
 #include <Global.test.hpp>
 
@@ -102,25 +102,25 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, CalculateStateAt)
     }
 
     {
-    const Nadir nadirModel(orbit_);
+        const Nadir nadirModel(orbit_);
 
-    const State state = nadirModel.calculateStateAt(epoch_);
+        const State state = nadirModel.calculateStateAt(epoch_);
 
-    const VectorXd coordinates = state.getCoordinates();
+        const VectorXd coordinates = state.getCoordinates();
 
-    // Value obtained from Orekit
+        // Value obtained from Orekit
 
-    const Vector6d expectedCoordinates = {
-        6378136.936099239,
-        2.6122573763132095E-4,
-        -6.584354159011127,
-        -0.07204923298218091,
-        -956.9095709619337,
-        6804.692417661864,
-    };
+        const Vector6d expectedCoordinates = {
+            6378136.936099239,
+            2.6122573763132095E-4,
+            -6.584354159011127,
+            -0.07204923298218091,
+            -956.9095709619337,
+            6804.692417661864,
+        };
 
-    EXPECT_VECTORS_ALMOST_EQUAL(coordinates, expectedCoordinates, 1e-5);
-}
+        EXPECT_VECTORS_ALMOST_EQUAL(coordinates, expectedCoordinates, 1e-5);
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, Clone)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Nadir.test.cpp
@@ -12,6 +12,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.hpp>
 
 #include <Global.test.hpp>
 
@@ -21,6 +22,7 @@ using ostk::mathematics::object::Vector6d;
 using ostk::mathematics::object::VectorXd;
 
 using ostk::physics::coordinate::Frame;
+using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::spherical::LLA;
 using ostk::physics::environment::object::Celestial;
 using ostk::physics::environment::object::celestial::Earth;
@@ -33,6 +35,7 @@ using ostk::physics::unit::Length;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
 
 using ostk::astrodynamics::trajectory::model::Nadir;
+using ostk::astrodynamics::trajectory::model::Static;
 using ostk::astrodynamics::trajectory::Orbit;
 using ostk::astrodynamics::trajectory::orbit::model::Kepler;
 using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
@@ -86,6 +89,19 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, IsDefined)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, CalculateStateAt)
 {
+    {
+        const Nadir nadirModel(orbit_);
+
+        EXPECT_THROW(nadirModel.calculateStateAt(Instant::Undefined()), ostk::core::error::runtime::Undefined);
+    }
+
+    {
+        const Nadir nadirModel(Orbit::Undefined());
+
+        EXPECT_THROW(nadirModel.calculateStateAt(epoch_), ostk::core::error::runtime::Undefined);
+    }
+
+    {
     const Nadir nadirModel(orbit_);
 
     const State state = nadirModel.calculateStateAt(epoch_);
@@ -104,6 +120,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, CalculateStateAt)
     };
 
     EXPECT_VECTORS_ALMOST_EQUAL(coordinates, expectedCoordinates, 1e-5);
+}
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Nadir, Clone)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -237,6 +237,40 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, IsDefined)
     }
 }
 
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, accessCelestialObject)
+{
+    {
+        const Environment environment = Environment::Default();
+
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.0;
+        const Angle inclination = Angle::Degrees(45.0);
+        const Angle raan = Angle::Degrees(0.0);
+        const Angle aop = Angle::Degrees(0.0);
+        const Angle trueAnomaly = Angle::Degrees(0.0);
+
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+
+        const Instant epoch = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Derived gravitationalParameter = EarthGravitationalModel::EGM2008.gravitationalParameter_;
+        const Length equatorialRadius = EarthGravitationalModel::EGM2008.equatorialRadius_;
+        const Real J2 = EarthGravitationalModel::EGM2008.J2_;
+        const Real J4 = EarthGravitationalModel::EGM2008.J4_;
+
+        const Kepler keplerianModel = {
+            coe, epoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
+
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        EXPECT_TRUE(orbit.accessCelestialObject()->isDefined());
+    }
+
+    {
+        EXPECT_THROW(Orbit::Undefined().accessCelestialObject(), ostk::core::error::runtime::Undefined);
+    }
+}
+
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetRevolutionNumberAt)
 {
     {


### PR DESCRIPTION
This MR improves the interface for the geodetic nadir ground track trajectory:
- Improved naming (geodeticNadirGroundTrack instead of groundStripGeodeticNadir)
- Improved interface (doesn't require instants or a celestial, just the orbit)
- Improved functionality (works for any instant that is valid for the orbit)
- Adds a trajectory model for this.

Deprecates the `groundStripGeodeticNadir` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Nadir trajectory model for geodetic nadir position computation of orbits.
  - Added Python bindings for the Nadir model with detailed functionality.
  - Added method to access the celestial object associated with an orbit.

- **Deprecations**
  - Deprecated the previous ground strip geodetic nadir trajectory method in favor of the Nadir model.

- **Tests**
  - Added extensive C++ and Python tests for the Nadir model covering construction, state calculation, cloning, and accessors.
  - Added tests for celestial object access in orbits.
  - Removed tests related to the deprecated ground strip geodetic nadir method.

- **Style**
  - Reformatted Python test method signatures for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->