### PR TITLE
refactor: update naming for compute_residuals_for_orbit

### DIFF
--- a/bindings/python/test/test_utilities.py
+++ b/bindings/python/test/test_utilities.py
@@ -239,8 +239,33 @@ class TestUtility:
         reference_states: list[State],
     ) -> None:
         result = utilities.compute_residuals_for_orbit(
-            orbit=orbit,
+            candidate_orbit=orbit,
             reference_states=reference_states,
+        )
+
+        assert len(result) == len(reference_states)
+        for entry in result:
+            assert isinstance(entry, utilities.Residual)
+            assert entry.timestamp is not None
+            assert entry.dr_x is not None
+            assert entry.dr_y is not None
+            assert entry.dr_z is not None
+            assert entry.dv_x is not None
+            assert entry.dv_y is not None
+            assert entry.dv_z is not None
+            assert isinstance(entry.timestamp, datetime)
+
+    def test_compute_residuals_for_orbit_identical_orbit_and_states_with_local_orbital_frame_factory(
+        self,
+        orbit: Orbit,
+        reference_states: list[State],
+    ) -> None:
+        result = utilities.compute_residuals_for_orbit(
+            candidate_orbit=orbit,
+            reference_states=reference_states,
+            local_orbital_frame_factory_or_frame=LocalOrbitalFrameFactory.VNC(
+                Frame.GCRF()
+            ),
         )
 
         assert len(result) == len(reference_states)

--- a/bindings/python/tools/python/ostk/astrodynamics/utilities.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/utilities.py
@@ -113,7 +113,7 @@ def compute_residuals(
 
 
 def compute_residuals_for_orbit(
-    orbit: Orbit,
+    candidate_orbit: Orbit,
     reference_states: list[State],
     local_orbital_frame_factory_or_frame: (
         LocalOrbitalFrameFactory | Frame
@@ -123,7 +123,7 @@ def compute_residuals_for_orbit(
     Compute position and velocity residuals for an orbit against a list of reference states.
 
     Args:
-        orbit (Orbit): Orbit used to generate states at the instants of the reference states.
+        candidate_orbit (Orbit): Candidate Orbit used to generate states at the instants of the reference states.
         reference_states (list[State]): List of reference States to compare against.
         local_orbital_frame_factory_or_frame (LocalOrbitalFrameFactory | Frame, optional): The local orbital frame factory to use. Defaults to Frame.GCRF().
 
@@ -131,10 +131,10 @@ def compute_residuals_for_orbit(
         list[Residual]: List of Residuals.
     """
     instants: list[Instant] = [state.get_instant() for state in reference_states]
-    orbit_states: list[State] = orbit.get_states_at(instants)
+    candidate_states: list[State] = candidate_orbit.get_states_at(instants)
 
     return compute_residuals(
-        candidate_states=orbit_states,
+        candidate_states=candidate_states,
         reference_states=reference_states,
         local_orbital_frame_factory_or_frame=local_orbital_frame_factory_or_frame,
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for computing residuals with respect to local orbital frames through the new `local_orbital_frame_factory_or_frame` parameter.

* **Breaking Changes**
  * The `compute_residuals_for_orbit` function parameter name changed from `orbit` to `candidate_orbit`.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->