### PR TITLE
feat: extract maneuvers for custom dynamics

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -203,13 +203,36 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
 
         .def(
             "extract_maneuvers",
-            &Segment::Solution::extractManeuvers,
+            overload_cast<const Shared<const Frame>&>(&Segment::Solution::extractManeuvers, const_),
             arg("frame"),
             R"doc(
-            Extract maneuvers from the (maneuvering) segment.
+                Extract maneuvers from the (maneuvering) segment.
 
-            Returns:
-                list[Maneuver]: The list of maneuvers.
+                Args:
+                    frame (Frame): The frame.
+
+                Returns:
+                    list[Maneuver]: The list of maneuvers.
+
+            )doc"
+        )
+
+        .def(
+            "extract_maneuvers",
+            overload_cast<const Shared<const Frame>&, const Shared<Dynamics>&>(
+                &Segment::Solution::extractManeuvers, const_
+            ),
+            arg("frame"),
+            arg("dynamics"),
+            R"doc(
+                Extract maneuvers from the (maneuvering) segment.
+
+                Args:
+                    frame (Frame): The frame.
+                    dynamics (Dynamics): The dynamics with which the maneuver was generated.
+
+                Returns:
+                    list[Maneuver]: The list of maneuvers.
 
             )doc"
         )

--- a/bindings/python/test/trajectory/test_segment.py
+++ b/bindings/python/test/trajectory/test_segment.py
@@ -186,8 +186,15 @@ class TestSegmentSolution:
     def test_extract_maneuvers(
         self,
         segment_solution: Segment.Solution,
+        thruster_dynamics: Thruster,
     ):
         assert segment_solution.extract_maneuvers(Frame.GCRF()) is not None
+        assert (
+            segment_solution.extract_maneuvers(
+                frame=Frame.GCRF(), dynamics=thruster_dynamics
+            )
+            is not None
+        )
 
     def test_calculate_states_at(
         self,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -46,7 +46,7 @@ using ostk::physics::unit::Mass;
 using ostk::astrodynamics::Dynamics;
 using ostk::astrodynamics::dynamics::Thruster;
 using ostk::astrodynamics::EventCondition;
-using flightManeuver = ostk::astrodynamics::flight::Maneuver;
+using FlightManeuver = ostk::astrodynamics::flight::Maneuver;
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::state::NumericalSolver;
 
@@ -117,8 +117,17 @@ class Segment
         /// @brief Extract maneuvers from the (maneuvering) segment
         ///
         /// @param aFrameSPtr Frame
+        /// @param aDynamicsSPtr Dynamics
         /// @return Array of maneuvers
-        Array<flightManeuver> extractManeuvers(const Shared<const Frame>& aFrameSPtr) const;
+        Array<FlightManeuver> extractManeuvers(
+            const Shared<const Frame>& aFrameSPtr, const Shared<Dynamics>& aDynamicsSPtr
+        ) const;
+
+        /// @brief Extract maneuvers from the (maneuvering) segment
+        ///
+        /// @param aFrameSPtr Frame
+        /// @return Array of maneuvers
+        Array<FlightManeuver> extractManeuvers(const Shared<const Frame>& aFrameSPtr) const;
 
         /// @brief Calculate intermediate states at specified Instants using the provided Numerical Solver
         ///

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -350,6 +350,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Extrac
         EXPECT_EQ(1, maneuvers.getSize());
         EXPECT_EQ(maneuveringSegmentSolution.states.getSize(), maneuvers[0].getStates().getSize());
 
+        // Check that a maneuver can be extracted when a thruster dynamics is provided as argument
+        {
+            const Array<Maneuver> maneuversWithThruster =
+                maneuveringSegmentSolution.extractManeuvers(defaultFrameSPtr_, defaultThrusterDynamicsSPtr_);
+
+            EXPECT_EQ(1, maneuvers.getSize());
+            EXPECT_EQ(maneuveringSegmentSolution.states.getSize(), maneuvers[0].getStates().getSize());
+        }
+
         for (Size i = 0; i < maneuvers[0].getStates().getSize(); i++)
         {
             EXPECT_EQ(


### PR DESCRIPTION
This allows us to extract maneuvers from segments where the maneuver was a tabulated dynamic. This is rare, but there can be situations where we would want to re-solve the maneuver with a fixed attitude for example.