### PR TITLE
feat: add binding for access celestial object

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -110,6 +110,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
             )
 
             .def(
+                "access_celestial_object",
+                &Orbit::accessCelestialObject,
+                return_value_policy::reference,
+                R"doc(
+                    Access the celestial object.
+
+                    Returns:
+                        Celestial: The celestial object.
+
+                )doc"
+            )
+
+            .def(
                 "access_model",
                 &Orbit::accessModel,
                 return_value_policy::reference,

--- a/bindings/python/test/trajectory/test_orbit.py
+++ b/bindings/python/test/trajectory/test_orbit.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from ostk.physics.environment.object.celestial import Earth
+from ostk.physics.environment.object.celestial import Earth, Celestial
+from ostk.physics.environment.object import Celestial
 from ostk.physics.unit import Length, Angle
 from ostk.physics.time import Scale, Instant, DateTime, Time, Duration, Interval
 
@@ -57,6 +58,12 @@ class TestOrbit:
 
         assert state is not None
         assert isinstance(state, State)
+
+    def test_access_celestial_object(self, orbit: Orbit):
+        celestial_object = orbit.access_celestial_object()
+
+        assert celestial_object is not None
+        assert isinstance(celestial_object, Celestial)
 
     @pytest.mark.parametrize(
         "frame_type",

--- a/bindings/python/test/trajectory/test_orbit.py
+++ b/bindings/python/test/trajectory/test_orbit.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ostk.physics.environment.object.celestial import Earth, Celestial
+from ostk.physics.environment.object.celestial import Earth
 from ostk.physics.environment.object import Celestial
 from ostk.physics.unit import Length, Angle
 from ostk.physics.time import Scale, Instant, DateTime, Time, Duration, Interval


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a method to the Orbit class that allows users to access the associated celestial object directly from Python.

- **Tests**
  - Introduced a new test to verify that the Orbit class correctly returns its associated celestial object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->