### PR TITLE
[draft] fix: constant lof maneuver segment missing maneuvers when considering maneuver constraints

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Segment.cpp
@@ -51,14 +51,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
 
             Fail: Will throw a RuntimeError if a maneuver exceeds the maximum duration.
             Skip: The maneuver will be skipped entirely.
-            TruncateEnd: The maneuver will be shortened to the maximum duration, truncating the end segment.
-            TruncateStart: The maneuver will be shortened to the maximum duration, truncating the start segment.
+            TruncateEnd: The maneuver will be shortened to the maximum duration, truncating the trailing edge.
+            TruncateStart: The maneuver will be shortened to the maximum duration, truncating the leading edge.
             Center: The maneuver will be shortened to the maximum duration, truncating the edges, keeping the centered part of the maneuver.
-
-            Proposed maneuver: [--------------------|------------]
-            TruncateEnd:       [--------------------]
-            TruncateStart:                  [--------------------]
-            Center:                     [--------------------]
+            
+            Example:
+            Maximum duration:  [------] 
+            Proposed maneuver: [---------------------------------]
+            TruncateEnd:       [------]
+            Center:                          [------]
+            TruncateStart:                                [------]
         )doc"
     )
 
@@ -73,12 +75,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Segment(pybind11::module&
         .value(
             "TruncateEnd",
             Segment::MaximumManeuverDurationViolationStrategy::TruncateEnd,
-            "The maneuver will be shortened to the maximum duration, truncating the end segment."
+            "The maneuver will be shortened to the maximum duration, truncating the trailing edge."
         )
         .value(
             "TruncateStart",
             Segment::MaximumManeuverDurationViolationStrategy::TruncateStart,
-            "The maneuver will be shortened to the maximum duration, truncating the start segment."
+            "The maneuver will be shortened to the maximum duration, truncating the leading edge."
         )
         .value(
             "Center",

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.hpp
@@ -239,6 +239,11 @@ class Maneuver
     /// @return A maneuver
     static Maneuver ConstantMassFlowRateProfile(const Array<State>& aStatearray, const Real& aMassFlowRate);
 
+    /// @brief Create an undefined maneuver
+    ///
+    /// @return An undefined maneuver
+    static Maneuver Undefined();
+
    private:
     Array<State> states_;
 };

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -69,18 +69,19 @@ class Segment
     /// Strategy to use when a maneuver exceeds the maximum duration constraint.
     ///
     /// Example:
-    /// Proposed maneuver: [--------------------|------------]
-    /// TruncateEnd:       [--------------------]
-    /// TruncateStart:                  [--------------------]
-    /// Center:                     [--------------------]
+    /// Maximum duration:  [------]
+    /// Proposed maneuver: [---------------------------------]
+    /// TruncateEnd:       [------]
+    /// Center:                          [------]
+    /// TruncateStart:                                [------]
     enum class MaximumManeuverDurationViolationStrategy
     {
         Fail,           ///< Will throw a RuntimeError if a maneuver exceeds the maximum duration.
         Skip,           ///< The maneuver will be skipped entirely.
-        TruncateEnd,    ///< The maneuver will be shortened to the maximum duration, truncating the end segment.
-        TruncateStart,  ///< The maneuver will be shortened to the maximum duration, truncating the start segment.
-        Center  ///< The maneuver will be shortened to the maximum duration, truncating the edges, keeping the centered
-                ///< part of the maneuver.
+        TruncateEnd,    ///< The maneuver will be shortened to the maximum duration, truncating the end.
+        TruncateStart,  ///< The maneuver will be shortened to the maximum duration, truncating the start.
+        Center,         ///< The maneuver will be shortened to the maximum duration, truncating the edges,
+                        ///< keeping the centered part of the maneuver.
     };
 
     struct ManeuverConstraints
@@ -435,17 +436,6 @@ class Segment
         const Shared<EventCondition>& anEventCondition
     ) const;
 
-    /// @brief Solve the maneuver segment with the provided thruster dynamics. Uses the internal event condition of the
-    /// segment.
-    ///
-    /// @param aState The initial state of the segment
-    /// @param maximumPropagationDuration The maximum propagation duration
-    /// @param aThrusterDynamics The thruster dynamics
-    /// @return The segment solution
-    Segment::Solution solveManeuver_(
-        const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& aThrusterDynamics
-    ) const;
-
     /// @brief Solve the coast segment, uses the internal free dynamics array and event condition of the segment.
     ///
     /// @param aState The initial state of the segment
@@ -453,24 +443,30 @@ class Segment
     /// @return The segment solution
     Segment::Solution solveCoast_(const State& aState, const Duration& maximumPropagationDuration) const;
 
