### PR TITLE
docs: fix statebuilder docs

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -36,7 +36,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                     coordinate_subsets list[CoordinateSubset]: The coordinate subsets.
 
                 Returns:
-                    StateBuilder
+                    StateBuilder: The new `StateBuilder` object.
             )doc"
         )
         .def(
@@ -156,13 +156,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             &StateBuilder::reduce,
             arg("state"),
             R"doc(
-                Reduce a `State` object to the `StateBuilder`.
+                Reduce a `State` object to the coordinate subsets of the `StateBuilder`.
 
                 Arguments:
                     state (State): The `State` object to reduce.
 
                 Returns:
-                    StateBuilder: The `StateBuilder` object reduced from the `State`.
+                    State: The reduced `State` object.
             )doc"
         )
         .def(
@@ -171,14 +171,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
             arg("state"),
             arg("default_state"),
             R"doc(
-                Expand a `State` object to the `StateBuilder`.
+                Expand a `State` object to the coordinate subsets of the `StateBuilder`.
 
                 Arguments:
                     state (State): The `State` object to expand.
-                    default_state (State): The default `State` object.
+                    default_state (State): The default `State` object to supply the additional coordinates.
 
                 Returns:
-                    StateBuilder: The `StateBuilder` object expanded from the `State`.
+                    State: The expanded `State` object.
             )doc"
         )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/StateBuilder.cpp
@@ -148,7 +148,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                     coordinates (VectorXd): The coordinates of the state.
 
                 Returns:
-                    State: The `State` object built from the `StateBuilder`.
+                    State: A `State` object built from the `StateBuilder`.
             )doc"
         )
         .def(
@@ -162,7 +162,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
                     state (State): The `State` object to reduce.
 
                 Returns:
-                    State: The reduced `State` object.
+                    State: A `State` object with the coordinate subsets of the `StateBuilder`.
             )doc"
         )
         .def(
@@ -175,10 +175,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_StateBuilder(pybind11::mo
 
                 Arguments:
                     state (State): The `State` object to expand.
-                    default_state (State): The default `State` object to supply the additional coordinates.
+                    default_state (State): The `State` object used to supply any additional coordinates.
 
                 Returns:
-                    State: The expanded `State` object.
+                    State: A `State` object with the coordinate subsets of the `StateBuilder`.
             )doc"
         )
 

--- a/bindings/python/test/test_display.py
+++ b/bindings/python/test/test_display.py
@@ -116,5 +116,3 @@ class TestDisplay:
             accesses=accesses_2,
             rgb=[0, 0, 180],
         )
-
-        accesses_plot.show()


### PR DESCRIPTION
Some of the python docstrings are wrong and doesn't actually say what the StateBuilder will do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Improved docstrings for the constructor and methods of the StateBuilder class to clarify return types and behavior descriptions.
- **Tests**
  - Updated test to prevent automatic display of plots during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->