### PR TITLE
feat: add LDTN computation to COE

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -404,20 +404,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
 
                 The critical angles for inclination are 63.4349 degrees and 116.5651 degrees.
                 The critical angles for AoP are 90.0 degrees and 270.0 degrees.
-                
+
                 At a minimum, a semi-major axis and shared pointer to a central celestial body with a defined J2 and J3
                 must be provided. In this case, the inclination and AoP are set to critical angles, and the eccentricity
                 is derived from inclination. RAAN and true anomaly default to zero degrees.
-                                
+
                 Additionally, the following combinations of inputs are supported:
                 - AoP (inclination set to critical value, eccentricity derived)
                 - AoP and eccentricity (inclination derived)
                 - AoP and inclination, but at least one of them must be a critical value (eccentricity derived)
                 - Inclination (AoP set to critical value, eccentricity derived)
                 - Eccentricity (AoP set to critical value, inclination derived)
-                
+
                 Note that inclination and eccentricity cannot both be provided.
-                
+
                 RAAN and True Anomaly may be provided alongside any of these arguments, and will be passed through
                 to the resulting COE as they do not impact the frozen orbit condition.
 
@@ -459,20 +459,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
 
                 The critical angles for inclination are 63.4349 degrees and 116.5651 degrees.
                 The critical angles for AoP are 90.0 degrees and 270.0 degrees.
-                
+
                 At a minimum, a semi-major axis, equatorial radius, J2, and J3 must be provided. In this case,
                 the inclination and AoP are set to critical angles, and the eccentricity is derived from inclination.
                 RAAN and true anomaly default to zero degrees.
-                
+
                 Additionally, the following combinations of inputs are supported:
                 - AoP (inclination set to critical value, eccentricity derived)
                 - AoP and eccentricity (inclination derived)
                 - AoP and inclination, but at least one of them must be a critical value (eccentricity derived)
                 - Inclination (AoP set to critical value, eccentricity derived)
                 - Eccentricity (AoP set to critical value, inclination derived)
-                
+
                 Note that inclination and eccentricity cannot both be provided.
-                
+
                 RAAN and True Anomaly may be provided alongside any of these arguments, and will be passed through
                 to the resulting COE as they do not impact the frozen orbit condition.
 
@@ -694,6 +694,44 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
 
                 Returns:
                     float: The Local Time of the Ascending Node (LTAN) in hours.
+            )doc",
+            arg("raan"),
+            arg("instant"),
+            arg_v("sun", ostk::physics::environment::object::celestial::Sun::Default(), "Sun.default()")
+        )
+
+        .def_static(
+            "compute_mean_ltdn",
+            &COE::ComputeMeanLTDN,
+            R"doc(
+                Compute the Mean Local Time of the Descending Node (MLTDN) from the RAAN and instant.
+
+                Args:
+                    raan (Angle): The Right Ascension of the Descending Node.
+                    instant (Instant): The instant at which to compute MLTDN.
+                    sun (Sun): The Sun model.
+
+                Returns:
+                    float: The Mean Local Time of the Descending Node (MLTDN) in hours.
+            )doc",
+            arg("raan"),
+            arg("instant"),
+            arg_v("sun", ostk::physics::environment::object::celestial::Sun::Default(), "Sun.default()")
+        )
+
+        .def_static(
+            "compute_ltdn",
+            &COE::ComputeLTDN,
+            R"doc(
+                Compute the Local Time of the Descending Node (LTDN) from the RAAN and instant.
+
+                Args:
+                    raan (Angle): The Right Ascension of the Descending Node.
+                    instant (Instant): The instant at which to compute LTDN.
+                    sun (Sun): The Sun model.
+
+                Returns:
+                    float: The Local Time of the Descending Node (LTDN) in hours.
             )doc",
             arg("raan"),
             arg("instant"),

--- a/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
+++ b/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
@@ -174,6 +174,16 @@ class TestCOE:
             COE.compute_mean_ltan(Angle.degrees(270.0), Instant.J2000(), Sun.default())
             is not None
         )