-    /// @brief Solve the maneuver segment producing multiple maneuvers, with the provided dynamics array.
+    /// @brief Solve the maneuver segment.
     ///
     /// @param aState The initial state of the segment
     /// @param maximumPropagationDuration The maximum propagation duration
-    /// @param aThrusterDynamics The thruster dynamics
     /// @return The segment solution
-    Segment::Solution solveMultipleManeuvers_(
+    Segment::Solution solveManeuver_(const State& aState, const Duration& maximumPropagationDuration) const;
+
+    /// @brief Solve the next maneuver in the segment.
+    ///
+    /// @param aState The initial state of the segment
+    /// @param maximumPropagationDuration The maximum propagation duration
+    /// @param aThrusterDynamics The thruster dynamics to use for solving the maneuver
+    /// @return The segment solution and the the maneuver (undefined if no maneuver is found)
+    std::pair<Segment::Solution, flightManeuver> solveNextManeuver_(
         const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& aThrusterDynamics
     ) const;
 
-    /// @brief Solve the maneuver segment producing at most one maneuver, with the provided dynamics array.
+    /// @brief Create a Local Orbital Frame (LOF) compliant solution from another one.
     ///
-    /// @param aState The initial state of the segment
-    /// @param maximumPropagationDuration The maximum propagation duration
-    /// @param thrusterDynamics The thruster dynamics.
-    /// @return The segment solution
-    Segment::Solution solveSingleManeuver_(
-        const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& thrusterDynamics
+    /// @param aSolution The solution to create a Local Orbital Frame (LOF) compliant solution from.
+    /// @param aManeuver The associated maneuver of the oslution
+    /// @return The Local Orbital Frame (LOF) compliant solution.
+    std::pair<Segment::Solution, flightManeuver> createLOFCompliantSolution_(
+        const Segment::Solution& aSolution, const flightManeuver& aManeuver
     ) const;
 };
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -47,7 +47,8 @@ Maneuver::Maneuver(const Array<State>& aStateArray)
     // Sanitize the inputs
     if (this->states_.isEmpty())
     {
-        throw ostk::core::error::RuntimeError("No states provided.");
+        // throw ostk::core::error::RuntimeError("No states provided.");
+        return;
     }
 
     for (const auto& coordinateSubset : RequiredCoordinateSubsets)
@@ -128,7 +129,7 @@ std::ostream& operator<<(std::ostream& anOutputStream, const Maneuver& aManeuver
 
 bool Maneuver::isDefined() const
 {
-    return true;
+    return states_.getSize() > 0;
 }
 
 Array<State> Maneuver::getStates() const
@@ -427,6 +428,11 @@ Maneuver Maneuver::ConstantMassFlowRateProfile(const Array<State>& aStateArray, 
     }
 
     return {maneuverStates};
+}
+
+Maneuver Maneuver::Undefined()
+{
+    return {Array<State>::Empty()};
 }
 
 }  // namespace flight

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -718,9 +718,12 @@ Segment::Solution Segment::solve(
         return solveCoast_(aState, maximumPropagationDuration);
     }
 
-    if (!maneuverConstraints_.isDefined())
+    if (!maneuverConstraints_.isDefined() && (this->constantManeuverDirectionLocalOrbitalFrameFactory_ == nullptr ||
+                                              !this->constantManeuverDirectionLocalOrbitalFrameFactory_->isDefined()))
     {
-        return solveManeuver_(aState, maximumPropagationDuration, this->getThrusterDynamics());
+        // There are no maneuver constraints and no constant local orbital frame direction enforcement.
+        // We can simply return the solution with all the maneuvers in it.
+        return solveManeuver_(aState, maximumPropagationDuration);
     }
 
     Array<State> segmentStates = {aState};
