### PR TITLE
docs: add eclipse to python.rst

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -16,6 +16,7 @@ Python API Documentation
    ostk.astrodynamics.display
    ostk.astrodynamics.dynamics
    ostk.astrodynamics.event_condition
+   ostk.astrodynamics.eclipse
    ostk.astrodynamics.estimator
    ostk.astrodynamics.flight
    ostk.astrodynamics.flight.profile


### PR DESCRIPTION
Adding eclipse module to the python.rst so that it gets rendered in the python documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Python API documentation to include the ostk.astrodynamics.eclipse module in the public API listing.
  - Ensures users can discover and navigate to the module’s reference pages directly from the API index.
  - No changes to runtime behavior; this is a visibility and discoverability improvement in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->