### PR TITLE
feat: add COE static constructors

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit.cpp
@@ -345,8 +345,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit(pybind11::module& a
             )
 
             .def_static(
-                "geo_synchronous",
-                &Orbit::GeoSynchronous,
+                "stationary",
+                &Orbit::Stationary,
                 arg("epoch"),
                 arg("inclination"),
                 arg("longitude"),

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -175,6 +175,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
         )
 
         .def(
+            "get_argument_of_latitude",
+            &COE::getArgumentOfLatitude,
+            R"doc(
+                Get the argument of latitude of the COE.
+
+                Returns:
+                    Angle: The argument of latitude (sum of argument of periapsis and true anomaly).
+            )doc"
+        )
+
+        .def(
             "get_true_anomaly",
             &COE::getTrueAnomaly,
             R"doc(
@@ -780,6 +791,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
                 Args:
                     local_time_at_ascending_node (Time): The local time at ascending node.
                     epoch (Instant): The epoch.
+                    celestial_object (Celestial): The celestial object.
                     sun (Sun, optional): The Sun model. Defaults to Sun.default().
 
                 Returns:
@@ -787,6 +799,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
             )doc",
             arg("local_time_at_ascending_node"),
             arg("epoch"),
+            arg("celestial_object"),
             arg_v("sun", ostk::physics::environment::object::celestial::Sun::Default(), "Sun.default()")
         )
 
@@ -816,10 +829,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
         )
 
         .def_static(
-            "geo_synchronous",
-            &COE::GeoSynchronous,
+            "stationary",
+            &COE::Stationary,
             R"doc(
-                Construct a Geo-synchronous COE.
+                Construct a Stationary COE.
 
                 Args:
                     epoch (Instant): The epoch.
@@ -828,7 +841,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
                     celestial_object (Celestial): The celestial object.
 
                 Returns:
-                    COE: The Geo-synchronous COE.
+                    COE: The Stationary COE.
             )doc",
             arg("epoch"),
             arg("inclination"),
@@ -847,14 +860,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
 
                 Args:
                     semi_major_axis (Length): The semi-major axis.
-                    inclination (Angle): The inclination.
+                    inclination (Angle, optional): The inclination. Defaults to Angle.zero().
                     argument_of_latitude (Angle, optional): The argument of latitude. Defaults to Angle.zero().
 
                 Returns:
                     COE: The Circular COE.
             )doc",
             arg("semi_major_axis"),
-            arg("inclination"),
+            arg_v("inclination", Angle::Zero(), "Angle.zero()"),
             arg_v("argument_of_latitude", Angle::Zero(), "Angle.zero()")
         )
 
@@ -893,17 +906,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
                     str: The string representation.
             )doc",
             arg("element")
-        )
-
-        .def(
-            "get_argument_of_latitude",
-            &COE::getArgumentOfLatitude,
-            R"doc(
-                Get the argument of latitude of the COE.
-
-                Returns:
-                    Angle: The argument of latitude (sum of argument of periapsis and true anomaly).
-            )doc"
         )
 
         ;

--- a/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
+++ b/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
@@ -201,7 +201,7 @@ class TestCOE:
             is not None
         )
         assert (
-            COE.compute_raan_from_ltan(Time.parse("12:00:00"), Instant.J2000())
+            COE.compute_raan_from_ltan(Time.parse("12:00:00"), Instant.J2000(), earth)
             is not None
         )
 
@@ -262,21 +262,23 @@ class TestCOE:
             is not None
         )
 
-    def test_geo_synchronous(self, earth: Celestial):
+    def test_stationary(self, earth: Celestial):
         epoch: Instant = Instant.J2000()
         inclination: Angle = Angle.degrees(0.01)
         longitude: Angle = Angle.degrees(0.0)
 
-        assert COE.geo_synchronous(epoch, inclination, longitude, earth) is not None
+        assert COE.stationary(epoch, inclination, longitude, earth) is not None
 
     def test_circular(self):
         semi_major_axis: Length = Length.kilometers(7000.0)
         inclination: Angle = Angle.degrees(45.0)
         argument_of_latitude: Angle = Angle.degrees(30.0)
 
-        coe: COE = COE.circular(semi_major_axis, inclination, argument_of_latitude)
-
-        assert coe is not None
+        assert (
+            COE.circular(semi_major_axis, inclination, argument_of_latitude) is not None
+        )
+        assert COE.circular(semi_major_axis, inclination) is not None
+        assert COE.circular(semi_major_axis) is not None
 
     def test_equatorial(self):
         semi_major_axis: Length = Length.kilometers(7000.0)