@@ -742,7 +745,8 @@ Segment::Solution Segment::solve(
 
     bool segmentConditionIsSatisfied = eventCondition_->isSatisfied(aState, aState);
 
-    // Helper lambda to solve a coast segment and update segmentStates
+    // Helper lambda to solve and accept a coast segment, updating segmentStates and segmentConditionIsSatisfied.
+    // Returns true if the segment condition is satisfied.
     const Instant maximumInstant = aState.accessInstant() + maximumPropagationDuration;
     const auto solveAndAcceptCoast = [&](const Instant& endInstant) -> bool
     {
@@ -751,47 +755,35 @@ Segment::Solution Segment::solve(
             solveCoast_(lastState, std::min(endInstant, maximumInstant) - lastState.accessInstant());
 
         segmentStates.add(Array<State>(coastSegmentSolution.states.begin() + 1, coastSegmentSolution.states.end()));
-
         segmentConditionIsSatisfied = coastSegmentSolution.conditionIsSatisfied;
+        return segmentConditionIsSatisfied;
+    };
+
+    // Helper lambda to accept a maneuver solution, updating segmentStates, segmentConditionIsSatisfied,
+    // segmentHeterogenousGuidanceLaw, and previousManeuverInterval.
+    // Returns true if the segment condition is satisfied.
+    const Shared<HeterogeneousGuidanceLaw> segmentHeterogenousGuidanceLaw =
+        std::make_shared<HeterogeneousGuidanceLaw>();
+    const auto acceptManeuver = [&](const Segment::Solution& maneuverSolution, const flightManeuver& maneuver) -> bool
+    {
+        const auto [lofCompliantManeuverSolution, lofCompliantManeuver] =
+            createLOFCompliantSolution_(maneuverSolution, maneuver);
+
+        segmentStates.add(
+            Array<State>(lofCompliantManeuverSolution.states.begin() + 1, lofCompliantManeuverSolution.states.end())
+        );
+        segmentConditionIsSatisfied = lofCompliantManeuverSolution.conditionIsSatisfied;
+        previousManeuverInterval = lofCompliantManeuver.getInterval();
+
+        segmentHeterogenousGuidanceLaw->addGuidanceLaw(
+            lofCompliantManeuverSolution.getThrusterDynamics()->getGuidanceLaw(), lofCompliantManeuver.getInterval()
+        );
 
         return segmentConditionIsSatisfied;
     };
 
-    // Helper lambda to solve a single maneuver and extract results
-    const auto solveManeuver = [&](const Shared<Thruster>& thrusterDynamics
-                               ) -> std::pair<Segment::Solution, Array<flightManeuver>>
-    {
-        const State& lastState = segmentStates.accessLast();
-        const Segment::Solution maneuverSolution =
-            solveManeuver_(lastState, maximumInstant - lastState.accessInstant(), thrusterDynamics);
-
-        if (maneuverSolution.states.getSize() <= 2)
-        {
-            return {maneuverSolution, Array<flightManeuver>::Empty()};
-        }
-
-        return {maneuverSolution, maneuverSolution.extractManeuvers(aState.accessFrame())};
-    };
-
-    // Helper lambda to accept a maneuver solution, updating segmentStates and segmentHeterogenousGuidanceLaw
-    // It also updates the last maneuver interval
-    const Shared<HeterogeneousGuidanceLaw> segmentHeterogenousGuidanceLaw =
-        std::make_shared<HeterogeneousGuidanceLaw>();
-    const auto acceptManeuver = [&](const Segment::Solution& maneuverSolution, const Interval& maneuverInterval) -> void
-    {
-        segmentStates.add(Array<State>(maneuverSolution.states.begin() + 1, maneuverSolution.states.end()));
-
-        segmentConditionIsSatisfied = maneuverSolution.conditionIsSatisfied;
-
-        previousManeuverInterval = maneuverInterval;
-
-        segmentHeterogenousGuidanceLaw->addGuidanceLaw(
-            maneuverSolution.getThrusterDynamics()->getGuidanceLaw(), maneuverInterval
-        );
-    };
-
-    // Helper lambda to handle maximum duration violation strategies, returning true if the segment condition is
-    // satisfied. It also updates the segment states and the guidance law if the maneuver is accepted.
+    // Helper lambda to handle maximum duration violation strategies.
+    // Returns true if the segment condition is satisfied.
     const auto handleMaximumDurationViolation = [&](const Interval& candidateManeuverInterval) -> bool
     {
         switch (maneuverConstraints_.maximumDurationStrategy)
@@ -817,11 +809,20 @@ Segment::Solution Segment::solve(
                 );
 
                 const Shared<Thruster> slicedThruster = buildThrusterDynamicsWithinInterval(validManeuverInterval);
-                const auto [maneuverSolution, _] = solveManeuver(slicedThruster);
+                const auto [validManeuverSolution, validManeuver] = solveNextManeuver_(
+                    segmentStates.accessLast(),
+                    (validManeuverInterval.getEnd() - segmentStates.accessLast().accessInstant()) +
+                        Duration::Seconds(1.0),
+                    slicedThruster
+                );
 
-                acceptManeuver(maneuverSolution, validManeuverInterval);
-
-                return maneuverSolution.conditionIsSatisfied;
+                if (acceptManeuver(validManeuverSolution, validManeuver))
+                {
+                    return true;
+                }
+                return solveAndAcceptCoast(
+                    std::min(candidateManeuverInterval.getEnd() + Duration::Seconds(1.0), maximumInstant)
+                );
             }
 
             case MaximumManeuverDurationViolationStrategy::TruncateStart:
@@ -831,11 +832,20 @@ Segment::Solution Segment::solve(
                     candidateManeuverInterval.getEnd()
                 );
                 const Shared<Thruster> slicedThruster = buildThrusterDynamicsWithinInterval(validManeuverInterval);
-                const auto [maneuverSolution, _] = solveManeuver(slicedThruster);
+                const auto [validManeuverSolution, validManeuver] = solveNextManeuver_(
+                    segmentStates.accessLast(),
+                    (validManeuverInterval.getEnd() - segmentStates.accessLast().accessInstant()) +
+                        Duration::Seconds(1.0),
+                    slicedThruster
+                );
 
-                acceptManeuver(maneuverSolution, validManeuverInterval);
-
-                return maneuverSolution.conditionIsSatisfied;
+                if (acceptManeuver(validManeuverSolution, validManeuver))
+                {
+                    return true;
+                }
+                return solveAndAcceptCoast(
+                    std::min(candidateManeuverInterval.getEnd() + Duration::Seconds(1.0), maximumInstant)
+                );
             }
 
             case MaximumManeuverDurationViolationStrategy::Center:
@@ -844,11 +854,20 @@ Segment::Solution Segment::solve(
                     candidateManeuverInterval.getCenter(), maneuverConstraints_.maximumDuration, Interval::Type::Closed
                 );
                 const Shared<Thruster> centeredThruster = buildThrusterDynamicsWithinInterval(validManeuverInterval);
-                const auto [maneuverSolution, _] = solveManeuver(centeredThruster);
+                const auto [validManeuverSolution, validManeuver] = solveNextManeuver_(
+                    segmentStates.accessLast(),
+                    (validManeuverInterval.getEnd() - segmentStates.accessLast().accessInstant()) +
+                        Duration::Seconds(1.0),
+                    centeredThruster
+                );
 
-                acceptManeuver(maneuverSolution, validManeuverInterval);
-
-                return maneuverSolution.conditionIsSatisfied;
+                if (acceptManeuver(validManeuverSolution, validManeuver))
+                {
+                    return true;
+                }
+                return solveAndAcceptCoast(
+                    std::min(candidateManeuverInterval.getEnd() + Duration::Seconds(1.0), maximumInstant)
+                );
             }
 
             default:
