### PR TITLE
feat: use celestial frame instead of ITRF when possible

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
@@ -73,12 +73,25 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
         )
         .def(
             "get_position",
-            &AccessTarget::getPosition,
+            overload_cast<>(&AccessTarget::getPosition, const_),
             R"doc(
                 Get the fixed position associated with the access target.
 
                 Returns:
                     Position: The position.
+            )doc"
+        )
+        .def(
+            "get_position",
+            overload_coast<const Shared<const Celestial>&>(&AccessTarget::getPosition, const_),
+            R"doc(
+                Get the fixed position associated with the access target.
+
+                Args:
+                    celestial (Celestial): The celestial whose body frame will be used.
+
+                Returns:
+                    Position: The position in the celestial body frame.
             )doc"
         )
         .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access/Generator.cpp
@@ -15,6 +15,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
 
     using ostk::physics::coordinate::spherical::AER;
     using ostk::physics::Environment;
+    using ostk::physics::environment::object::Celestial;
     using ostk::physics::time::Duration;
     using ostk::physics::time::Interval;
 
@@ -83,7 +84,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access_Generator(pybind11::module& a
         )
         .def(
             "get_position",
-            overload_coast<const Shared<const Celestial>&>(&AccessTarget::getPosition, const_),
+            overload_cast<const Shared<const Celestial>&>(&AccessTarget::getPosition, const_),
             R"doc(
                 Get the fixed position associated with the access target.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -510,9 +510,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
             {
                 PyErr_WarnEx(
                     PyExc_DeprecationWarning,
-                    "Use AlignAndConstrain(const Shared<const Target>& anAlignmentTargetSPtr, const Shared<const "
-                    "Target>& aClockingTargetSPtr, const Shared<const Celestial>& aCelestialSPtr, const Angle& "
-                    "anAngularOffset = Angle::Zero()) instead.",
+                    "Use align_and_constraint(alignment_target, clocking_target, celestial, angular_offset) instead.",
                     1
                 );
                 return Profile::AlignAndConstrain(anAlignmentTargetSPtr, aClockingTargetSPtr, anAngularOffset);
@@ -543,12 +541,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
                 const Angle&>(&Profile::AlignAndConstrain),
             R"doc(
                 Generate a function that provides a quaternion that aligns to the `alignment_target` and constrains to the `clocking_target` for a given state.
-                Uses the celestial object's frame instead of ITRF for geodetic nadir and sliding ground velocity calculations.
 
                 Args:
                     alignment_target (Profile.Target | Profile.TrajectoryTarget | Profile.OrientationProfileTarget | Profile.CustomTarget): The alignment target.
                     clocking_target (Profile.Target | Profile.TrajectoryTarget | Profile.OrientationProfileTarget | Profile.CustomTarget): The clocking target.
-                    celestial (Celestial): The celestial object whose frame will be used for geodetic nadir and sliding ground velocity calculations.
+                    celestial (Celestial): The celestial object. It's body frame will be used for geodetic nadir and sliding ground velocity calculations.
                     angular_offset (Angle): The angular offset. Defaults to `Angle.Zero()`.
 
                 Returns:

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -545,7 +545,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
                 Args:
                     alignment_target (Profile.Target | Profile.TrajectoryTarget | Profile.OrientationProfileTarget | Profile.CustomTarget): The alignment target.
                     clocking_target (Profile.Target | Profile.TrajectoryTarget | Profile.OrientationProfileTarget | Profile.CustomTarget): The clocking target.
-                    celestial (Celestial): The celestial object. It's body frame will be used for geodetic nadir and sliding ground velocity calculations.
+                    celestial (Celestial): The celestial object. Its body frame will be used for geodetic nadir and sliding ground velocity calculations.
                     angular_offset (Angle): The angular offset. Defaults to `Angle.Zero()`.
 
                 Returns:

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile.cpp
@@ -510,7 +510,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile(pybind11::module& aMo
             {
                 PyErr_WarnEx(
                     PyExc_DeprecationWarning,
-                    "Use align_and_constraint(alignment_target, clocking_target, celestial, angular_offset) instead.",
+                    "Use align_and_constrain(alignment_target, clocking_target, celestial, angular_offset) instead.",
                     1
                 );
                 return Profile::AlignAndConstrain(anAlignmentTargetSPtr, aClockingTargetSPtr, anAngularOffset);

--- a/bindings/python/test/access/test_generator.py
+++ b/bindings/python/test/access/test_generator.py
@@ -36,7 +36,7 @@ def environment() -> Environment:
 
 
 @pytest.fixture
-def earth(environment: Environment) -> Celestial:
+def earth(environment: Environment) -> Earth:
     return environment.access_celestial_object_with_name("Earth")
 
 
@@ -117,22 +117,41 @@ def trajectory_target(
 
 
 class TestAccessTarget:
-    def test_constructor_success(self, access_target: AccessTarget):
+    def test_constructor_success(
+        self,
+        access_target: AccessTarget,
+    ):
         assert isinstance(access_target, AccessTarget)
 
-    def test_get_type_success(self, access_target: AccessTarget):
+    def test_get_type_success(
+        self,
+        access_target: AccessTarget,
+    ):
         assert access_target.get_type() == AccessTarget.Type.Fixed
 
-    def test_get_visibility_criterion_success(self, access_target: AccessTarget):
+    def test_get_visibility_criterion_success(
+        self,
+        access_target: AccessTarget,
+    ):
         assert access_target.get_visibility_criterion() is not None
         assert isinstance(access_target.get_visibility_criterion(), VisibilityCriterion)
 
-    def test_get_trajectory_success(self, access_target: AccessTarget):
+    def test_get_trajectory_success(
+        self,
+        access_target: AccessTarget,
+    ):
         assert access_target.get_trajectory() is not None
         assert isinstance(access_target.get_trajectory(), Trajectory)
 
-    def test_get_position_success(self, access_target: AccessTarget):
+    def test_get_position_success(
+        self,
+        access_target: AccessTarget,
+        earth: Earth,
+    ):
         assert access_target.get_position() is not None
+        assert isinstance(access_target.get_position(), Position)
+
+        assert access_target.get_position(earth) is not None
         assert isinstance(access_target.get_position(), Position)
 
     def test_get_lla_success(

--- a/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
@@ -266,7 +266,8 @@ class Generator
         const physics::time::Interval& anAnalysisInterval,
         const Vector3d& fromPositionCoordinate_ITRF,
         const Trajectory& aToTrajectory,
-        const AccessTarget& anAccessTarget
+        const AccessTarget& anAccessTarget,
+        const Shared<const Celestial>& aCelestialSPtr
     ) const;
 
     static Array<physics::time::Interval> ComputeIntervals(const VectorXi& inAccess, const Array<Instant>& instants);
@@ -276,7 +277,8 @@ class Generator
         const physics::time::Interval& aGlobalInterval,
         const Trajectory& aFromTrajectory,
         const Trajectory& aToTrajectory,
-        const Duration& aTolerance
+        const Duration& aTolerance,
+        const Shared<const Celestial>& aCelestialSPtr
     );
 
     static Instant FindTimeOfClosestApproach(
@@ -287,14 +289,17 @@ class Generator
     );
 
     static Angle CalculateElevationAt(
-        const Instant& anInstant, const Trajectory& aFromTrajectory, const Trajectory& aToTrajectory
+        const Instant& anInstant,
+        const Trajectory& aFromTrajectory,
+        const Trajectory& aToTrajectory,
+        const Shared<const Celestial>& aCelestialSPtr
     );
 
     static AER CalculateAer(
         const Instant& anInstant,
         const Position& aFromPosition,
         const Position& aToPosition,
-        const Shared<const Celestial>& anEarthSPtr
+        const Shared<const Celestial>& aCelestialSPtr
     );
 };
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
@@ -441,7 +441,8 @@ class Generator
         const physics::time::Interval& anAnalysisInterval,
         const Vector3d& fromPositionCoordinate_ITRF,
         const Trajectory& aToTrajectory,
-        const AccessTarget& anAccessTarget
+        const AccessTarget& anAccessTarget,
+        const Shared<const Celestial>& aCelestialSPtr
     ) const;
 
     static Array<physics::time::Interval> ComputeIntervals(const VectorXi& inAccess, const Array<Instant>& instants);
@@ -451,7 +452,8 @@ class Generator
         const physics::time::Interval& aGlobalInterval,
         const Trajectory& aFromTrajectory,
         const Trajectory& aToTrajectory,
-        const Duration& aTolerance
+        const Duration& aTolerance,
+        const Shared<const Celestial>& aCelestialSPtr
     );
 
     static Instant FindTimeOfClosestApproach(
@@ -462,14 +464,17 @@ class Generator
     );
 
     static Angle CalculateElevationAt(
-        const Instant& anInstant, const Trajectory& aFromTrajectory, const Trajectory& aToTrajectory
+        const Instant& anInstant,
+        const Trajectory& aFromTrajectory,
+        const Trajectory& aToTrajectory,
+        const Shared<const Celestial>& aCelestialSPtr
     );
 
     static AER CalculateAer(
         const Instant& anInstant,
         const Position& aFromPosition,
         const Position& aToPosition,
-        const Shared<const Celestial>& anEarthSPtr
+        const Shared<const Celestial>& aCelestialSPtr
     );
 };
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
@@ -460,7 +460,8 @@ class Generator
         const physics::time::Interval& anAccessInterval,
         const Trajectory& aFromTrajectory,
         const Trajectory& aToTrajectory,
