### PR TITLE
test: remove unnecessary use of TEME frame in tests

### DIFF
--- a/bindings/python/test/estimator/test_tle_solver.py
+++ b/bindings/python/test/estimator/test_tle_solver.py
@@ -203,11 +203,11 @@ class TestTLESolver:
         initial_state_with_b_star: tuple[State, float],
         observations: list[State],
     ):
-        # Convert observations to TEME frame
-        teme_observations = [obs.in_frame(Frame.TEME()) for obs in observations]
+        # Convert observations to ITRF frame
+        itrf_observations = [obs.in_frame(Frame.ITRF()) for obs in observations]
 
         analysis: TLESolver.Analysis = tle_solver.estimate(
-            initial_guess=initial_state_with_b_star, observations=teme_observations
+            initial_guess=initial_state_with_b_star, observations=itrf_observations
         )
         assert isinstance(analysis, TLESolver.Analysis)
         assert isinstance(analysis.estimated_tle, TLE)

--- a/test/OpenSpaceToolkit/Astrodynamics/Estimator/OrbitDeterminationSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Estimator/OrbitDeterminationSolver.test.cpp
@@ -267,17 +267,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solver_OrbitDeterminationSolver, Estimate)
             environment_, numericalSolver_, leastSquaresSolver_, estimationFrame
         };
 
-        const Array<State> observationStatesInTEME = observationStates_.map<State>(
+        const Array<State> observationStatesInITRF = observationStates_.map<State>(
             [](const State& aState) -> State
             {
-                return aState.inFrame(Frame::TEME());
+                return aState.inFrame(Frame::ITRF());
             }
         );
 
         const State initialGuessStateInGCRF = observationStates_[0].inFrame(Frame::GCRF());
 
         const OrbitDeterminationSolver::Analysis analysis =
-            odSolver.estimate(initialGuessStateInGCRF, observationStatesInTEME);
+            odSolver.estimate(initialGuessStateInGCRF, observationStatesInITRF);
 
         EXPECT_EQ(*estimationFrame, *analysis.estimatedState.accessFrame());
         EXPECT_EQ(analysis.solverAnalysis.terminationCriteria, "RMS Update Threshold");

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/COECondition.test.cpp
@@ -84,7 +84,7 @@ class OpenSpaceToolkit_Astrodynamics_EventCondition_COECondition
    protected:
     const Derived gravitationalParameter_ = Earth::Spherical.gravitationalParameter_;
     const Instant defaultInstant_ = Instant::J2000();
-    const Shared<const Frame> defaultFrame_ = Frame::TEME();
+    const Shared<const Frame> defaultFrame_ = Frame::GCRF();
     State currentState_ = State::Undefined();
     State previousState_ = State::Undefined();
 };

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.test.cpp
@@ -127,7 +127,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset, InFrame
     {
         const Instant instant = Instant::J2000();
         const Shared<const Frame> fromFrame = Frame::GCRF();
-        const Shared<const Frame> toFrame = Frame::TEME();
+        const Shared<const Frame> toFrame = Frame::ITRF();
         VectorXd fullCoordinatesVector(3);
         fullCoordinatesVector << 1.0e7, -1e7, 5e6;
 
@@ -150,7 +150,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset, InFrame
 
         const Instant instant = Instant::J2000();
         const Shared<const Frame> fromFrame = Frame::GCRF();
-        const Shared<const Frame> toFrame = Frame::TEME();
+        const Shared<const Frame> toFrame = Frame::ITRF();
         VectorXd fullCoordinatesVector(3);
         fullCoordinatesVector << 1.0e7, -1e7, 5e6;
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.test.cpp
@@ -49,7 +49,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset_AngularV
     {
         const Instant instant = Instant::J2000();
         const Shared<const Frame> fromFrame = Frame::GCRF();
-        const Shared<const Frame> toFrame = Frame::TEME();
+        const Shared<const Frame> toFrame = Frame::ITRF();
         VectorXd fullCoordinatesVector(7);
         fullCoordinatesVector << 0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0;
         const Array<Shared<const CoordinateSubset>> coordinateSubsets = {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.test.cpp
@@ -47,7 +47,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset_Attitude
     {
         const Instant instant = Instant::J2000();
         const Shared<const Frame> fromFrame = Frame::GCRF();
-        const Shared<const Frame> toFrame = Frame::TEME();
+        const Shared<const Frame> toFrame = Frame::ITRF();
         VectorXd fullCoordinatesVector(4);
         fullCoordinatesVector << 0.0, 0.0, 0.0, 1.0;
         const Shared<const CoordinateBroker> brokerkSPtr = defaultCoordinateBroker_;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.test.cpp
@@ -86,7 +86,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset_Cartesia
     {
         const Instant instant = Instant::J2000();
         const Shared<const Frame> fromFrame = Frame::GCRF();
-        const Shared<const Frame> toFrame = Frame::TEME();
+        const Shared<const Frame> toFrame = Frame::ITRF();
         VectorXd fullCoordinatesVector(3);
         fullCoordinatesVector << 1.0e7, -1e7, 5e6;
         const Shared<const CoordinateBroker> brokerkSPtr = defaultCoordinateBroker_;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.test.cpp
@@ -90,7 +90,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_CoordinateSubset_Cartesia
     {
         const Instant instant = Instant::J2000();
         const Shared<const Frame> fromFrame = Frame::GCRF();
-        const Shared<const Frame> toFrame = Frame::TEME();
+        const Shared<const Frame> toFrame = Frame::ITRF();
         VectorXd fullCoordinatesVector(6);
         fullCoordinatesVector << 1.0e6, 2.0e6, 3.0e5, 4.0e3, -5.0e3, 6.0e3;
         const Array<Shared<const CoordinateSubset>> coordinateSubsets = {


### PR DESCRIPTION
Since TEME is an old frame without a clear definition, even though our implementation is correct - we should avoid using it outside of an SGP4 context.