@@ -876,27 +895,28 @@ Segment::Solution Segment::solve(
             }
         }
 
-        const auto [maneuverSubSegmentSolution, subsegmentManeuvers] = solveManeuver(segmentThrusterDynamics);
+        const auto [nextManeuverSolution, nextManeuver] = solveNextManeuver_(
+            segmentStates.accessLast(),
+            maximumInstant - segmentStates.accessLast().accessInstant(),
+            thrusterDynamicsSPtr_
+        );
 
         // No maneuvers found - add states
-        if (subsegmentManeuvers.isEmpty())
+        if (!nextManeuver.isDefined())
         {
-            segmentStates.add(
-                Array<State>(maneuverSubSegmentSolution.states.begin() + 1, maneuverSubSegmentSolution.states.end())
-            );
-            segmentConditionIsSatisfied = maneuverSubSegmentSolution.conditionIsSatisfied;
-
+            segmentStates.add(Array<State>(nextManeuverSolution.states.begin() + 1, nextManeuverSolution.states.end()));
+            segmentConditionIsSatisfied = nextManeuverSolution.conditionIsSatisfied;
             continue;
         }
 
-        const Interval candidateManeuverInterval = subsegmentManeuvers.accessFirst().getInterval();
+        const Interval candidateManeuverInterval = nextManeuver.getInterval();
 
         // Check minimum maneuver duration constraint
         if (!maneuverConstraints_.intervalHasValidMinimumDuration(candidateManeuverInterval))
         {
             // The extracted maneuver might be a single-point maneuver. This happens as the maneuver window
             // might have been small enough (see note below) for the propagator to only step inside it once. Producing a
-            // single-point acceleration bluck and thus a zero duration Maneuver.
+            // single-point acceleration block and thus a zero duration Maneuver.
             //
             // In order for the segment to advance, and not get stuck at the single-point maneuver time,
             // we add a small buffer to the end of the maneuver interval.
@@ -906,25 +926,28 @@ Segment::Solution Segment::solve(
             // short maneuver is filtered out as it doesn't meet the minimum duration constraint. The satellite will
             // coast until the end of the original manevuer and then check for the next maneuver. The guidance law might
             // still produce a yet smaller maneuver (since the satellite might still be at an optimum orbit location),
-            // which again gest filtered out. This process continues until the maneuver is finally skipped.
+            // which again gets filtered out. This process continues until the maneuver is finally skipped.
             Instant instantToCoastTo = candidateManeuverInterval.getEnd();
             if (candidateManeuverInterval.getDuration().isZero())
             {
                 instantToCoastTo += Duration::Seconds(1.0);
             }
-            segmentConditionIsSatisfied = solveAndAcceptCoast(instantToCoastTo);
+            solveAndAcceptCoast(instantToCoastTo);
         }
 
         // Check maximum maneuver duration constraint
         else if (!maneuverConstraints_.intervalHasValidMaximumDuration(candidateManeuverInterval))
         {
-            segmentConditionIsSatisfied = handleMaximumDurationViolation(candidateManeuverInterval);
+            handleMaximumDurationViolation(candidateManeuverInterval);
         }
 
         else
         {
             // Candidate maneuver passed all constraints - accept it
-            acceptManeuver(maneuverSubSegmentSolution, candidateManeuverInterval);
+            if (!acceptManeuver(nextManeuverSolution, nextManeuver))
+            {
+                solveAndAcceptCoast(nextManeuver.getInterval().getEnd() + Duration::Seconds(1.0));
+            }
         }
     }
 