-        const Duration& aTolerance
+        const Duration& aTolerance,
+        const Shared<const Celestial>& aCelestialSPtr
     );
 
     static Angle CalculateElevationAt(

--- a/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Access/Generator.hpp
@@ -110,7 +110,19 @@ class AccessTarget
     /// @endcode
     ///
     /// @return The position
+    [[deprecated("Use getPosition(getPosition(const Shared<const Celestial>& aCelestialSPtr) instead.")]]
     Position getPosition() const;
+
+    /// @brief Get the position
+    ///
+    /// @code{.cpp}
+    ///              AccessTarget accessTarget = { ... } ;
+    ///              Shared<const Celestial> celestialSPtr = ...;
+    ///              Position position = accessTarget.getPosition(celestialSPtr);
+    /// @endcode
+    ///
+    /// @return The position
+    Position getPosition(const Shared<const Celestial>& aCelestialSPtr) const;
 
     /// @brief Get the latitude, longitude, and altitude (LLA)
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -421,7 +421,7 @@ class Profile
     ///
     /// @param anAlignmentTargetSPtr An alignment target
     /// @param aClockingTargetSPtr A clocking target
-    /// @param aCelestialSPtr A celestial object. It's body frame will be used for geodetic nadir and
+    /// @param aCelestialSPtr A celestial object. Its body frame will be used for geodetic nadir and
     /// sliding ground velocity calculations
     /// @param anAngularOffset An angular offset applied to the clocking axis
     static std::function<Quaternion(const State&)> AlignAndConstrain(

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -421,7 +421,7 @@ class Profile
     ///
     /// @param anAlignmentTargetSPtr An alignment target
     /// @param aClockingTargetSPtr A clocking target
-    /// @param aCelestialSPtr A celestial object whose frame will be used instead of ITRF for geodetic nadir and
+    /// @param aCelestialSPtr A celestial object. It's body frame will be used for geodetic nadir and
     /// sliding ground velocity calculations
     /// @param anAngularOffset An angular offset applied to the clocking axis
     static std::function<Quaternion(const State&)> AlignAndConstrain(

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile.hpp
@@ -406,10 +406,28 @@ class Profile
     /// @param anAlignmentTargetSPtr An alignment target
     /// @param aClockingTargetSPtr A clocking target
     /// @param anAngularOffset An angular offset applied to the clocking axis
-
+    [[deprecated(
+        "Use AlignAndConstrain(const Shared<const Target>& anAlignmentTargetSPtr, const Shared<const Target>& "
+        "aClockingTargetSPtr, const Shared<const Celestial>& aCelestialSPtr, const Angle& anAngularOffset = "
+        "Angle::Zero()) instead."
+    )]]
     static std::function<Quaternion(const State&)> AlignAndConstrain(
         const Shared<const Target>& anAlignmentTargetSPtr,
         const Shared<const Target>& aClockingTargetSPtr,
+        const Angle& anAngularOffset = Angle::Zero()
+    );
+
+    /// @brief Generate a function that provides a quaternion that aligns and constrains for a given state.
+    ///
+    /// @param anAlignmentTargetSPtr An alignment target
+    /// @param aClockingTargetSPtr A clocking target
+    /// @param aCelestialSPtr A celestial object whose frame will be used instead of ITRF for geodetic nadir and
+    /// sliding ground velocity calculations
+    /// @param anAngularOffset An angular offset applied to the clocking axis
+    static std::function<Quaternion(const State&)> AlignAndConstrain(
+        const Shared<const Target>& anAlignmentTargetSPtr,
+        const Shared<const Target>& aClockingTargetSPtr,
+        const Shared<const Celestial>& aCelestialSPtr,
         const Angle& anAngularOffset = Angle::Zero()
     );
 
@@ -420,7 +438,9 @@ class Profile
 
     static Vector3d ComputeGeocentricNadirDirectionVector(const State& aState);
 
-    static Vector3d ComputeGeodeticNadirDirectionVector(const State& aState);
+    static Vector3d ComputeGeodeticNadirDirectionVector(
+        const State& aState, const Shared<const Celestial>& aCelestialSPtr
+    );
 
     static Vector3d ComputeTargetDirectionVector(
         const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory
@@ -429,8 +449,11 @@ class Profile
     static Vector3d ComputeTargetVelocityVector(
         const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory
     );
+
     static Vector3d ComputeTargetSlidingGroundVelocityVector(
-        const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory
+        const State& aState,
+        const ostk::astrodynamics::Trajectory& aTrajectory,
+        const Shared<const Frame>& aCelestialFrameSPtr
     );
 
     static Vector3d ComputeCelestialDirectionVector(const State& aState, const Celestial& aCelestial);

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -225,6 +225,7 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
 
     return [&anAccessTarget, &aToTrajectory, this](const Instant& anInstant) mutable -> bool
     {
+        // TBR: Deprecate this check in a future release
         const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
                                                         ? this->environment_.accessCentralCelestialObject()
                                                         : this->environment_.accessCelestialObjectWithName("Earth");

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -101,7 +101,8 @@ AccessTarget AccessTarget::FromLLA(
         AccessTarget::Type::Fixed,
         aVisibilityCriterion,
         Trajectory::Position(Position::Meters(
-            anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()), Frame::ITRF()
+            anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()),
+            aCelestialSPtr->accessFrame()
         ))
     );
 }
@@ -150,6 +151,17 @@ Generator::Generator(
       accessFilter_(anAccessFilter),
       stateFilter_(aStateFilter)
 {
+    if (anEnvironment.isDefined() && !anEnvironment.hasCentralCelestialObject())
+    {
+        std::cout << "Warning: Environment must have a central celestial object for Access Generator." << std::endl;
+
+        if (anEnvironment.accessCelestialObjectWithName("Earth") == nullptr)
+        {
+            throw ostk::core::error::RuntimeError(
+                "Environment must have an Earth celestial object for Access Generator."
+            );
+        }
+    }
 }
 
 bool Generator::isDefined() const
@@ -213,6 +225,10 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
 
     return [&anAccessTarget, &aToTrajectory, this](const Instant& anInstant) mutable -> bool
     {
+        const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
+                                                        ? this->environment_.accessCentralCelestialObject()
+                                                        : this->environment_.accessCelestialObjectWithName("Earth");
+
         const State fromState = anAccessTarget.accessTrajectory().getStateAt(anInstant);
         const State toState = aToTrajectory.getStateAt(anInstant);
 
@@ -224,8 +240,8 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
         const Position fromPosition = fromState.getPosition();
         const Position toPosition = toState.getPosition();
 
-        const Position fromPosition_ITRF = fromPosition.inFrame(Frame::ITRF(), anInstant);
-        const Position toPosition_ITRF = toPosition.inFrame(Frame::ITRF(), anInstant);
+        const Position fromPosition_ITRF = fromPosition.inFrame(celestialSPtr->accessFrame(), anInstant);
+        const Position toPosition_ITRF = toPosition.inFrame(celestialSPtr->accessFrame(), anInstant);
 
         const VisibilityCriterion& visibilityCriterion = anAccessTarget.accessVisibilityCriterion();
 
@@ -236,9 +252,7 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
             );
         }
 
-        const AER aer = Generator::CalculateAer(
-            anInstant, fromPosition, toPosition, this->environment_.accessCelestialObjectWithName("Earth")
-        );
+        const AER aer = Generator::CalculateAer(anInstant, fromPosition, toPosition, celestialSPtr);
 
         if (visibilityCriterion.is<VisibilityCriterion::AERMask>())
         {
@@ -413,6 +427,10 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
     const bool& coarse
 ) const
 {
+    const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
+                                                    ? this->environment_.accessCentralCelestialObject()
+                                                    : this->environment_.accessCelestialObjectWithName("Earth");
+
     // create a stacked matrix of SEZ rotations for all access targets
 
     const Index targetCount = someAccessTargets.getSize();
@@ -656,7 +674,7 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
 
         // calculate target to satellite vector in ITRF
         const Vector3d toPositionCoordinates_ITRF =
-            toTrajectoryState.inFrame(Frame::ITRF()).getPosition().getCoordinates();
+            toTrajectoryState.inFrame(celestialSPtr->accessFrame()).getPosition().getCoordinates();
 
         // check if satellite is in access
         auto inAccess = visibilityCriterionFilter(fromPositionCoordinates_ITRF, toPositionCoordinates_ITRF, instant);
@@ -691,7 +709,8 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
                 anInterval,
                 fromPositionCoordinates_ITRF.col(i),
                 aToTrajectory,
-                someAccessTargets[i]
+                someAccessTargets[i],
+                celestialSPtr
             );
         }
     }
