### PR TITLE
fix: validation tests expected error messages

### DIFF
--- a/validation/OpenSpaceToolkit/Astrodynamics/Parser.test.cpp
+++ b/validation/OpenSpaceToolkit/Astrodynamics/Parser.test.cpp
@@ -149,7 +149,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_Parser, CreateInitialState)
                 }
                 catch (const ostk::core::error::runtime::Wrong& e)
                 {
-                    EXPECT_EQ("{KEPLERIAN initial conditions not yet supported} is wrong.", e.getMessage());
+                    EXPECT_EQ("Orbit type = KEPLERIAN is wrong.", e.getMessage());
                     throw;
                 }
             },
@@ -168,7 +168,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_Parser, CreateInitialState)
                 }
                 catch (const ostk::core::error::runtime::Wrong& e)
                 {
-                    EXPECT_EQ("{Time scale} is wrong.", e.getMessage());
+                    EXPECT_EQ("Time scale = TAI is wrong.", e.getMessage());
                     throw;
                 }
             },
@@ -187,7 +187,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_Parser, CreateInitialState)
                 }
                 catch (const ostk::core::error::runtime::Wrong& e)
                 {
-                    EXPECT_EQ("{Initial Condition frame} is wrong.", e.getMessage());
+                    EXPECT_EQ("Initial Condition frame = ITRF is wrong.", e.getMessage());
                     throw;
                 }
             },


### PR DESCRIPTION
The exception strings were changed [here](https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/582/files#diff-b2cba9a14478a817d4b2f774b8a4131c8f41bc24baaed13caf2e4986408f7061), but never propagated to the validation tests.

Ran validation tests locally to confirm this works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated error message expectations in parser initialization failure scenarios to be more explicit (clarifying orbit type, time scale, and frame).
  * Improves clarity and consistency of test assertions.

* **Chores**
  * No functional changes; behavior and public APIs remain unchanged.
  * End users will not see any differences in features or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->