@@ -1079,90 +1102,22 @@ Segment::Solution Segment::solveCoast_(const State& aState, const Duration& maxi
     return solveWithDynamics_(aState, maximumPropagationDuration, freeDynamicsArray_, eventCondition_);
 }
 
-Segment::Solution Segment::solveManeuver_(
-    const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& aThrusterDynamics
-) const
+Segment::Solution Segment::solveManeuver_(const State& aState, const Duration& maximumPropagationDuration) const
 {
-    const Segment::Solution solution =
-        maneuverConstraints_.isDefined()
-            ? solveSingleManeuver_(aState, maximumPropagationDuration, aThrusterDynamics)
-            : solveMultipleManeuvers_(aState, maximumPropagationDuration, aThrusterDynamics);
-
-    // If we're not forcing a constant maneuver direction in the Local Orbital Frame, return the solution
-    if (this->constantManeuverDirectionLocalOrbitalFrameFactory_ == nullptr ||
-        !this->constantManeuverDirectionLocalOrbitalFrameFactory_->isDefined())
-    {
-        return solution;
-    }
-
-    const Array<flightManeuver> solutionManeuvers = solution.extractManeuvers(aState.accessFrame());
-    if (solutionManeuvers.isEmpty())
-    {
-        return solution;
-    }
-
-    Shared<HeterogeneousGuidanceLaw> heterogeneousGuidanceLaw =
-        std::make_shared<HeterogeneousGuidanceLaw>(HeterogeneousGuidanceLaw());
-
-    // TBI: in the future, we might want to solve in-between maneuvers.
-    for (const flightManeuver& solutionManeuver : solutionManeuvers)
-    {
-        const Shared<ConstantThrust> constantThrust = std::make_shared<ConstantThrust>(ConstantThrust::FromManeuver(
-            solutionManeuver,
-            this->constantManeuverDirectionLocalOrbitalFrameFactory_,
-            this->constantManeuverDirectionMaximumAllowedAngularOffset_
-        ));
-        heterogeneousGuidanceLaw->addGuidanceLaw(constantThrust, solutionManeuver.getInterval());
-    }
-
-    const Shared<Thruster> heterogeneousThrustDynamicsSPtr = std::make_shared<Thruster>(
-        thrusterDynamicsSPtr_->getSatelliteSystem(),
-        heterogeneousGuidanceLaw,
-        thrusterDynamicsSPtr_->getName() + " (With Heterogeneous Guidance Law)"
-    );
-
     Array<Shared<Dynamics>> dynamicsArray = freeDynamicsArray_;
-    dynamicsArray.add(heterogeneousThrustDynamicsSPtr);
+    dynamicsArray.add(thrusterDynamicsSPtr_);
 
-    // If there are maneuver constraints, we're solving maneuver by maneuver.
-    // In that case, solving until the maximum propagation instant would return coast fragments to the
-    // outer loop, missing maneuvers beyond the first one.
-    return solveWithDynamics_(
-        aState,
-        maneuverConstraints_.isDefined() ? (solutionManeuvers.accessLast().getInterval().getEnd() - aState.getInstant()
-                                           ) + Duration::Seconds(1.0)  // Add small buffer to
-                                         : maximumPropagationDuration,
-        dynamicsArray,
-        eventCondition_
-    );
-}
-
-Segment::Solution Segment::solveMultipleManeuvers_(
-    const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& aThrusterDynamics
-) const
-{
-    // Combine free dynamics and thruster dynamics into a single array
-    Array<Shared<Dynamics>> dynamicsArray = freeDynamicsArray_;
-    if (aThrusterDynamics != nullptr)
-    {
-        dynamicsArray.add(aThrusterDynamics);
-    }
     return solveWithDynamics_(aState, maximumPropagationDuration, dynamicsArray, eventCondition_);
 }
 
