### PR TITLE
fix: don't overshoot access gaps at end of analysis span

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -834,9 +834,9 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
     {
         const physics::time::Interval& interval = accessIntervals[i];
 
-        // If the analysisInterval is Closed on the right-half, then the final Instant is possibly less than `step_`
-        // after the previous Instant. If we take `step_` back, we could "overshoot" the previous coarse step and
-        // potentially miss a gap in the access.
+        // If the analysisInterval is closed at the right-hand endpoint, then the final Instant is possibly less than
+        // `step_` after the previous Instant. If we take `step_` back, we could "overshoot" the previous coarse step
+        // and potentially miss a gap in the access.
         //
         // e.g. if `step_` = 10s:
         // t  | coarse step | inAccess
@@ -848,8 +848,9 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
         // 30 |      y      | false
         // 35 |      y      | true   <- end of analysisInterval
         //
-        // At t=35, if we took a 10s back to t=25, then both endpoints appear to be in an access, and the root finding
-        // will fail. Instead, we should start from the end of the previous Interval at t=20, and take a 10s forward.
+        // At t=35, if we took a 10s step back to t=25, then both endpoints appear to be in an access, and the root
+        // finder will fail because it doesn't bracket a zero-crossing. Instead, we should start from the end of the
+        // previous Interval at t=20, and take a 10s step forward.
         const Instant lowerBoundPreviousInstant =
             i == 0 ? (interval.getStart() - this->step_) : (accessIntervals[i - 1].getEnd() + this->step_);
 


### PR DESCRIPTION
At the end of the analysis span, when an access interval can be less than one "step" long, we risk overshooting/skipping-over an access gap if we directly take one step back. This can lead to a case where, when doing the "fine" solve, both endpoints appear to be in-access, leading the root solver (bracketing) to fail. See test case for representative example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access interval boundary handling to avoid missed gaps or overshoots between consecutive accesses and at analysis window edges (e.g., when passing through overhead blind spots). Users will see more accurate start/end times for partial accesses.

- **Tests**
  - Added a test validating blind-spot and boundary alignment, ensuring accesses end precisely at the analysis interval when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->