### PR TITLE
perf: improve eclipse generator performance

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Eclipse/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Eclipse/Generator.cpp
@@ -130,7 +130,7 @@ Array<Eclipse> Generator::generate(
 
     Array<Eclipse> eclipses = Array<Eclipse>::Empty();
     eclipses.reserve(penumbraAndUmbraIntervals.getSize());
-        
+
     // Process each penumbra and umbra interval
     for (const Interval& penumbraAndUmbraInterval : penumbraAndUmbraIntervals)
     {
@@ -143,7 +143,7 @@ Array<Eclipse> Generator::generate(
         // Create eclipse phases
         Array<EclipsePhase> phases = Array<EclipsePhase>::Empty();
         phases.reserve(penumbraIntervals.getSize() + umbraIntervals.getSize());
-        
+
         // Add penumbra phases
         for (const Interval& penumbraInterval : penumbraIntervals)
         {

--- a/src/OpenSpaceToolkit/Astrodynamics/Eclipse/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Eclipse/Generator.cpp
@@ -129,7 +129,8 @@ Array<Eclipse> Generator::generate(
     };
 
     Array<Eclipse> eclipses = Array<Eclipse>::Empty();
-
+    eclipses.reserve(penumbraAndUmbraIntervals.getSize());
+        
     // Process each penumbra and umbra interval
     for (const Interval& penumbraAndUmbraInterval : penumbraAndUmbraIntervals)
     {
@@ -141,7 +142,8 @@ Array<Eclipse> Generator::generate(
 
         // Create eclipse phases
         Array<EclipsePhase> phases = Array<EclipsePhase>::Empty();
-
+        phases.reserve(penumbraIntervals.getSize() + umbraIntervals.getSize());
+        
         // Add penumbra phases
         for (const Interval& penumbraInterval : penumbraIntervals)
         {


### PR DESCRIPTION
Pre-allocate memory for the std::vector to avoid it copying the whole vector each time you `.add()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance by optimizing memory allocation during eclipse calculations. No changes to functionality or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->