### PR TITLE
revert: "feat: add COE getCartesianState frame check (#571)"

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -311,11 +311,6 @@ COE::CartesianState COE::getCartesianState(
     const Derived& aGravitationalParameter, const Shared<const Frame>& aFrameSPtr
 ) const
 {
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("COE");
-    }
-
     if (!aGravitationalParameter.isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Gravitational parameter");
@@ -326,9 +321,9 @@ COE::CartesianState COE::getCartesianState(
         throw ostk::core::error::runtime::Undefined("Frame");
     }
 
-    if (!aFrameSPtr->isQuasiInertial())
+    if (!this->isDefined())
     {
-        throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
+        throw ostk::core::error::runtime::Undefined("COE");
     }
 
     const Real a_m = semiMajorAxis_.inMeters();
@@ -456,12 +451,6 @@ COE COE::Cartesian(const COE::CartesianState& aCartesianState, const Derived& aG
     if (!aGravitationalParameter.isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Gravitational parameter");
-    }
-
-    if (!aCartesianState.first.accessFrame()->isQuasiInertial() ||
-        !aCartesianState.second.accessFrame()->isQuasiInertial())
-    {
-        throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
     }
 
     static const Real tolerance = 1e-11;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/ModifiedEquinoctial.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/ModifiedEquinoctial.cpp
@@ -206,7 +206,7 @@ Pair<Position, Velocity> ModifiedEquinoctial::getCartesianState(
 
     if (!aFrameSPtr->isQuasiInertial())
     {
-        throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
+        throw ostk::core::error::runtime::Wrong("Frame");
     }
 
     const Real p_m = semiLatusRectum_.inMeters();
@@ -308,7 +308,7 @@ ModifiedEquinoctial ModifiedEquinoctial::Cartesian(
     if (!aCartesianState.first.accessFrame()->isQuasiInertial() ||
         !aCartesianState.second.accessFrame()->isQuasiInertial())
     {
-        throw ostk::core::error::RuntimeError("Frame must be Quasi Inertial");
+        throw ostk::core::error::runtime::Wrong("Frame");
     }
 
     const Real mu = aGravitationalParameter.in(GravitationalParameterSIUnit);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -1,6 +1,5 @@
 /// Apache License 2.0
 
-#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 
@@ -20,7 +19,6 @@
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
-using ostk::core::container::Pair;
 using ostk::core::container::Tuple;
 using ostk::core::type::Real;
 using ostk::core::type::String;
@@ -549,23 +547,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetCart
         // [TBI] Add more tests
     }
 
-    // Non-quasi inertial Frame
-    {
-        const Length semiMajorAxis = Length::Kilometers(7000.0);
-        const Real eccentricity = 0.05;
-        const Angle inclination = Angle::Degrees(45.0);
-        const Angle raan = Angle::Degrees(10.0);
-        const Angle aop = Angle::Degrees(20.0);
-        const Angle trueAnomaly = Angle::Degrees(30.0);
-
-        const COE coe = {semiMajorAxis, eccentricity, inclination, raan, aop, trueAnomaly};
-
-        EXPECT_THROW(
-            coe.getCartesianState(Earth::EGM2008.gravitationalParameter_, Frame::ITRF()),
-            ostk::core::error::RuntimeError
-        );
-    }
-
     {
         EXPECT_ANY_THROW(COE::Undefined().getCartesianState(Earth::EGM2008.gravitationalParameter_, Frame::GCRF()));
     }
@@ -673,17 +654,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, Cartesi
         EXPECT_ANY_THROW(COE::Cartesian(
             COE::CartesianState({Position::Undefined(), Velocity::Undefined()}), Earth::EGM2008.gravitationalParameter_
         ));
-    }
-
-    // Non-quasi inertial Frame
-    {
-        const Position position = Position::Meters({1000000.0, 2000000.0, 3000000.0}, Frame::ITRF());
-        const Velocity velocity = Velocity::MetersPerSecond({1.0, 2.0, 3.0}, Frame::ITRF());
-        const Pair<Position, Velocity> cartesianState = {position, velocity};
-
-        EXPECT_THROW(
-            COE::Cartesian(cartesianState, Earth::EGM2008.gravitationalParameter_), ostk::core::error::RuntimeError
-        );
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/ModifiedEquinoctial.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/ModifiedEquinoctial.test.cpp
@@ -97,11 +97,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEqui
         );
     }
 
-    // Non-quasi inertial Frame
     {
         EXPECT_THROW(
             modifiedEquinoctial_.getCartesianState(earthGravitationalParameter_, Frame::ITRF()),
-            ostk::core::error::RuntimeError
+            ostk::core::error::runtime::Wrong
         );
     }
 
@@ -161,7 +160,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEqui
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEquinoctial, Cartesian)
 {
-    // Non-quasi inertial Frame
     {
         const Position position = Position::Meters({1000000.0, 2000000.0, 3000000.0}, Frame::ITRF());
         const Velocity velocity = Velocity::MetersPerSecond({1.0, 2.0, 3.0}, Frame::ITRF());
@@ -169,7 +167,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_ModifiedEqui
 
         EXPECT_THROW(
             ModifiedEquinoctial::Cartesian(cartesianState, earthGravitationalParameter_),
-            ostk::core::error::RuntimeError
+            ostk::core::error::runtime::Wrong
         );
     }
 


### PR DESCRIPTION
This reverts commit 578d85b045d62fa62c99429a482bd92a9454bfdf.
Reverting this as it was a breaking change, we will discuss how best we want to handle this and deal with it downstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for non-quasi inertial frames in orbit modeling, providing more specific error messages.
* **Tests**
  * Updated tests to reflect the new exception type for non-quasi inertial frames.
  * Removed tests that are no longer relevant due to changes in frame validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->