### PR TITLE
fix: handle round fractional days in TLE

### DIFF
--- a/bindings/python/test/trajectory/orbit/models/sgp4/test_tle.py
+++ b/bindings/python/test/trajectory/orbit/models/sgp4/test_tle.py
@@ -13,8 +13,12 @@ from ostk.physics.unit import Derived
 from ostk.physics.time import Instant
 from ostk.physics.time import Scale
 from ostk.physics.time import DateTime
+from ostk.physics.time import Duration
 
 from ostk.astrodynamics.trajectory.orbit.model.sgp4 import TLE
+
+# Only 8 decimal places of numerical precision for fractional portion of day (=864 us)
+TLE_EPOCH_NUMERICAL_PRECISION: Duration = Duration.days(1.0) * 1e-8
 
 
 @pytest.fixture
@@ -144,16 +148,18 @@ class TestTLE:
             Instant.date_time(DateTime(2019, 9, 20, 5, 18, 28, 232, 361, 0), Scale.UTC)
         )
 
-        assert tle.get_epoch() == Instant.date_time(
-            DateTime(2019, 9, 20, 5, 18, 28, 231, 776, 0), Scale.UTC
+        assert tle.get_epoch().is_near(
+            Instant.date_time(DateTime(2019, 9, 20, 5, 18, 28, 232, 361, 0), Scale.UTC),
+            TLE_EPOCH_NUMERICAL_PRECISION,
         )
 
         tle.set_epoch(
             Instant.date_time(DateTime(2018, 8, 19, 4, 17, 27, 231, 360, 0), Scale.UTC)
         )
 
-        assert tle.get_epoch() == Instant.date_time(
-            DateTime(2018, 8, 19, 4, 17, 27, 231, 360, 0), Scale.UTC
+        assert tle.get_epoch().is_near(
+            Instant.date_time(DateTime(2018, 8, 19, 4, 17, 27, 231, 360, 0), Scale.UTC),
+            TLE_EPOCH_NUMERICAL_PRECISION,
         )
 
     def test_set_revolution_number_at_epoch(self, tle: TLE):

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.hpp
@@ -243,15 +243,15 @@ class TLE
     /// @return void
     void setSatelliteNumber(const Integer& aSatelliteNumber);
 
-    /// @brief Set new revolution number at epoch in the existing TLE
-    ///
-    /// @param aRevolutionNumberAtEpoch a Revolution Number at Epoch
-    /// @return void
-    void setEpoch(const Instant& anInstant);
-
     /// @brief Set new epoch in the existing TLE
     ///
     /// @param anInstant an Instant (new Epoch)
+    /// @return void
+    void setEpoch(const Instant& anInstant);
+
+    /// @brief Set new revolution number at epoch in the existing TLE
+    ///
+    /// @param aRevolutionNumberAtEpoch a Revolution Number at Epoch
     /// @return void
     void setRevolutionNumberAtEpoch(const Integer& aRevolutionNumberAtEpoch);
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
@@ -70,11 +70,7 @@ State SGP4::Impl::calculateStateAt(const Instant& anInstant) const
 
     const State state_TEME = {anInstant, position_TEME, velocity_TEME};
 
-    static const Shared<const Frame> gcrfSPtr = Frame::GCRF();
-
-    const State state_GCRF = state_TEME.inFrame(gcrfSPtr);
-
-    return state_GCRF;
+    return state_TEME.inFrame(Frame::GCRF());
 }
 
 SGP4::SGP4(const TLE& aTle)

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.cpp
@@ -394,7 +394,7 @@ void TLE::setEpoch(const Instant& anInstant)
         String::Replicate("0", 3 - epochDayIntegerString.getLength()) + epochDayIntegerString;
 
     const Real epochDayFraction = epochDay - Real::Integer(epochDayInteger);
-    const String epochDayFractionString = epochDayFraction.toString();
+    const String epochDayFractionString = epochDayFraction.toString(8);  // day fraction has 8 decimal places
     const String sanitizedEpochDayFractionString = epochDayFractionString.getSubstring(1, 9);
 
     const String newIntermediateFirstLine = firstLine_.getSubstring(0, 18) + epochYearTwoDigitsString +


### PR DESCRIPTION
`TLE::setEpoch()` breaks if provided a round fractional day number, because we lost the necessary trailing zeros when serializing it as a `String`. 

Also some minor cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased precision of epoch day fraction in TLE output to 8 decimal places for more accurate orbital data.
  * Simplified internal state conversion to improve reliability (no change to user-visible behavior).

* **Documentation**
  * Clarified descriptions for epoch and revolution-number parameters in public API docs.

* **Tests**
  * Added epoch tolerance constant and new tests for fractional-day rounding/zero-padding; switched equality checks to precision-aware comparisons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->