### PR TITLE
refactor!: remove VelocityECEF enum from Profile.Target

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -66,7 +66,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
         .value("Sun", Profile::TargetType::Sun, "Sun")
         .value("Moon", Profile::TargetType::Moon, "Moon")
         .value("VelocityECI", Profile::TargetType::VelocityECI, "Velocity in ECI")
-        .value("VelocityECEF", Profile::TargetType::VelocityECEF, "Velocity in ECEF")
         .value("OrbitalMomentum", Profile::TargetType::OrbitalMomentum, "Orbital momentum")
         .value("OrientationProfile", Profile::TargetType::OrientationProfile, "Orientation profile")
         .value("Custom", Profile::TargetType::Custom, "Custom")

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -89,7 +89,6 @@ class Profile
         Sun,                          /// The position of the Sun
         Moon,                         /// The position of the Moon
         VelocityECI,                  /// The velocity vector in the ECI frame
-        VelocityECEF,                 /// The velocity vector in the ECEF frame
         OrbitalMomentum,              /// The orbital momentum vector of the satellite in the ECI frame
         OrientationProfile,           /// Points towards a profile of orientations in the ECI frame
         Custom,                       /// Custom target
@@ -437,8 +436,6 @@ class Profile
     static Vector3d ComputeCelestialDirectionVector(const State& aState, const Celestial& aCelestial);
 
     static Vector3d ComputeVelocityDirectionVector_ECI(const State& aState);
-
-    static Vector3d ComputeVelocityDirectionVector_ECEF(const State& aState);
 
     static Vector3d ComputeOrbitalMomentumDirectionVector(const State& aState);
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
@@ -374,12 +374,6 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
     const Angle& anAngularOffset
 )
 {
-    if ((anAlignmentTargetSPtr->type == TargetType::VelocityECEF) ||
-        (aClockingTargetSPtr->type == TargetType::VelocityECEF))
-    {
-        throw ostk::core::error::runtime::ToBeImplemented("Velocity ECEF");
-    }
-
     if ((anAlignmentTargetSPtr->type == aClockingTargetSPtr->type) &&
         (anAlignmentTargetSPtr->type != TargetType::TargetPosition) &&
         (anAlignmentTargetSPtr->type != TargetType::TargetVelocity))
@@ -456,8 +450,6 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
                 };
             case TargetType::VelocityECI:
                 return Profile::ComputeVelocityDirectionVector_ECI;
-            case TargetType::VelocityECEF:
-                return Profile::ComputeVelocityDirectionVector_ECEF;
             case TargetType::OrbitalMomentum:
                 return Profile::ComputeOrbitalMomentumDirectionVector;
             case TargetType::OrientationProfile:
@@ -608,11 +600,6 @@ Vector3d Profile::ComputeCelestialDirectionVector(const State& aState, const Cel
 Vector3d Profile::ComputeVelocityDirectionVector_ECI(const State& aState)
 {
     return aState.inFrame(DEFAULT_PROFILE_FRAME).getVelocity().accessCoordinates().normalized();
-}
-
-Vector3d Profile::ComputeVelocityDirectionVector_ECEF(const State& aState)
-{
-    return aState.inFrame(Frame::ITRF()).getVelocity().accessCoordinates().normalized();
 }
 
 Vector3d Profile::ComputeOrbitalMomentumDirectionVector(const State& aState)

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile.test.cpp
@@ -1226,26 +1226,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, YawCompensationOrekit)
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile, AlignAndConstrain)
 {
-    {
-        EXPECT_THROW(
-            Profile::AlignAndConstrain(
-                std::make_shared<const Profile::Target>(Profile::TargetType::VelocityECEF, Vector3d::X()),
-                std::make_shared<const Profile::Target>(Profile::TargetType::GeocentricNadir, Vector3d::Y())
-            ),
-            ostk::core::error::runtime::ToBeImplemented
-        );
-    }
-
-    {
-        EXPECT_THROW(
-            Profile::AlignAndConstrain(
-                std::make_shared<const Profile::Target>(Profile::TargetType::GeocentricNadir, Vector3d::Y()),
-                std::make_shared<const Profile::Target>(Profile::TargetType::VelocityECEF, Vector3d::X())
-            ),
-            ostk::core::error::runtime::ToBeImplemented
-        );
-    }
-
     const Instant epoch = Instant::J2000();
 
     const Shared<Earth> earthSPtr = std::make_shared<Earth>(Earth::Default());


### PR DESCRIPTION
This enum was never implemented and is functionally equivalent IMO to the TargetSlidingGroundVelocity target