-Segment::Solution Segment::solveSingleManeuver_(
-    const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& thrusterDynamics
-
+std::pair<Segment::Solution, flightManeuver> Segment::solveNextManeuver_(
+    const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& aThrusterDynamics
 ) const
 {
-    // Combine free dynamics and thruster dynamics into a single array
     Array<Shared<Dynamics>> dynamicsArray = freeDynamicsArray_;
-    dynamicsArray.add(thrusterDynamics);
+    dynamicsArray.add(aThrusterDynamics);
 
-    // Determine the event condition to use for solving
-    Shared<EventCondition> singleManeuverEventCondition = eventCondition_;
-
-    const Shared<const GuidanceLaw> guidanceLaw = thrusterDynamics->getGuidanceLaw();
+    const Shared<const GuidanceLaw> guidanceLaw = thrusterDynamicsSPtr_->getGuidanceLaw();
 
     const std::function<Real(const State&)> thrustAccelerationNormEvaluator = [&guidanceLaw](const State& state) -> Real
     {
@@ -1184,21 +1139,105 @@ Segment::Solution Segment::solveSingleManeuver_(
         "Thrust Off Condition", RealCondition::Criterion::NegativeCrossing, thrustAccelerationNormEvaluator, 0.5
     );
 
-    singleManeuverEventCondition = std::make_shared<LogicalCondition>(
+    // Determine the event condition to use for solving
+    Shared<EventCondition> eventConditionToUse = std::make_shared<LogicalCondition>(
         "Combined Event or Thrust Off Condition",
         LogicalCondition::Type::Or,
         Array<Shared<EventCondition>> {eventCondition_, thrustOffCondition}
     );
 
     Segment::Solution solution =
-        solveWithDynamics_(aState, maximumPropagationDuration, dynamicsArray, singleManeuverEventCondition);
+        solveWithDynamics_(aState, maximumPropagationDuration, dynamicsArray, eventConditionToUse);
+
+    const Array<flightManeuver> maneuvers = solution.extractManeuvers(aState.accessFrame());
+
+    if (maneuvers.isEmpty())
+    {
+        return {solution, flightManeuver::Undefined()};
+    }
+
+    if (maneuvers.getSize() > 1)
+    {
+        throw ostk::core::error::RuntimeError("Multiple maneuvers found when solving next maneuver.");
+    }
 
     // As the event condition could have terminated due to the thruster off condition, we want to re-evaluate the
     // segment event condition to see if it's satisfied.
-    // To do so, we can check the last state against the initial state to see if the event condition is satisfied.
-    solution.conditionIsSatisfied = eventCondition_->isSatisfied(solution.states.accessLast(), aState);
+    // To do so, we propagate from the second to last solution state to one second after the last solution state,
+    // and re-evaluate the event condition.
+    const Propagator propagator = {
+        numericalSolver_,
+        freeDynamicsArray_,
+    };
 
-    return solution;
+    const State& lastSolutionState = solution.states.accessLast();
+    const State& secondToLastSolutionState =
+        (solution.states.getSize() > 2) ? solution.states[solution.states.getSize() - 2] : lastSolutionState;
+
+    solution.conditionIsSatisfied = eventCondition_->isSatisfied(
+        propagator.calculateStateAt(lastSolutionState, lastSolutionState.accessInstant() + Duration::Seconds(1.0)),
+        secondToLastSolutionState
+    );
+
+    return {solution, maneuvers.accessFirst()};
+}
+
+std::pair<Segment::Solution, flightManeuver> Segment::createLOFCompliantSolution_(
+    const Segment::Solution& aSolution, const flightManeuver& aManeuver
+) const
+{
+    // If there are no maneuvers, we can simply return the solution as is.
+    if (!aManeuver.isDefined())
+    {
+        return {aSolution, aManeuver};
+    }
+
+    // If there are no Local Orbital Frame (LOF) constraints, we can simply return the solution as is.
+    if (this->constantManeuverDirectionLocalOrbitalFrameFactory_ == nullptr ||
+        !this->constantManeuverDirectionLocalOrbitalFrameFactory_->isDefined())
+    {
+        return {aSolution, aManeuver};
+    }
+
+    const State& initialState = aSolution.states.accessFirst();
+    Shared<HeterogeneousGuidanceLaw> constantLOFGuidanceLaw =
+        std::make_shared<HeterogeneousGuidanceLaw>(HeterogeneousGuidanceLaw());
+
+    const Shared<ConstantThrust> constantThrust = std::make_shared<ConstantThrust>(ConstantThrust::FromManeuver(
+        aManeuver,
+        this->constantManeuverDirectionLocalOrbitalFrameFactory_,
+        this->constantManeuverDirectionMaximumAllowedAngularOffset_
+    ));
+    constantLOFGuidanceLaw->addGuidanceLaw(constantThrust, aManeuver.getInterval());
+
+    const Shared<Thruster> constantLOFThrusterDynamics = std::make_shared<Thruster>(
+        thrusterDynamicsSPtr_->getSatelliteSystem(),
+        constantLOFGuidanceLaw,
+        thrusterDynamicsSPtr_->getName() + " (Constant LOF)"
+    );
+
+    Array<Shared<Dynamics>> dynamicsArray = freeDynamicsArray_;
+    dynamicsArray.add(constantLOFThrusterDynamics);
+
+    const Segment::Solution lofCompliantSolution = solveWithDynamics_(
+        initialState,
+        (aSolution.accessEndInstant() - initialState.accessInstant()) + Duration::Seconds(1.0),
+        dynamicsArray,
+        eventCondition_
+    );
+
+    const Array<flightManeuver> lofCompliantManeuvers =
+        lofCompliantSolution.extractManeuvers(initialState.accessFrame());
+
+    if (lofCompliantManeuvers.getSize() != 1)
+    {
+        throw ostk::core::error::RuntimeError(
+            "Expected exactly one maneuver when creating LOF compliant solution, found " +
+            std::to_string(lofCompliantManeuvers.getSize())
+        );
+    }
+
+    return {lofCompliantSolution, lofCompliantManeuvers.accessFirst()};
 }
 
 }  // namespace trajectory

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
@@ -1140,35 +1140,60 @@ INSTANTIATE_TEST_SUITE_P(
                 Tuple<Duration, Duration, bool> {Duration::Minutes(20.0), Duration::Minutes(25.0), false},
             }
         },
-        // With Maximum Maneuver Duration Constraint (Slice Strategy)
+        // With Maximum Maneuver Duration Constraint (Truncate Start Strategy)
+        ManeuveringConstraintsTestParams {
+            "MaximumManeuverDurationTruncateStart",
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {
+                    Duration::Minutes(-5.0), Duration::Minutes(14.0)
+                },  // Too long, truncated to [4, 14]
+                Tuple<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(25.0)},
+                Tuple<Duration, Duration> {
+                    Duration::Minutes(30.0), Duration::Minutes(50.0)
+                },  // Too long, truncated to [40, 50]
+                Tuple<Duration, Duration> {
+                    Duration::Minutes(60.0), Duration::Minutes(110.0)
+                }  // Too long, truncated to [90, 100]
+            },
+            Segment::ManeuverConstraints(
+                Duration::Seconds(1.0),
+                Duration::Minutes(10.0),
+                Duration::Seconds(1.0),
+                Segment::MaximumManeuverDurationViolationStrategy::TruncateStart
+            ),
+            Array<Tuple<Duration, Duration, bool>> {
+                Tuple<Duration, Duration, bool> {Duration::Minutes(4.0), Duration::Minutes(14.0), false},
+                Tuple<Duration, Duration, bool> {Duration::Minutes(20.0), Duration::Minutes(25.0), false},
+                Tuple<Duration, Duration, bool> {Duration::Minutes(40.0), Duration::Minutes(50.0), false},
+                Tuple<Duration, Duration, bool> {Duration::Minutes(90.0), Duration::Minutes(100.0), false},
+            }
+        },
+        // With Maximum Maneuver Duration Constraint (Truncate End Strategy)
         ManeuveringConstraintsTestParams {
             "MaximumManeuverDurationTruncateEnd",
             Array<Tuple<Duration, Duration>> {
                 Tuple<Duration, Duration> {
                     Duration::Minutes(-5.0), Duration::Minutes(14.0)
-                },  // Too long, sliced [0, 10] (skiping [13, 14] as it would be too short)
+                },  // Too long, truncated to [0, 10]
                 Tuple<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(25.0)},
                 Tuple<Duration, Duration> {
                     Duration::Minutes(30.0), Duration::Minutes(50.0)
-                },  // Too long, sliced to [30, 40] and [43, 50]
+                },  // Too long, truncated to [30, 40]
                 Tuple<Duration, Duration> {
                     Duration::Minutes(60.0), Duration::Minutes(110.0)
-                }  // Too long, sliced to [60, 70], [73, 83], [86, 96] (skiping [99, 100] as it would be too short)
+                }  // Too long, truncated to [60, 70]
             },
             Segment::ManeuverConstraints(
-                Duration::Minutes(4.0),
+                Duration::Seconds(1.0),
                 Duration::Minutes(10.0),
-                Duration::Minutes(3.0),
+                Duration::Seconds(1.0),
                 Segment::MaximumManeuverDurationViolationStrategy::TruncateEnd
             ),
             Array<Tuple<Duration, Duration, bool>> {
                 Tuple<Duration, Duration, bool> {Duration::Minutes(0.0), Duration::Minutes(10.0), false},
                 Tuple<Duration, Duration, bool> {Duration::Minutes(20.0), Duration::Minutes(25.0), false},
                 Tuple<Duration, Duration, bool> {Duration::Minutes(30.0), Duration::Minutes(40.0), false},
-                Tuple<Duration, Duration, bool> {Duration::Minutes(43.0), Duration::Minutes(50.0), true},
                 Tuple<Duration, Duration, bool> {Duration::Minutes(60.0), Duration::Minutes(70.0), false},
-                Tuple<Duration, Duration, bool> {Duration::Minutes(73.0), Duration::Minutes(83.0), true},
-                Tuple<Duration, Duration, bool> {Duration::Minutes(86.0), Duration::Minutes(96.0), true}
             }
         },
         // With Maximum Maneuver Duration Constraint (Center Strategy)
