### PR TITLE
feat: distinguish between profile target velocity and ground velocity

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -90,18 +90,19 @@ class Profile
 
     enum class TargetType
     {
-        GeocentricNadir,     /// Negative of the position vector of the satellite in the ECI frame
-        GeodeticNadir,       /// Negative of the geodetic normal of the satellite in the ECI frame
-        Trajectory,          /// Points towards the provided trajectory, eg. Ground Station in ECEF
-        TargetPosition,      /// Points towards the provided target position
-        TargetVelocity,      /// Points along the target velocity vector
-        Sun,                 /// The position of the Sun
-        Moon,                /// The position of the Moon
-        VelocityECI,         /// The velocity vector in the ECI frame
-        VelocityECEF,        /// The velocity vector in the ECEF frame
-        OrbitalMomentum,     /// The orbital momentum vector of the satellite in the ECI frame
-        OrientationProfile,  /// Points towards a profile of orientations in the ECI frame
-        Custom,              /// Custom target
+        GeocentricNadir,       /// Negative of the position vector of the satellite in the ECI frame
+        GeodeticNadir,         /// Negative of the geodetic normal of the satellite in the ECI frame
+        Trajectory,            /// Points towards the provided trajectory, eg. Ground Station in ECEF
+        TargetPosition,        /// Points towards the provided target position
+        TargetVelocity,        /// Points along the provided target's velocity vector
+        TargetGroundVelocity,  /// Points along the provided target's ground velocity vector (aka the scan direction)
+        Sun,                   /// The position of the Sun
+        Moon,                  /// The position of the Moon
+        VelocityECI,           /// The velocity vector in the ECI frame
+        VelocityECEF,          /// The velocity vector in the ECEF frame
+        OrbitalMomentum,       /// The orbital momentum vector of the satellite in the ECI frame
+        OrientationProfile,    /// Points towards a profile of orientations in the ECI frame
+        Custom,                /// Custom target
     };
 
     /// @brief Represents a target for alignment or pointing purposes.
@@ -149,6 +150,17 @@ class Profile
         /// @param anAxis The axis of the target.
         /// @param isAntiDirection Whether the target is in the anti-direction.
         static TrajectoryTarget TargetVelocity(
+            const ostk::astrodynamics::Trajectory& aTrajectory, const Axis& anAxis, const bool& isAntiDirection = false
+        );
+
+        /// @brief Constructs a TrajectoryTarget object of type TargetGroundVelocity, pointing along the ground velocity
+        /// vector (aka the scan direction). When choosing this as a clocking target, the resulting profile will be yaw
+        /// compensated.
+        ///
+        /// @param aTrajectory The trajectory to point towards.
+        /// @param anAxis The axis of the target.
+        /// @param isAntiDirection Whether the target is in the anti-direction.
+        static TrajectoryTarget TargetGroundVelocity(
             const ostk::astrodynamics::Trajectory& aTrajectory, const Axis& anAxis, const bool& isAntiDirection = false
         );
 
@@ -389,6 +401,10 @@ class Profile
     static Vector3d ComputeOrbitalMomentumDirectionVector(const State& aState);
 
     static Vector3d ComputeTargetVelocityVector(
+        const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory
+    );
+
+    static Vector3d ComputeTargetGroundVelocityVector(
         const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory
     );
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -246,10 +246,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, GetStatesAt)
     }
 
     {
-        EXPECT_ANY_THROW(Profile::Undefined().getStatesAt(
-            {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
-             Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC)}
-        ));
+        EXPECT_ANY_THROW(
+            Profile::Undefined().getStatesAt(
+                {Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC),
+                 Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 1), Scale::UTC)}
+            )
+        );
     }
 }
 
@@ -306,9 +308,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, InertialPointing)
 
         // Reference data setup
 
-        const File referenceDataFile =
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/InertialPointing/Satellite "
-                                   "t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"));
+        const File referenceDataFile = File::Path(
+            Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/InertialPointing/Satellite "
+                "t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"
+            )
+        );
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
 
@@ -421,8 +426,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, LocalOrbitalFramePointing_
         // Reference data setup
 
         const File referenceDataFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
-                        "Satellite_1 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv")
+            Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
+                "Satellite_1 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"
+            )
         );
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
@@ -532,8 +539,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, LocalOrbitalFramePointing_
         // Reference data setup
 
         const File referenceDataFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
-                        "Satellite_2 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv")
+            Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
+                "Satellite_2 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"
+            )
         );
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
@@ -643,8 +652,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, LocalOrbitalFramePointing_
         // Reference data setup
 
         const File referenceDataFile = File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
-                        "Satellite_3 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv")
+            Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/LocalOrbitalFramePointing/VVLH/"
+                "Satellite_3 t_UTC x_GCRF v_GCRF q_B_GCRF w_B_GCRF_in_GCRF.csv"
+            )
         );
 
         const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
@@ -847,7 +858,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, TrajectoryTarget)
             ostk::core::error::runtime::Undefined
         );
         EXPECT_THROW(
-            Profile::TrajectoryTarget::TargetVelocity(Trajectory::Undefined(), Profile::Axis::X),
+            Profile::TrajectoryTarget::TargetGroundVelocity(Trajectory::Undefined(), Profile::Axis::X),
             ostk::core::error::runtime::Undefined
         );
     }
@@ -860,8 +871,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, TrajectoryTarget)
         // Testing static factory methods
         EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetPosition(trajectory, Profile::Axis::X));
         EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetPosition(trajectory, Profile::Axis::X, true));
-        EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetVelocity(trajectory, Profile::Axis::X));
-        EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetVelocity(trajectory, Profile::Axis::X, true));
+        EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetGroundVelocity(trajectory, Profile::Axis::X));
+        EXPECT_NO_THROW(Profile::TrajectoryTarget::TargetGroundVelocity(trajectory, Profile::Axis::X, true));
     }
 }
 
@@ -939,7 +950,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, YawCompensation)
             Profile::TrajectoryTarget::TargetPosition(trajectory, Profile::Axis::Z)
         ),
         std::make_shared<const Profile::TrajectoryTarget>(
-            Profile::TrajectoryTarget::TargetVelocity(trajectory, Profile::Axis::X)
+            Profile::TrajectoryTarget::TargetGroundVelocity(trajectory, Profile::Axis::X)
         )
     );
 


### PR DESCRIPTION
Non-breaking change that moves the yaw compensation functionality over to `TargetGroundVelocity`, while the leaving the `TargetVelocity` to be used for non-yaw compensated profiles. This more clearly indicates the intent of each target type, since yaw compensation doesn't align the clocking axis with the target's general velocity, it aligns it with the target's ground velocity.

Additionally, this corrects the computation of the `ComputeTargetGroundVelocityVector` method - because before it was projecting the target's ground velocity onto the plane that was normal to the target's relative direction, but this isn't needed due to how the clocking/alignement logic works. Further, if a user wanted to Align with the TargetGroundVelocity, previously they would have gotten the wrong result.

Things left to do:
- Modify python bindings accordingly
- Add more unit test cases for the yaw compensation and not yaw compensated profiles - including simple geometry cases where we can back out the expected clocking vectors from 2D geometry
