### PR TITLE
fix: improve logging for TLE constructor

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.cpp
@@ -31,7 +31,9 @@ TLE::TLE(const String& aFirstLine, const String& aSecondLine)
 {
     if (((!aFirstLine.isEmpty()) || (!aSecondLine.isEmpty())) && (!TLE::CanParse(aFirstLine, aSecondLine)))
     {
-        throw ostk::core::error::runtime::Wrong("TLE");
+        throw ostk::core::error::runtime::Wrong(
+            "TLE", String::Format("First line: [{}], Second line: [{}]", aFirstLine, aSecondLine)
+        );
     }
 }
 
@@ -42,7 +44,9 @@ TLE::TLE(const String& aSatelliteName, const String& aFirstLine, const String& a
 {
     if (((!aFirstLine.isEmpty()) || (!aSecondLine.isEmpty())) && (!TLE::CanParse(aFirstLine, aSecondLine)))
     {
-        throw ostk::core::error::runtime::Wrong("TLE");
+        throw ostk::core::error::runtime::Wrong(
+            "TLE", String::Format("First line: [{}], Second line: [{}]", aFirstLine, aSecondLine)
+        );
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.test.cpp
@@ -33,6 +33,22 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4_TLE, Constructor
 
         EXPECT_NO_THROW(TLE(firstLine, secondLine));
     }
+
+    // Wrong checksum
+    {
+        const String firstLine = "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2925";
+        const String secondLine = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563533";
+
+        EXPECT_THROW(TLE(firstLine, secondLine), ostk::core::error::runtime::Wrong);
+    }
+
+    // Invalid first and second lines
+    {
+        const String firstLine = "Some random string";
+        const String secondLine = "Another string that is random";
+
+        EXPECT_THROW(TLE(firstLine, secondLine), ostk::core::error::runtime::Wrong);
+    }
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4_TLE, EqualToOperator)


### PR DESCRIPTION
Changes from:
`TLE is wrong.`
to
`TLE = First line: [Some random string], Second line: [Another string that is random] is wrong." thrown in the test body.`