@@ -1187,18 +1212,16 @@ INSTANTIATE_TEST_SUITE_P(
                 }  // Too long, centered around 80.0
             },
             Segment::ManeuverConstraints(
-                Duration::Seconds(30.0),
+                Duration::Seconds(1.0),
                 Duration::Minutes(10.0),
-                Duration::Minutes(3.0),
+                Duration::Seconds(1.0),
                 Segment::MaximumManeuverDurationViolationStrategy::Center
             ),
             Array<Tuple<Duration, Duration, bool>> {
                 Tuple<Duration, Duration, bool> {Duration::Minutes(2.0), Duration::Minutes(12.0), false},
                 Tuple<Duration, Duration, bool> {Duration::Minutes(20.0), Duration::Minutes(25.0), false},
                 Tuple<Duration, Duration, bool> {Duration::Minutes(35.0), Duration::Minutes(45.0), false},
-                Tuple<Duration, Duration, bool> {Duration::Minutes(48.0), Duration::Minutes(50.0), false},
                 Tuple<Duration, Duration, bool> {Duration::Minutes(75.0), Duration::Minutes(85.0), false},
-                Tuple<Duration, Duration, bool> {Duration::Minutes(89.0), Duration::Minutes(99.0), false},
             }
         }
     ),


### PR DESCRIPTION
Constant LOF segment misses maneuvers (basically only includes the first one) **only when** including maneuvering constraints:

