### PR TITLE
docs: include trajectory.model

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -24,6 +24,7 @@ Python API Documentation
    ostk.astrodynamics.guidance_law
    ostk.astrodynamics.solver
    ostk.astrodynamics.trajectory
+   ostk.astrodynamics.trajectory.model
    ostk.astrodynamics.trajectory.orbit
    ostk.astrodynamics.trajectory.orbit.message.spacex
    ostk.astrodynamics.trajectory.orbit.model


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Python API documentation to include the new `ostk.astrodynamics.trajectory.model` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->