### PR TITLE
feat: add COE getCartesianState frame check

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -328,7 +328,7 @@ COE::CartesianState COE::getCartesianState(
 
     if (!aFrameSPtr->isQuasiInertial())
     {
-        throw ostk::core::error::runtime::Wrong("Frame must be Quasi Inertial");
+        throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
     }
 
     const Real a_m = semiMajorAxis_.inMeters();
@@ -458,6 +458,12 @@ COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aG
         throw ostk::core::error::runtime::Undefined("Gravitational parameter");
     }
 
+    if (!aCartesianState.first.accessFrame()->isQuasiInertial() ||
+    !aCartesianState.second.accessFrame()->isQuasiInertial())
+    {
+        throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
+    }
+    
     static const Real tolerance = 1e-11;
 
     const Real mu = aGravitationalParameter.in(GravitationalParameterSIUnit);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -311,6 +311,11 @@ COE::CartesianState COE::getCartesianState(
     const Derived& aGravitationalParameter, const Shared<const Frame>& aFrameSPtr
 ) const
 {
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("COE");
+    }
+    
     if (!aGravitationalParameter.isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Gravitational parameter");
@@ -321,9 +326,9 @@ COE::CartesianState COE::getCartesianState(
         throw ostk::core::error::runtime::Undefined("Frame");
     }
 
-    if (!this->isDefined())
+    if (!aFrameSPtr->isQuasiInertial())
     {
-        throw ostk::core::error::runtime::Undefined("COE");
+        throw ostk::core::error::runtime::Wrong("Frame must be Quasi Inertial");
     }
 
     const Real a_m = semiMajorAxis_.inMeters();

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -315,7 +315,7 @@ COE::CartesianState COE::getCartesianState(
     {
         throw ostk::core::error::runtime::Undefined("COE");
     }
-    
+
     if (!aGravitationalParameter.isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Gravitational parameter");
@@ -459,11 +459,11 @@ COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aG
     }
 
     if (!aCartesianState.first.accessFrame()->isQuasiInertial() ||
-    !aCartesianState.second.accessFrame()->isQuasiInertial())
+        !aCartesianState.second.accessFrame()->isQuasiInertial())
     {
         throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
     }
-    
+
     static const Real tolerance = 1e-11;
 
     const Real mu = aGravitationalParameter.in(GravitationalParameterSIUnit);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/ModifiedEquinoctial.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/ModifiedEquinoctial.cpp
@@ -176,7 +176,7 @@ Pair<Position, Velocity> ModifiedEquinoctial::getCartesianState(
 
     if (!aFrameSPtr->isQuasiInertial())
     {
-        throw ostk::core::error::runtime::Wrong("Frame");
+        throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
     }
 
     const Real p_m = semiLatusRectum_.inMeters();
@@ -278,7 +278,7 @@ ModifiedEquinoctial ModifiedEquinoctial::Cartesian(
     if (!aCartesianState.first.accessFrame()->isQuasiInertial() ||
         !aCartesianState.second.accessFrame()->isQuasiInertial())
     {
-        throw ostk::core::error::runtime::Wrong("Frame");
+        throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
     }
 
     const Real mu = aGravitationalParameter.in(GravitationalParameterSIUnit);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -547,6 +547,23 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetCart
         // [TBI] Add more tests
     }
 
+    // Non-quasi inertial Frame
+    {
+        const Length semiMajorAxis = Length::Kilometers(7000.0);
+        const Real eccentricity = 0.05;
+        const Angle inclination = Angle::Degrees(45.0);
+        const Angle raan = Angle::Degrees(10.0);
+        const Angle aop = Angle::Degrees(20.0);
+        const Angle trueAnomaly = Angle::Degrees(30.0);
+
+        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
+
+        EXPECT_THROW(
+            coe.getCartesianState(Earth::EGM2008.gravitationalParameter_, Frame::ITRF()),
+            ostk::core::error::RuntimeError
+        );
+    }
+
     {
         EXPECT_ANY_THROW(COE::Undefined().getCartesianState(Earth::EGM2008.gravitationalParameter_, Frame::GCRF()));
     }
@@ -654,6 +671,18 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, Cartesi
         EXPECT_ANY_THROW(COE::Cartesian(
             COE::CartesianState({Position::Undefined(), Velocity::Undefined()}), Earth::EGM2008.gravitationalParameter_
         ));
+    }
+
+    // Non-quasi inertial Frame
+    {
+        const Position position = Position::Meters({1000000.0, 2000000.0, 3000000.0}, Frame::ITRF());
+        const Velocity velocity = Velocity::MetersPerSecond({1.0, 2.0, 3.0}, Frame::ITRF());
+        const Pair<Position, Velocity> cartesianState = {position, velocity};
+
+        EXPECT_THROW(
+            COE::Cartesian(cartesianState, Earth::EGM2008.gravitationalParameter_),
+            ostk::core::error::RuntimeError
+        );
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -20,8 +20,8 @@
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
-using ostk::core::container::Tuple;
 using ostk::core::container::Pair;
+using ostk::core::container::Tuple;
 using ostk::core::type::Real;
 using ostk::core::type::String;
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -21,7 +21,7 @@
 
 using ostk::core::container::Array;
 using ostk::core::container::Tuple;
-using ostk::core::type::Pair;
+using ostk::core::container::Pair;
 using ostk::core::type::Real;
 using ostk::core::type::String;
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -1,8 +1,8 @@
 /// Apache License 2.0
 
+#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
-#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
@@ -21,8 +21,8 @@
 
 using ostk::core::container::Array;
 using ostk::core::container::Tuple;
-using ostk::core::type::Real;
 using ostk::core::type::Pair;
+using ostk::core::type::Real;
 using ostk::core::type::String;
 
 using ostk::mathematics::object::Vector3d;
@@ -682,8 +682,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, Cartesi
         const Pair<Position, Velocity> cartesianState = {position, velocity};
 
         EXPECT_THROW(
-            COE::Cartesian(cartesianState, Earth::EGM2008.gravitationalParameter_),
-            ostk::core::error::RuntimeError
+            COE::Cartesian(cartesianState, Earth::EGM2008.gravitationalParameter_), ostk::core::error::RuntimeError
         );
     }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -2,6 +2,7 @@
 
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
+#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
@@ -21,6 +22,7 @@
 using ostk::core::container::Array;
 using ostk::core::container::Tuple;
 using ostk::core::type::Real;
+using ostk::core::type::Pair;
 using ostk::core::type::String;
 
 using ostk::mathematics::object::Vector3d;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/ModifiedEquinoctial.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/ModifiedEquinoctial.test.cpp
@@ -100,7 +100,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEqui
     {
         EXPECT_THROW(
             modifiedEquinoctial_.getCartesianState(earthGravitationalParameter_, Frame::ITRF()),
-            ostk::core::error::runtime::Wrong
+            ostk::core::error::RuntimeError
         );
     }
 
@@ -167,7 +167,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEqui
 
         EXPECT_THROW(
             ModifiedEquinoctial::Cartesian(cartesianState, earthGravitationalParameter_),
-            ostk::core::error::runtime::Wrong
+            ostk::core::error::RuntimeError
         );
     }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/ModifiedEquinoctial.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/ModifiedEquinoctial.test.cpp
@@ -97,6 +97,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEqui
         );
     }
 
+    // Non-quasi inertial Frame
     {
         EXPECT_THROW(
             modifiedEquinoctial_.getCartesianState(earthGravitationalParameter_, Frame::ITRF()),
@@ -160,6 +161,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEqui
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEquinoctial, Cartesian)
 {
+    // Non-quasi inertial Frame
     {
         const Position position = Position::Meters({1000000.0, 2000000.0, 3000000.0}, Frame::ITRF());
         const Velocity velocity = Velocity::MetersPerSecond({1.0, 2.0, 3.0}, Frame::ITRF());


### PR DESCRIPTION
Doesn't make sense to be able to create a set of COEs in a non-quasi inertial frame

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for undefined states and non-quasi-inertial frames in orbital element to Cartesian state conversions.
  * Enhanced error messages for frame validation to provide clearer and more consistent feedback.

* **Tests**
  * Added and updated tests to verify runtime errors are correctly raised when non-quasi-inertial frames are used in orbital state conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->