### PR TITLE
feat: add ground station method for display

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
     "name": "Open Space Toolkit Astrodynamics",
     "image": "openspacecollective/open-space-toolkit-astrodynamics-development-non-root:latest",
-    // "initializeCommand": "make build-development-image-non-root && mkdir -p ${localWorkspaceFolder}/build",
     "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
     "workspaceFolder": "/app",
     "containerUser": "developer",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "Open Space Toolkit Astrodynamics",
     "image": "openspacecollective/open-space-toolkit-astrodynamics-development-non-root:latest",
-    "initializeCommand": "make build-development-image-non-root && mkdir -p ${localWorkspaceFolder}/build",
+    // "initializeCommand": "make build-development-image-non-root && mkdir -p ${localWorkspaceFolder}/build",
     "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
     "workspaceFolder": "/app",
     "containerUser": "developer",
@@ -9,7 +9,6 @@
     "runArgs": [
         "--name",
         "open-space-toolkit-astrodynamics-dev-non-root"
-
     ],
     "mounts": [
         "source=ostk_astrodynamics_vscode_extensions,target=/home/developer/.vscode-server/extensions,type=volume",

--- a/bindings/python/test/test_display.py
+++ b/bindings/python/test/test_display.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-from ostk.mathematics.object import RealInterval
-
 from ostk.physics import Environment
 from ostk.physics.coordinate import Position
 from ostk.physics.coordinate.spherical import LLA
@@ -37,7 +35,7 @@ def earth(environment: Environment) -> Celestial:
 
 
 @pytest.fixture
-def search_interval() -> RealInterval:
+def search_interval() -> Interval:
     start_instant: Instant = Instant.date_time(
         DateTime(2023, 1, 3, 0, 0, 0),
         Scale.UTC,
@@ -111,7 +109,7 @@ def access_generator(environment: Environment) -> AccessGenerator:
 def satellite_1_accesses(
     satellite_1_trajectory: Orbit,
     environment: Environment,
-    search_interval: RealInterval,
+    search_interval: Interval,
     access_target: AccessTarget,
     access_generator: AccessGenerator,
 ) -> list[Access]:
@@ -126,7 +124,7 @@ def satellite_1_accesses(
 def satellite_2_accesses(
     satellite_2_trajectory: Orbit,
     environment: Environment,
-    search_interval: RealInterval,
+    search_interval: Interval,
     access_target: AccessTarget,
     access_generator: AccessGenerator,
 ) -> list[Access]:
@@ -142,7 +140,7 @@ class TestDisplay:
         self,
         environment: Environment,
         earth: Celestial,
-        search_interval: RealInterval,
+        search_interval: Interval,
         access_target: AccessTarget,
         ground_station_lla: LLA,
         satellite_1_trajectory: Orbit,
@@ -189,7 +187,7 @@ class TestDisplay:
         self,
         environment: Environment,
         earth: Celestial,
-        search_interval: RealInterval,
+        search_interval: Interval,
         access_target: AccessTarget,
         satellite_1_trajectory: Orbit,
         satellite_2_trajectory: Orbit,
@@ -197,23 +195,31 @@ class TestDisplay:
         satellite_2_accesses: list[Access],
         ground_station_lla: LLA,
     ):
-        accesses_plot = display.AccessesPlot(
-            earth=earth,
-            interval=search_interval,
-            trajectory_step=Duration.minutes(5.0),
-            access_step=Duration.seconds(10.0),
-            ground_station_lla=ground_station_lla,
-            color="green",
-        )
+        with pytest.warns(
+            DeprecationWarning,
+            match="Ground station and color are deprecated",
+        ):
+            accesses_plot = display.AccessesPlot(
+                earth=earth,
+                interval=search_interval,
+                trajectory_step=Duration.minutes(5.0),
+                access_step=Duration.seconds(10.0),
+                ground_station_lla=ground_station_lla,
+                color="green",
+            )
 
-        accesses_plot.add_satellite(
-            trajectory=satellite_1_trajectory,
-            accesses=satellite_1_accesses,
-            rgb=[180, 0, 0],
-        )
+        with pytest.warns(
+            DeprecationWarning,
+            match="Passing accesses to add_satellite\(\) is deprecated.*",
+        ):
+            accesses_plot.add_satellite(
+                trajectory=satellite_1_trajectory,
+                accesses=satellite_1_accesses,
+                rgb=[180, 0, 0],
+            )
 
-        accesses_plot.add_satellite(
-            trajectory=satellite_2_trajectory,
-            accesses=satellite_2_accesses,
-            rgb=[0, 0, 180],
-        )
+            accesses_plot.add_satellite(
+                trajectory=satellite_2_trajectory,
+                accesses=satellite_2_accesses,
+                rgb=[0, 0, 180],
+            )

--- a/bindings/python/test/test_display.py
+++ b/bindings/python/test/test_display.py
@@ -1,5 +1,7 @@
 # Apache License 2.0
 
+import pytest
+
 from ostk.mathematics.object import RealInterval
 
 from ostk.physics import Environment
@@ -22,80 +24,158 @@ from ostk.astrodynamics.trajectory.orbit.model import SGP4
 from ostk.astrodynamics.trajectory.orbit.model.sgp4 import TLE
 from ostk.astrodynamics.access import AccessTarget
 from ostk.astrodynamics.access import VisibilityCriterion
+from ostk.astrodynamics.access import Access
+
+
+@pytest.fixture
+def environment() -> Environment:
+    return Environment.default()
+
+
+@pytest.fixture
+def earth() -> Celestial:
+    return environment.access_celestial_object_with_name("Earth")
+
+
+@pytest.fixture
+def search_interval(earth: Celestial) -> RealInterval:
+    start_instant: Instant = Instant.date_time(
+        DateTime(2023, 1, 3, 0, 0, 0),
+        Scale.UTC,
+    )
+    duration: Duration = Duration.hours(1.0)
+    stop_instant: Instant = start_instant + duration
+    return Interval.closed(start_instant, stop_instant)
+
+
+@pytest.fixture
+def access_plot() -> display.AccessesPlot:
+    return display.AccessesPlot(
+        earth=earth,
+        interval=search_interval,
+        trajectory_step=Duration.minutes(5.0),
+        access_step=Duration.seconds(10.0),
+    )
+
+
+@pytest.fixture
+def satellite_1_trajectory(earth: Celestial) -> Orbit:
+    tle_1 = TLE(
+        "1 55076U 23001BV  23146.17959645  .00004328  00000-0  23719-3 0  9993",
+        "2 55076  97.4793 205.9529 0016244  89.9523 270.3571 15.14609100 21723",
+    )
+    return Orbit(SGP4(tle_1), earth)
+
+
+@pytest.fixture
+def satellite_2_trajectory(earth: Celestial) -> Orbit:
+    tle_2 = TLE(
+        "1 48915U 21059AN  23146.32782040  .00004955  00000-0  24678-3 0  9999",
+        "2 48915  97.5954 279.7041 0010303 354.9434   5.1694 15.18004448105867",
+    )
+    return Orbit(SGP4(tle_2), earth)
+
+
+@pytest.fixture
+def ground_station_lla() -> LLA:
+    return LLA(
+        Angle.degrees(70.0),
+        Angle.degrees(160.0),
+        Length.meters(0.0),
+    )
+
+
+@pytest.fixture
+def access_target(
+    environment: Environment,
+    ground_station_lla: LLA,
+) -> AccessTarget:
+    return AccessTarget.from_position(
+        VisibilityCriterion.from_line_of_sight(environment),
+        Position.from_lla(
+            ground_station_lla,
+            environment.access_celestial_object_with_name("Earth"),
+        ),
+    )
+
+
+@pytest.fixture
+def satellite_1_accesses(
+    satellite_1_trajectory: Orbit,
+    environment: Environment,
+    search_interval: RealInterval,
+    access_target: AccessTarget,
+) -> list[Access]:
+    return AccessGenerator(
+        environment=environment,
+        step=Duration.seconds(10.0),
+        tolerance=Duration.seconds(1.0),
+    ).compute_accesses(
+        interval=search_interval,
+        access_target=access_target,
+        to_trajectory=satellite_1_trajectory,
+    )
 
 
 class TestDisplay:
-    def test_accesses_plot(self):
-        start_instant: Instant = Instant.date_time(
-            DateTime(2023, 1, 3, 0, 0, 0),
-            Scale.UTC,
-        )
-        duration: Duration = Duration.hours(1.0)
-        step: Duration = Duration.seconds(10.0)
-        tolerance: Duration = Duration.seconds(1.0)
+    def test_accesses_plot(
+        self,
+        environment: Environment,
+        earth: Celestial,
+        search_interval: RealInterval,
+        access_target: AccessTarget,
+        ground_station_lla: LLA,
+        satellite_1_trajectory: Orbit,
+        satellite_2_trajectory: Orbit,
+        satellite_1_accesses: list[Access],
+        satellite_2_accesses: list[Access],
+    ):
 
-        ground_station_lla: LLA = LLA(
-            Angle.degrees(70.0),
-            Angle.degrees(160.0),
-            Length.meters(0.0),
-        )
-
-        tle_1 = TLE(
-            "1 55076U 23001BV  23146.17959645  .00004328  00000-0  23719-3 0  9993",
-            "2 55076  97.4793 205.9529 0016244  89.9523 270.3571 15.14609100 21723",
-        )
-
-        tle_2 = TLE(
-            "1 48915U 21059AN  23146.32782040  .00004955  00000-0  24678-3 0  9999",
-            "2 48915  97.5954 279.7041 0010303 354.9434   5.1694 15.18004448105867",
-        )
-
-        environment: Environment = Environment.default()
-        earth: Celestial = environment.access_celestial_object_with_name("Earth")
-
-        visibility_criterion: VisibilityCriterion = (
-            VisibilityCriterion.from_line_of_sight(environment)
-        )
-
-        access_target: AccessTarget = AccessTarget.from_position(
-            visibility_criterion,
-            Position.meters(
-                ground_station_lla.to_cartesian(
-                    earth.get_equatorial_radius(),
-                    earth.get_flattening(),
-                ),
-                Frame.ITRF(),
-            ),
-        )
-
-        stop_instant: Instant = start_instant + duration
-        search_interval: RealInterval = Interval.closed(start_instant, stop_instant)
-
-        orbit_1: Orbit = Orbit(SGP4(tle_1), earth)
-        orbit_2: Orbit = Orbit(SGP4(tle_2), earth)
-
-        generator = AccessGenerator(
-            environment=environment,
-            step=step,
-            tolerance=tolerance,
-        )
-
-        accesses_1 = generator.compute_accesses(
+        accesses_plot = display.AccessesPlot(
+            earth=earth,
             interval=search_interval,
-            access_target=access_target,
-            to_trajectory=orbit_1,
+            trajectory_step=Duration.minutes(5.0),
+            access_step=Duration.seconds(10.0),
         )
 
-        assert len(accesses_1) > 0
-
-        accesses_2 = generator.compute_accesses(
-            interval=search_interval,
-            access_target=access_target,
-            to_trajectory=orbit_2,
+        accesses_plot.add_satellite(
+            trajectory=satellite_1_trajectory,
+            accesses=[],
+            rgb=[180, 0, 0],
         )
 
-        assert len(accesses_2) > 0
+        accesses_plot.add_satellite(
+            trajectory=satellite_2_trajectory,
+            accesses=[],
+            rgb=[0, 0, 180],
+        )
 
+        accesses_plot.add_accesses(
+            trajectory=satellite_1_trajectory,
+            accesses=satellite_1_accesses,
+            rgb=[180, 0, 0],
+        )
+
+        accesses_plot.add_accesses(
+            trajectory=satellite_2_trajectory,
+            accesses=satellite_2_accesses,
+            rgb=[0, 0, 180],
+        )
+
+        accesses_plot.add_ground_station(ground_station_lla)
+
+    def test_accesses_plot_backwards_compatibility(
+        self,
+        environment: Environment,
+        earth: Celestial,
+        search_interval: RealInterval,
+        access_target: AccessTarget,
+        satellite_1_trajectory: Orbit,
+        satellite_2_trajectory: Orbit,
+        satellite_1_accesses: list[Access],
+        satellite_2_accesses: list[Access],
+        ground_station_lla: LLA,
+    ):
         accesses_plot = display.AccessesPlot(
             earth=earth,
             interval=search_interval,
@@ -106,13 +186,13 @@ class TestDisplay:
         )
 
         accesses_plot.add_satellite(
-            trajectory=orbit_1,
-            accesses=accesses_1,
+            trajectory=satellite_1_trajectory,
+            accesses=satellite_1_accesses,
             rgb=[180, 0, 0],
         )
 
         accesses_plot.add_satellite(
-            trajectory=orbit_2,
-            accesses=accesses_2,
+            trajectory=satellite_2_trajectory,
+            accesses=satellite_2_accesses,
             rgb=[0, 0, 180],
         )

--- a/bindings/python/tools/python/ostk/astrodynamics/display.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/display.py
@@ -132,17 +132,18 @@ class AccessesPlot:
         ground_station_lla: LLA | None = None,
         color: str | None = None,
     ):
-        if ground_station_lla is not None and color is not None:
-            warnings.warn(
-                "Ground station and color are deprecated, please use add_ground_station instead.",
-                DeprecationWarning,
-            )
-            self.add_ground_station(ground_station_lla, color)
-
+        self._data = []
         self._earth = earth
         self._trajectory_grid: list[Instant] = interval.generate_grid(trajectory_step)
-        self._access_step: Instant = access_step
-        self._data = []
+        self._access_step: Duration = access_step
+
+        if ground_station_lla is not None and color is not None:
+            warnings.warn(
+                "Ground station and color are deprecated; use add_ground_station instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.add_ground_station(ground_station_lla, color)
 
     def _generate_and_append_data(
         self,
@@ -231,7 +232,7 @@ class AccessesPlot:
                 trajectory,
                 access.get_interval().generate_grid(self._access_step),
             )
-            satellite_access_df: pd.Dataframe = pd.DataFrame(
+            satellite_access_df: pd.DataFrame = pd.DataFrame(
                 satellite_access_data,
                 columns=["Longitude", "Latitude"],
             )
@@ -260,8 +261,9 @@ class AccessesPlot:
         """
         if accesses:
             warnings.warn(
-                "Providing accesses with the satellite is deprecated, please use add_accesses instead.",
+                "Passing accesses to add_satellite() is deprecated; use add_accesses() instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             self.add_accesses(
                 trajectory,
@@ -276,7 +278,7 @@ class AccessesPlot:
             trajectory,
             self._trajectory_grid,
         )
-        satellite_trajectory_df: pd.Dataframe = pd.DataFrame(
+        satellite_trajectory_df: pd.DataFrame = pd.DataFrame(
             satellite_trajectory_data,
             columns=["Longitude", "Latitude"],
         )

--- a/bindings/python/tools/python/ostk/astrodynamics/display.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/display.py
@@ -170,8 +170,7 @@ class AccessesPlot:
         self,
         df: pd.DataFrame,
         width: int,
-        rgb: list[int],
-        alpha: float,
+        rgb: str,
     ) -> None:
         self._data.append(
             dict(
@@ -181,7 +180,7 @@ class AccessesPlot:
                 mode="lines",
                 line=dict(
                     width=width,
-                    color=f"rgba({str(rgb[0])},{str(rgb[1])},{str(rgb[2])},{str(alpha)})",
+                    color=rgb,
                 ),
             )
         )
@@ -189,15 +188,18 @@ class AccessesPlot:
     def add_ground_station(
         self,
         ground_station_lla: LLA,
-        color: str,
+        color: str | tuple[float, float, float],
     ) -> None:
         """
         Add a ground station to the plot.
 
         Args:
             ground_station_lla (LLA): The ground station location.
-            color (str): The color of the ground station.
+            color (str | tuple[float, float, float]): The color of the ground station.
         """
+        if isinstance(color, tuple):
+            color = f"rgba({str(color[0])},{str(color[1])},{str(color[2])},1.0)"
+
         self._data.append(
             dict(
                 type="scattergeo",
@@ -215,7 +217,7 @@ class AccessesPlot:
         self,
         trajectory: Trajectory,
         accesses: list[Access],
-        rgb: list[int],
+        rgb: str | tuple[int, int, int],
     ) -> None:
         """
         Add accesses to the plot.
@@ -223,8 +225,11 @@ class AccessesPlot:
         Args:
             trajectory (Trajectory): The satellite trajectory.
             accesses (list[Access]): The list of accesses.
-            rgb (list[int]): The RGB color of the accesses.
+            rgb (str | tuple[int, int, int]): The color of the accesses, as a string or tuple of RGB values.
         """
+        if isinstance(rgb, tuple):
+            rgb = f"rgba({str(rgb[0])},{str(rgb[1])},{str(rgb[2])},1.0)"
+
         for access in accesses:
             satellite_access_data: list[list[float]] = []
             self._generate_and_append_data(
@@ -240,14 +245,13 @@ class AccessesPlot:
                 satellite_access_df,
                 2,
                 rgb,
-                1.0,
             )
 
     def add_satellite(
         self,
         trajectory: Trajectory,
-        accesses: list[Access],
-        rgb: list[int],
+        accesses: list[Access] | None = None,
+        rgb: str | tuple[int, int, int] | None = None,
         opacity: float = 0.3,
     ) -> None:
         """
@@ -256,11 +260,17 @@ class AccessesPlot:
 
         Args:
             trajectory (Trajectory): The satellite trajectory.
-            accesses (list[Access]): (Deprecated) Accesses to plot; use add_accesses().
-            rgb (list[int]): The RGB color of the satellite.
-            opacity (float): Opacity of the satellite trajectory line.
+            accesses (list[Access] | None, optional): (Deprecated) Accesses to plot; use add_accesses().
+            rgb (str | tuple[int, int, int] | None, optional): The color of the satellite, as a string or tuple of RGB values.
+            opacity (float, optional): Opacity of the satellite trajectory line.
         """
-        if accesses:
+        if rgb is None:
+            rgb = f"rgba(255, 0, 0, {opacity})"
+
+        elif isinstance(rgb, tuple):
+            rgb = f"rgba({str(rgb[0])},{str(rgb[1])},{str(rgb[2])},{opacity})"
+
+        if accesses is not None:
             warnings.warn(
                 "Passing accesses to add_satellite() is deprecated; use add_accesses() instead.",
                 DeprecationWarning,
@@ -272,7 +282,6 @@ class AccessesPlot:
                 rgb,
             )
 
-        # Satellite trajectory
         satellite_trajectory_data: list[list[float]] = []
         self._generate_and_append_data(
             satellite_trajectory_data,
@@ -287,7 +296,6 @@ class AccessesPlot:
             satellite_trajectory_df,
             1,
             rgb,
-            opacity,
         )
 
     def show(self):

--- a/bindings/python/tools/python/ostk/astrodynamics/display.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/display.py
@@ -188,16 +188,16 @@ class AccessesPlot:
     def add_ground_station(
         self,
         ground_station_lla: LLA,
-        color: str | tuple[float, float, float],
+        color: str | tuple[int, int, int],
     ) -> None:
         """
         Add a ground station to the plot.
 
         Args:
             ground_station_lla (LLA): The ground station location.
-            color (str | tuple[float, float, float]): The color of the ground station.
+            color (str | tuple[int, int, int]): The color of the ground station.
         """
-        if isinstance(color, tuple):
+        if isinstance(color, (tuple, list)):
             color = f"rgba({str(color[0])},{str(color[1])},{str(color[2])},1.0)"
 
         self._data.append(
@@ -227,7 +227,7 @@ class AccessesPlot:
             accesses (list[Access]): The list of accesses.
             rgb (str | tuple[int, int, int]): The color of the accesses, as a string or tuple of RGB values.
         """
-        if isinstance(rgb, tuple):
+        if isinstance(rgb, (tuple, list)):
             rgb = f"rgba({str(rgb[0])},{str(rgb[1])},{str(rgb[2])},1.0)"
 
         for access in accesses:
@@ -267,7 +267,7 @@ class AccessesPlot:
         if rgb is None:
             rgb = f"rgba(255, 0, 0, {opacity})"
 
-        elif isinstance(rgb, tuple):
+        elif isinstance(rgb, (tuple, list)):
             rgb = f"rgba({str(rgb[0])},{str(rgb[1])},{str(rgb[2])},{opacity})"
 
         if accesses is not None:

--- a/bindings/python/tools/python/ostk/astrodynamics/display.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/display.py
@@ -251,13 +251,14 @@ class AccessesPlot:
         opacity: float = 0.3,
     ) -> None:
         """
-        Add a satellite trajectory to the plot, including a highligh of the accesses.
+        Add a satellite trajectory to the plot. If `accesses` is provided (deprecated),
+        they will be plotted and a deprecation warning will be emitted.
 
         Args:
             trajectory (Trajectory): The satellite trajectory.
-            accesses (list[Access]): The list of accesses.
+            accesses (list[Access]): (Deprecated) Accesses to plot; use add_accesses().
             rgb (list[int]): The RGB color of the satellite.
-            opacity (float): The opacity of the accesses.
+            opacity (float): Opacity of the satellite trajectory line.
         """
         if accesses:
             warnings.warn(


### PR DESCRIPTION
Updates the interface so that ground stations can be added separately, similar to satellites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public APIs to add ground-station markers, satellites, and access data to plots at runtime.

- **Changes**
  - Constructor accepts optional ground-station inputs (deprecated path warns and delegates to new method).
  - Ground stations no longer auto-added at init.
  - Satellite trajectory opacity reduced by default; accesses remain fully opaque.
  - Plotting flows split into distinct add_* methods.

- **Tests**
  - Tests refactored to fixture-driven design; added backwards-compatibility test.

- **Chores**
  - Minor docs, formatting, removed unused imports, devcontainer init removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->