### PR TITLE
fix: access generator stepping outside analysis interval

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -839,7 +839,7 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
 
         Instant intervalStart = anAnalysisInterval.getStart();
 
-        // compute start crossing if it is not the start of the requested analysis interval
+        // Compute start crossing if both bounding instants are within the analysis interval
         if (lowerBoundPreviousInstant >= anAnalysisInterval.getStart())
         {
             const auto startCrossingDurationSeconds = rootSolver.solve(
@@ -854,12 +854,12 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
         }
 
         const Instant upperBoundInstant = interval.getEnd();
-        const Instant upperBoundNextInstant = interval.getEnd() + this->step_;
+        const Instant upperBoundNextInstant = std::min(interval.getEnd() + this->step_, anAnalysisInterval.getEnd());
 
         Instant intervalEnd = anAnalysisInterval.getEnd();
 
-        // compute end crossing if it is not the end of the requested analysis interval
-        if (upperBoundNextInstant <= anAnalysisInterval.getEnd())
+        // Compute end crossing if both bounding instants are within the analysis interval
+        if (upperBoundNextInstant <= anAnalysisInterval.getEnd() && upperBoundNextInstant != upperBoundInstant)
         {
             const auto endCrossingDurationSeconds = rootSolver.solve(
                 [&upperBoundInstant, &condition](double aDurationInSeconds) -> double

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -840,7 +840,7 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
         Instant intervalStart = anAnalysisInterval.getStart();
 
         // compute start crossing if it is not the start of the requested analysis interval
-        if (lowerBoundInstant != anAnalysisInterval.getStart())
+        if (lowerBoundPreviousInstant >= anAnalysisInterval.getStart())
         {
             const auto startCrossingDurationSeconds = rootSolver.solve(
                 [&lowerBoundPreviousInstant, &condition](double aDurationInSeconds) -> double
@@ -859,7 +859,7 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
         Instant intervalEnd = anAnalysisInterval.getEnd();
 
         // compute end crossing if it is not the end of the requested analysis interval
-        if (upperBoundInstant != anAnalysisInterval.getEnd())
+        if (upperBoundNextInstant <= anAnalysisInterval.getEnd())
         {
             const auto endCrossingDurationSeconds = rootSolver.solve(
                 [&upperBoundInstant, &condition](double aDurationInSeconds) -> double


### PR DESCRIPTION
Fixes a bug where if a solved coarse access interval is between the analysis interval boundary and the last step, then it steps outside the analysis interval.

For example, if the analysis interval ends at 13:30:25, and the step size is 1 minute, and the analysis interval ends at 13:30:00,
then if the last step satisfies the access condition at 13:29:25, it will try and check for the step beyond by 1 minute to see if it can find a precise crossing, even though it is outside the analysis interval.

To fix this, we only solve for the crossing if within bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of access interval boundaries to ensure precise computation at the edges of analysis intervals.

* **Tests**
  * Added a new test to verify that interpolation does not occur outside the specified analysis interval, ensuring correct access detection at interval boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->