### PR TITLE
fix: allow overriding of 'calculate_thrust_acceleration_at' function …

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/GuidanceLaw.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/GuidanceLaw.cpp
@@ -37,7 +37,7 @@ class PyGuidanceLaw : public GuidanceLaw
         const Vector3d& aVelocityCoordinates,
         const Real& aThrustAcceleration,
         const Shared<const Frame>& outputFrameSPtr
-    ) const
+    ) const override
     {
         PYBIND11_OVERRIDE_PURE_NAME(
             Vector3d,


### PR DESCRIPTION
I believe there is a missing "override" modifier in Guidance Law trampoline class, and the reason why it can't be overriden in python:

<img width="725" height="74" alt="image" src="https://github.com/user-attachments/assets/953dd99a-62e4-46f7-b4c6-8edfeb3e2f49" />
