### PR TITLE
fix: lazy evaluation for temporal condition solver

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Solvers/TemporalConditionSolver.cpp
@@ -141,14 +141,14 @@ bool TemporalConditionSolver::EvaluateConditionAt(
     const Instant& anInstant, const Array<TemporalConditionSolver::Condition>& aConditionArray
 )
 {
-    return std::all_of(
-        aConditionArray.begin(),
-        aConditionArray.end(),
-        [&anInstant](const TemporalConditionSolver::Condition& aCondition)
+    for (const auto& condition : aConditionArray)
+    {
+        if (!condition(anInstant))
         {
-            return aCondition(anInstant);
+            return false;
         }
-    );
+    }
+    return true;
 }
 
 }  // namespace solver


### PR DESCRIPTION
using std::all_of is quite clean, but requires evaluation of every single condition which can be expensive. Instead we can return early if any of the conditions return False