+        assert COE.compute_ltdn(Angle.degrees(270.0), Instant.J2000()) is not None
+        assert (
+            COE.compute_ltdn(Angle.degrees(270.0), Instant.J2000(), Sun.default())
+            is not None
+        )
+        assert COE.compute_mean_ltdn(Angle.degrees(270.0), Instant.J2000()) is not None
+        assert (
+            COE.compute_mean_ltdn(Angle.degrees(270.0), Instant.J2000(), Sun.default())
+            is not None
+        )
 
     def test_from_SI_vector(
         self,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
@@ -421,12 +421,26 @@ class COE
     /// @return Mean Local Time of the Ascending Node (MLTAN) in hours
     static Time ComputeMeanLTAN(const Angle& raan, const Instant& anInstant, const Sun& sun = Sun::Default());
 
+    /// @brief Compute Mean Local Time of the Descending Node (MLTDN) from RAAN and instant
+    ///
+    /// @param raan Right Ascension of the Ascending Node
+    /// @param anInstant The instant at which to compute LTAN
+    /// @return Mean Local Time of the Descending Node (MLTDN) in hours
+    static Time ComputeMeanLTDN(const Angle& raan, const Instant& anInstant, const Sun& sun = Sun::Default());
+
     /// @brief Compute Local Time of the Ascending Node (LTAN) from RAAN and instant
     ///
     /// @param raan Right Ascension of the Ascending Node
     /// @param anInstant The instant at which to compute LTAN
     /// @return Local Time of the Ascending Node (LTAN) in hours
     static Time ComputeLTAN(const Angle& raan, const Instant& anInstant, const Sun& sun = Sun::Default());
+
+    /// @brief Compute Local Time of the Descending Node (LTDN) from RAAN and instant
+    ///
+    /// @param raan Right Ascension of the Ascending Node
+    /// @param anInstant The instant at which to compute LTAN
+    /// @return Local Time of the Descending Node (LTDN) in hours
+    static Time ComputeLTDN(const Angle& raan, const Instant& anInstant, const Sun& sun = Sun::Default());
 
     /// @brief Convert element to string
     ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -1064,6 +1064,15 @@ Time COE::ComputeMeanLTAN(const Angle& raan, const Instant& anInstant, const Sun
     return Time::Hours(meanLTAN);
 }
 
+Time COE::ComputeMeanLTDN(const Angle& raan, const Instant& anInstant, const Sun& aSun)
+{
+    const Real meanLTAN = COE::ComputeMeanLTAN(raan, anInstant, aSun).getTotalFloatingHours();
+
+    const Real meanLTDN = std::fmod(meanLTAN + 12.0, 24.0);
+
+    return Time::Hours(meanLTDN);
+}
+
 Time COE::ComputeLTAN(const Angle& raan, const Instant& anInstant, const Sun& aSun)
 {
     // Calculate sun position
@@ -1079,6 +1088,15 @@ Time COE::ComputeLTAN(const Angle& raan, const Instant& anInstant, const Sun& aS
     const Real LTAN = std::fmod((alpha * 12.0 / M_PI) + 12.0, 24.0);
 
     return Time::Hours(LTAN);
+}
+
+Time COE::ComputeLTDN(const Angle& raan, const Instant& anInstant, const Sun& aSun)
+{
+    const Real LTAN = COE::ComputeLTAN(raan, anInstant, aSun).getTotalFloatingHours();
+
+    const Real LTDN = std::fmod(LTAN + 12.0, 24.0);
+
+    return Time::Hours(LTDN);
 }
 
 String COE::StringFromElement(const COE::Element& anElement)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -1,8 +1,10 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
+#include <OpenSpaceToolkit/Core/Type/Size.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 
+#include <OpenSpaceToolkit/Mathematics/Object/Interval.hpp>
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
@@ -21,10 +23,12 @@
 using ostk::core::container::Array;
 using ostk::core::container::Tuple;
 using ostk::core::type::Real;
+using ostk::core::type::Size;
 using ostk::core::type::String;
 
 using ostk::mathematics::object::Vector3d;
 using ostk::mathematics::object::Vector6d;
+using ostk::mathematics::object::VectorXd;
 
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
@@ -301,21 +305,29 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, Compute
 {
     {
         const Instant instant = Instant::DateTime(DateTime::Parse("2024-01-01T01:34:36.978"), Scale::UTC);
-        const Time expectedMeanLTAN = Time::Parse("11:59:55.403");
-        const Angle raan = Angle::Degrees(279.823758664135426);
 
+        const Time startMeanLTAN = Time::Parse("11:59:55.403");
+        const Angle startRaan = Angle::Degrees(279.823758664135426);
+
+        for (Size i = 0; i < 24; ++i)
         {
-            const Time meanLTAN = COE::ComputeMeanLTAN(raan, instant);
+            const Angle raan = startRaan + Angle::Degrees(15.0 * i);
+            const Time expectedMeanLTAN = Time::Hours(std::fmod(startMeanLTAN.getTotalFloatingHours() + 1.0 * i, 24.0));
+            {
+                const Time meanLTAN = COE::ComputeMeanLTAN(raan, instant);
 
-            EXPECT_EQ(meanLTAN.getHour(), expectedMeanLTAN.getHour());
-            EXPECT_NEAR(meanLTAN.getMinute(), expectedMeanLTAN.getMinute(), 5.0);
-        }
+                EXPECT_EQ(meanLTAN.getHour(), expectedMeanLTAN.getHour());
+                EXPECT_NEAR(meanLTAN.getMinute(), expectedMeanLTAN.getMinute(), 1.0);
+                EXPECT_NEAR(meanLTAN.getSecond(), expectedMeanLTAN.getSecond(), 15.0);
+            }
 
-        {
-            const Time meanLTAN = COE::ComputeMeanLTAN(raan, instant, Sun::Default());
+            {
+                const Time meanLTAN = COE::ComputeMeanLTAN(raan, instant, Sun::Default());
 
-            EXPECT_EQ(meanLTAN.getHour(), expectedMeanLTAN.getHour());
-            EXPECT_NEAR(meanLTAN.getMinute(), expectedMeanLTAN.getMinute(), 5.0);
+                EXPECT_EQ(meanLTAN.getHour(), expectedMeanLTAN.getHour());
+                EXPECT_NEAR(meanLTAN.getMinute(), expectedMeanLTAN.getMinute(), 1.0);
+                EXPECT_NEAR(meanLTAN.getSecond(), expectedMeanLTAN.getSecond(), 15.0);
+            }
         }
     }
 }
@@ -324,21 +336,94 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, Compute
 {
     {
         const Instant instant = Instant::DateTime(DateTime::Parse("2024-01-01T01:34:36.978"), Scale::UTC);
-        const Time expectedLTAN = Time::Parse("11:56:50.133");
-        const Angle raan = Angle::Degrees(279.823758664135426);
 
+        const Time startLTAN = Time::Parse("11:56:50.133");
+        const Angle startRaan = Angle::Degrees(279.823758664135426);
+
+        for (Size i = 0; i < 24; ++i)
         {
-            const Time LTAN = COE::ComputeLTAN(raan, instant);
+            const Angle raan = startRaan + Angle::Degrees(15.0 * i);
+            const Time expectedLTAN = Time::Hours(std::fmod(startLTAN.getTotalFloatingHours() + 1.0 * i, 24.0));
 
-            EXPECT_EQ(LTAN.getHour(), expectedLTAN.getHour());
-            EXPECT_NEAR(LTAN.getMinute(), expectedLTAN.getMinute(), 5.0);
+            {
+                const Time LTAN = COE::ComputeLTAN(raan, instant);
+
+                EXPECT_EQ(LTAN.getHour(), expectedLTAN.getHour());
+                EXPECT_NEAR(LTAN.getMinute(), expectedLTAN.getMinute(), 1.0);
+                EXPECT_NEAR(LTAN.getSecond(), expectedLTAN.getSecond(), 15.0);
+            }
+
+            {
+                const Time LTAN = COE::ComputeLTAN(raan, instant, Sun::Default());
+
+                EXPECT_EQ(LTAN.getHour(), expectedLTAN.getHour());
+                EXPECT_NEAR(LTAN.getMinute(), expectedLTAN.getMinute(), 1.0);
+                EXPECT_NEAR(LTAN.getSecond(), expectedLTAN.getSecond(), 15.0);
+            }
         }
+    }
+}
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, ComputeMeanLTDN)
+{
+    {
+        const Instant instant = Instant::DateTime(DateTime::Parse("2024-01-01T01:34:36.978"), Scale::UTC);
+
+        const Time startMeanLTDN = Time::Parse("23:59:55.403");
+        const Angle startRaan = Angle::Degrees(279.823758664135426);
+
+        for (Size i = 0; i < 24; ++i)
         {
-            const Time LTAN = COE::ComputeLTAN(raan, instant, Sun::Default());
+            const Angle raan = startRaan + Angle::Degrees(15.0 * i);
+            const Time expectedMeanLTDN = Time::Hours(std::fmod(startMeanLTDN.getTotalFloatingHours() + 1.0 * i, 24.0));
 
-            EXPECT_EQ(LTAN.getHour(), expectedLTAN.getHour());
-            EXPECT_NEAR(LTAN.getMinute(), expectedLTAN.getMinute(), 5.0);
+            {
+                const Time meanLTDN = COE::ComputeMeanLTDN(raan, instant);
+
+                EXPECT_EQ(meanLTDN.getHour(), expectedMeanLTDN.getHour());
+                EXPECT_NEAR(meanLTDN.getMinute(), expectedMeanLTDN.getMinute(), 1.0);
+                EXPECT_NEAR(meanLTDN.getSecond(), expectedMeanLTDN.getSecond(), 15.0);
+            }
+
+            {
+                const Time meanLTDN = COE::ComputeMeanLTDN(raan, instant, Sun::Default());
+
+                EXPECT_EQ(meanLTDN.getHour(), expectedMeanLTDN.getHour());
+                EXPECT_NEAR(meanLTDN.getMinute(), expectedMeanLTDN.getMinute(), 1.0);
+                EXPECT_NEAR(meanLTDN.getSecond(), expectedMeanLTDN.getSecond(), 15.0);
+            }
+        }
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, ComputeLTDN)
+{
+    {
+        const Instant instant = Instant::DateTime(DateTime::Parse("2024-01-01T01:34:36.978"), Scale::UTC);
+
+        const Time startLTDN = Time::Parse("23:56:50.133");
+        const Angle startRaan = Angle::Degrees(279.823758664135426);
+
+        for (Size i = 0; i < 24; ++i)
+        {
+            const Angle raan = startRaan + Angle::Degrees(15.0 * i);
+            const Time expectedLTDN = Time::Hours(std::fmod(startLTDN.getTotalFloatingHours() + 1.0 * i, 24.0));
+
+            {
+                const Time LTDN = COE::ComputeLTDN(raan, instant);
+
+                EXPECT_EQ(LTDN.getHour(), expectedLTDN.getHour());
+                EXPECT_NEAR(LTDN.getMinute(), expectedLTDN.getMinute(), 1.0);
+                EXPECT_NEAR(LTDN.getSecond(), expectedLTDN.getSecond(), 15.0);
+            }
+
+            {
+                const Time LTDN = COE::ComputeLTDN(raan, instant, Sun::Default());
+
+                EXPECT_EQ(LTDN.getHour(), expectedLTDN.getHour());
+                EXPECT_NEAR(LTDN.getMinute(), expectedLTDN.getMinute(), 1.0);
+                EXPECT_NEAR(LTDN.getSecond(), expectedLTDN.getSecond(), 15.0);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds LDTN computation in addition to LTAN that already exists.

Leverages the LTAN method for the computation, since LDTN is exactly 12 hours ahead of LTAN by definition