### PR TITLE
fix: aer mask lower bound

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/AERMask.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/AERMask.cpp
@@ -88,9 +88,17 @@ bool VisibilityCriterion::AERMask::isSatisfied(
     const Real& anAzimuth_Radians, const Real& anElevation_Radians, const Real& aRange_Meters
 ) const
 {
-    auto itLow = this->azimuthElevationMask.lower_bound(anAzimuth_Radians);
-    itLow--;
-    auto itUp = this->azimuthElevationMask.upper_bound(anAzimuth_Radians);
+    Real anAzimuthReduced_Radians = Angle(anAzimuth_Radians, Angle::Unit::Radian).inRadians(0.0, Real::TwoPi());
+    Real anElevationReduced_Radians =
+        Angle(anElevation_Radians, Angle::Unit::Radian).inRadians(-Real::Pi(), Real::Pi());
+
+    auto itLow = this->azimuthElevationMask.lower_bound(anAzimuthReduced_Radians);
+
+    if (itLow->first != anAzimuthReduced_Radians)
+    {
+        itLow--;
+    }
+    const auto itUp = this->azimuthElevationMask.upper_bound(anAzimuthReduced_Radians);
 
     // Vector between the two successive mask data points with bounding azimuth values
 
@@ -98,7 +106,9 @@ bool VisibilityCriterion::AERMask::isSatisfied(
 
     // Vector from data point with azimuth lower bound to tested point
 
-    const Vector2d lowToPointVector = {anAzimuth_Radians - itLow->first, anElevation_Radians - itLow->second};
+    const Vector2d lowToPointVector = {
+        anAzimuthReduced_Radians - itLow->first, anElevationReduced_Radians - itLow->second
+    };
 
     // If the determinant of these two vectors is positive, the tested point lies above the function defined by the
     // mask

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
@@ -425,27 +425,92 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, AERIntervalIsS
     }
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, AERMaskIsSatisfied)
+struct AERMaskIsSatisfiedTestCase
 {
+    Angle azimuth;
+    Angle elevation;
+    Length range;
+    bool expectedResult;
+
+    friend std::ostream& operator<<(std::ostream& os, const AERMaskIsSatisfiedTestCase& testCase)
     {
-        Map<Real, Real> azimuthElevationMask = {{0.0, 10.0}, {45.0, 15.0}, {90.0, 20.0}};
-        const Interval<Real> rangeInterval = Interval<Real>::Closed(0.0, 1e6);
+        os << "{ "
+           << "Azimuth: " << testCase.azimuth.toString() << ", "
+           << "Elevation: " << testCase.elevation.toString() << ", "
+           << "Range: " << testCase.range.toString() << ", "
+           << "Expected: " << (testCase.expectedResult ? "True" : "False")
+           << " }";
+        return os;
+    }
+};
 
-        const VisibilityCriterion visibilityCriterion =
-            VisibilityCriterion::FromAERMask(azimuthElevationMask, rangeInterval);
+class OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion_AERMaskIsSatisfied
+    : public OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion,
+      public ::testing::WithParamInterface<AERMaskIsSatisfiedTestCase>
+{
+};
 