--- a/bindings/python/test/trajectory/test_orbit.py
+++ b/bindings/python/test/trajectory/test_orbit.py
@@ -156,12 +156,12 @@ class TestOrbit:
         assert isinstance(orbit, Orbit)
         assert orbit.is_defined()
 
-    def test_geo_synchronous(self, earth):
+    def test_stationary(self, earth):
         epoch = Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC)
         inclination = Angle.degrees(45.0)
         longitude = Angle.degrees(45.0)
 
-        orbit: Orbit = Orbit.geo_synchronous(epoch, inclination, longitude, earth)
+        orbit: Orbit = Orbit.stationary(epoch, inclination, longitude, earth)
 
         assert orbit is not None
         assert isinstance(orbit, Orbit)

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp
@@ -230,7 +230,7 @@ class Orbit : public Trajectory
     /// @param aLongitude A longitude above the surface
     /// @param aCelestialObjectSPtr A shared pointer to a central celestial body
     /// @return Circular orbit
-    static Orbit GeoSynchronous(
+    static Orbit Stationary(
         const Instant& anEpoch,
         const Angle& anInclination,
         const Angle& aLongitude,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
@@ -470,10 +470,14 @@ class COE
     ///
     /// @param aLocalTimeAtAscendingNode A local time at ascending node
     /// @param anEpoch An epoch
+    /// @param aCelestialObjectSPtr A shared pointer to a central celestial body
     /// @param sun A Sun model
     /// @return Right Ascension of the Ascending Node
     static Angle ComputeRaanFromLTAN(
-        const Time& aLocalTimeAtAscendingNode, const Instant& anEpoch, const Sun& sun = Sun::Default()
+        const Time& aLocalTimeAtAscendingNode,
+        const Instant& anEpoch,
+        const Shared<const Celestial>& aCelestialObjectSPtr,
+        const Sun& sun = Sun::Default()
     );
 
     /// @brief Construct a Sun-synchronous COE
@@ -494,14 +498,14 @@ class COE
         const Angle& anArgumentOfLatitude = Angle::Zero()
     );
 
-    /// @brief Construct a Geosynchronous COE
+    /// @brief Construct a Stationary COE
     ///
     /// @param anEpoch An epoch
     /// @param anInclination An inclination
     /// @param aLongitude A longitude above the surface
     /// @param aCelestialObjectSPtr A shared pointer to a central celestial body
     /// @return COE
-    static COE GeoSynchronous(
+    static COE Stationary(
         const Instant& anEpoch,
         const Angle& anInclination,
         const Angle& aLongitude,
@@ -514,11 +518,13 @@ class COE
     /// RAAN and AoP are set to zero (AoP is indeterminate for circular orbits).
     ///
     /// @param aSemiMajorAxis A semi-major axis
-    /// @param anInclination An inclination
+    /// @param anInclination An inclination (defaults to zero)
     /// @param anArgumentOfLatitude An argument of latitude (defaults to zero)
     /// @return COE
     static COE Circular(
-        const Length& aSemiMajorAxis, const Angle& anInclination, const Angle& anArgumentOfLatitude = Angle::Zero()
+        const Length& aSemiMajorAxis,
+        const Angle& anInclination = Angle::Zero(),
+        const Angle& anArgumentOfLatitude = Angle::Zero()
     );
 
     /// @brief Construct an Equatorial COE

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -854,7 +854,7 @@ Orbit Orbit::CircularEquatorial(
     return Orbit::Circular(anEpoch, anAltitude, Angle::Zero(), aCelestialObjectSPtr);
 }
 
-Orbit Orbit::GeoSynchronous(
+Orbit Orbit::Stationary(
     const Instant& anEpoch,
     const Angle& anInclination,
     const Angle& aLongitude,
@@ -884,7 +884,7 @@ Orbit Orbit::GeoSynchronous(
         throw ostk::core::error::runtime::Undefined("Celestial object");
     }
 
-    const COE coe = COE::GeoSynchronous(anEpoch, anInclination, aLongitude, aCelestialObjectSPtr);
+    const COE coe = COE::Stationary(anEpoch, anInclination, aLongitude, aCelestialObjectSPtr);
 
     const Kepler orbitalModel = {coe, anEpoch, (*aCelestialObjectSPtr), Kepler::PerturbationType::J2, false};
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -1131,6 +1131,13 @@ Angle COE::ComputeSunSynchronousInclination(
         throw ostk::core::error::runtime::Undefined("Celestial object");
     }
 
+    if (aCelestialObjectSPtr->getType() != Celestial::Type::Earth)
+    {
+        throw ostk::core::error::runtime::ToBeImplemented(
+            "Sun-synchronous orbits currently not supported for celestial bodies other than Earth."
+        );
+    }
+
     if (anEccentricity < 0.0 || anEccentricity >= 1.0)
     {
         throw ostk::core::error::runtime::Wrong("Eccentricity", anEccentricity.toString());
@@ -1202,7 +1209,12 @@ Angle COE::ComputeSunSynchronousInclination(
     throw ostk::core::error::RuntimeError("Newton-Raphson did not converge.");
 }
 
-Angle COE::ComputeRaanFromLTAN(const Time& aLocalTimeAtAscendingNode, const Instant& anEpoch, const Sun& aSun)
+Angle COE::ComputeRaanFromLTAN(
+    const Time& aLocalTimeAtAscendingNode,
+    const Instant& anEpoch,
+    const Shared<const Celestial>& aCelestialObjectSPtr,
+    const Sun& aSun
+)
 {
     if (!aLocalTimeAtAscendingNode.isDefined())
     {
@@ -1212,6 +1224,19 @@ Angle COE::ComputeRaanFromLTAN(const Time& aLocalTimeAtAscendingNode, const Inst
     if (!anEpoch.isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Epoch");
+    }
+
+    if ((aCelestialObjectSPtr == nullptr) || (!aCelestialObjectSPtr->isDefined()))
+    {
+        throw ostk::core::error::runtime::Undefined("Celestial object");
+    }
+
+    if (aCelestialObjectSPtr->getType() != Celestial::Type::Earth)
+    {
+        throw ostk::core::error::runtime::ToBeImplemented(
+            "Right Ascension of the Ascending Node (RAAN) computation currently not supported for celestial bodies "
+            "other than Earth."
+        );
     }
 
     const Real localTime = (aLocalTimeAtAscendingNode.getHour() / 1.0) +
@@ -1281,7 +1306,7 @@ COE COE::SunSynchronous(
 
     const Angle inclination =
         COE::ComputeSunSynchronousInclination(aSemiMajorAxis, anEccentricity, aCelestialObjectSPtr);
-    const Angle raan = COE::ComputeRaanFromLTAN(aLocalTimeAtAscendingNode, anEpoch);
+    const Angle raan = COE::ComputeRaanFromLTAN(aLocalTimeAtAscendingNode, anEpoch, aCelestialObjectSPtr);
     const Angle aop = Angle::Zero();
     const Angle trueAnomaly = anArgumentOfLatitude - aop;
 
@@ -1295,7 +1320,7 @@ COE COE::SunSynchronous(
     };
 }
 
-COE COE::GeoSynchronous(
+COE COE::Stationary(
     const Instant& anEpoch,
     const Angle& anInclination,
     const Angle& aLongitude,

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -1906,7 +1906,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, CircularEquatorial)
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Stationary)
 {
     // Test longitude alignement for a certain longitude
     {
@@ -1922,7 +1922,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
 
         // Orbit setup
         const Orbit orbit =
-            Orbit::GeoSynchronous(epoch, inclination, longitude, environment.accessCelestialObjectWithName("Earth"));
+            Orbit::Stationary(epoch, inclination, longitude, environment.accessCelestialObjectWithName("Earth"));
 
         // Test
         const State state = orbit.getStateAt(epoch);
@@ -1949,7 +1949,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
 
         // Orbit setup
         const Orbit orbit =
-            Orbit::GeoSynchronous(epoch, inclination, longitude, environment.accessCelestialObjectWithName("Earth"));
+            Orbit::Stationary(epoch, inclination, longitude, environment.accessCelestialObjectWithName("Earth"));
 
         // Test
         const State state = orbit.getStateAt(epoch);
@@ -1976,7 +1976,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
 
         // Orbit setup
         const Orbit orbit =
-            Orbit::GeoSynchronous(epoch, inclination, longitude, environment.accessCelestialObjectWithName("Earth"));
+            Orbit::Stationary(epoch, inclination, longitude, environment.accessCelestialObjectWithName("Earth"));
 
         // Test
         const State state = orbit.getStateAt(epoch);


### PR DESCRIPTION
- Implemented methods to compute Sun-synchronous inclination and RAAN from LTAN in the COE class.
- Added static methods for constructing Sun-synchronous, Geosynchronous COEs, Circular, Equatorial, CircularEquatorial COEs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added high‑level orbit constructors: sun‑synchronous, stationary (geo‑synchronous renamed), circular, equatorial, plus utilities to compute sun‑synchronous inclination and RAAN from local time.

* **Documentation**
  * Clarified docstrings; sun_synchronous marks argument_of_latitude as optional with a default.

* **Refactor**
  * Replaced manual element assembly with COE factory constructors; public API renamed geo_synchronous → stationary.

* **Tests**
  * Expanded Python and C++ tests covering new constructors, computations, defaults and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->