### PR TITLE
fix: deal with single-point maneuvers during segment convergence

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -50,11 +50,6 @@ Maneuver::Maneuver(const Array<State>& aStateArray)
         throw ostk::core::error::RuntimeError("No states provided.");
     }
 
-    if (states_.getSize() < 2)
-    {
-        throw ostk::core::error::RuntimeError("At least two states are required to define a maneuver.");
-    }
-
     for (const auto& coordinateSubset : RequiredCoordinateSubsets)
     {
         if (!std::all_of(
@@ -148,6 +143,11 @@ Interval Maneuver::getInterval() const
 
 Real Maneuver::calculateDeltaV() const
 {
+    if (states_.getSize() < 2)
+    {
+        throw ostk::core::error::RuntimeError("At least two states are required to calculate the delta V.");
+    }
+
     // Use simple forward trapezoidal rule to calculate the total delta-v
     Real totalDeltaV = 0.0;
     for (Size i = 0; i < states_.getSize() - 1; i++)
@@ -170,6 +170,11 @@ Real Maneuver::calculateDeltaV() const
 
 Mass Maneuver::calculateDeltaMass() const
 {
+    if (states_.getSize() < 2)
+    {
+        throw ostk::core::error::RuntimeError("At least two states are required to calculate the delta mass.");
+    }
+
     // Use simple forward trapezoidal rule to calculate the total delta-mass
     Real totalDeltaMass = 0.0;
     for (Size i = 0; i < states_.getSize() - 1; i++)
@@ -190,6 +195,11 @@ Mass Maneuver::calculateDeltaMass() const
 
 Real Maneuver::calculateAverageThrust(const Mass& anInitialSpacecraftMass) const
 {
+    if (states_.getSize() < 2)
+    {
+        throw ostk::core::error::RuntimeError("At least two states are required to calculate the average thrust.");
+    }
+
     Real currentMass = anInitialSpacecraftMass.inKilograms();
     Real weightedThrustSum = 0.0;
 
@@ -221,6 +231,13 @@ Real Maneuver::calculateAverageThrust(const Mass& anInitialSpacecraftMass) const
 
 Real Maneuver::calculateAverageSpecificImpulse(const Mass& anInitialSpacecraftMass) const
 {
+    if (states_.getSize() < 2)
+    {
+        throw ostk::core::error::RuntimeError(
+            "At least two states are required to calculate the average specific impulse."
+        );
+    }
+
     const Real averageSpecificImpulse =
         (this->calculateAverageThrust(anInitialSpacecraftMass) * this->getInterval().getDuration().inSeconds()) /
         (this->calculateDeltaMass().inKilograms() * EarthGravitationalModel::gravityConstant);
@@ -232,6 +249,13 @@ Shared<Tabulated> Maneuver::toTabulatedDynamics(
     const Shared<const Frame>& aFrameSPtr, const Interpolator::Type& anInterpolationType
 ) const
 {
+    if (states_.getSize() < 2)
+    {
+        throw ostk::core::error::RuntimeError(
+            "At least two states are required to convert a maneuver to tabulated dynamics."
+        );
+    }
+
     const Array<Vector3d> accelerationProfileCustomFrame = states_.map<Vector3d>(
         [this, aFrameSPtr](const State& aState) -> Vector3d
         {

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -894,7 +894,18 @@ Segment::Solution Segment::solve(
         // Check minimum maneuver duration constraint
         if (!maneuverConstraints_.intervalHasValidMinimumDuration(candidateManeuverInterval))
         {
-            segmentConditionIsSatisfied = solveAndAcceptCoast(candidateManeuverInterval.getEnd());
+            // The maneuuver might have converged to a zero duration (this happens especially when using state-dependent
+            // thruster dynamics like Q-Law). In order for the segment to advance, and not get stuck at the maneuver
+            // time, we add a small buffer to the end of the maneuver interval.
+            if (candidateManeuverInterval.getDuration().isZero())
+            {
+                segmentConditionIsSatisfied =
+                    solveAndAcceptCoast(candidateManeuverInterval.getEnd() + Duration::Seconds(1.0));
+            }
+            else
+            {
+                segmentConditionIsSatisfied = solveAndAcceptCoast(candidateManeuverInterval.getEnd());
+            }
         }
 
         // Check maximum maneuver duration constraint

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -563,6 +563,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, AddMane
         EXPECT_EQ(defaultPropagatorWithManeuvers_.getNumberOfCoordinates(), 7);
         EXPECT_EQ(defaultPropagatorWithManeuvers_.getDynamics().getSize(), 4);
     }
+
+    // Check single-state maneuvers can't be added
+    {
+        const Maneuver singleStateManeuver = {{secondManeuverStates.accessFirst()}};
+
+        EXPECT_THROW(defaultPropagator_.addManeuver(singleStateManeuver), ostk::core::error::RuntimeError);
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, ClearDynamics)


### PR DESCRIPTION
Deals with single-point maneuver creation attempts at segment convergence.

Maneuver skipping due to minimum maneuver duration, might cause to attempt to create single-point maneuvers.

This MR:

- adds a test to keep track of this bug
- allows single-point maneuver creation (with the corresponding checks on their methods)
- fixes bug on the segment-side by preventing the sequence getting stuck when a single-point maneuver is returned

Why this fix and not another one?

The issue is non-deterministic: at some point the maneuver window becomes small enough for the propagator to potentially only step inside it once. Which later results in a single-poing acceleration block that is attempted to be extracted as a Maneuver (raising the "minimum of 2 points required" error).

By allowing single-point Maneuvers we can circumvent the non-deterministic aspect of the bug, and simply letting the existing sequence logic filter it out given its short duration, and eventually coasting beyond the maneuver window. This way, where we've not introduced any manipulation, we preserve the segment solution integrity (position, velocity and thruster acceleration consistency).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where extremely short thrust segments could generate invalid maneuvers during trajectory computation. The trajectory solver now properly handles edge cases when extracting maneuvers, preventing degenerate results from single-point thrust accelerations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->