-        const auto aerMask = visibilityCriterion.as<VisibilityCriterion::AERMask>();
-        ASSERT_TRUE(aerMask.has_value());
+TEST_P(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion_AERMaskIsSatisfied, Test)
+{
+    const auto& param = GetParam();
 
-        AER aer(Angle::Degrees(22.5), Angle::Degrees(20.0), Length::Meters(500e3));
+    const Map<Real, Real> azimuthElevationMask = {{0.0, 10.0}, {45.0, 15.0}, {90.0, 20.0}};
+    const Interval<Real> rangeInterval = Interval<Real>::Closed(0.0, 1e6);
 
-        EXPECT_TRUE(aerMask.value().isSatisfied(aer));
+    const VisibilityCriterion visibilityCriterion =
+        VisibilityCriterion::FromAERMask(azimuthElevationMask, rangeInterval);
 
-        AER aerOutside(Angle::Degrees(22.5), Angle::Degrees(5.0), Length::Meters(500e3));
+    const auto aerMask = visibilityCriterion.as<VisibilityCriterion::AERMask>();
+    ASSERT_TRUE(aerMask.has_value());
 
-        EXPECT_FALSE(aerMask.value().isSatisfied(aerOutside));
+    EXPECT_EQ(
+        aerMask.value().isSatisfied(
+            param.azimuth.inRadians(), param.elevation.inRadians(), param.range.inMeters()
+        ),
+        param.expectedResult
+    );
+
+    if (std::abs(param.elevation.inDegrees()) <= 90.0 && param.azimuth.inDegrees() <= 360.0)
+    {
+        const AER aer(param.azimuth, param.elevation, param.range);
+        EXPECT_EQ(aerMask.value().isSatisfied(aer), param.expectedResult);
     }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    AERMaskIsSatisfied,
+    OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion_AERMaskIsSatisfied,
+    ::testing::Values(
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(22.5), Angle::Degrees(20.0), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(0.0), Angle::Degrees(10.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(0.1), Angle::Degrees(10.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(360.0), Angle::Degrees(10.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(360.1), Angle::Degrees(10.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(360.1), Angle::Degrees(91.0), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{
+            Angle::Degrees(360.0 * (1.0 - std::numeric_limits<double>::epsilon())),
+            Angle::Degrees(10.1),
+            Length::Meters(500e3),
+            true
+        },
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(45.0), Angle::Degrees(15.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(90.0), Angle::Degrees(20.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(89.9), Angle::Degrees(20.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(90.1), Angle::Degrees(20.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(22.5), Angle::Degrees(12.4), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(0.0), Angle::Degrees(9.9), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(0.1), Angle::Degrees(9.9), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase{
+            Angle::Degrees(360.0 * (1.0 - std::numeric_limits<double>::epsilon())),
+            Angle::Degrees(9.9),
+            Length::Meters(500e3),
+            false
+        },
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(90.0), Angle::Degrees(19.9), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(89.9), Angle::Degrees(19.9), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase{Angle::Degrees(90.1), Angle::Degrees(19.9), Length::Meters(500e3), false}
+    )
+);
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion, LineOfSightIsSatisfied)
 {

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion.test.cpp
@@ -438,8 +438,7 @@ struct AERMaskIsSatisfiedTestCase
            << "Azimuth: " << testCase.azimuth.toString() << ", "
            << "Elevation: " << testCase.elevation.toString() << ", "
            << "Range: " << testCase.range.toString() << ", "
-           << "Expected: " << (testCase.expectedResult ? "True" : "False")
-           << " }";
+           << "Expected: " << (testCase.expectedResult ? "True" : "False") << " }";
         return os;
     }
 };
@@ -464,9 +463,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion_AERMaskIsSatisf
     ASSERT_TRUE(aerMask.has_value());
 
     EXPECT_EQ(
-        aerMask.value().isSatisfied(
-            param.azimuth.inRadians(), param.elevation.inRadians(), param.range.inMeters()
-        ),
+        aerMask.value().isSatisfied(param.azimuth.inRadians(), param.elevation.inRadians(), param.range.inMeters()),
         param.expectedResult
     );
 
@@ -481,34 +478,34 @@ INSTANTIATE_TEST_SUITE_P(
     AERMaskIsSatisfied,
     OpenSpaceToolkit_Astrodynamics_Access_VisibilityCriterion_AERMaskIsSatisfied,
     ::testing::Values(
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(22.5), Angle::Degrees(20.0), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(0.0), Angle::Degrees(10.1), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(0.1), Angle::Degrees(10.1), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(360.0), Angle::Degrees(10.1), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(360.1), Angle::Degrees(10.1), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(360.1), Angle::Degrees(91.0), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(22.5), Angle::Degrees(20.0), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(0.0), Angle::Degrees(10.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(0.1), Angle::Degrees(10.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(360.0), Angle::Degrees(10.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(360.1), Angle::Degrees(10.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(360.1), Angle::Degrees(91.0), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {
             Angle::Degrees(360.0 * (1.0 - std::numeric_limits<double>::epsilon())),
             Angle::Degrees(10.1),
             Length::Meters(500e3),
             true
         },
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(45.0), Angle::Degrees(15.1), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(90.0), Angle::Degrees(20.1), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(89.9), Angle::Degrees(20.1), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(90.1), Angle::Degrees(20.1), Length::Meters(500e3), true},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(22.5), Angle::Degrees(12.4), Length::Meters(500e3), false},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(0.0), Angle::Degrees(9.9), Length::Meters(500e3), false},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(0.1), Angle::Degrees(9.9), Length::Meters(500e3), false},
-        AERMaskIsSatisfiedTestCase{
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(45.0), Angle::Degrees(15.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(90.0), Angle::Degrees(20.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(89.9), Angle::Degrees(20.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(90.1), Angle::Degrees(20.1), Length::Meters(500e3), true},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(22.5), Angle::Degrees(12.4), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(0.0), Angle::Degrees(9.9), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(0.1), Angle::Degrees(9.9), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase {
             Angle::Degrees(360.0 * (1.0 - std::numeric_limits<double>::epsilon())),
             Angle::Degrees(9.9),
             Length::Meters(500e3),
             false
         },
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(90.0), Angle::Degrees(19.9), Length::Meters(500e3), false},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(89.9), Angle::Degrees(19.9), Length::Meters(500e3), false},
-        AERMaskIsSatisfiedTestCase{Angle::Degrees(90.1), Angle::Degrees(19.9), Length::Meters(500e3), false}
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(90.0), Angle::Degrees(19.9), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(89.9), Angle::Degrees(19.9), Length::Meters(500e3), false},
+        AERMaskIsSatisfiedTestCase {Angle::Degrees(90.1), Angle::Degrees(19.9), Length::Meters(500e3), false}
     )
 );
 


### PR DESCRIPTION
Taking the fixes from https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/606
Authored by litghost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize azimuth and elevation before mask lookups to ensure consistent geometric comparisons and correct boundary handling, fixing incorrect outcomes near wraparound and edge cases.

* **Tests**
  * Expanded coverage with 18 parameterized cases covering a broad range of azimuth, elevation, and range values, including boundary and near-boundary scenarios and tiny offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->