### PR TITLE
build: bump OSTk physics to 13.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,9 +344,9 @@ IF (NOT OpenSpaceToolkitMathematics_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Physics [12.x.y]
+### Open Space Toolkit ▸ Physics [13.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "12" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "13" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,4 +3,4 @@
 open-space-toolkit-core~=5.0
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3
-open-space-toolkit-physics~=12.5
+open-space-toolkit-physics~=13.0

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -148,7 +148,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG TARGETPLATFORM
-ARG OSTK_PHYSICS_MAJOR="12"
+ARG OSTK_PHYSICS_MAJOR="13"
 
 ## Force an image rebuild when new Physics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR} /tmp/open-space-toolkit-physics/versions.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the required version of the OpenSpaceToolkitPhysics package to 13.x in build configuration, Python dependencies, and development Docker setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->