See output from test:

```
Maneuver 0: start = 2000-01-01 12:17:31.824.908.211 [UTC], end = 2000-01-01 12:27:30.277.418.665 [UTC]
Maneuver 1: start = 2000-01-01 12:32:30.277.418.665 [UTC], end = 2000-01-01 12:37:55.216.093.263 [UTC]
Maneuver 2: start = 2000-01-01 13:04:02.098.954.713 [UTC], end = 2000-01-01 13:14:00.199.409.230 [UTC]
Maneuver 3: start = 2000-01-01 13:19:00.199.409.231 [UTC], end = 2000-01-01 13:23:50.424.065.027 [UTC]

Constant LOF Maneuver 0: start = 2000-01-01 12:17:33.908.491.009 [UTC], end = 2000-01-01 12:27:30.148.229.849 [UTC]
```

(Expected maneuvers 4, got 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Center" option for maximum-maneuver-duration handling and a public Undefined maneuver factory.

* **Documentation**
  * Clarified TruncateStart/TruncateEnd edge semantics and added an example illustrating truncation outcomes.

* **Tests**
  * Reworked tests to use a "similar-solution" validation path, loosened/adjusted timing and position tolerances, and added a constrained vs. unconstrained comparison.

* **Bug Fixes / Behavior**
  * Maneuver flow updated to be LOF-aware, producing more LOF-compliant solutions with adjusted maneuver counts and final-state proximity checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->