### PR TITLE
docs: clarify mltan input

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -666,10 +666,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
             "compute_mean_ltan",
             &COE::ComputeMeanLTAN,
             R"doc(
-                Compute the Mean Local Time of the Ascending Node (MLTAN) from the mean RAAN and instant.
+                Compute the Mean Local Time of the Ascending Node (MLTAN) from the RAAN and instant.
+
+                Note:
+                    It is recommended to use the BrouwerLyddaneMean RAAN instead of the osculating RAAN for this computation to get a more stable result.
 
                 Args:
-                    raan (Angle): The Right Ascension of the Ascending Node (mean element, not osculating element).
+                    raan (Angle): The Right Ascension of the Ascending Node.
                     instant (Instant): The instant at which to compute MLTAN.
                     sun (Sun): The Sun model.
 
@@ -685,10 +688,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
             "compute_ltan",
             &COE::ComputeLTAN,
             R"doc(
-                Compute the Local Time of the Ascending Node (LTAN) from the mean RAAN and instant.
+                Compute the Local Time of the Ascending Node (LTAN) from the RAAN and instant.
+
+                Note:
+                    It is recommended to use the BrouwerLyddaneMean RAAN instead of the osculating RAAN for this computation to get a more stable result.
 
                 Args:
-                    raan (Angle): The Right Ascension of the Ascending Node (mean element, not osculating element).
+                    raan (Angle): The Right Ascension of the Ascending Node.
                     instant (Instant): The instant at which to compute LTAN.
                     sun (Sun): The Sun model.
 
@@ -704,10 +710,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
             "compute_mean_ltdn",
             &COE::ComputeMeanLTDN,
             R"doc(
-                Compute the Mean Local Time of the Descending Node (MLTDN) from the mean RAAN and instant.
+                Compute the Mean Local Time of the Descending Node (MLTDN) from the RAAN and instant.
+
+                Note:
+                    It is recommended to use the BrouwerLyddaneMean RAAN instead of the osculating RAAN for this computation to get a more stable result.
 
                 Args:
-                    raan (Angle): The Right Ascension of the Descending Node (mean element, not osculating element).
+                    raan (Angle): The Right Ascension of the Ascending Node.
                     instant (Instant): The instant at which to compute MLTDN.
                     sun (Sun): The Sun model.
 
@@ -723,10 +732,13 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
             "compute_ltdn",
             &COE::ComputeLTDN,
             R"doc(
-                Compute the Local Time of the Descending Node (LTDN) from the mean RAAN and instant.
+                Compute the Local Time of the Descending Node (LTDN) from the RAAN and instant.
+
+                Note:
+                    It is recommended to use the BrouwerLyddaneMean RAAN instead of the osculating RAAN for this computation to get a more stable result.
 
                 Args:
-                    raan (Angle): The Right Ascension of the Descending Node (mean element, not osculating element).
+                    raan (Angle): The Right Ascension of the Ascending Node.
                     instant (Instant): The instant at which to compute LTDN.
                     sun (Sun): The Sun model.
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
@@ -414,30 +414,42 @@ class COE
     /// @return Radial distance in meters.
     static Real ComputeRadialDistance(const Real& aSemiMajorAxis, const Real& anEccentricity, const Real& trueAnomaly);
 
-    /// @brief Compute Mean Local Time of the Ascending Node (MLTAN) from RAAN and instant
+    /// @brief Compute Mean Local Time of the Ascending Node (MLTAN) from the RAAN and instant
     ///
-    /// @param raan Right Ascension of the Ascending Node (mean element, not osculating element)
+    /// @note It is recommended to use the BrouwerLyddaneMean RAAN instead of the osculating RAAN for this computation
+    /// to get a more stable result.
+    ///
+    /// @param raan Right Ascension of the Ascending Node
     /// @param anInstant The instant at which to compute LTAN
     /// @return Mean Local Time of the Ascending Node (MLTAN) in hours
     static Time ComputeMeanLTAN(const Angle& raan, const Instant& anInstant, const Sun& sun = Sun::Default());
 
-    /// @brief Compute Mean Local Time of the Descending Node (MLTDN) from RAAN and instant
+    /// @brief Compute Mean Local Time of the Descending Node (MLTDN) from the RAAN and instant
     ///
-    /// @param raan Right Ascension of the Ascending Node (mean element, not osculating element)
+    /// @note It is recommended to use the BrouwerLyddaneMean RAAN instead of the osculating RAAN for this computation
+    /// to get a more stable result.
+    ///
+    /// @param raan Right Ascension of the Ascending Node
     /// @param anInstant The instant at which to compute LTAN
     /// @return Mean Local Time of the Descending Node (MLTDN) in hours
     static Time ComputeMeanLTDN(const Angle& raan, const Instant& anInstant, const Sun& sun = Sun::Default());
 
-    /// @brief Compute Local Time of the Ascending Node (LTAN) from RAAN and instant
+    /// @brief Compute Local Time of the Ascending Node (LTAN) from the RAAN and instant
     ///
-    /// @param raan Right Ascension of the Ascending Node (mean element, not osculating element)
+    /// @note It is recommended to use the BrouwerLyddaneMean RAAN instead of the osculating RAAN for this computation
+    /// to get a more stable result.
+    ///
+    /// @param raan Right Ascension of the Ascending Node
     /// @param anInstant The instant at which to compute LTAN
     /// @return Local Time of the Ascending Node (LTAN) in hours
     static Time ComputeLTAN(const Angle& raan, const Instant& anInstant, const Sun& sun = Sun::Default());
 
-    /// @brief Compute Local Time of the Descending Node (LTDN) from RAAN and instant
+    /// @brief Compute Local Time of the Descending Node (LTDN) from the RAAN and instant
     ///
-    /// @param raan Right Ascension of the Ascending Node (mean element, not osculating element)
+    /// @note It is recommended to use the BrouwerLyddaneMean RAAN instead of the osculating RAAN for this computation
+    /// to get a more stable result.
+    ///
+    /// @param raan Right Ascension of the Ascending Node
     /// @param anInstant The instant at which to compute LTAN
     /// @return Local Time of the Descending Node (LTDN) in hours
     static Time ComputeLTDN(const Angle& raan, const Instant& anInstant, const Sun& sun = Sun::Default());


### PR DESCRIPTION
LTAN and MLTAN should be computed using the mean RAAN instead of the osculating RAAN, because using the osculating RAAN makes the LTAN/MLTAN value fluctuate within an orbital period. For completeness, the Mean in MLTAN signifies mean solar time, which is the solar time averaged over an entire year.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added notes recommending the use of a mean RAAN variant for more stable LTAN/LTDN calculations.
  * Clarified argument wording to state the reference is the Ascending Node (RAAN) and emphasized that RAAN refers to mean, not osculating, elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->