### PR TITLE
fix: make FiniteDifferenceSolver gradient behaviour consistent

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solver/FiniteDifferenceSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Solver/FiniteDifferenceSolver.cpp
@@ -160,7 +160,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Solver_FiniteDifferenceSolver(pybind
                     generate_state_coordinates (function): The function to generate the state coordinates.
 
                 Returns:
-                    np.array: The gradient.
+                    np.array: The gradient of the state, matching the coordinates from generate_state_coordinates.
             )doc",
             arg("state"),
             arg("generate_state_coordinates")

--- a/include/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.hpp
@@ -118,7 +118,7 @@ class FiniteDifferenceSolver
     /// @param generateStateCoordinates Callable to generate coordinates of a State at the
     /// requested Instant.
     ///
-    /// @return The gradient.
+    /// @return The gradient of the state, matching the coordinates from generateStateCoordinates.
     VectorXd computeGradient(
         const State& aState, const std::function<VectorXd(const State&, const Instant&)>& generateStateCoordinates
     ) const;

--- a/src/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Solvers/FiniteDifferenceSolver.cpp
@@ -173,7 +173,7 @@ VectorXd FiniteDifferenceSolver::computeGradient(
     {
         case FiniteDifferenceSolver::Type::Forward:
         {
-            const VectorXd& coordinates = aState.accessCoordinates();
+            const VectorXd& coordinates = generateStateCoordinates(aState, aState.getInstant());
 
             const Instant instant = aState.accessInstant() + stepDuration_;
             const VectorXd forwardCoordinates = generateStateCoordinates(aState, instant);
@@ -183,7 +183,7 @@ VectorXd FiniteDifferenceSolver::computeGradient(
 
         case FiniteDifferenceSolver::Type::Backward:
         {
-            const VectorXd& coordinates = aState.accessCoordinates();
+            const VectorXd& coordinates = generateStateCoordinates(aState, aState.getInstant());
 
             const Instant instant = aState.accessInstant() - stepDuration_;
             const VectorXd backwardCoordinates = generateStateCoordinates(aState, instant);

--- a/test/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Solver/FiniteDifferenceSolver.test.cpp
@@ -311,50 +311,56 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Solvers_FiniteDifferenceSolver, ComputeGra
             {std::make_shared<const CoordinateSubset>(CoordinateSubset("Position", 1))}
         };
 
+        // A dummy coordinate generator that returns the same coordinates as the base state, plus an extra coordinate
+        // equal to the step size. Equivalent to a gradient of 0.0 in the first coordinate, and 1.0 in the second.
+        // e.g.
+        //  t  | base state | generated coordinates
+        // 0.0 |  (1.0, ?)  | (1.0, 0.0)
+        // 0.1 |     ---    | (1.0, 0.1)
         const auto generateStateCoordinates = [](const State& aState, const Instant& anInstant) -> VectorXd
         {
             const Real offset = (anInstant - aState.accessInstant()).inSeconds();
 
             VectorXd coordinates(2, 1);
-            coordinates << offset, offset;
+            coordinates << aState.getCoordinates(), offset;
 
             return coordinates;
         };
 
-        VectorXd expectedGradient_(2);
-        expectedGradient_ << 1.0, 1.0;  // In this case, same as the step size of the solver
+        VectorXd expectedDummyGradient(2);
+        expectedDummyGradient << 0.0, 1.0;
 
         {
             const FiniteDifferenceSolver solver = {
                 FiniteDifferenceSolver::Type::Central,
                 defaultStepPercentage_,
-                Duration::Seconds(1.0),
+                defaultStepDuration_,
             };
-            const VectorXd gradient = solver.computeGradient(baseState, generateStateCoordinates);
+            const VectorXd dummyGradient = solver.computeGradient(baseState, generateStateCoordinates);
 
-            EXPECT_TRUE(gradient.isApprox(expectedGradient_, 1e-6));
+            EXPECT_TRUE(dummyGradient.isApprox(expectedDummyGradient, 1e-6));
         }
 
         {
             const FiniteDifferenceSolver solver = {
                 FiniteDifferenceSolver::Type::Forward,
                 defaultStepPercentage_,
-                Duration::Seconds(1.0),
+                defaultStepDuration_,
             };
-            const VectorXd gradient = solver.computeGradient(baseState, generateStateCoordinates);
+            const VectorXd dummyGradient = solver.computeGradient(baseState, generateStateCoordinates);
 
-            EXPECT_TRUE(gradient.isApprox(expectedGradient_, 1e-6));
+            EXPECT_TRUE(dummyGradient.isApprox(expectedDummyGradient, 1e-6));
         }
 
         {
             const FiniteDifferenceSolver solver = {
                 FiniteDifferenceSolver::Type::Backward,
                 defaultStepPercentage_,
-                Duration::Seconds(1.0),
+                defaultStepDuration_,
             };
-            const VectorXd gradient = solver.computeGradient(baseState, generateStateCoordinates);
+            const VectorXd dummyGradient = solver.computeGradient(baseState, generateStateCoordinates);
 
-            EXPECT_TRUE(gradient.isApprox(expectedGradient_, 1e-6));
+            EXPECT_TRUE(dummyGradient.isApprox(expectedDummyGradient, 1e-6));
         }
     }
 }


### PR DESCRIPTION
See details in https://github.com/open-space-collective/open-space-toolkit-astrodynamics/issues/577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced the description of the gradient output to clarify its alignment with generated state coordinates.

* **Bug Fixes**
  * Refined the method for obtaining base coordinates in gradient computation to improve consistency.

* **Tests**
  * Introduced a test case validating gradient calculations when state coordinates differ from those generated by the coordinate function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->