### PR TITLE
fix: AERMask behaved incorrectly when azimuth values equal boundries.

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/AERMask.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/AERMask.cpp
@@ -88,9 +88,16 @@ bool VisibilityCriterion::AERMask::isSatisfied(
     const Real& anAzimuth_Radians, const Real& anElevation_Radians, const Real& aRange_Meters
 ) const
 {
-    auto itLow = this->azimuthElevationMask.lower_bound(anAzimuth_Radians);
-    itLow--;
-    auto itUp = this->azimuthElevationMask.upper_bound(anAzimuth_Radians);
+    Real anAzimuthReduced_Radians = Angle(anAzimuth_Radians, Angle::Unit::Radian).inRadians(0.0, Real::TwoPi());
+    Real anElevationReduced_Radians =
+        Angle(anElevation_Radians, Angle::Unit::Radian).inRadians(-Real::Pi(), Real::Pi());
+
+    auto itLow = this->azimuthElevationMask.lower_bound(anAzimuthReduced_Radians);
+    if (itLow->first != anAzimuthReduced_Radians)
+    {
+        itLow--;
+    }
+    auto itUp = this->azimuthElevationMask.upper_bound(anAzimuthReduced_Radians);
 
     // Vector between the two successive mask data points with bounding azimuth values
 
@@ -98,7 +105,9 @@ bool VisibilityCriterion::AERMask::isSatisfied(
 
     // Vector from data point with azimuth lower bound to tested point
 
-    const Vector2d lowToPointVector = {anAzimuth_Radians - itLow->first, anElevation_Radians - itLow->second};
+    const Vector2d lowToPointVector = {
+        anAzimuthReduced_Radians - itLow->first, anElevationReduced_Radians - itLow->second
+    };
 
     // If the determinant of these two vectors is positive, the tested point lies above the function defined by the
     // mask

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
@@ -441,9 +441,85 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, AERMaskIsSatis
 
         EXPECT_TRUE(aerMask.value().isSatisfied(aer));
 
-        AER aerOutside(Angle::Degrees(22.5), Angle::Degrees(5.0), Length::Meters(500e3));
+        AER aer2(Angle::Degrees(0.0), Angle::Degrees(10.1), Length::Meters(500e3));
+
+        EXPECT_TRUE(aerMask.value().isSatisfied(aer2));
+
+        EXPECT_TRUE(aerMask.value().isSatisfied(
+            Angle::Degrees(0.0).inRadians(), Angle::Degrees(10.1).inRadians(), Length::Meters(500e3).inMeters()
+        ));
+        EXPECT_TRUE(aerMask.value().isSatisfied(
+            Angle::Degrees(0.1).inRadians(), Angle::Degrees(10.1).inRadians(), Length::Meters(500e3).inMeters()
+        ));
+        EXPECT_TRUE(aerMask.value().isSatisfied(
+            Angle::Degrees(360.0).inRadians(), Angle::Degrees(10.1).inRadians(), Length::Meters(500e3).inMeters()
+        ));
+        EXPECT_TRUE(aerMask.value().isSatisfied(
+            Angle::Degrees(360.1).inRadians(), Angle::Degrees(10.1).inRadians(), Length::Meters(500e3).inMeters()
+        ));
+        EXPECT_TRUE(aerMask.value().isSatisfied(
+            Angle::Degrees(360.1).inRadians(), Angle::Degrees(91.0).inRadians(), Length::Meters(500e3).inMeters()
+        ));
+
+        AER aer3(Angle::Degrees(0.1), Angle::Degrees(10.1), Length::Meters(500e3));
+
+        EXPECT_TRUE(aerMask.value().isSatisfied(aer3));
+
+        AER aer4(
+            Angle::Degrees(360. * (1.0 - std::numeric_limits<double>::epsilon())),
+            Angle::Degrees(10.1),
+            Length::Meters(500e3)
+        );
+
+        EXPECT_TRUE(aerMask.value().isSatisfied(aer4));
+
+        AER aer5(Angle::Degrees(45.0), Angle::Degrees(15.1), Length::Meters(500e3));
+
+        EXPECT_TRUE(aerMask.value().isSatisfied(aer5));
+
+        AER aer6(Angle::Degrees(90.0), Angle::Degrees(20.1), Length::Meters(500e3));
+
+        EXPECT_TRUE(aerMask.value().isSatisfied(aer6));
+
+        AER aer7(Angle::Degrees(89.9), Angle::Degrees(20.1), Length::Meters(500e3));
+
+        EXPECT_TRUE(aerMask.value().isSatisfied(aer7));
+
+        AER aer8(Angle::Degrees(90.1), Angle::Degrees(20.1), Length::Meters(500e3));
+
+        EXPECT_TRUE(aerMask.value().isSatisfied(aer8));
+
+        AER aerOutside(Angle::Degrees(22.5), Angle::Degrees(12.4), Length::Meters(500e3));
 
         EXPECT_FALSE(aerMask.value().isSatisfied(aerOutside));
+
+        AER aerOutside2(Angle::Degrees(0.0), Angle::Degrees(9.9), Length::Meters(500e3));
+
+        EXPECT_FALSE(aerMask.value().isSatisfied(aerOutside2));
+
+        AER aerOutside3(Angle::Degrees(0.1), Angle::Degrees(9.9), Length::Meters(500e3));
+
+        EXPECT_FALSE(aerMask.value().isSatisfied(aerOutside3));
+
+        AER aerOutside4(
+            Angle::Degrees(360. * (1.0 - std::numeric_limits<double>::epsilon())),
+            Angle::Degrees(9.9),
+            Length::Meters(500e3)
+        );
+
+        EXPECT_FALSE(aerMask.value().isSatisfied(aerOutside4));
+
+        AER aerOutside5(Angle::Degrees(90.0), Angle::Degrees(19.9), Length::Meters(500e3));
+
+        EXPECT_FALSE(aerMask.value().isSatisfied(aerOutside5));
+
+        AER aerOutside6(Angle::Degrees(89.9), Angle::Degrees(19.9), Length::Meters(500e3));
+
+        EXPECT_FALSE(aerMask.value().isSatisfied(aerOutside6));
+
+        AER aerOutside7(Angle::Degrees(90.1), Angle::Degrees(19.9), Length::Meters(500e3));
+
+        EXPECT_FALSE(aerMask.value().isSatisfied(aerOutside7));
     }
 }
 


### PR DESCRIPTION
- When azimuth equals 0., itLow would go out of bounds
- When azimuth equals a map value, its limit was ignored
- If azimuth was outside of [0, 2*pi), the map would correctly wrap the input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized azimuth and elevation handling in visibility checks so boundary and wrap-around angles are evaluated consistently, preventing mismatches near 0°/360° and at elevation sign boundaries.

* **Tests**
  * Expanded unit tests to cover wrap-around and boundary azimuth/elevation scenarios, with multiple positive/negative cases and varied input forms (including radian inputs) to validate correct inclusion/exclusion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->