@@ -714,16 +733,18 @@ Array<Access> Generator::generateAccessesFromIntervals(
     const Trajectory& aToTrajectory
 ) const
 {
-    const Shared<const Celestial> earthSPtr = this->environment_.accessCelestialObjectWithName("Earth");
+    const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
+                                                    ? this->environment_.accessCentralCelestialObject()
+                                                    : this->environment_.accessCelestialObjectWithName("Earth");
 
     return someIntervals
         .map<Access>(
-            [&anInterval, &aFromTrajectory, &aToTrajectory, &earthSPtr, this](
+            [&anInterval, &aFromTrajectory, &aToTrajectory, &celestialSPtr, this](
                 const physics::time::Interval& anAccessInterval
             ) -> Access
             {
                 return Generator::GenerateAccess(
-                    anAccessInterval, anInterval, aFromTrajectory, aToTrajectory, this->tolerance_
+                    anAccessInterval, anInterval, aFromTrajectory, aToTrajectory, this->tolerance_, celestialSPtr
                 );
             }
         )
@@ -740,22 +761,22 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
     const physics::time::Interval& anAnalysisInterval,
     const Vector3d& fromPositionCoordinate_ITRF,
     const Trajectory& aToTrajectory,
-    const AccessTarget& anAccessTarget
+    const AccessTarget& anAccessTarget,
+    const Shared<const Celestial>& aCelestialSPtr
 ) const
 {
     const RootSolver rootSolver = RootSolver(100, this->tolerance_.inSeconds());
 
-    const Shared<const Celestial> earthSPtr = this->environment_.accessCelestialObjectWithName("Earth");
-
-    const Matrix3d SEZRotation = anAccessTarget.computeR_SEZ_ECEF(earthSPtr);
+    const Matrix3d SEZRotation = anAccessTarget.computeR_SEZ_ECEF(aCelestialSPtr);
 
     std::function<bool(const Instant&)> condition;
 
-    const auto computeAER = [&fromPositionCoordinate_ITRF, &SEZRotation, &aToTrajectory](const Instant& instant
+    const auto computeAER = [&fromPositionCoordinate_ITRF, &SEZRotation, &aToTrajectory, &aCelestialSPtr](
+                                const Instant& instant
                             ) -> Triple<Real, Real, Real>
     {
         const Vector3d toPositionCoordinates_ITRF =
-            aToTrajectory.getStateAt(instant).inFrame(Frame::ITRF()).getPosition().getCoordinates();
+            aToTrajectory.getStateAt(instant).inFrame(aCelestialSPtr->accessFrame()).getPosition().getCoordinates();
 
         const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinate_ITRF;
 
@@ -798,10 +819,12 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
         const VisibilityCriterion::LineOfSight visibilityCriterion =
             anAccessTarget.accessVisibilityCriterion().as<VisibilityCriterion::LineOfSight>().value();
 
-        condition = [&fromPositionCoordinate_ITRF, &aToTrajectory, visibilityCriterion](const Instant& instant) -> bool
+        condition = [&fromPositionCoordinate_ITRF, &aToTrajectory, &aCelestialSPtr, visibilityCriterion](
+                        const Instant& instant
+                    ) -> bool
         {
             const Vector3d toPositionCoordinates_ITRF =
-                aToTrajectory.getStateAt(instant).inFrame(Frame::ITRF()).getPosition().getCoordinates();
+                aToTrajectory.getStateAt(instant).inFrame(aCelestialSPtr->accessFrame()).getPosition().getCoordinates();
 
             return visibilityCriterion.isSatisfied(instant, fromPositionCoordinate_ITRF, toPositionCoordinates_ITRF);
         };
@@ -811,10 +834,12 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
         const VisibilityCriterion::ElevationInterval visibilityCriterion =
             anAccessTarget.accessVisibilityCriterion().as<VisibilityCriterion::ElevationInterval>().value();
 
-        condition = [&fromPositionCoordinate_ITRF, &aToTrajectory, visibilityCriterion](const Instant& instant) -> bool
+        condition = [&fromPositionCoordinate_ITRF, &aToTrajectory, &aCelestialSPtr, visibilityCriterion](
+                        const Instant& instant
+                    ) -> bool
         {
             const Vector3d toPositionCoordinates_ITRF =
-                aToTrajectory.getStateAt(instant).inFrame(Frame::ITRF()).getPosition().getCoordinates();
+                aToTrajectory.getStateAt(instant).inFrame(aCelestialSPtr->accessFrame()).getPosition().getCoordinates();
 
             const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinate_ITRF;
 
@@ -950,7 +975,8 @@ Access Generator::GenerateAccess(
     const physics::time::Interval& aGlobalInterval,
     const Trajectory& aFromTrajectory,
     const Trajectory& aToTrajectory,
-    const Duration& aTolerance
+    const Duration& aTolerance,
+    const Shared<const Celestial>& aCelestialSPtr
 )
 {
     const Access::Type type = ((aGlobalInterval.accessStart() != anAccessInterval.accessStart()) &&
@@ -976,7 +1002,7 @@ Access Generator::GenerateAccess(
 
     const Angle maxElevation =
         timeOfClosestApproach.isDefined()
-            ? Generator::CalculateElevationAt(timeOfClosestApproach, aFromTrajectory, aToTrajectory)
+            ? Generator::CalculateElevationAt(timeOfClosestApproach, aFromTrajectory, aToTrajectory, aCelestialSPtr)
             : Angle::Undefined();
 
     return Access {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
@@ -1074,13 +1100,16 @@ Instant Generator::FindTimeOfClosestApproach(
 }
 
 Angle Generator::CalculateElevationAt(
-    const Instant& anInstant, const Trajectory& aFromTrajectory, const Trajectory& aToTrajectory
+    const Instant& anInstant,
+    const Trajectory& aFromTrajectory,
+    const Trajectory& aToTrajectory,
+    const Shared<const Celestial>& aCelestialSPtr
 )
 {
     const Vector3d fromPositionCoordinates_ITRF =
-        aFromTrajectory.getStateAt(anInstant).inFrame(Frame::ITRF()).getPosition().getCoordinates();
+        aFromTrajectory.getStateAt(anInstant).inFrame(aCelestialSPtr->accessFrame()).getPosition().getCoordinates();
     const Vector3d toPositionCoordinates_ITRF =
-        aToTrajectory.getStateAt(anInstant).inFrame(Frame::ITRF()).getPosition().getCoordinates();
+        aToTrajectory.getStateAt(anInstant).inFrame(aCelestialSPtr->accessFrame()).getPosition().getCoordinates();
 
     const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinates_ITRF;
 
@@ -1091,15 +1120,17 @@ AER Generator::CalculateAer(
     const Instant& anInstant,
     const Position& aFromPosition,
     const Position& aToPosition,
-    const Shared<const Celestial>& anEarthSPtr
+    const Shared<const Celestial>& aCelestialSPtr
 )
 {
-    const Vector3d referenceCoordinates_ITRF = aFromPosition.inFrame(Frame::ITRF(), anInstant).accessCoordinates();
+    const Vector3d referenceCoordinates_ITRF =
+        aFromPosition.inFrame(aCelestialSPtr->accessFrame(), anInstant).accessCoordinates();
 
-    const LLA referencePoint_LLA =
-        LLA::Cartesian(referenceCoordinates_ITRF, anEarthSPtr->getEquatorialRadius(), anEarthSPtr->getFlattening());
+    const LLA referencePoint_LLA = LLA::Cartesian(
+        referenceCoordinates_ITRF, aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()
+    );
 
-    const Shared<const Frame> nedFrameSPtr = anEarthSPtr->getFrameAt(referencePoint_LLA, Earth::FrameType::NED);
+    const Shared<const Frame> nedFrameSPtr = aCelestialSPtr->getFrameAt(referencePoint_LLA, Celestial::FrameType::NED);
 
     const Position fromPosition_NED = aFromPosition.inFrame(nedFrameSPtr, anInstant);
     const Position toPosition_NED = aToPosition.inFrame(nedFrameSPtr, anInstant);

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -223,8 +223,6 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
         throw ostk::core::error::runtime::Undefined("Generator");
     }
 
-    // Resolve the central celestial and bind the state filter once, rather than on every evaluation of the returned
-    // condition.
     // TBR: Deprecate the Earth fallback in a future release
     const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
                                                     ? this->environment_.accessCentralCelestialObject()

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -100,10 +100,12 @@ AccessTarget AccessTarget::FromLLA(
     return AccessTarget(
         AccessTarget::Type::Fixed,
         aVisibilityCriterion,
-        Trajectory::Position(Position::Meters(
-            anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()),
-            aCelestialSPtr->accessFrame()
-        ))
+        Trajectory::Position(
+            Position::Meters(
+                anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()),
+                aCelestialSPtr->accessFrame()
+            )
+        )
     );
 }
 
@@ -153,7 +155,7 @@ Generator::Generator(
 {
     if (anEnvironment.isDefined() && !anEnvironment.hasCentralCelestialObject())
     {
-        std::cout << "Warning: Environment must have a central celestial object for Access Generator." << std::endl;
+        std::cerr << "Warning: Environment must have a central celestial object for Access Generator." << std::endl;
 
         if (anEnvironment.accessCelestialObjectWithName("Earth") == nullptr)
         {
@@ -487,7 +489,8 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
         }
     );
 
-    const auto computeAer = [&SEZRotations, &fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF
+    const auto computeAer = [&SEZRotations, &fromPositionCoordinates_ITRF](
+                                const Vector3d& aToPositionCoordinates_ITRF
                             ) -> Triple<VectorXd, VectorXd, VectorXd>
     {
         const MatrixXd dx = (-fromPositionCoordinates_ITRF).colwise() + aToPositionCoordinates_ITRF;
@@ -520,8 +523,8 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
         return {azimuth_rad, elevation_rad, range_m};
     };
 
-    const auto computeElevations = [&fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF
-                                   ) -> VectorXd
+    const auto computeElevations =
+        [&fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF) -> VectorXd
     {
         const MatrixXd dx = (-fromPositionCoordinates_ITRF).colwise() + aToPositionCoordinates_ITRF;
         const MatrixXd fromPositionDirection_ITRF = fromPositionCoordinates_ITRF.colwise().normalized();
@@ -1037,8 +1040,8 @@ Instant Generator::FindTimeOfClosestApproach(
 
     // Capture-less, so that it converts to the plain function pointer NLopt expects: everything it
     // needs travels through the data context.
-    const auto calculateRange = [](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext
-                                ) -> double
+    const auto calculateRange =
+        [](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext) -> double
     {
         (void)aGradient;
         if (aDataContext == nullptr)

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -782,8 +782,10 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
                                 const Instant& instant
                             ) -> Triple<Real, Real, Real>
     {
-        const Vector3d toPositionCoordinates_ITRF =
-            aToTrajectory.getStateAt(instant).getPosition().inFrame(aCelestialSPtr->accessFrame(), instant).getCoordinates();
+        const Vector3d toPositionCoordinates_ITRF = aToTrajectory.getStateAt(instant)
+                                                        .getPosition()
+                                                        .inFrame(aCelestialSPtr->accessFrame(), instant)
+                                                        .getCoordinates();
 
         const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinate_ITRF;
 
@@ -830,8 +832,10 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
                         const Instant& instant
                     ) -> bool
         {
-            const Vector3d toPositionCoordinates_ITRF =
-                aToTrajectory.getStateAt(instant).getPosition().inFrame(aCelestialSPtr->accessFrame(), instant).getCoordinates();
+            const Vector3d toPositionCoordinates_ITRF = aToTrajectory.getStateAt(instant)
+                                                            .getPosition()
+                                                            .inFrame(aCelestialSPtr->accessFrame(), instant)
+                                                            .getCoordinates();
 
             return visibilityCriterion.isSatisfied(instant, fromPositionCoordinate_ITRF, toPositionCoordinates_ITRF);
         };
@@ -845,8 +849,10 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
                         const Instant& instant
                     ) -> bool
         {
-            const Vector3d toPositionCoordinates_ITRF =
-                aToTrajectory.getStateAt(instant).getPosition().inFrame(aCelestialSPtr->accessFrame(), instant).getCoordinates();
+            const Vector3d toPositionCoordinates_ITRF = aToTrajectory.getStateAt(instant)
+                                                            .getPosition()
+                                                            .inFrame(aCelestialSPtr->accessFrame(), instant)
+                                                            .getCoordinates();
 
             const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinate_ITRF;
 
@@ -993,8 +999,9 @@ Access Generator::GenerateAccess(
 
     const Instant acquisitionOfSignal = anAccessInterval.getStart();
 
-    const Instant timeOfClosestApproach =
-        Generator::FindTimeOfClosestApproach(anAccessInterval, aFromTrajectory, aToTrajectory, aTolerance, aCelestialSPtr);
+    const Instant timeOfClosestApproach = Generator::FindTimeOfClosestApproach(
+        anAccessInterval, aFromTrajectory, aToTrajectory, aTolerance, aCelestialSPtr
+    );
 
     const Instant lossOfSignal = anAccessInterval.getEnd();
 
@@ -1032,8 +1039,8 @@ Instant Generator::FindTimeOfClosestApproach(
 
     // Capture-less, so that it converts to the plain function pointer NLopt expects: everything it
     // needs travels through the data context.
-    const auto calculateRange =
-        [](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext) -> double
+    const auto calculateRange = [](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext
+                                ) -> double
     {
         (void)aGradient;
         if (aDataContext == nullptr)
@@ -1124,10 +1131,14 @@ Angle Generator::CalculateElevationAt(
     const Shared<const Celestial>& aCelestialSPtr
 )
 {
-    const Vector3d fromPositionCoordinates_ITRF =
-        aFromTrajectory.getStateAt(anInstant).getPosition().inFrame(aCelestialSPtr->accessFrame(), anInstant).getCoordinates();
-    const Vector3d toPositionCoordinates_ITRF =
-        aToTrajectory.getStateAt(anInstant).getPosition().inFrame(aCelestialSPtr->accessFrame(), anInstant).getCoordinates();
+    const Vector3d fromPositionCoordinates_ITRF = aFromTrajectory.getStateAt(anInstant)
+                                                      .getPosition()
+                                                      .inFrame(aCelestialSPtr->accessFrame(), anInstant)
+                                                      .getCoordinates();
+    const Vector3d toPositionCoordinates_ITRF = aToTrajectory.getStateAt(anInstant)
+                                                    .getPosition()
+                                                    .inFrame(aCelestialSPtr->accessFrame(), anInstant)
+                                                    .getCoordinates();
 
     const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinates_ITRF;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -229,6 +229,7 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
 
     return [&anAccessTarget, &aToTrajectory, earthSPtr, stateFilter](const Instant& anInstant) -> bool
     {
+        // TBR: Deprecate this check in a future release
         const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
                                                         ? this->environment_.accessCentralCelestialObject()
                                                         : this->environment_.accessCelestialObjectWithName("Earth");

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -694,13 +694,13 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
         // check if satellite is in access
         auto inAccess = visibilityCriterionFilter(fromPositionCoordinates_ITRF, toPositionCoordinates_ITRF, instant);
 
-        if (this->stateFilter_)
+        if (stateFilter)
         {
             for (Index i = 0; i < targetCount; ++i)
             {
                 const State fromState = someAccessTargets[i].accessTrajectory().getStateAt(instant);
 
-                inAccess(i) = inAccess(i) && this->stateFilter_(fromState, toTrajectoryState);
+                inAccess(i) = inAccess(i) && stateFilter(fromState, toTrajectoryState);
             }
         }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -100,12 +100,10 @@ AccessTarget AccessTarget::FromLLA(
     return AccessTarget(
         AccessTarget::Type::Fixed,
         aVisibilityCriterion,
-        Trajectory::Position(
-            Position::Meters(
-                anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()),
-                aCelestialSPtr->accessFrame()
-            )
-        )
+        Trajectory::Position(Position::Meters(
+            anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()),
+            aCelestialSPtr->accessFrame()
+        ))
     );
 }
 
@@ -489,8 +487,7 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
         }
     );
 
-    const auto computeAer = [&SEZRotations, &fromPositionCoordinates_ITRF](
-                                const Vector3d& aToPositionCoordinates_ITRF
+    const auto computeAer = [&SEZRotations, &fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF
                             ) -> Triple<VectorXd, VectorXd, VectorXd>
     {
         const MatrixXd dx = (-fromPositionCoordinates_ITRF).colwise() + aToPositionCoordinates_ITRF;
@@ -523,8 +520,8 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
         return {azimuth_rad, elevation_rad, range_m};
     };
 
-    const auto computeElevations =
-        [&fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF) -> VectorXd
+    const auto computeElevations = [&fromPositionCoordinates_ITRF](const Vector3d& aToPositionCoordinates_ITRF
+                                   ) -> VectorXd
     {
         const MatrixXd dx = (-fromPositionCoordinates_ITRF).colwise() + aToPositionCoordinates_ITRF;
         const MatrixXd fromPositionDirection_ITRF = fromPositionCoordinates_ITRF.colwise().normalized();
@@ -1040,8 +1037,8 @@ Instant Generator::FindTimeOfClosestApproach(
 
     // Capture-less, so that it converts to the plain function pointer NLopt expects: everything it
     // needs travels through the data context.
-    const auto calculateRange =
-        [](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext) -> double
+    const auto calculateRange = [](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext
+                                ) -> double
     {
         (void)aGradient;
         if (aDataContext == nullptr)

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -101,7 +101,8 @@ AccessTarget AccessTarget::FromLLA(
         AccessTarget::Type::Fixed,
         aVisibilityCriterion,
         Trajectory::Position(Position::Meters(
-            anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()), Frame::ITRF()
+            anLLA.toCartesian(aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()),
+            aCelestialSPtr->accessFrame()
         ))
     );
 }
@@ -150,6 +151,17 @@ Generator::Generator(
       accessFilter_(anAccessFilter),
       stateFilter_(aStateFilter)
 {
+    if (anEnvironment.isDefined() && !anEnvironment.hasCentralCelestialObject())
+    {
+        std::cout << "Warning: Environment must have a central celestial object for Access Generator." << std::endl;
+
+        if (anEnvironment.accessCelestialObjectWithName("Earth") == nullptr)
+        {
+            throw ostk::core::error::RuntimeError(
+                "Environment must have an Earth celestial object for Access Generator."
+            );
+        }
+    }
 }
 
 bool Generator::isDefined() const
@@ -217,6 +229,10 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
 
     return [&anAccessTarget, &aToTrajectory, earthSPtr, stateFilter](const Instant& anInstant) -> bool
     {
+        const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
+                                                        ? this->environment_.accessCentralCelestialObject()
+                                                        : this->environment_.accessCelestialObjectWithName("Earth");
+
         const State fromState = anAccessTarget.accessTrajectory().getStateAt(anInstant);
         const State toState = aToTrajectory.getStateAt(anInstant);
 
@@ -228,8 +244,8 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
         const Position fromPosition = fromState.getPosition();
         const Position toPosition = toState.getPosition();
 
-        const Position fromPosition_ITRF = fromPosition.inFrame(Frame::ITRF(), anInstant);
-        const Position toPosition_ITRF = toPosition.inFrame(Frame::ITRF(), anInstant);
+        const Position fromPosition_ITRF = fromPosition.inFrame(celestialSPtr->accessFrame(), anInstant);
+        const Position toPosition_ITRF = toPosition.inFrame(celestialSPtr->accessFrame(), anInstant);
 
         const VisibilityCriterion& visibilityCriterion = anAccessTarget.accessVisibilityCriterion();
 
@@ -240,7 +256,7 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
             );
         }
 
-        const AER aer = Generator::CalculateAer(anInstant, fromPosition, toPosition, earthSPtr);
+        const AER aer = Generator::CalculateAer(anInstant, fromPosition, toPosition, celestialSPtr);
 
         if (visibilityCriterion.is<VisibilityCriterion::AERMask>())
         {
@@ -415,6 +431,10 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
     const bool& coarse
 ) const
 {
+    const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
+                                                    ? this->environment_.accessCentralCelestialObject()
+                                                    : this->environment_.accessCelestialObjectWithName("Earth");
+
     // create a stacked matrix of SEZ rotations for all access targets
 
     const Index targetCount = someAccessTargets.getSize();
@@ -661,7 +681,7 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
 
         // calculate target to satellite vector in ITRF (transform only the position, not the whole state)
         const Vector3d toPositionCoordinates_ITRF =
-            toTrajectoryState.getPosition().inFrame(Frame::ITRF(), instant).getCoordinates();
+            toTrajectoryState.getPosition().inFrame(celestialSPtr->accessFrame(), instant).getCoordinates();
 
         // check if satellite is in access
         auto inAccess = visibilityCriterionFilter(fromPositionCoordinates_ITRF, toPositionCoordinates_ITRF, instant);
@@ -696,7 +716,8 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
                 anInterval,
                 fromPositionCoordinates_ITRF.col(i),
                 aToTrajectory,
-                someAccessTargets[i]
+                someAccessTargets[i],
+                celestialSPtr
             );
         }
     }
@@ -719,16 +740,18 @@ Array<Access> Generator::generateAccessesFromIntervals(
     const Trajectory& aToTrajectory
 ) const
 {
-    const Shared<const Celestial> earthSPtr = this->environment_.accessCelestialObjectWithName("Earth");
+    const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
+                                                    ? this->environment_.accessCentralCelestialObject()
+                                                    : this->environment_.accessCelestialObjectWithName("Earth");
 
     return someIntervals
         .map<Access>(
-            [&anInterval, &aFromTrajectory, &aToTrajectory, &earthSPtr, this](
+            [&anInterval, &aFromTrajectory, &aToTrajectory, &celestialSPtr, this](
                 const physics::time::Interval& anAccessInterval
             ) -> Access
             {
                 return Generator::GenerateAccess(
-                    anAccessInterval, anInterval, aFromTrajectory, aToTrajectory, this->tolerance_
+                    anAccessInterval, anInterval, aFromTrajectory, aToTrajectory, this->tolerance_, celestialSPtr
                 );
             }
         )
@@ -745,22 +768,22 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
     const physics::time::Interval& anAnalysisInterval,
     const Vector3d& fromPositionCoordinate_ITRF,
     const Trajectory& aToTrajectory,
-    const AccessTarget& anAccessTarget
+    const AccessTarget& anAccessTarget,
+    const Shared<const Celestial>& aCelestialSPtr
 ) const
 {
     const RootSolver rootSolver = RootSolver(100, this->tolerance_.inSeconds());
 
-    const Shared<const Celestial> earthSPtr = this->environment_.accessCelestialObjectWithName("Earth");
-
-    const Matrix3d SEZRotation = anAccessTarget.computeR_SEZ_ECEF(earthSPtr);
+    const Matrix3d SEZRotation = anAccessTarget.computeR_SEZ_ECEF(aCelestialSPtr);
 
     std::function<bool(const Instant&)> condition;
 
-    const auto computeAER = [&fromPositionCoordinate_ITRF, &SEZRotation, &aToTrajectory](const Instant& instant
+    const auto computeAER = [&fromPositionCoordinate_ITRF, &SEZRotation, &aToTrajectory, &aCelestialSPtr](
+                                const Instant& instant
                             ) -> Triple<Real, Real, Real>
     {
         const Vector3d toPositionCoordinates_ITRF =
-            aToTrajectory.getStateAt(instant).getPosition().inFrame(Frame::ITRF(), instant).getCoordinates();
+            aToTrajectory.getStateAt(instant).getPosition().inFrame(aCelestialSPtr->accessFrame(), instant).getCoordinates();
 
         const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinate_ITRF;
 
@@ -803,10 +826,12 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
         const VisibilityCriterion::LineOfSight visibilityCriterion =
             anAccessTarget.accessVisibilityCriterion().as<VisibilityCriterion::LineOfSight>().value();
 
-        condition = [&fromPositionCoordinate_ITRF, &aToTrajectory, visibilityCriterion](const Instant& instant) -> bool
+        condition = [&fromPositionCoordinate_ITRF, &aToTrajectory, &aCelestialSPtr, visibilityCriterion](
+                        const Instant& instant
+                    ) -> bool
         {
             const Vector3d toPositionCoordinates_ITRF =
-                aToTrajectory.getStateAt(instant).getPosition().inFrame(Frame::ITRF(), instant).getCoordinates();
+                aToTrajectory.getStateAt(instant).getPosition().inFrame(aCelestialSPtr->accessFrame(), instant).getCoordinates();
 
             return visibilityCriterion.isSatisfied(instant, fromPositionCoordinate_ITRF, toPositionCoordinates_ITRF);
         };
@@ -816,10 +841,12 @@ Array<physics::time::Interval> Generator::computePreciseCrossings(
         const VisibilityCriterion::ElevationInterval visibilityCriterion =
             anAccessTarget.accessVisibilityCriterion().as<VisibilityCriterion::ElevationInterval>().value();
 
-        condition = [&fromPositionCoordinate_ITRF, &aToTrajectory, visibilityCriterion](const Instant& instant) -> bool
+        condition = [&fromPositionCoordinate_ITRF, &aToTrajectory, &aCelestialSPtr, visibilityCriterion](
+                        const Instant& instant
+                    ) -> bool
         {
             const Vector3d toPositionCoordinates_ITRF =
-                aToTrajectory.getStateAt(instant).getPosition().inFrame(Frame::ITRF(), instant).getCoordinates();
+                aToTrajectory.getStateAt(instant).getPosition().inFrame(aCelestialSPtr->accessFrame(), instant).getCoordinates();
 
             const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinate_ITRF;
 
@@ -955,7 +982,8 @@ Access Generator::GenerateAccess(
     const physics::time::Interval& aGlobalInterval,
     const Trajectory& aFromTrajectory,
     const Trajectory& aToTrajectory,
-    const Duration& aTolerance
+    const Duration& aTolerance,
+    const Shared<const Celestial>& aCelestialSPtr
 )
 {
     const Access::Type type = ((aGlobalInterval.accessStart() != anAccessInterval.accessStart()) &&
@@ -966,7 +994,7 @@ Access Generator::GenerateAccess(
     const Instant acquisitionOfSignal = anAccessInterval.getStart();
 
     const Instant timeOfClosestApproach =
-        Generator::FindTimeOfClosestApproach(anAccessInterval, aFromTrajectory, aToTrajectory, aTolerance);
+        Generator::FindTimeOfClosestApproach(anAccessInterval, aFromTrajectory, aToTrajectory, aTolerance, aCelestialSPtr);
 
     const Instant lossOfSignal = anAccessInterval.getEnd();
 
@@ -981,7 +1009,7 @@ Access Generator::GenerateAccess(
 
     const Angle maxElevation =
         timeOfClosestApproach.isDefined()
-            ? Generator::CalculateElevationAt(timeOfClosestApproach, aFromTrajectory, aToTrajectory)
+            ? Generator::CalculateElevationAt(timeOfClosestApproach, aFromTrajectory, aToTrajectory, aCelestialSPtr)
             : Angle::Undefined();
 
     return Access {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
@@ -991,7 +1019,8 @@ Instant Generator::FindTimeOfClosestApproach(
     const physics::time::Interval& anAccessInterval,
     const Trajectory& aFromTrajectory,
     const Trajectory& aToTrajectory,
-    const Duration& aTolerance
+    const Duration& aTolerance,
+    const Shared<const Celestial>& aCelestialSPtr
 )
 {
     struct Context
@@ -1000,7 +1029,7 @@ Instant Generator::FindTimeOfClosestApproach(
         const std::function<Pair<State, State>(const Instant& anInstant)>& getStatesAt;
     };
 
-    const auto calculateRange = [](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext
+    const auto calculateRange = [aCelestialSPtr](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext
                                 ) -> double
     {
         (void)aGradient;
@@ -1016,8 +1045,8 @@ Instant Generator::FindTimeOfClosestApproach(
         const auto [queryFromState, queryToState] = contextPtr->getStatesAt(queryInstant);
 
         const Vector3d deltaPosition =
-            queryFromState.getPosition().inFrame(Frame::ITRF(), queryInstant).accessCoordinates() -
-            queryToState.getPosition().inFrame(Frame::ITRF(), queryInstant).accessCoordinates();
+            queryFromState.getPosition().inFrame(aCelestialSPtr->accessFrame(), queryInstant).accessCoordinates() -
+            queryToState.getPosition().inFrame(aCelestialSPtr->accessFrame(), queryInstant).accessCoordinates();
 
         const Real rangeSquared = deltaPosition.squaredNorm();
 
@@ -1080,13 +1109,16 @@ Instant Generator::FindTimeOfClosestApproach(
 }
 
 Angle Generator::CalculateElevationAt(
-    const Instant& anInstant, const Trajectory& aFromTrajectory, const Trajectory& aToTrajectory
+    const Instant& anInstant,
+    const Trajectory& aFromTrajectory,
+    const Trajectory& aToTrajectory,
+    const Shared<const Celestial>& aCelestialSPtr
 )
 {
     const Vector3d fromPositionCoordinates_ITRF =
-        aFromTrajectory.getStateAt(anInstant).getPosition().inFrame(Frame::ITRF(), anInstant).getCoordinates();
+        aFromTrajectory.getStateAt(anInstant).getPosition().inFrame(aCelestialSPtr->accessFrame(), anInstant).getCoordinates();
     const Vector3d toPositionCoordinates_ITRF =
-        aToTrajectory.getStateAt(anInstant).getPosition().inFrame(Frame::ITRF(), anInstant).getCoordinates();
+        aToTrajectory.getStateAt(anInstant).getPosition().inFrame(aCelestialSPtr->accessFrame(), anInstant).getCoordinates();
 
     const Vector3d dx = toPositionCoordinates_ITRF - fromPositionCoordinates_ITRF;
 
@@ -1097,15 +1129,17 @@ AER Generator::CalculateAer(
     const Instant& anInstant,
     const Position& aFromPosition,
     const Position& aToPosition,
-    const Shared<const Celestial>& anEarthSPtr
+    const Shared<const Celestial>& aCelestialSPtr
 )
 {
-    const Vector3d referenceCoordinates_ITRF = aFromPosition.inFrame(Frame::ITRF(), anInstant).accessCoordinates();
+    const Vector3d referenceCoordinates_ITRF =
+        aFromPosition.inFrame(aCelestialSPtr->accessFrame(), anInstant).accessCoordinates();
 
-    const LLA referencePoint_LLA =
-        LLA::Cartesian(referenceCoordinates_ITRF, anEarthSPtr->getEquatorialRadius(), anEarthSPtr->getFlattening());
+    const LLA referencePoint_LLA = LLA::Cartesian(
+        referenceCoordinates_ITRF, aCelestialSPtr->getEquatorialRadius(), aCelestialSPtr->getFlattening()
+    );
 
-    const Shared<const Frame> nedFrameSPtr = anEarthSPtr->getFrameAt(referencePoint_LLA, Earth::FrameType::NED);
+    const Shared<const Frame> nedFrameSPtr = aCelestialSPtr->getFrameAt(referencePoint_LLA, Celestial::FrameType::NED);
 
     const Position fromPosition_NED = aFromPosition.inFrame(nedFrameSPtr, anInstant);
     const Position toPosition_NED = aToPosition.inFrame(nedFrameSPtr, anInstant);

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -69,6 +69,16 @@ Position AccessTarget::getPosition() const
     return trajectory_.getStateAt(Instant::J2000()).inFrame(Frame::ITRF()).getPosition();
 }
 
+Position AccessTarget::getPosition(const Shared<const Celestial>& aCelestialSPtr) const
+{
+    if (type_ != Type::Fixed)
+    {
+        throw ostk::core::error::RuntimeError("Position is only defined for fixed targets.");
+    }
+
+    return trajectory_.getStateAt(Instant::J2000()).inFrame(aCelestialSPtr->accessFrame()).getPosition();
+}
+
 LLA AccessTarget::getLLA(const Shared<const Celestial>& aCelestialSPtr) const
 {
     return LLA::Cartesian(
@@ -451,7 +461,7 @@ Array<Array<Access>> Generator::computeAccessesForFixedTargets(
 
     for (Index i = 0; i < targetCount; ++i)
     {
-        fromPositionCoordinates_ITRF.col(i) = someAccessTargets[i].getPosition().getCoordinates();
+        fromPositionCoordinates_ITRF.col(i) = someAccessTargets[i].getPosition(celestialSPtr).getCoordinates();
     }
 
     const bool allAccessTargetsHaveMasks = std::all_of(

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/Generator.cpp
@@ -223,17 +223,16 @@ std::function<bool(const Instant&)> Generator::getConditionFunction(
         throw ostk::core::error::runtime::Undefined("Generator");
     }
 
-    // Resolve the Earth and bind the state filter once, rather than on every evaluation of the returned condition.
-    const Shared<const Celestial> earthSPtr = this->environment_.accessCelestialObjectWithName("Earth");
+    // Resolve the central celestial and bind the state filter once, rather than on every evaluation of the returned
+    // condition.
+    // TBR: Deprecate the Earth fallback in a future release
+    const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
+                                                    ? this->environment_.accessCentralCelestialObject()
+                                                    : this->environment_.accessCelestialObjectWithName("Earth");
     const std::function<bool(const State&, const State&)> stateFilter = this->stateFilter_;
 
-    return [&anAccessTarget, &aToTrajectory, earthSPtr, stateFilter](const Instant& anInstant) -> bool
+    return [&anAccessTarget, &aToTrajectory, celestialSPtr, stateFilter](const Instant& anInstant) -> bool
     {
-        // TBR: Deprecate this check in a future release
-        const Shared<const Celestial> celestialSPtr = this->environment_.hasCentralCelestialObject()
-                                                        ? this->environment_.accessCentralCelestialObject()
-                                                        : this->environment_.accessCelestialObjectWithName("Earth");
-
         const State fromState = anAccessTarget.accessTrajectory().getStateAt(anInstant);
         const State toState = aToTrajectory.getStateAt(anInstant);
 
@@ -1028,10 +1027,13 @@ Instant Generator::FindTimeOfClosestApproach(
     {
         const Instant& startInstant;
         const std::function<Pair<State, State>(const Instant& anInstant)>& getStatesAt;
+        const Shared<const Celestial>& celestialSPtr;
     };
 
-    const auto calculateRange = [aCelestialSPtr](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext
-                                ) -> double
+    // Capture-less, so that it converts to the plain function pointer NLopt expects: everything it
+    // needs travels through the data context.
+    const auto calculateRange =
+        [](const std::vector<double>& x, std::vector<double>& aGradient, void* aDataContext) -> double
     {
         (void)aGradient;
         if (aDataContext == nullptr)
@@ -1045,24 +1047,30 @@ Instant Generator::FindTimeOfClosestApproach(
 
         const auto [queryFromState, queryToState] = contextPtr->getStatesAt(queryInstant);
 
+        const Shared<const Frame>& celestialFrameSPtr = contextPtr->celestialSPtr->accessFrame();
+
         const Vector3d deltaPosition =
-            queryFromState.getPosition().inFrame(aCelestialSPtr->accessFrame(), queryInstant).accessCoordinates() -
-            queryToState.getPosition().inFrame(aCelestialSPtr->accessFrame(), queryInstant).accessCoordinates();
+            queryFromState.getPosition().inFrame(celestialFrameSPtr, queryInstant).accessCoordinates() -
+            queryToState.getPosition().inFrame(celestialFrameSPtr, queryInstant).accessCoordinates();
 
         const Real rangeSquared = deltaPosition.squaredNorm();
 
         return rangeSquared;
     };
 
+    const std::function<Pair<State, State>(const Instant& anInstant)> getStatesAt =
+        [&aFromTrajectory, &aToTrajectory](const Instant& anInstant) -> Pair<State, State>
+    {
+        return {
+            aFromTrajectory.getStateAt(anInstant),
+            aToTrajectory.getStateAt(anInstant),
+        };
+    };
+
     Context context = {
         anAccessInterval.getStart(),
-        [&aFromTrajectory, &aToTrajectory](const Instant& anInstant) -> Pair<State, State>
-        {
-            return {
-                aFromTrajectory.getStateAt(anInstant),
-                aToTrajectory.getStateAt(anInstant),
-            };
-        },
+        getStatesAt,
+        aCelestialSPtr,
     };
 
     nlopt::opt optimizer = {nlopt::LN_COBYLA, 1};

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/LineOfSight.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/LineOfSight.cpp
@@ -25,13 +25,26 @@ using ostk::physics::environment::Object;
 VisibilityCriterion::LineOfSight::LineOfSight(const Environment& anEnvironment)
     : environment(anEnvironment)
 {
+    if (!anEnvironment.hasCentralCelestialObject())
+    {
+        std::cout << "Warning: Environment must have a central celestial object for LineOfSight criterion."
+                  << std::endl;
+    }
 }
 
 bool VisibilityCriterion::LineOfSight::isSatisfied(
     const Instant& anInstant, const Vector3d& aFromPositionCoordinates_ITRF, const Vector3d& aToPositionCoordinates_ITRF
 ) const
 {
-    static const Shared<const Frame> commonFrameSPtr = Frame::ITRF();
+    Shared<const Frame> commonFrameSPtr = nullptr;
+    if (this->environment.hasCentralCelestialObject())
+    {
+        commonFrameSPtr = this->environment.accessCentralCelestialObject()->accessFrame();
+    }
+    else
+    {
+        commonFrameSPtr = Frame::ITRF();
+    }
 
     this->environment.setInstant(anInstant);
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/LineOfSight.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/LineOfSight.cpp
@@ -36,6 +36,7 @@ bool VisibilityCriterion::LineOfSight::isSatisfied(
     const Instant& anInstant, const Vector3d& aFromPositionCoordinates_ITRF, const Vector3d& aToPositionCoordinates_ITRF
 ) const
 {
+    // TBR: Deprecate this check in a future release
     Shared<const Frame> commonFrameSPtr = nullptr;
     if (this->environment.hasCentralCelestialObject())
     {

--- a/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/LineOfSight.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access/VisibilityCriterion/LineOfSight.cpp
@@ -27,13 +27,13 @@ VisibilityCriterion::LineOfSight::LineOfSight(const Environment& anEnvironment)
 {
     if (!anEnvironment.hasCentralCelestialObject())
     {
-        std::cout << "Warning: Environment must have a central celestial object for LineOfSight criterion."
+        std::cerr << "Warning: Environment must have a central celestial object for LineOfSight criterion."
                   << std::endl;
     }
 }
 
 bool VisibilityCriterion::LineOfSight::isSatisfied(
-    const Instant& anInstant, const Vector3d& aFromPositionCoordinates_ITRF, const Vector3d& aToPositionCoordinates_ITRF
+    const Instant& anInstant, const Vector3d& aFromPositionCoordinates_Body, const Vector3d& aToPositionCoordinates_Body
 ) const
 {
     // TBR: Deprecate this check in a future release
@@ -49,8 +49,8 @@ bool VisibilityCriterion::LineOfSight::isSatisfied(
 
     this->environment.setInstant(anInstant);
 
-    const Point fromPositionCoordinates = Point::Vector(aFromPositionCoordinates_ITRF);
-    const Point toPositionCoordinates = Point::Vector(aToPositionCoordinates_ITRF);
+    const Point fromPositionCoordinates = Point::Vector(aFromPositionCoordinates_Body);
+    const Point toPositionCoordinates = Point::Vector(aToPositionCoordinates_Body);
 
     if (fromPositionCoordinates == toPositionCoordinates)
     {

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/AtmosphericDrag.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/AtmosphericDrag.cpp
@@ -103,7 +103,7 @@ VectorXd AtmosphericDrag::computeContribution(
             .getValue();
 
     const Vector3d earthAngularVelocity =
-        aFrameSPtr->getTransformTo(Frame::ITRF(), anInstant).getAngularVelocity();  // rad/s
+        aFrameSPtr->getTransformTo(celestialObjectSPtr_->accessFrame(), anInstant).getAngularVelocity();  // rad/s
 
     const Vector3d relativeVelocity = velocityCoordinates - earthAngularVelocity.cross(positionCoordinates);
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
@@ -418,7 +418,7 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
 
     const Shared<const Frame> celestialFrameSPtr = aCelestialSPtr->accessFrame();
 
-    const auto targetVectorGenerator = [aCelestialSPtr, celestialFrame](const Shared<const Target>& aTargetSPtr
+    const auto targetVectorGenerator = [aCelestialSPtr, celestialFrameSPtr](const Shared<const Target>& aTargetSPtr
                                        ) -> std::function<Vector3d(const State&)>
     {
         switch (aTargetSPtr->type)
@@ -452,10 +452,10 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
             {
                 const Shared<const TrajectoryTarget> targetVelocitySPtr =
                     std::static_pointer_cast<const TrajectoryTarget>(aTargetSPtr);
-                return [targetVelocitySPtr, celestialFrame](const State& aState) -> Vector3d
+                return [targetVelocitySPtr, celestialFrameSPtr](const State& aState) -> Vector3d
                 {
                     return Profile::ComputeTargetSlidingGroundVelocityVector(
-                        aState, targetVelocitySPtr->trajectory, celestialFrame
+                        aState, targetVelocitySPtr->trajectory, celestialFrameSPtr
                     );
                 };
             }
@@ -542,9 +542,9 @@ Vector3d Profile::ComputeGeodeticNadirDirectionVector(
     const State& aState, const Shared<const Celestial>& aCelestialSPtr
 )
 {
-    const Shared<const Frame> celestialFrame = aCelestialSPtr->accessFrame();
+    const Shared<const Frame> celestialFrameSPtr = aCelestialSPtr->accessFrame();
     const Transform celestialFrame_GCRF_transform =
-        celestialFrame->getTransformTo(DEFAULT_PROFILE_FRAME, aState.accessInstant());
+        celestialFrameSPtr->getTransformTo(DEFAULT_PROFILE_FRAME, aState.accessInstant());
 
     const LLA lla = LLA::Cartesian(
         celestialFrame_GCRF_transform.getInverse().applyToPosition(

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
@@ -4,6 +4,7 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp>
 #include <OpenSpaceToolkit/Physics/Coordinate/Transform.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Moon.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Sun.hpp>
 
@@ -19,6 +20,7 @@ namespace flight
 
 using ostk::core::type::Real;
 
+using ostk::physics::environment::object::celestial::Earth;
 using ostk::physics::environment::object::celestial::Moon;
 using ostk::physics::environment::object::celestial::Sun;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
@@ -338,8 +340,9 @@ Profile Profile::CustomPointing(
     const Angle& anAngularOffset
 )
 {
-    const auto orientationGenerator =
-        Profile::AlignAndConstrain(anAlignmentTargetSPtr, aClockingTargetSPtr, anAngularOffset);
+    const auto orientationGenerator = Profile::AlignAndConstrain(
+        anAlignmentTargetSPtr, aClockingTargetSPtr, anOrbit.accessCelestialObject(), anAngularOffset
+    );
 
     return Profile::CustomPointing(anOrbit, orientationGenerator);
 }
@@ -374,6 +377,17 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
     const Angle& anAngularOffset
 )
 {
+    const Shared<const Celestial> celestialSPtr = std::make_shared<Earth>(Earth::Default());
+    return Profile::AlignAndConstrain(anAlignmentTargetSPtr, aClockingTargetSPtr, celestialSPtr, anAngularOffset);
+}
+
+std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
+    const Shared<const Target>& anAlignmentTargetSPtr,
+    const Shared<const Target>& aClockingTargetSPtr,
+    const Shared<const Celestial>& aCelestialSPtr,
+    const Angle& anAngularOffset
+)
+{
     if ((anAlignmentTargetSPtr->type == aClockingTargetSPtr->type) &&
         (anAlignmentTargetSPtr->type != TargetType::TargetPosition) &&
         (anAlignmentTargetSPtr->type != TargetType::TargetVelocity))
@@ -402,7 +416,9 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
         );
     }
 
-    const auto targetVectorGenerator = [](const Shared<const Target>& aTargetSPtr
+    const Shared<const Frame> celestialFrame = aCelestialSPtr->accessFrame();
+
+    const auto targetVectorGenerator = [aCelestialSPtr, celestialFrame](const Shared<const Target>& aTargetSPtr
                                        ) -> std::function<Vector3d(const State&)>
     {
         switch (aTargetSPtr->type)
@@ -410,7 +426,10 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
             case TargetType::GeocentricNadir:
                 return Profile::ComputeGeocentricNadirDirectionVector;
             case TargetType::GeodeticNadir:
-                return Profile::ComputeGeodeticNadirDirectionVector;
+                return [aCelestialSPtr](const State& aState) -> Vector3d
+                {
+                    return Profile::ComputeGeodeticNadirDirectionVector(aState, aCelestialSPtr);
+                };
             case TargetType::TargetPosition:
             {
                 const Shared<const TrajectoryTarget> targetPositionSPtr =
@@ -433,9 +452,11 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
             {
                 const Shared<const TrajectoryTarget> targetVelocitySPtr =
                     std::static_pointer_cast<const TrajectoryTarget>(aTargetSPtr);
-                return [targetVelocitySPtr](const State& aState) -> Vector3d
+                return [targetVelocitySPtr, celestialFrame](const State& aState) -> Vector3d
                 {
-                    return Profile::ComputeTargetSlidingGroundVelocityVector(aState, targetVelocitySPtr->trajectory);
+                    return Profile::ComputeTargetSlidingGroundVelocityVector(
+                        aState, targetVelocitySPtr->trajectory, celestialFrame
+                    );
                 };
             }
             case TargetType::Sun:
@@ -517,16 +538,20 @@ Vector3d Profile::ComputeGeocentricNadirDirectionVector(const State& aState)
     return -aState.inFrame(DEFAULT_PROFILE_FRAME).getPosition().accessCoordinates().normalized();
 }
 
-Vector3d Profile::ComputeGeodeticNadirDirectionVector(const State& aState)
+Vector3d Profile::ComputeGeodeticNadirDirectionVector(
+    const State& aState, const Shared<const Celestial>& aCelestialSPtr
+)
 {
-    const Transform ITRF_GCRF_transform = Frame::ITRF()->getTransformTo(DEFAULT_PROFILE_FRAME, aState.accessInstant());
+    const Shared<const Frame> celestialFrame = aCelestialSPtr->accessFrame();
+    const Transform celestialFrame_GCRF_transform =
+        celestialFrame->getTransformTo(DEFAULT_PROFILE_FRAME, aState.accessInstant());
 
     const LLA lla = LLA::Cartesian(
-        ITRF_GCRF_transform.getInverse().applyToPosition(
+        celestialFrame_GCRF_transform.getInverse().applyToPosition(
             aState.inFrame(DEFAULT_PROFILE_FRAME).getPosition().accessCoordinates()
         ),
-        EarthGravitationalModel::EGM2008.equatorialRadius_,
-        EarthGravitationalModel::EGM2008.flattening_
+        aCelestialSPtr->getEquatorialRadius(),
+        aCelestialSPtr->getFlattening()
     );
 
     const Vector3d nadir = {
@@ -535,7 +560,7 @@ Vector3d Profile::ComputeGeodeticNadirDirectionVector(const State& aState)
         -std::sin(lla.getLatitude().inRadians()),
     };
 
-    return ITRF_GCRF_transform.applyToVector(nadir).normalized();
+    return celestialFrame_GCRF_transform.applyToVector(nadir).normalized();
 }
 
 Vector3d Profile::ComputeTargetDirectionVector(const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory)
@@ -563,13 +588,15 @@ Vector3d Profile::ComputeTargetVelocityVector(const State& aState, const ostk::a
 }
 
 Vector3d Profile::ComputeTargetSlidingGroundVelocityVector(
-    const State& aState, const ostk::astrodynamics::Trajectory& aTrajectory
+    const State& aState,
+    const ostk::astrodynamics::Trajectory& aTrajectory,
+    const Shared<const Frame>& aCelestialFrameSPtr
 )
 {
     const Instant& instant = aState.accessInstant();
 
     const Vector3d targetSlidingGroundVelocityCoordinates =
-        aTrajectory.getStateAt(instant).inFrame(Frame::ITRF()).getVelocity().accessCoordinates();
+        aTrajectory.getStateAt(instant).inFrame(aCelestialFrameSPtr).getVelocity().accessCoordinates();
 
     if (targetSlidingGroundVelocityCoordinates.isZero())
     {
@@ -579,10 +606,10 @@ Vector3d Profile::ComputeTargetSlidingGroundVelocityVector(
         );
     }
 
-    const Transform ITRF_GCRF_transform = Frame::ITRF()->getTransformTo(DEFAULT_PROFILE_FRAME, instant);
+    const Transform celestialFrame_GCRF_transform = aCelestialFrameSPtr->getTransformTo(DEFAULT_PROFILE_FRAME, instant);
 
     const Vector3d slidingTargetGroundVelocityCoordinatesRotated =
-        ITRF_GCRF_transform.applyToVector(targetSlidingGroundVelocityCoordinates);
+        celestialFrame_GCRF_transform.applyToVector(targetSlidingGroundVelocityCoordinates);
 
     return slidingTargetGroundVelocityCoordinatesRotated.normalized();
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile.cpp
@@ -416,7 +416,7 @@ std::function<Quaternion(const State&)> Profile::AlignAndConstrain(
         );
     }
 
-    const Shared<const Frame> celestialFrame = aCelestialSPtr->accessFrame();
+    const Shared<const Frame> celestialFrameSPtr = aCelestialSPtr->accessFrame();
 
     const auto targetVectorGenerator = [aCelestialSPtr, celestialFrame](const Shared<const Target>& aTargetSPtr
                                        ) -> std::function<Vector3d(const State&)>

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.cpp
@@ -18,9 +18,11 @@ Static::Static(const Position& aPosition)
     : Model(),
       position_(aPosition)
 {
-    if (aPosition.accessFrame() != Frame::ITRF())
+    if (aPosition.accessFrame()->isQuasiInertial())
     {
-        throw ostk::core::error::runtime::Wrong("Position Frame", aPosition.accessFrame()->getName());
+        throw ostk::core::error::runtime::Wrong(
+            "Position Frame Quasi Inertial", aPosition.accessFrame()->isQuasiInertial()
+        );
     }
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.cpp
@@ -18,9 +18,11 @@ Static::Static(const Position& aPosition)
     : Model(),
       position_(aPosition)
 {
-    if ((*aPosition.accessFrame()) != (*Frame::ITRF()))
+    if (aPosition.accessFrame()->isQuasiInertial())
     {
-        throw ostk::core::error::runtime::Wrong("Position Frame", aPosition.accessFrame()->getName());
+        throw ostk::core::error::runtime::Wrong(
+            "Position Frame Quasi Inertial", aPosition.accessFrame()->isQuasiInertial()
+        );
     }
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.cpp
@@ -624,9 +624,10 @@ Shared<const Frame> Orbit::getOrbitalFrame(const Orbit::FrameType& aFrameType) c
                     std::sin(latitude_radians),
                 };
 
-                const Vector3d xAxis = -(Frame::ITRF()->getTransformTo(Frame::GCRF(), aState.accessInstant()))
-                                            .applyToVector(nadir_ITRF)
-                                            .normalized();
+                const Vector3d xAxis =
+                    -(this->celestialObjectSPtr_->accessFrame()->getTransformTo(Frame::GCRF(), aState.accessInstant()))
+                         .applyToVector(nadir_ITRF)
+                         .normalized();
 
                 const Vector3d zAxis = (xAxis.cross(x_GCRF.cross(v_GCRF).normalized())).cross(xAxis).normalized();
                 const Vector3d yAxis = zAxis.cross(xAxis).normalized();
@@ -673,9 +674,10 @@ Shared<const Frame> Orbit::getOrbitalFrame(const Orbit::FrameType& aFrameType) c
                     std::sin(latitude_radians),
                 };
 
-                const Vector3d xAxis = -(Frame::ITRF()->getTransformTo(Frame::GCRF(), aState.accessInstant()))
-                                            .applyToVector(nadir_ITRF)
-                                            .normalized();
+                const Vector3d xAxis =
+                    -(this->celestialObjectSPtr_->accessFrame()->getTransformTo(Frame::GCRF(), aState.accessInstant()))
+                         .applyToVector(nadir_ITRF)
+                         .normalized();
 
                 const Vector3d zAxis = (xAxis.cross(x_GCRF.cross(v_GCRF).normalized())).cross(xAxis).normalized();
                 const Vector3d yAxis = zAxis.cross(xAxis).normalized();
@@ -698,7 +700,9 @@ Shared<const Frame> Orbit::getOrbitalFrame(const Orbit::FrameType& aFrameType) c
                 const bool isPassDescending = v_GCRF.z() < 0.0;
 
                 const Real w_ITRF_GCRF_in_ITRF_z =
-                    (Frame::GCRF()->getTransformTo(Frame::ITRF(), aState.accessInstant())).getAngularVelocity().z();
+                    (Frame::GCRF()->getTransformTo(this->celestialObjectSPtr_->accessFrame(), aState.accessInstant()))
+                        .getAngularVelocity()
+                        .z();
 
                 const Real k = meanMotion.in(AngularVelocitySIUnit) /
                                (w_ITRF_GCRF_in_ITRF_z - nodalPrecessionRate.in(AngularVelocitySIUnit));

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -1361,7 +1361,8 @@ COE COE::GeoSynchronous(
     const LLA lla = {Angle::Zero(), aLongitude, geosynchronousAltitude};
     const Vector3d ascendingNodeVectorITRF =
         lla.toCartesian(aCelestialObjectSPtr->getEquatorialRadius(), aCelestialObjectSPtr->getFlattening());
-    const Position ascendingNodePositionITRF = Position::Meters(ascendingNodeVectorITRF, Frame::ITRF());
+    const Position ascendingNodePositionITRF =
+        Position::Meters(ascendingNodeVectorITRF, aCelestialObjectSPtr->accessFrame());
     const Vector3d ascendingNodeVectorGCRF = ascendingNodePositionITRF.inFrame(Frame::GCRF(), anEpoch).getCoordinates();
 
     // Define COEs that make up this orbit

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -1443,7 +1443,8 @@ COE COE::GeoSynchronous(
     const LLA lla = {Angle::Zero(), aLongitude, geosynchronousAltitude};
     const Vector3d ascendingNodeVectorITRF =
         lla.toCartesian(aCelestialObjectSPtr->getEquatorialRadius(), aCelestialObjectSPtr->getFlattening());
-    const Position ascendingNodePositionITRF = Position::Meters(ascendingNodeVectorITRF, Frame::ITRF());
+    const Position ascendingNodePositionITRF =
+        Position::Meters(ascendingNodeVectorITRF, aCelestialObjectSPtr->accessFrame());
     const Vector3d ascendingNodeVectorGCRF = ascendingNodePositionITRF.inFrame(Frame::GCRF(), anEpoch).getCoordinates();
 
     // Define COEs that make up this orbit

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -1443,9 +1443,10 @@ COE COE::GeoSynchronous(
     const LLA lla = {Angle::Zero(), aLongitude, geosynchronousAltitude};
     const Vector3d ascendingNodeVectorITRF =
         lla.toCartesian(aCelestialObjectSPtr->getEquatorialRadius(), aCelestialObjectSPtr->getFlattening());
-    const Position ascendingNodePositionITRF =
+    const Position ascendingNodePositionBodyFrame =
         Position::Meters(ascendingNodeVectorITRF, aCelestialObjectSPtr->accessFrame());
-    const Vector3d ascendingNodeVectorGCRF = ascendingNodePositionITRF.inFrame(Frame::GCRF(), anEpoch).getCoordinates();
+    const Vector3d ascendingNodeVectorGCRF =
+        ascendingNodePositionBodyFrame.inFrame(Frame::GCRF(), anEpoch).getCoordinates();
 
     // Define COEs that make up this orbit
     const Length semiMajorAxis = aCelestialObjectSPtr->getEquatorialRadius() + geosynchronousAltitude;

--- a/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access/Generator.test.cpp
@@ -214,6 +214,20 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Access_AccessTarget, GetPosition)
     }
 
     {
+        EXPECT_VECTORS_ALMOST_EQUAL(
+            defaultAccessTarget_.getPosition(defaultEarthSPtr_).accessCoordinates(),
+            Position::Meters(
+                defaultLLA_.toCartesian(
+                    EarthGravitationalModel::EGM2008.equatorialRadius_, EarthGravitationalModel::EGM2008.flattening_
+                ),
+                defaultEarthSPtr_->accessFrame()
+            )
+                .accessCoordinates(),
+            1e-13
+        );
+    }
+
+    {
         const AccessTarget nonFixedAccessTarget = AccessTarget::FromTrajectory(
             defaultVisibilityCriterion_, Trajectory::Position(defaultAccessTarget_.getPosition())
         );


### PR DESCRIPTION
Cleaning up any hardcoded Frame::ITRF(), ideally these are taken from the relevant Celestial's ephemeris body frame, rather than always using the Frame::ITRF() (which is an order of magnitude slower than the SPICE based frame).

  1. Access Generator (Generator.cpp, Generator.hpp)

  - Updated internal methods to accept Shared<const Celestial> parameter
  - Uses celestialSPtr->accessFrame() instead of Frame::ITRF() for position transformations
  - Uses celestial's getEquatorialRadius() and getFlattening() for LLA calculations
  - Uses Celestial::FrameType::NED instead of Earth::FrameType::NED
  - AccessTarget::FromLLA now uses aCelestialSPtr->accessFrame() for positions
  - Added warning if environment lacks a central celestial object

  2. Line of Sight Visibility Criterion (LineOfSight.cpp)

  - Uses environment.accessCentralCelestialObject()->accessFrame() instead of hardcoded ITRF
  - Falls back to Frame::ITRF() if no central celestial object exists (will eventually be deprecated)
  - Added warning for missing central celestial object

  3. Atmospheric Drag Dynamics (AtmosphericDrag.cpp)

  - Uses celestialObjectSPtr_->accessFrame() for computing Earth angular velocity

  4. Flight Profile (Profile.hpp, Profile.cpp, bindings)

  - New overload: AlignAndConstrain(alignmentTarget, clockingTarget, celestialSPtr, angularOffset)
  - Deprecated: Original AlignAndConstrain without celestial parameter
  - CustomPointing now uses anOrbit.accessCelestialObject() to get the celestial
  - Updated helper functions:
    - ComputeGeodeticNadirDirectionVector(state, celestialSPtr) - uses celestial's frame and shape parameters
    - ComputeTargetSlidingGroundVelocityVector(state, trajectory, celestialFrameSPtr) - uses provided frame
  - Python bindings updated with deprecation warning for old signature

  5. Trajectory Components

  - Static.cpp: Minor frame-related updates
  - Orbit.cpp: Uses celestial frame where appropriate
  - COE.cpp: Minor updates for celestial frame usage

  6. Tests (Profile.test.cpp)

  - Added AlignAndConstrain_Celestial test verifying:
    - GeodeticNadir with Earth celestial matches original behavior
    - TargetSlidingGroundVelocity with Earth celestial matches original
    - Angular offset works with celestial parameter

  Migration Path

  Replace:
```
  Profile::AlignAndConstrain(alignmentTarget, clockingTarget, angularOffset);
```
  With:
```
  Profile::AlignAndConstrain(alignmentTarget, clockingTarget, celestialSPtr, angularOffset);
```

When instantiating `Generator`, or `LineOfSight` Visibility Conditions, use an environment that has a central celestial body (the default Environment does).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alignment, access, trajectory, dynamics, and visibility calculations now support explicit celestial contexts and reference frames for bodies beyond Earth.
  * Access generation uses the environment’s central celestial body and its shape parameters when available.
* **Deprecations**
  * The legacy alignment overload is deprecated; use the celestial-aware variant instead.
* **Backward Compatibility**
  * The legacy overload remains available, emits a warning, and defaults to Earth.
* **Tests**
  * Updated coverage validates celestial-aware alignment and Earth-context results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->