### PR TITLE
feat: generalize condition based solving

### DIFF
--- a/benchmark/OpenSpaceToolkit/Astrodynamics/Segment.benchmark.cpp
+++ b/benchmark/OpenSpaceToolkit/Astrodynamics/Segment.benchmark.cpp
@@ -96,6 +96,7 @@ using ostk::astrodynamics::flight::system::PropulsionSystem;
 using ostk::astrodynamics::flight::system::SatelliteSystem;
 using ostk::astrodynamics::guidancelaw::ConstantThrust;
 using ostk::astrodynamics::guidancelaw::QLaw;
+using ostk::astrodynamics::RootSolver;
 using ostk::astrodynamics::trajectory::Segment;
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::state::CoordinateBroker;
@@ -170,7 +171,13 @@ static Array<Shared<Dynamics>> BuildDynamics()
 static NumericalSolver BuildSolver()
 {
     return NumericalSolver(
-        NumericalSolver::LogType::NoLog, NumericalSolver::StepperType::RungeKuttaFehlberg78, 5.0, 1.0e-12, 1.0e-12
+        NumericalSolver::LogType::NoLog,
+        NumericalSolver::StepperType::RungeKuttaFehlberg78,
+        5.0,
+        1.0e-12,
+        1.0e-12,
+        RootSolver::Default(),
+        NumericalSolver::RootFindingStrategy::Integration
     );
 }
 

--- a/benchmark/OpenSpaceToolkit/Astrodynamics/Segment.benchmark.cpp
+++ b/benchmark/OpenSpaceToolkit/Astrodynamics/Segment.benchmark.cpp
@@ -177,7 +177,7 @@ static NumericalSolver BuildSolver()
         1.0e-12,
         1.0e-12,
         RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::Integration
+        NumericalSolver::RootFindingStrategy::CubicInterpolation
     );
 }
 

--- a/benchmark/OpenSpaceToolkit/Astrodynamics/Segment.benchmark.cpp
+++ b/benchmark/OpenSpaceToolkit/Astrodynamics/Segment.benchmark.cpp
@@ -170,7 +170,7 @@ static Array<Shared<Dynamics>> BuildDynamics()
 static NumericalSolver BuildSolver()
 {
     return NumericalSolver(
-        NumericalSolver::LogType::NoLog, NumericalSolver::StepperType::RungeKuttaDopri5, 5.0, 1.0e-12, 1.0e-12
+        NumericalSolver::LogType::NoLog, NumericalSolver::StepperType::RungeKuttaFehlberg78, 5.0, 1.0e-12, 1.0e-12
     );
 }
 
@@ -570,5 +570,4 @@ BENCHMARK(BM_Segment_ConstantThrust_Intrack_550_to_580)->Iterations(1)->Unit(ben
 BENCHMARK(BM_Segment_QLaw_Analytical_SMA_550_to_580)->Iterations(1)->Unit(benchmark::kSecond);
 BENCHMARK(BM_Segment_QLaw_FiniteDifference_SMA_550_to_580)->Iterations(1)->Unit(benchmark::kSecond);
 BENCHMARK(BM_Segment_QLaw_Analytical_Frozen_550_to_580)->Iterations(1)->Unit(benchmark::kSecond);
-BENCHMARK(BM_Segment_QLaw_FiniteDifference_Frozen_550_to_580)->Iterations(1)->Unit(benchmark::kSecond);
 BENCHMARK(BM_Segment_ConstantThrust_Intrack_DutyCycle_550_to_580)->Iterations(1)->Unit(benchmark::kSecond);

--- a/benchmark/OpenSpaceToolkit/Astrodynamics/Segment.benchmark.cpp
+++ b/benchmark/OpenSpaceToolkit/Astrodynamics/Segment.benchmark.cpp
@@ -176,8 +176,7 @@ static NumericalSolver BuildSolver()
         5.0,
         1.0e-12,
         1.0e-12,
-        RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::CubicInterpolation
+        RootSolver::Default()
     );
 }
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Sequence.cpp
@@ -228,7 +228,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
 
                     Args:
                     segments (list[Segment], optional): The segments. Defaults to an empty list.
-                    numerical_solver (NumericalSolver, optional): The numerical solver. Defaults to the default conditional numerical solver.
+                    numerical_solver (NumericalSolver, optional): The numerical solver. Defaults to the default numerical solver.
                     dynamics (list[Dynamics], optional): The dynamics. Defaults to an empty list.
                     maximum_propagation_duration (Duration, optional): The maximum propagation duration. Defaults to 30 days.
                     verbosity (int, optional): The verbosity level. Defaults to 1.
@@ -238,9 +238,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Sequence(pybind11::module
 
                 )doc",
                 arg_v("segments", Array<Segment>::Empty(), "[]"),
-                arg_v(
-                    "numerical_solver", NumericalSolver::DefaultConditional(), "NumericalSolver.default_conditional()"
-                ),
+                arg_v("numerical_solver", NumericalSolver::Default(), "NumericalSolver.default()"),
                 arg_v("dynamics", Array<Shared<Dynamics>>::Empty(), "[]"),
                 arg_v("maximum_propagation_duration", Duration::Days(30.0), "Duration.days(30.0)"),
                 arg("verbosity") = 1

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -366,7 +366,15 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             )
             .def_static(
                 "default_conditional",
-                &NumericalSolver::DefaultConditional,
+                +[](const std::function<void(const State&)>& stateLogger = nullptr) -> NumericalSolver
+                {
+                    PyErr_WarnEx(
+                        PyExc_DeprecationWarning,
+                        "NumericalSolver.default_conditional is deprecated. Use NumericalSolver.default instead.",
+                        1
+                    );
+                    return NumericalSolver::DefaultConditional(stateLogger);
+                },
                 R"doc(
                     Return the default conditional numerical solver.
 
@@ -380,7 +388,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             )
             .def_static(
                 "conditional",
-                &NumericalSolver::Conditional,
+                +[](const Real& aTimeStep,
+                    const Real& aRelativeTolerance,
+                    const Real& anAbsoluteTolerance,
+                    const std::function<void(const State&)>& stateLogger = nullptr) -> NumericalSolver
+                {
+                    PyErr_WarnEx(
+                        PyExc_DeprecationWarning,
+                        "NumericalSolver.conditional is deprecated. Use NumericalSolver constructor instead.",
+                        1
+                    );
+                    return NumericalSolver::Conditional(
+                        aTimeStep, aRelativeTolerance, anAbsoluteTolerance, stateLogger
+                    );
+                },
                 R"doc(
                     Return a conditional numerical solver.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -51,6 +51,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             "Re-integrate with smaller steps during root finding"
         )
         .value(
+            "CubicInterpolation",
+            NumericalSolver::RootFindingStrategy::CubicInterpolation,
+            "Cubic interpolation between step endpoints"
+        )
+        .value(
             "Skip",
             NumericalSolver::RootFindingStrategy::Skip,
             "Skip the root finding and return the first step boundary where condition is satisfied"
@@ -228,9 +233,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
 
                     const NumericalSolver::SystemOfEquationsWrapper& systemOfEquations =
-                        [&](const NumericalSolver::StateVector& x,
-                            NumericalSolver::StateVector& dxdt,
-                            const double t) -> void
+                        [&](const NumericalSolver::StateVector& x, NumericalSolver::StateVector& dxdt, const double t
+                        ) -> void
                     {
                         dxdt = pythonDynamicsEquation(x, dxdt, t);
                     };
@@ -265,9 +269,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
 
                     const NumericalSolver::SystemOfEquationsWrapper& systemOfEquations =
-                        [&](const NumericalSolver::StateVector& x,
-                            NumericalSolver::StateVector& dxdt,
-                            const double t) -> void
+                        [&](const NumericalSolver::StateVector& x, NumericalSolver::StateVector& dxdt, const double t
+                        ) -> void
                     {
                         dxdt = pythonDynamicsEquation(x, dxdt, t);
                     };
@@ -303,9 +306,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
 
                     const NumericalSolver::SystemOfEquationsWrapper& systemOfEquations =
-                        [&](const NumericalSolver::StateVector& x,
-                            NumericalSolver::StateVector& dxdt,
-                            const double t) -> void
+                        [&](const NumericalSolver::StateVector& x, NumericalSolver::StateVector& dxdt, const double t
+                        ) -> void
                     {
                         dxdt = pythonDynamicsEquation(x, dxdt, t);
                     };

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -38,18 +38,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
         "RootFindingStrategy",
         R"doc(
             The strategy for finding the exact event crossing time during conditional integration.
-
-            - DenseOutput: Use dense stepper interpolation (only for RungeKuttaDopri5). Most accurate.
-            - Linear: Linear interpolation between step endpoints. Fast but less accurate.
-            - Propagated: Re-integrate with smaller sub-steps. Accurate but slower.
-            - Boundary: Return step boundary where condition is first satisfied. Simplest, no refinement.
         )doc"
     )
-        .value(
-            "DenseOutput",
-            NumericalSolver::RootFindingStrategy::DenseOutput,
-            "Use dense output interpolation (RungeKuttaDopri5 only)"
-        )
         .value("Linear", NumericalSolver::RootFindingStrategy::Linear, "Linear interpolation between step endpoints")
         .value(
             "Propagated",
@@ -135,7 +125,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         relative_tolerance (float): The relative tolerance.
                         absolute_tolerance (float): The absolute tolerance.
                         root_solver (RootSolver, optional): The root solver. Defaults to RootSolver.Default().
-                        root_finding_strategy (RootFindingStrategy, optional): The root finding strategy. Defaults to DenseOutput.
 
                 )doc",
                 arg("log_type"),
@@ -144,11 +133,37 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 arg("relative_tolerance"),
                 arg("absolute_tolerance"),
                 arg_v("root_solver", RootSolver::Default(), "RootSolver.default()"),
-                arg_v(
-                    "root_finding_strategy",
-                    NumericalSolver::RootFindingStrategy::DenseOutput,
-                    "NumericalSolver.RootFindingStrategy.DenseOutput"
-                )
+            )
+
+            .def(
+                init<
+                    const NumericalSolver::LogType&,
+                    const NumericalSolver::StepperType&,
+                    const Real&,
+                    const Real&,
+                    const Real&,
+                    const RootSolver&,
+                    const NumericalSolver::RootFindingStrategy&>(),
+                R"doc(
+                    Constructor.
+
+                    Args:
+                        log_type (NumericalSolver.LogType): The type of logging.
+                        stepper_type (NumericalSolver.StepperType): The type of stepper.
+                        time_step (float): The time step.
+                        relative_tolerance (float): The relative tolerance.
+                        absolute_tolerance (float): The absolute tolerance.
+                        root_solver (RootSolver): The root solver.
+                        root_finding_strategy (RootFindingStrategy): The root finding strategy.
+
+                )doc",
+                arg("log_type"),
+                arg("stepper_type"),
+                arg("time_step"),
+                arg("relative_tolerance"),
+                arg("absolute_tolerance"),
+                arg("root_solver"),
+                arg("root_finding_strategy")
             )
 
             .def(self == self)
@@ -357,17 +372,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Args:
                         state_logger (StateLogger, optional): The state logger. Defaults to None.
-                        root_finding_strategy (RootFindingStrategy, optional): The root finding strategy. Defaults to DenseOutput.
 
                     Returns:
                         NumericalSolver: The default conditional numerical solver.
                 )doc",
-                arg_v("state_logger", nullptr, "None"),
-                arg_v(
-                    "root_finding_strategy",
-                    NumericalSolver::RootFindingStrategy::DenseOutput,
-                    "NumericalSolver.RootFindingStrategy.DenseOutput"
-                )
+                arg_v("state_logger", nullptr, "None")
             )
             .def_static(
                 "conditional",
@@ -380,7 +389,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         relative_tolerance (float): The relative tolerance.
                         absolute_tolerance (float): The absolute tolerance.
                         state_logger (StateLogger, optional): The state logger. Defaults to None.
-                        root_finding_strategy (RootFindingStrategy, optional): The root finding strategy. Defaults to DenseOutput.
 
                     Returns:
                         NumericalSolver: The conditional numerical solver.
@@ -388,11 +396,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 arg("time_step"),
                 arg("relative_tolerance"),
                 arg("absolute_tolerance"),
-                arg_v("state_logger", nullptr, "None") arg_v(
-                    "root_finding_strategy",
-                    NumericalSolver::RootFindingStrategy::DenseOutput,
-                    "NumericalSolver.RootFindingStrategy.DenseOutput"
-                )
+                arg_v("state_logger", nullptr, "None")
             )
             .def_static(
                 "string_from_root_finding_strategy",

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -40,16 +40,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             The strategy for finding the exact event crossing time during conditional integration.
         )doc"
     )
-        .value("Linear", NumericalSolver::RootFindingStrategy::Linear, "Linear interpolation between step endpoints")
+        .value(
+            "LinearInterpolation",
+            NumericalSolver::RootFindingStrategy::LinearInterpolation,
+            "Linear interpolation between step endpoints"
+        )
         .value(
             "Propagated",
             NumericalSolver::RootFindingStrategy::Propagated,
             "Re-integrate with smaller steps during root finding"
         )
         .value(
-            "Boundary",
-            NumericalSolver::RootFindingStrategy::Boundary,
-            "Return first step boundary where condition is satisfied"
+            "Skip",
+            NumericalSolver::RootFindingStrategy::Skip,
+            "Skip the root finding and return the first step boundary where condition is satisfied"
         );
 
     class_<NumericalSolver::ConditionSolution>(
@@ -113,8 +117,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     const Real&,
                     const Real&,
                     const Real&,
-                    const RootSolver&,
-                    const NumericalSolver::RootFindingStrategy&>(),
+                    const RootSolver&>(),
                 R"doc(
                     Constructor.
 
@@ -132,7 +135,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 arg("time_step"),
                 arg("relative_tolerance"),
                 arg("absolute_tolerance"),
-                arg_v("root_solver", RootSolver::Default(), "RootSolver.default()"),
+                arg_v("root_solver", RootSolver::Default(), "RootSolver.default()")
             )
 
             .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -33,6 +33,35 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             )doc"
     );
 
+    enum_<NumericalSolver::RootFindingStrategy>(
+        numericalSolver,
+        "RootFindingStrategy",
+        R"doc(
+            The strategy for finding the exact event crossing time during conditional integration.
+
+            - DenseOutput: Use dense stepper interpolation (only for RungeKuttaDopri5). Most accurate.
+            - Linear: Linear interpolation between step endpoints. Fast but less accurate.
+            - Propagated: Re-integrate with smaller sub-steps. Accurate but slower.
+            - Boundary: Return step boundary where condition is first satisfied. Simplest, no refinement.
+        )doc"
+    )
+        .value(
+            "DenseOutput",
+            NumericalSolver::RootFindingStrategy::DenseOutput,
+            "Use dense output interpolation (RungeKuttaDopri5 only)"
+        )
+        .value("Linear", NumericalSolver::RootFindingStrategy::Linear, "Linear interpolation between step endpoints")
+        .value(
+            "Propagated",
+            NumericalSolver::RootFindingStrategy::Propagated,
+            "Re-integrate with smaller steps during root finding"
+        )
+        .value(
+            "Boundary",
+            NumericalSolver::RootFindingStrategy::Boundary,
+            "Return first step boundary where condition is satisfied"
+        );
+
     class_<NumericalSolver::ConditionSolution>(
         numericalSolver,
         "ConditionSolution",
@@ -94,7 +123,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     const Real&,
                     const Real&,
                     const Real&,
-                    const RootSolver&>(),
+                    const RootSolver&,
+                    const NumericalSolver::RootFindingStrategy&>(),
                 R"doc(
                     Constructor.
 
@@ -105,6 +135,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         relative_tolerance (float): The relative tolerance.
                         absolute_tolerance (float): The absolute tolerance.
                         root_solver (RootSolver, optional): The root solver. Defaults to RootSolver.Default().
+                        root_finding_strategy (RootFindingStrategy, optional): The root finding strategy. Defaults to DenseOutput.
 
                 )doc",
                 arg("log_type"),
@@ -112,7 +143,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 arg("time_step"),
                 arg("relative_tolerance"),
                 arg("absolute_tolerance"),
-                arg_v("root_solver", RootSolver::Default(), "RootSolver.default()")
+                arg_v("root_solver", RootSolver::Default(), "RootSolver.default()"),
+                arg_v(
+                    "root_finding_strategy",
+                    NumericalSolver::RootFindingStrategy::DenseOutput,
+                    "NumericalSolver.RootFindingStrategy.DenseOutput"
+                )
             )
 
             .def(self == self)
@@ -152,6 +188,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         RootSolver: The root solver.
                 )doc"
             )
+            .def(
+                "get_root_finding_strategy",
+                &NumericalSolver::getRootFindingStrategy,
+                R"doc(
+                    Get the root finding strategy.
+
+                    Returns:
+                        RootFindingStrategy: The root finding strategy.
+                )doc"
+            )
 
             .def(
                 "integrate_time",
@@ -164,8 +210,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
 
                     const NumericalSolver::SystemOfEquationsWrapper& systemOfEquations =
-                        [&](const NumericalSolver::StateVector& x, NumericalSolver::StateVector& dxdt, const double t
-                        ) -> void
+                        [&](const NumericalSolver::StateVector& x,
+                            NumericalSolver::StateVector& dxdt,
+                            const double t) -> void
                     {
                         dxdt = pythonDynamicsEquation(x, dxdt, t);
                     };
@@ -200,8 +247,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
 
                     const NumericalSolver::SystemOfEquationsWrapper& systemOfEquations =
-                        [&](const NumericalSolver::StateVector& x, NumericalSolver::StateVector& dxdt, const double t
-                        ) -> void
+                        [&](const NumericalSolver::StateVector& x,
+                            NumericalSolver::StateVector& dxdt,
+                            const double t) -> void
                     {
                         dxdt = pythonDynamicsEquation(x, dxdt, t);
                     };
@@ -237,8 +285,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         pybind11::cast<pythonSystemOfEquationsSignature>(aSystemOfEquationsObject);
 
                     const NumericalSolver::SystemOfEquationsWrapper& systemOfEquations =
-                        [&](const NumericalSolver::StateVector& x, NumericalSolver::StateVector& dxdt, const double t
-                        ) -> void
+                        [&](const NumericalSolver::StateVector& x,
+                            NumericalSolver::StateVector& dxdt,
+                            const double t) -> void
                     {
                         dxdt = pythonDynamicsEquation(x, dxdt, t);
                     };
@@ -308,11 +357,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Args:
                         state_logger (StateLogger, optional): The state logger. Defaults to None.
+                        root_finding_strategy (RootFindingStrategy, optional): The root finding strategy. Defaults to DenseOutput.
 
                     Returns:
                         NumericalSolver: The default conditional numerical solver.
                 )doc",
-                arg_v("state_logger", nullptr, "None")
+                arg_v("state_logger", nullptr, "None"),
+                arg_v(
+                    "root_finding_strategy",
+                    NumericalSolver::RootFindingStrategy::DenseOutput,
+                    "NumericalSolver.RootFindingStrategy.DenseOutput"
+                )
             )
             .def_static(
                 "conditional",
@@ -321,10 +376,11 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Return a conditional numerical solver.
 
                     Args:
-                        time_step (float): The time step (in seconds).
+                        time_step (float): The time step.
                         relative_tolerance (float): The relative tolerance.
                         absolute_tolerance (float): The absolute tolerance.
                         state_logger (StateLogger, optional): The state logger. Defaults to None.
+                        root_finding_strategy (RootFindingStrategy, optional): The root finding strategy. Defaults to DenseOutput.
 
                     Returns:
                         NumericalSolver: The conditional numerical solver.
@@ -332,7 +388,25 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 arg("time_step"),
                 arg("relative_tolerance"),
                 arg("absolute_tolerance"),
-                arg_v("state_logger", nullptr, "None")
+                arg_v("state_logger", nullptr, "None") arg_v(
+                    "root_finding_strategy",
+                    NumericalSolver::RootFindingStrategy::DenseOutput,
+                    "NumericalSolver.RootFindingStrategy.DenseOutput"
+                )
+            )
+            .def_static(
+                "string_from_root_finding_strategy",
+                &NumericalSolver::StringFromRootFindingStrategy,
+                R"doc(
+                    Return the string representation of a root finding strategy.
+
+                    Args:
+                        strategy (RootFindingStrategy): The root finding strategy.
+
+                    Returns:
+                        str: The string representation.
+                )doc",
+                arg("strategy")
             );
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -33,34 +33,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             )doc"
     );
 
-    enum_<NumericalSolver::RootFindingStrategy>(
-        numericalSolver,
-        "RootFindingStrategy",
-        R"doc(
-            The strategy for finding the exact event crossing time during conditional integration.
-        )doc"
-    )
-        .value(
-            "LinearInterpolation",
-            NumericalSolver::RootFindingStrategy::LinearInterpolation,
-            "Linear interpolation between step endpoints"
-        )
-        .value(
-            "Integration",
-            NumericalSolver::RootFindingStrategy::Integration,
-            "Re-integrate with smaller steps during root finding"
-        )
-        .value(
-            "CubicInterpolation",
-            NumericalSolver::RootFindingStrategy::CubicInterpolation,
-            "Cubic interpolation between step endpoints"
-        )
-        .value(
-            "Skip",
-            NumericalSolver::RootFindingStrategy::First,
-            "Skip the root finding and return the first step boundary where condition is satisfied"
-        );
-
     class_<NumericalSolver::ConditionSolution>(
         numericalSolver,
         "ConditionSolution",
@@ -143,37 +115,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 arg_v("root_solver", RootSolver::Default(), "RootSolver.default()")
             )
 
-            .def(
-                init<
-                    const NumericalSolver::LogType&,
-                    const NumericalSolver::StepperType&,
-                    const Real&,
-                    const Real&,
-                    const Real&,
-                    const RootSolver&,
-                    const NumericalSolver::RootFindingStrategy&>(),
-                R"doc(
-                    Constructor.
-
-                    Args:
-                        log_type (NumericalSolver.LogType): The type of logging.
-                        stepper_type (NumericalSolver.StepperType): The type of stepper.
-                        time_step (float): The time step.
-                        relative_tolerance (float): The relative tolerance.
-                        absolute_tolerance (float): The absolute tolerance.
-                        root_solver (RootSolver): The root solver.
-                        root_finding_strategy (RootFindingStrategy): The root finding strategy.
-
-                )doc",
-                arg("log_type"),
-                arg("stepper_type"),
-                arg("time_step"),
-                arg("relative_tolerance"),
-                arg("absolute_tolerance"),
-                arg("root_solver"),
-                arg("root_finding_strategy")
-            )
-
             .def(self == self)
             .def(self != self)
 
@@ -209,16 +150,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Returns:
                         RootSolver: The root solver.
-                )doc"
-            )
-            .def(
-                "get_root_finding_strategy",
-                &NumericalSolver::getRootFindingStrategy,
-                R"doc(
-                    Get the root finding strategy.
-
-                    Returns:
-                        RootFindingStrategy: The root finding strategy.
                 )doc"
             )
 
@@ -411,7 +342,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Return a conditional numerical solver.
 
                     Args:
-                        time_step (float): The time step.
+                        time_step (float): The time step (in seconds).
                         relative_tolerance (float): The relative tolerance.
                         absolute_tolerance (float): The absolute tolerance.
                         state_logger (StateLogger, optional): The state logger. Defaults to None.
@@ -423,20 +354,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                 arg("relative_tolerance"),
                 arg("absolute_tolerance"),
                 arg_v("state_logger", nullptr, "None")
-            )
-            .def_static(
-                "string_from_root_finding_strategy",
-                &NumericalSolver::StringFromRootFindingStrategy,
-                R"doc(
-                    Return the string representation of a root finding strategy.
-
-                    Args:
-                        strategy (RootFindingStrategy): The root finding strategy.
-
-                    Returns:
-                        str: The string representation.
-                )doc",
-                arg("strategy")
             );
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -46,8 +46,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
             "Linear interpolation between step endpoints"
         )
         .value(
-            "Propagated",
-            NumericalSolver::RootFindingStrategy::Propagated,
+            "Integration",
+            NumericalSolver::RootFindingStrategy::Integration,
             "Re-integrate with smaller steps during root finding"
         )
         .value(
@@ -57,7 +57,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
         )
         .value(
             "Skip",
-            NumericalSolver::RootFindingStrategy::Skip,
+            NumericalSolver::RootFindingStrategy::First,
             "Skip the root finding and return the first step boundary where condition is satisfied"
         );
 

--- a/bindings/python/test/trajectory/test_propagator.py
+++ b/bindings/python/test/trajectory/test_propagator.py
@@ -218,7 +218,7 @@ def numerical_solver() -> NumericalSolver:
 def conditional_numerical_solver() -> NumericalSolver:
     return NumericalSolver(
         NumericalSolver.LogType.NoLog,
-        NumericalSolver.StepperType.RungeKuttaDopri5,
+        NumericalSolver.StepperType.RungeKuttaFehlberg78,
         5.0,
         1.0e-15,
         1.0e-15,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -178,13 +178,15 @@ class Segment
         /// @param aStateArray Array of states for the segment
         /// @param aConditionIsSatisfied True if the event condition is satisfied
         /// @param aSegmentType Type of segment
+        /// @param aManeuverIntervals Array of maneuver intervals (for maneuver segments). Defaults to empty.
         /// @return An instance of Solution
         Solution(
             const String& aName,
             const Array<Shared<Dynamics>>& aDynamicsArray,
             const Array<State>& aStateArray,
             const bool& aConditionIsSatisfied,
-            const Segment::Type& aSegmentType
+            const Segment::Type& aSegmentType,
+            const Array<Interval>& aManeuverIntervals = Array<Interval>::Empty()
         );
 
         /// @brief Constructor

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -178,15 +178,13 @@ class Segment
         /// @param aStateArray Array of states for the segment
         /// @param aConditionIsSatisfied True if the event condition is satisfied
         /// @param aSegmentType Type of segment
-        /// @param aManeuverIntervals Array of maneuver intervals (for maneuver segments). Defaults to empty.
         /// @return An instance of Solution
         Solution(
             const String& aName,
             const Array<Shared<Dynamics>>& aDynamicsArray,
             const Array<State>& aStateArray,
             const bool& aConditionIsSatisfied,
-            const Segment::Type& aSegmentType,
-            const Array<Interval>& aManeuverIntervals = Array<Interval>::Empty()
+            const Segment::Type& aSegmentType
         );
 
         /// @brief Constructor
@@ -196,7 +194,7 @@ class Segment
         /// @param aStateArray Array of states for the segment
         /// @param aConditionIsSatisfied True if the event condition is satisfied
         /// @param aSegmentType Type of segment
-        /// @param aManeuverIntervals Array of maneuver intervals (for maneuver segments). Defaults to empty.
+        /// @param aManeuverIntervals Array of maneuver intervals (for maneuver segments).
         /// @return An instance of Solution
         Solution(
             const String& aName,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -512,8 +512,8 @@ class Segment
     /// @param anEndInstant The end instant
     /// @param aDynamicsArray The dynamics array
     /// @param anEventCondition The event condition
-    /// @param limitMaxStepSize If true, the maximum step size will be limited to 5 seconds or 1/10th of the segment
-    /// duration, whichever is smaller. Defaults to false.
+    /// @param limitMaxStepSize If true, the maximum step size will be limited to 2 minutes, or the duration of the
+    /// subsegment, whichever is smaller. Defaults to false.
     /// @return The segment solution
     Segment::Solution solveWithDynamics_(
         const State& aState,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -512,12 +512,15 @@ class Segment
     /// @param anEndInstant The end instant
     /// @param aDynamicsArray The dynamics array
     /// @param anEventCondition The event condition
+    /// @param limitMaxStepSize If true, the maximum step size will be limited to 5 seconds or 1/10th of the segment
+    /// duration, whichever is smaller. Defaults to false.
     /// @return The segment solution
     Segment::Solution solveWithDynamics_(
         const State& aState,
         const Instant& anEndInstant,
         const Array<Shared<Dynamics>>& aDynamicsArray,
-        const Shared<EventCondition>& anEventCondition
+        const Shared<EventCondition>& anEventCondition,
+        const bool& limitMaxStepSize = false
     ) const;
 
     /// @brief For a given maneuver, construct a solution that is Local Orbital Frame (LOF) compliant.

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.hpp
@@ -147,14 +147,14 @@ class Sequence
     /// @endcode
     ///
     /// @param aSegmentArray An array of segments. Defaults to empty.
-    /// @param aNumericalSolver A Numerical Solver. Defaults to NumericalSolver::DefaultConditional().
+    /// @param aNumericalSolver A Numerical Solver. Defaults to NumericalSolver::Default().
     /// @param aDynamicsArray An array of shared dynamics. Defaults to empty.
     /// @param aSegmentPropagationDurationLimit Maximum duration for propagation. Defaults to 30.0
     /// days.
     /// @param aVerbosityLevel Verbosity level for the solver [0 (low) - 5 (high)]. Defaults to 0.
     Sequence(
         const Array<Segment>& aSegmentArray = Array<Segment>::Empty(),
-        const NumericalSolver& aNumericalSolver = NumericalSolver::DefaultConditional(),
+        const NumericalSolver& aNumericalSolver = NumericalSolver::Default(),
         const Array<Shared<Dynamics>>& aDynamicsArray = Array<Shared<Dynamics>>::Empty(),
         const Duration& aSegmentPropagationDurationLimit = Duration::Days(30.0),
         const Size& aVerbosityLevel = 0

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -52,6 +52,7 @@ class NumericalSolver : public MathNumericalSolver
                               ///< dynamics.
         Propagated,           ///< Re-integrate with smaller steps during root finding. Accurate but slower.
         Skip,                 ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
+        CubicInterpolation,   ///< Cubic interpolation between step endpoints. Fast and accurate.
     };
 
     /// @brief Constructor

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -181,7 +181,7 @@ class NumericalSolver : public MathNumericalSolver
     /// @brief Construct an undefined numerical solver.
     ///
     /// @code{.cpp}
-    ///     NumericalSolver solver = NumericalSolver::Undefined() ;
+    ///     NumericalSolver solver = NumericalSolver::Undefined();
     /// @endcode
     ///
     /// @return An undefined numerical solver.
@@ -190,7 +190,7 @@ class NumericalSolver : public MathNumericalSolver
     /// @brief Construct a default numerical solver.
     ///
     /// @code{.cpp}
-    ///     NumericalSolver solver = NumericalSolver::Default() ;
+    ///     NumericalSolver solver = NumericalSolver::Default();
     /// @endcode
     ///
     /// @return A default numerical solver.
@@ -201,7 +201,7 @@ class NumericalSolver : public MathNumericalSolver
     /// @code{.cpp}
     ///     NumericalSolver solver = NumericalSolver::FixedStepSize(
     ///         NumericalSolver::StepperType::RungeKutta4, 30.0
-    ///     ) ;
+    ///     );
     /// @endcode
     ///
     /// @param aTimeStep The time step (in seconds) to use for integration.
@@ -213,7 +213,7 @@ class NumericalSolver : public MathNumericalSolver
     /// @brief Default conditional
     ///
     /// @code{.cpp}
-    ///     NumericalSolver solver = NumericalSolver::DefaultConditional() ;
+    ///     NumericalSolver solver = NumericalSolver::DefaultConditional();
     /// @endcode
     ///
     /// @param stateLogger A function that takes a `State` object and logs. Defaults to `nullptr`.
@@ -336,9 +336,18 @@ class NumericalSolver : public MathNumericalSolver
         const RootFindingStrategy& aRootFindingStrategy
     );
 
+    /// @brief Observe a state, storing it's coordinates in the observedStates_ array
+    ///
+    /// @param aState The state to observe
     void observeState(const State& aState);
 
     /// @brief Integrate with controlled stepper using specified root solving strategy
+    ///
+    /// @param aState The initial state for integration
+    /// @param anInstant The instant to integrate to
+    /// @param aSystemOfEquations The system of equations to integrate
+    /// @param anEventCondition The event condition to check
+    /// @return The condition solution
     ConditionSolution integrateTimeWithControlledStepper(
         const State& aState,
         const Instant& anInstant,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -45,6 +45,20 @@ class NumericalSolver : public MathNumericalSolver
         bool rootSolverHasConverged;  ///< Whether the root solver has converged.
     };
 
+    /// @brief Strategy for finding the exact event crossing time during conditional integration.
+    ///
+    /// - DenseOutput: Use dense stepper's calc_state() for interpolation (RungeKuttaDopri5 only). Most accurate.
+    /// - Linear: Linear interpolation between step endpoints. Fast but less accurate for nonlinear dynamics.
+    /// - Propagated: Re-integrate with smaller sub-steps during bisection. Accurate but slower.
+    /// - Boundary: Return the first step boundary where condition is satisfied. Simplest, no refinement.
+    enum class RootFindingStrategy
+    {
+        DenseOutput,
+        Linear,
+        Propagated,
+        Boundary
+    };
+
     /// @brief Constructor
     ///
     /// @code{.cpp}
@@ -61,13 +75,16 @@ class NumericalSolver : public MathNumericalSolver
     /// @param aRelativeTolerance A number indicating the relative integration tolerance
     /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
     /// @param aRootSolver A root solver to be used to solve the event condition
+    /// @param aRootFindingStrategy Strategy for finding exact event crossing time. Defaults to
+    ///                  DenseOutput (requires RungeKuttaDopri5)
     NumericalSolver(
         const NumericalSolver::LogType& aLogType,
         const NumericalSolver::StepperType& aStepperType,
         const Real& aTimeStep,
         const Real& aRelativeTolerance,
         const Real& anAbsoluteTolerance,
-        const RootSolver& aRootSolver = RootSolver::Default()
+        const RootSolver& aRootSolver = RootSolver::Default(),
+        const RootFindingStrategy& aRootFindingStrategy = RootFindingStrategy::DenseOutput
     );
 
     /// @brief Access observed states
@@ -96,6 +113,15 @@ class NumericalSolver : public MathNumericalSolver
     ///
     /// @return Observed states
     Array<State> getObservedStates() const;
+
+    /// @brief Get root finding strategy
+    ///
+    /// @code{.cpp}
+    ///                  numericalSolver.getRootFindingStrategy();
+    /// @endcode
+    ///
+    /// @return RootFindingStrategy
+    RootFindingStrategy getRootFindingStrategy() const;
 
     /// @brief Perform numerical integration for a given array of time instants.
     ///
@@ -171,8 +197,12 @@ class NumericalSolver : public MathNumericalSolver
     /// @endcode
     ///
     /// @param stateLogger A function that takes a `State` object and logs. Defaults to `nullptr`.
+    /// @param aRootFindingStrategy Strategy for finding exact event crossing time. Defaults to DenseOutput.
     /// @return A default conditional numerical solver.
-    static NumericalSolver DefaultConditional(const std::function<void(const State&)>& stateLogger = nullptr);
+    static NumericalSolver DefaultConditional(
+        const std::function<void(const State&)>& stateLogger = nullptr,
+        const RootFindingStrategy& aRootFindingStrategy = RootFindingStrategy::DenseOutput
+    );
 
     /// @brief Create a conditional numerical solver.
     ///
@@ -180,14 +210,26 @@ class NumericalSolver : public MathNumericalSolver
     /// @param aRelativeTolerance The relative tolerance to use.
     /// @param anAbsoluteTolerance The absolute tolerance to use.
     /// @param stateLogger A function that takes a `State` object and logs.
+    /// @param aRootFindingStrategy Strategy for finding exact event crossing time. Defaults to DenseOutput.
     ///
     /// @return A conditional numerical solver.
     static NumericalSolver Conditional(
         const Real& aTimeStep,
         const Real& aRelativeTolerance,
         const Real& anAbsoluteTolerance,
-        const std::function<void(const State&)>& stateLogger
+        const std::function<void(const State&)>& stateLogger = nullptr,
+        const RootFindingStrategy& aRootFindingStrategy = RootFindingStrategy::DenseOutput
     );
+
+    /// @brief Convert RootFindingStrategy to string
+    ///
+    /// @code{.cpp}
+    ///                  NumericalSolver::StringFromRootFindingStrategy(aStrategy);
+    /// @endcode
+    ///
+    /// @param aStrategy A root finding strategy enum
+    /// @return String representation
+    static String StringFromRootFindingStrategy(const RootFindingStrategy& aStrategy);
 
     /// Delete undesired methods from parent
     Array<MathNumericalSolver::Solution> integrateTime(
@@ -224,6 +266,7 @@ class NumericalSolver : public MathNumericalSolver
     RootSolver rootSolver_;
     Array<State> observedStates_;
     std::function<void(const State&)> stateLogger_;
+    RootFindingStrategy rootFindingStrategy_;
 
     /// @brief Constructor
     ///
@@ -242,6 +285,7 @@ class NumericalSolver : public MathNumericalSolver
     /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
     /// @param aRootSolver A root solver to be used to solve the event condition
     /// @param stateLogger A function that takes a `State` object and logs
+    /// @param aRootFindingStrategy Strategy for finding exact event crossing time
     NumericalSolver(
         const NumericalSolver::LogType& aLogType,
         const NumericalSolver::StepperType& aStepperType,
@@ -249,10 +293,27 @@ class NumericalSolver : public MathNumericalSolver
         const Real& aRelativeTolerance,
         const Real& anAbsoluteTolerance,
         const RootSolver& aRootSolver,
-        const std::function<void(const State&)>& stateLogger
+        const std::function<void(const State&)>& stateLogger,
+        const RootFindingStrategy& aRootFindingStrategy
     );
 
     void observeState(const State& aState);
+
+    /// @brief Integrate with dense output stepper (RKDP5 only)
+    ConditionSolution integrateTimeWithDenseOutput(
+        const State& aState,
+        const Instant& anInstant,
+        const SystemOfEquationsWrapper& aSystemOfEquations,
+        const EventCondition& anEventCondition
+    );
+
+    /// @brief Integrate with controlled stepper using Linear/Propagated/Boundary strategy
+    ConditionSolution integrateTimeWithControlledStepper(
+        const State& aState,
+        const Instant& anInstant,
+        const SystemOfEquationsWrapper& aSystemOfEquations,
+        const EventCondition& anEventCondition
+    );
 };
 
 }  // namespace state

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -48,9 +48,9 @@ class NumericalSolver : public MathNumericalSolver
     /// @brief Strategy for finding the exact event crossing time during conditional integration.
     enum class RootFindingStrategy
     {
-        Linear,  ///< Linear interpolation between step endpoints. Fast but less accurate for nonlinear dynamics.
+        Linear,      ///< Linear interpolation between step endpoints. Fast but less accurate for nonlinear dynamics.
         Propagated,  ///< Re-integrate with smaller sub-steps during bisection. Accurate but slower.
-        Boundary,  ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
+        Boundary,    ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
     };
 
     /// @brief Constructor
@@ -216,7 +216,10 @@ class NumericalSolver : public MathNumericalSolver
     ///
     /// @param stateLogger A function that takes a `State` object and logs. Defaults to `nullptr`.
     /// @return A default conditional numerical solver.
-    [[deprecated("Use NumericalSolver::Default() instead. All solvers now support conditional solving. This method will be removed in a future version.")]]
+    [[deprecated(
+        "Use NumericalSolver::Default() instead. All solvers now support conditional solving. This method will be "
+        "removed in a future version."
+    )]]
     static NumericalSolver DefaultConditional(const std::function<void(const State&)>& stateLogger = nullptr);
 
     /// @brief Create a conditional numerical solver.
@@ -227,7 +230,10 @@ class NumericalSolver : public MathNumericalSolver
     /// @param stateLogger A function that takes a `State` object and logs. Defaults to `nullptr`.
     ///
     /// @return A conditional numerical solver.
-    [[deprecated("Use NumericalSolver constructor instead. All solvers now support conditional solving. This method will be removed in a future version.")]]
+    [[deprecated(
+        "Use NumericalSolver constructor instead. All solvers now support conditional solving. This method will be "
+        "removed in a future version."
+    )]]
     static NumericalSolver Conditional(
         const Real& aTimeStep,
         const Real& aRelativeTolerance,
@@ -329,14 +335,6 @@ class NumericalSolver : public MathNumericalSolver
     );
 
     void observeState(const State& aState);
-
-    /// @brief Integrate with dense output stepper (RKDP5 only)
-    ConditionSolution integrateTimeWithDenseOutput(
-        const State& aState,
-        const Instant& anInstant,
-        const SystemOfEquationsWrapper& aSystemOfEquations,
-        const EventCondition& anEventCondition
-    );
 
     /// @brief Integrate with controlled stepper using Linear/Propagated/Boundary strategy
     ConditionSolution integrateTimeWithControlledStepper(

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -143,6 +143,19 @@ class NumericalSolver : public MathNumericalSolver
     /// @return RootFindingStrategy
     RootFindingStrategy getRootFindingStrategy() const;
 
+    /// @brief Get the maximum step size
+    ///
+    /// @return Maximum step size in seconds, or Real::Undefined() if not set
+    Real getMaxStepSize() const;
+
+    /// @brief Set the maximum step size the integrator is allowed to take during conditional
+    ///        integration. Useful for detecting discrete/step-function events (e.g., thrust
+    ///        toggles) that can be missed when the adaptive stepper grows its step too large.
+    ///
+    /// @param aMaxStepSize Maximum step size in seconds. Use Real::Undefined() to remove the
+    ///                     limit.
+    void setMaxStepSize(const Real& aMaxStepSize);
+
     /// @brief Perform numerical integration for a given array of time instants.
     ///
     /// @param aState Initial state for integration.
@@ -289,6 +302,7 @@ class NumericalSolver : public MathNumericalSolver
     Array<State> observedStates_;
     std::function<void(const State&)> stateLogger_;
     RootFindingStrategy rootFindingStrategy_;
+    Real maxStepSize_ = Real::Undefined();
 
     /// @brief Constructor
     ///

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -46,17 +46,11 @@ class NumericalSolver : public MathNumericalSolver
     };
 
     /// @brief Strategy for finding the exact event crossing time during conditional integration.
-    ///
-    /// - DenseOutput: Use dense stepper's calc_state() for interpolation (RungeKuttaDopri5 only). Most accurate.
-    /// - Linear: Linear interpolation between step endpoints. Fast but less accurate for nonlinear dynamics.
-    /// - Propagated: Re-integrate with smaller sub-steps during bisection. Accurate but slower.
-    /// - Boundary: Return the first step boundary where condition is satisfied. Simplest, no refinement.
     enum class RootFindingStrategy
     {
-        DenseOutput,
-        Linear,
-        Propagated,
-        Boundary
+        Linear,  ///< Linear interpolation between step endpoints. Fast but less accurate for nonlinear dynamics.
+        Propagated,  ///< Re-integrate with smaller sub-steps during bisection. Accurate but slower.
+        Boundary,  ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
     };
 
     /// @brief Constructor
@@ -75,16 +69,40 @@ class NumericalSolver : public MathNumericalSolver
     /// @param aRelativeTolerance A number indicating the relative integration tolerance
     /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
     /// @param aRootSolver A root solver to be used to solve the event condition
-    /// @param aRootFindingStrategy Strategy for finding exact event crossing time. Defaults to
-    ///                  DenseOutput (requires RungeKuttaDopri5)
     NumericalSolver(
         const NumericalSolver::LogType& aLogType,
         const NumericalSolver::StepperType& aStepperType,
         const Real& aTimeStep,
         const Real& aRelativeTolerance,
         const Real& anAbsoluteTolerance,
-        const RootSolver& aRootSolver = RootSolver::Default(),
-        const RootFindingStrategy& aRootFindingStrategy = RootFindingStrategy::DenseOutput
+        const RootSolver& aRootSolver = RootSolver::Default()
+    );
+
+    /// @brief Constructor
+    ///
+    /// @code{.cpp}
+    ///                  NumericalSolver numericalSolver = { aLogType, aStepperType, aTimeStep,
+    ///                  aRelativeTolerance, anAbsoluteTolerance, aRootSolver, aRootFindingStrategy };
+    /// @endcode
+    ///
+    /// @param aLogType An enum indicating the amount of verbosity wanted to be logged during
+    ///                  numerical integration
+    /// @param aStepperType An enum indicating the type of numerical stepper used to perform
+    ///                  integration
+    /// @param aTimeStep A number indicating the initial guess time step the numerical solver will
+    ///                  take
+    /// @param aRelativeTolerance A number indicating the relative integration tolerance
+    /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
+    /// @param aRootSolver A root solver to be used to solve the event condition
+    /// @param aRootFindingStrategy Strategy for finding exact event crossing time
+    NumericalSolver(
+        const NumericalSolver::LogType& aLogType,
+        const NumericalSolver::StepperType& aStepperType,
+        const Real& aTimeStep,
+        const Real& aRelativeTolerance,
+        const Real& anAbsoluteTolerance,
+        const RootSolver& aRootSolver,
+        const RootFindingStrategy& aRootFindingStrategy
     );
 
     /// @brief Access observed states
@@ -197,28 +215,24 @@ class NumericalSolver : public MathNumericalSolver
     /// @endcode
     ///
     /// @param stateLogger A function that takes a `State` object and logs. Defaults to `nullptr`.
-    /// @param aRootFindingStrategy Strategy for finding exact event crossing time. Defaults to DenseOutput.
     /// @return A default conditional numerical solver.
-    static NumericalSolver DefaultConditional(
-        const std::function<void(const State&)>& stateLogger = nullptr,
-        const RootFindingStrategy& aRootFindingStrategy = RootFindingStrategy::DenseOutput
-    );
+    [[deprecated("Use NumericalSolver::Default() instead. All solvers now support conditional solving. This method will be removed in a future version.")]]
+    static NumericalSolver DefaultConditional(const std::function<void(const State&)>& stateLogger = nullptr);
 
     /// @brief Create a conditional numerical solver.
     ///
     /// @param aTimeStep The initial time step (in seconds) to use.
     /// @param aRelativeTolerance The relative tolerance to use.
     /// @param anAbsoluteTolerance The absolute tolerance to use.
-    /// @param stateLogger A function that takes a `State` object and logs.
-    /// @param aRootFindingStrategy Strategy for finding exact event crossing time. Defaults to DenseOutput.
+    /// @param stateLogger A function that takes a `State` object and logs. Defaults to `nullptr`.
     ///
     /// @return A conditional numerical solver.
+    [[deprecated("Use NumericalSolver constructor instead. All solvers now support conditional solving. This method will be removed in a future version.")]]
     static NumericalSolver Conditional(
         const Real& aTimeStep,
         const Real& aRelativeTolerance,
         const Real& anAbsoluteTolerance,
-        const std::function<void(const State&)>& stateLogger = nullptr,
-        const RootFindingStrategy& aRootFindingStrategy = RootFindingStrategy::DenseOutput
+        const std::function<void(const State&)>& stateLogger = nullptr
     );
 
     /// @brief Convert RootFindingStrategy to string
@@ -270,10 +284,27 @@ class NumericalSolver : public MathNumericalSolver
 
     /// @brief Constructor
     ///
-    /// @code{.cpp}
-    ///                  NumericalSolver numericalSolver = { aLogType, aStepperType, aTimeStep,
-    ///                  aRelativeTolerance, anAbsoluteTolerance };
-    /// @endcode
+    /// @param aLogType An enum indicating the amount of verbosity wanted to be logged during
+    ///                  numerical integration
+    /// @param aStepperType An enum indicating the type of numerical stepper used to perform
+    ///                  integration
+    /// @param aTimeStep A number indicating the initial guess time step the numerical solver will
+    ///                  take
+    /// @param aRelativeTolerance A number indicating the relative integration tolerance
+    /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
+    /// @param aRootSolver A root solver to be used to solve the event condition
+    /// @param stateLogger A function that takes a `State` object and logs
+    NumericalSolver(
+        const NumericalSolver::LogType& aLogType,
+        const NumericalSolver::StepperType& aStepperType,
+        const Real& aTimeStep,
+        const Real& aRelativeTolerance,
+        const Real& anAbsoluteTolerance,
+        const RootSolver& aRootSolver,
+        const std::function<void(const State&)>& stateLogger
+    );
+
+    /// @brief Constructor
     ///
     /// @param aLogType An enum indicating the amount of verbosity wanted to be logged during
     ///                  numerical integration

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -48,9 +48,10 @@ class NumericalSolver : public MathNumericalSolver
     /// @brief Strategy for finding the exact event crossing time during conditional integration.
     enum class RootFindingStrategy
     {
-        Linear,      ///< Linear interpolation between step endpoints. Fast but less accurate for nonlinear dynamics.
-        Propagated,  ///< Re-integrate with smaller sub-steps during bisection. Accurate but slower.
-        Boundary,    ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
+        LinearInterpolation,  ///< Linear interpolation between step endpoints. Fast but less accurate for nonlinear
+                              ///< dynamics.
+        Propagated,           ///< Re-integrate with smaller steps during root finding. Accurate but slower.
+        Skip,                 ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
     };
 
     /// @brief Constructor
@@ -336,7 +337,7 @@ class NumericalSolver : public MathNumericalSolver
 
     void observeState(const State& aState);
 
-    /// @brief Integrate with controlled stepper using Linear/Propagated/Boundary strategy
+    /// @brief Integrate with controlled stepper using specified root solving strategy
     ConditionSolution integrateTimeWithControlledStepper(
         const State& aState,
         const Instant& anInstant,

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -50,8 +50,8 @@ class NumericalSolver : public MathNumericalSolver
     {
         LinearInterpolation,  ///< Linear interpolation between step endpoints. Fast but less accurate for nonlinear
                               ///< dynamics.
-        Propagated,           ///< Re-integrate with smaller steps during root finding. Accurate but slower.
-        Skip,                 ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
+        Integration,          ///< Re-integrate with smaller steps during root finding. Accurate but slower.
+        First,                ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
         CubicInterpolation,   ///< Cubic interpolation between step endpoints. Fast and accurate.
     };
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -33,6 +33,9 @@ using MathNumericalSolver = ostk::mathematics::solver::NumericalSolver;
 
 /// @brief Define an astrodynamics state contextual Numerical Solver. This class inherits from the OSTk Mathematics
 /// Numerical Solver.
+///
+/// Event-crossing refinement uses a forced Dormand-Prince 5 dense-output step, regardless of the
+/// main stepper type.
 class NumericalSolver : public MathNumericalSolver
 {
    public:
@@ -43,16 +46,6 @@ class NumericalSolver : public MathNumericalSolver
         bool conditionIsSatisfied;    ///< Whether the condition is met.
         Size iterationCount;          ///< Number of iterations performed.
         bool rootSolverHasConverged;  ///< Whether the root solver has converged.
-    };
-
-    /// @brief Strategy for finding the exact event crossing time during conditional integration.
-    enum class RootFindingStrategy
-    {
-        LinearInterpolation,  ///< Linear interpolation between step endpoints. Fast but less accurate for nonlinear
-                              ///< dynamics.
-        Integration,          ///< Re-integrate with smaller steps during root finding. Accurate but slower.
-        First,                ///< Return the first step boundary where condition is satisfied. Simplest, no refinement.
-        CubicInterpolation,   ///< Cubic interpolation between step endpoints. Fast and accurate.
     };
 
     /// @brief Constructor
@@ -78,33 +71,6 @@ class NumericalSolver : public MathNumericalSolver
         const Real& aRelativeTolerance,
         const Real& anAbsoluteTolerance,
         const RootSolver& aRootSolver = RootSolver::Default()
-    );
-
-    /// @brief Constructor
-    ///
-    /// @code{.cpp}
-    ///                  NumericalSolver numericalSolver = { aLogType, aStepperType, aTimeStep,
-    ///                  aRelativeTolerance, anAbsoluteTolerance, aRootSolver, aRootFindingStrategy };
-    /// @endcode
-    ///
-    /// @param aLogType An enum indicating the amount of verbosity wanted to be logged during
-    ///                  numerical integration
-    /// @param aStepperType An enum indicating the type of numerical stepper used to perform
-    ///                  integration
-    /// @param aTimeStep A number indicating the initial guess time step the numerical solver will
-    ///                  take
-    /// @param aRelativeTolerance A number indicating the relative integration tolerance
-    /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
-    /// @param aRootSolver A root solver to be used to solve the event condition
-    /// @param aRootFindingStrategy Strategy for finding exact event crossing time
-    NumericalSolver(
-        const NumericalSolver::LogType& aLogType,
-        const NumericalSolver::StepperType& aStepperType,
-        const Real& aTimeStep,
-        const Real& aRelativeTolerance,
-        const Real& anAbsoluteTolerance,
-        const RootSolver& aRootSolver,
-        const RootFindingStrategy& aRootFindingStrategy
     );
 
     /// @brief Access observed states
@@ -133,15 +99,6 @@ class NumericalSolver : public MathNumericalSolver
     ///
     /// @return Observed states
     Array<State> getObservedStates() const;
-
-    /// @brief Get root finding strategy
-    ///
-    /// @code{.cpp}
-    ///                  numericalSolver.getRootFindingStrategy();
-    /// @endcode
-    ///
-    /// @return RootFindingStrategy
-    RootFindingStrategy getRootFindingStrategy() const;
 
     /// @brief Get the maximum step size
     ///
@@ -256,16 +213,6 @@ class NumericalSolver : public MathNumericalSolver
         const std::function<void(const State&)>& stateLogger = nullptr
     );
 
-    /// @brief Convert RootFindingStrategy to string
-    ///
-    /// @code{.cpp}
-    ///                  NumericalSolver::StringFromRootFindingStrategy(aStrategy);
-    /// @endcode
-    ///
-    /// @param aStrategy A root finding strategy enum
-    /// @return String representation
-    static String StringFromRootFindingStrategy(const RootFindingStrategy& aStrategy);
-
     /// Delete undesired methods from parent
     Array<MathNumericalSolver::Solution> integrateTime(
         const MathNumericalSolver::StateVector& anInitialStateVector,
@@ -301,7 +248,6 @@ class NumericalSolver : public MathNumericalSolver
     RootSolver rootSolver_;
     Array<State> observedStates_;
     std::function<void(const State&)> stateLogger_;
-    RootFindingStrategy rootFindingStrategy_;
     Real maxStepSize_ = Real::Undefined();
 
     /// @brief Constructor
@@ -310,7 +256,7 @@ class NumericalSolver : public MathNumericalSolver
     ///                  numerical integration
     /// @param aStepperType An enum indicating the type of numerical stepper used to perform
     ///                  integration
-    /// @param aTimeStep A number indicating the initial guess time step the numerical solver will
+    /// @param aTimeStep A number indicating the initial guess time step (in seconds) the numerical solver will
     ///                  take
     /// @param aRelativeTolerance A number indicating the relative integration tolerance
     /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
@@ -326,36 +272,12 @@ class NumericalSolver : public MathNumericalSolver
         const std::function<void(const State&)>& stateLogger
     );
 
-    /// @brief Constructor
-    ///
-    /// @param aLogType An enum indicating the amount of verbosity wanted to be logged during
-    ///                  numerical integration
-    /// @param aStepperType An enum indicating the type of numerical stepper used to perform
-    ///                  integration
-    /// @param aTimeStep A number indicating the initial guess time step (in seconds) the numerical solver will
-    ///                  take
-    /// @param aRelativeTolerance A number indicating the relative integration tolerance
-    /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
-    /// @param aRootSolver A root solver to be used to solve the event condition
-    /// @param stateLogger A function that takes a `State` object and logs
-    /// @param aRootFindingStrategy Strategy for finding exact event crossing time
-    NumericalSolver(
-        const NumericalSolver::LogType& aLogType,
-        const NumericalSolver::StepperType& aStepperType,
-        const Real& aTimeStep,
-        const Real& aRelativeTolerance,
-        const Real& anAbsoluteTolerance,
-        const RootSolver& aRootSolver,
-        const std::function<void(const State&)>& stateLogger,
-        const RootFindingStrategy& aRootFindingStrategy
-    );
-
     /// @brief Observe a state, storing it's coordinates in the observedStates_ array
     ///
     /// @param aState The state to observe
     void observeState(const State& aState);
 
-    /// @brief Integrate with controlled stepper using specified root solving strategy
+    /// @brief Integrate with controlled stepper using the unified dense-output refinement.
     ///
     /// @param aState The initial state for integration
     /// @param anInstant The instant to integrate to
@@ -367,6 +289,25 @@ class NumericalSolver : public MathNumericalSolver
         const Instant& anInstant,
         const SystemOfEquationsWrapper& aSystemOfEquations,
         const EventCondition& anEventCondition
+    );
+
+    /// @brief Templated implementation of conditional integration. Defined out-of-line in
+    ///        the .cpp so the boost odeint stepper types do not leak into this header.
+    ///
+    /// @param aStepper The stepper instance used for the main integration loop.
+    /// @param aState Initial state.
+    /// @param anInstant Maximum time to integrate to.
+    /// @param aSystemOfEquations System of equations to integrate.
+    /// @param anEventCondition Condition to detect.
+    /// @param aSignedTimeStep Signed initial step size (negative for backward integration).
+    template <typename Stepper>
+    ConditionSolution integrateTimeWithStepperImpl_(
+        Stepper& aStepper,
+        const State& aState,
+        const Instant& anInstant,
+        const SystemOfEquationsWrapper& aSystemOfEquations,
+        const EventCondition& anEventCondition,
+        double aSignedTimeStep
     );
 };
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -33,9 +33,6 @@ using MathNumericalSolver = ostk::mathematics::solver::NumericalSolver;
 
 /// @brief Define an astrodynamics state contextual Numerical Solver. This class inherits from the OSTk Mathematics
 /// Numerical Solver.
-///
-/// Event-crossing refinement uses a forced Dormand-Prince 5 dense-output step, regardless of the
-/// main stepper type.
 class NumericalSolver : public MathNumericalSolver
 {
    public:

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -201,9 +201,6 @@ Array<State> Maneuver::getStates() const
 
 Interval Maneuver::getInterval() const
 {
-    // The interval spans from the first state (when thrust starts) to the last state.
-    // The last state may be an "off" state (zero acceleration) representing when the thruster turned off,
-    // and this should be included in the interval since the maneuver duration spans from on to off.
     return Interval::Closed(states_.accessFirst().accessInstant(), states_.accessLast().accessInstant());
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Maneuver.cpp
@@ -201,6 +201,9 @@ Array<State> Maneuver::getStates() const
 
 Interval Maneuver::getInterval() const
 {
+    // The interval spans from the first state (when thrust starts) to the last state.
+    // The last state may be an "off" state (zero acceleration) representing when the thruster turned off,
+    // and this should be included in the interval since the maneuver duration spans from on to off.
     return Interval::Closed(states_.accessFirst().accessInstant(), states_.accessLast().accessInstant());
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -131,8 +131,7 @@ Segment::ManeuverConstraints::ManeuverConstraints(
         // Minimum separation must be defined if maximum duty cycle is defined.
         if (!minimumSeparation.isDefined())
         {
-            throw ostk::core::error::RuntimeError(
-                "Minimum separation must be defined if maximum duty cycle is defined."
+            throw ostk::core::error::RuntimeError("Minimum separation must be defined if maximum duty cycle is defined."
             );
         }
     }
@@ -615,12 +614,10 @@ MatrixXd Segment::Solution::getDynamicsContribution(
     {
         if (!dynamicsWriteCoordinateSubsets.contains(aCoordinateSubsetSPtr))
         {
-            throw ostk::core::error::RuntimeError(
-                String::Format(
-                    "Provided coordinate subset [{}] is not part of the dynamics write coordinate subsets.",
-                    aCoordinateSubsetSPtr->getName()
-                )
-            );
+            throw ostk::core::error::RuntimeError(String::Format(
+                "Provided coordinate subset [{}] is not part of the dynamics write coordinate subsets.",
+                aCoordinateSubsetSPtr->getName()
+            ));
         }
     }
 
@@ -678,8 +675,7 @@ MatrixXd Segment::Solution::getDynamicsAccelerationContribution(
     return this->getDynamicsContribution(aDynamicsSPtr, aFrameSPtr, {CartesianVelocity::Default()});
 }
 
-Map<Shared<Dynamics>, MatrixXd> Segment::Solution::getAllDynamicsContributions(
-    const Shared<const Frame>& aFrameSPtr
+Map<Shared<Dynamics>, MatrixXd> Segment::Solution::getAllDynamicsContributions(const Shared<const Frame>& aFrameSPtr
 ) const
 {
     // Each MatrixXd contains the contribution of a single dynamics for all the segment states
@@ -890,14 +886,12 @@ Segment::Solution Segment::solve(
     {
         if (previousManeuverInterval.getEnd() > aState.accessInstant())
         {
-            throw ostk::core::error::RuntimeError(
-                String::Format(
-                    "All maneuver intervals must be before the initial state instant. Maneuver interval [{}] ends "
-                    "after "
-                    "the initial state instant.",
-                    previousManeuverInterval.toString()
-                )
-            );
+            throw ostk::core::error::RuntimeError(String::Format(
+                "All maneuver intervals must be before the initial state instant. Maneuver interval [{}] ends "
+                "after "
+                "the initial state instant.",
+                previousManeuverInterval.toString()
+            ));
         }
     }
 
@@ -947,8 +941,8 @@ Segment::Solution Segment::solve(
     };
 
     // Helper lambda to solve a single maneuver and extract results
-    const auto solveSingleManeuver =
-        [&](const Shared<Thruster>& thrusterDynamics) -> std::pair<Segment::Solution, std::optional<FlightManeuver>>
+    const auto solveSingleManeuver = [&](const Shared<Thruster>& thrusterDynamics
+                                     ) -> std::pair<Segment::Solution, std::optional<FlightManeuver>>
     {
         const State& lastState = segmentStates.accessLast();
         const Segment::Solution coastSolution = solveUntilThrusterOn_(lastState, maximumInstant, thrusterDynamics);
@@ -1549,13 +1543,11 @@ Segment::Solution Segment::solve(
     // Build final solution
     Array<Shared<Dynamics>> segmentDynamics = freeDynamicsArray_;
 
-    segmentDynamics.add(
-        std::make_shared<Thruster>(
-            this->getThrusterDynamics()->getSatelliteSystem(),
-            segmentHeterogenousGuidanceLaw,
-            this->getThrusterDynamics()->getName() + " (Maneuvering Constraints)"
-        )
-    );
+    segmentDynamics.add(std::make_shared<Thruster>(
+        this->getThrusterDynamics()->getSatelliteSystem(),
+        segmentHeterogenousGuidanceLaw,
+        this->getThrusterDynamics()->getName() + " (Maneuvering Constraints)"
+    ));
 
     return Segment::Solution(
         name_,
@@ -1723,9 +1715,8 @@ Array<State> Segment::propagateWithDynamics_(
     return states;
 }
 
-Segment::Solution Segment::constructLOFCompliantManeuverSolution_(
-    const State& aState, const FlightManeuver& aManeuver
-) const
+Segment::Solution Segment::constructLOFCompliantManeuverSolution_(const State& aState, const FlightManeuver& aManeuver)
+    const
 {
     const Shared<ConstantThrust> constantThrust = std::make_shared<ConstantThrust>(ConstantThrust::FromManeuver(
         aManeuver,
@@ -1750,9 +1741,8 @@ Segment::Solution Segment::solveCoast_(const State& aState, const Instant& anEnd
     return solution;
 }
 
-Shared<RealCondition> Segment::getThrusterToggleCondition_(
-    const Shared<Thruster>& thrusterDynamics, const bool& isOn
-) const
+Shared<RealCondition> Segment::getThrusterToggleCondition_(const Shared<Thruster>& thrusterDynamics, const bool& isOn)
+    const
 {
     const Shared<const GuidanceLaw> guidanceLaw = thrusterDynamics->getGuidanceLaw();
 
@@ -1796,7 +1786,25 @@ Segment::Solution Segment::solveUntilThrusterOff_(
         Array<Shared<EventCondition>> {eventCondition_, thrusterToggleCondition}
     );
 
-    Segment::Solution solution = solveWithDynamics_(aState, anEndInstant, dynamicsArray, combinedCondition);
+    // Use a solver with a max step size to ensure the integrator doesn't overshoot the thrust-off
+    // boundary. The thrust toggle condition is a step function that can be missed entirely if the
+    // adaptive stepper takes a step larger than the remaining thrust window.
+    NumericalSolver stepLimitedSolver = numericalSolver_;
+    stepLimitedSolver.setMaxStepSize((anEndInstant - aState.accessInstant()).inSeconds() / 10.0);
+
+    const Propagator propagator = {stepLimitedSolver, dynamicsArray};
+    const NumericalSolver::ConditionSolution conditionSolution =
+        propagator.calculateStateToCondition(aState, anEndInstant, *combinedCondition);
+
+    const StateBuilder stateBuilder = {aState};
+    Array<State> states = Array<State>::Empty();
+    states.reserve(propagator.accessNumericalSolver().accessObservedStates().getSize());
+    for (const State& state : propagator.accessNumericalSolver().accessObservedStates())
+    {
+        states.add(stateBuilder.expand(state.inFrame(aState.accessFrame()), aState));
+    }
+
+    Segment::Solution solution = {name_, dynamicsArray, states, conditionSolution.conditionIsSatisfied, type_};
 
     // As the event condition could have terminated due to the thruster off condition, we want to
     // re-evaluate the segment event condition to see if it's satisfied.
@@ -1820,7 +1828,25 @@ Segment::Solution Segment::solveUntilThrusterOn_(
         Array<Shared<EventCondition>> {eventCondition_, thrusterToggleCondition}
     );
 
-    Segment::Solution solution = solveWithDynamics_(aState, anEndInstant, freeDynamicsArray_, combinedCondition);
+    // Use a solver with a max step size to ensure the integrator doesn't overshoot the thrust-on
+    // boundary. The thrust toggle condition is a step function that can be missed entirely if the
+    // adaptive stepper takes a step larger than the thrust window.
+    NumericalSolver stepLimitedSolver = numericalSolver_;
+    stepLimitedSolver.setMaxStepSize((anEndInstant - aState.accessInstant()).inSeconds() / 10.0);
+
+    const Propagator propagator = {stepLimitedSolver, freeDynamicsArray_};
+    const NumericalSolver::ConditionSolution conditionSolution =
+        propagator.calculateStateToCondition(aState, anEndInstant, *combinedCondition);
+
+    const StateBuilder stateBuilder = {aState};
+    Array<State> states = Array<State>::Empty();
+    states.reserve(propagator.accessNumericalSolver().accessObservedStates().getSize());
+    for (const State& state : propagator.accessNumericalSolver().accessObservedStates())
+    {
+        states.add(stateBuilder.expand(state.inFrame(aState.accessFrame()), aState));
+    }
+
+    Segment::Solution solution = {name_, freeDynamicsArray_, states, conditionSolution.conditionIsSatisfied, type_};
 
     // As the event condition could have terminated due to the thruster on condition, we want to
     // re-evaluate the segment event condition to see if it's satisfied.

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -307,15 +307,13 @@ Segment::Solution::Solution(
     const Array<Shared<Dynamics>>& aDynamicsArray,
     const Array<State>& aStateArray,
     const bool& aConditionIsSatisfied,
-    const Segment::Type& aSegmentType,
-    const Array<Interval>& aManeuverIntervals
+    const Segment::Type& aSegmentType
 )
     : name(aName),
       dynamics(aDynamicsArray),
       states(aStateArray),
       conditionIsSatisfied(aConditionIsSatisfied),
-      segmentType(aSegmentType),
-      maneuverIntervals(aManeuverIntervals)
+      segmentType(aSegmentType)
 {
 }
 
@@ -496,45 +494,6 @@ Array<FlightManeuver> Segment::Solution::extractManeuvers(const Shared<const Fra
             maneuverBlockStartStopIndices.add(Pair<Size, Size>(blockStart, blockEnd));
         }
     }
-    // }
-    // else
-    // {
-    //     // Fall back to detecting maneuver blocks from acceleration on/off transitions
-    //     Integer maneuverStart = Integer::Undefined();
-    //     for (Size i = 0; i < numberOfStates; i++)
-    //     {
-    //         if (fullSegmentContributions.row(i).norm() != 0.0)  // If thrusting
-    //         {
-    //             // If a new block hasn't started yet, mark its start
-    //             if (!maneuverStart.isDefined())
-    //             {
-    //                 maneuverStart = i;
-    //             }
-
-    //             // If end of segment is thrusting, close last block
-    //             if (i == numberOfStates - 1)
-    //             {
-    //                 // Store stop index as i + 1 because you don't get a chance to "close this
-    //                 // block" by seeing the thrust go to zero on the next iteration, since the loop ends on this
-    //                 // iteration
-    //                 maneuverBlockStartStopIndices.add(Pair<Size, Size>(maneuverStart, i + 1));
-    //             }
-    //         }
-    //         else  // If not thrusting
-    //         {
-    //             // If we have reached the end of a block, save the start and end indices
-    //             // Include the current "off" state (i + 1 as exclusive end) because thrust was applied
-    //             // during the interval from the previous state to this state. The maneuver duration
-    //             // should span the full interval over which thrust was applied.
-    //             if (maneuverStart.isDefined())
-    //             {
-    //                 maneuverBlockStartStopIndices.add(Pair<Size, Size>(maneuverStart, i + 1));
-
-    //                 maneuverStart = Integer::Undefined();  // Close the block by marking the start as undefined
-    //             }
-    //         }
-    //     }
-    // }
 
     // If no thrusting has occured during this maneuvering segment (which is possible), return an empty array
     if (maneuverBlockStartStopIndices.isEmpty())
@@ -554,10 +513,6 @@ Array<FlightManeuver> Segment::Solution::extractManeuvers(const Shared<const Fra
 
     Array<FlightManeuver> extractedManeuvers = Array<FlightManeuver>::Empty();
 
-    for (const auto& block : maneuverBlockStartStopIndices)
-    {
-        std::cout << "block: " << block.first << " " << block.second << std::endl;
-    }
     for (const Pair<Size, Size>& startStopPair : maneuverBlockStartStopIndices)
     {
         const Size blockLength = startStopPair.second - startStopPair.first;
@@ -577,17 +532,11 @@ Array<FlightManeuver> Segment::Solution::extractManeuvers(const Shared<const Fra
                 CartesianPosition::Default(),
                 CartesianVelocity::Default(),
             });
-
-            // Use the actual contribution values (including zero for the "off" state)
-            // The "off" state is included to enable accurate trapezoidal integration:
-            // the final interval contribution is (a_n-1 + 0) / 2 * dt
             coordinates.segment<3>(6) = maneuverContributionBlock.block<1, 3>(i, 0);
             coordinates(9) = fullSegmentContributions(startStopPair.first + i, 3);
 
             maneuverStatesBlock.add(stateBuilder.build(state.accessInstant(), coordinates));
         }
-
-        std::cout << "maneuverStatesBlock: " << maneuverStatesBlock << std::endl;
 
         extractedManeuvers.add(FlightManeuver(maneuverStatesBlock));
     }
@@ -1053,8 +1002,6 @@ Segment::Solution Segment::solve(
             return {maneuverSolution, std::nullopt};
         }
 
-        std::cout << "maneuverSolution: " << maneuverSolution << std::endl;
-
         const Array<FlightManeuver> maneuvers = maneuverSolution.extractManeuvers(aState.accessFrame());
 
         if (maneuvers.isEmpty())
@@ -1073,9 +1020,6 @@ Segment::Solution Segment::solve(
         {
             return maneuverSolution;
         }
-
-        // std::cout << "--------Constructing LOF compliant maneuver solution for maneuver: "
-        //           << maneuver.getInterval().toString() << "--------" << std::endl;
 
         return constructLOFCompliantManeuverSolution_(segmentStates.accessLast(), maneuver);
     };
@@ -1097,9 +1041,6 @@ Segment::Solution Segment::solve(
         std::make_shared<HeterogeneousGuidanceLaw>();
     const auto acceptManeuver = [&](const Segment::Solution& maneuverSolution, const FlightManeuver& maneuver) -> void
     {
-        // std::cout << "Accepting maneuver states from " << maneuverSolution.states[1].getInstant().toString() << " to
-        // "
-        //           << maneuverSolution.states.accessLast().getInstant().toString() << std::endl;
         segmentStates.add(Array<State>(maneuverSolution.states.begin() + 1, maneuverSolution.states.end()));
 
         segmentConditionIsSatisfied = maneuverSolution.conditionIsSatisfied;
@@ -1508,8 +1449,6 @@ Segment::Solution Segment::solve(
 
         const Interval candidateManeuverInterval = subsegmentManeuver->getInterval();
 
-        // std::cout << "candidateManeuverInterval: " << candidateManeuverInterval.toString() << std::endl;
-
         if (candidateManeuverInterval.getDuration() < shortManeuverThreshold)
         {
             segmentConditionIsSatisfied =
@@ -1603,7 +1542,6 @@ Segment::Solution Segment::solve(
             const Segment::Solution maneuverLOFCompliantSolution =
                 constructLOFCompliantManeuverSolution(maneuverSubSegmentSolution, subsegmentManeuver.value());
 
-            // std::cout << "Accepting maneuver: " << subsegmentManeuver->getInterval().toString() << std::endl;
             acceptManeuver(maneuverLOFCompliantSolution, subsegmentManeuver.value());
         }
     }
@@ -1751,16 +1689,6 @@ Segment::Solution Segment::solveWithDynamics_(
         states.add(stateBuilder.expand(state.inFrame(aState.accessFrame()), aState));
     }
 
-    // if (states.getSize() >= 3)
-    // {
-    //     std::cout << "third last state: " << states[states.getSize() - 3].getInstant().toString() << std::endl;
-    // }
-    // if (states.getSize() >= 2)
-    // {
-    //     std::cout << "second last state: " << states[states.getSize() - 2].getInstant().toString() << std::endl;
-    // }
-    // std::cout << "last state: " << states[states.getSize() - 1].getInstant().toString() << std::endl;
-
     return {
         name_,
         aDynamicsArray,
@@ -1900,60 +1828,6 @@ Segment::Solution Segment::solveUntilThrusterOn_(
     solution.segmentType = Segment::Type::Coast;
 
     return solution;
-}
-
-Segment::Solution Segment::solveTillThrusterOn_(
-    const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& thrusterDynamics
-) const
-{
-    std::cout << "solveTillThrusterOn_: " << aState.getInstant().toString() << " to "
-              << maximumPropagationDuration.toString() << std::endl;
-    // Determine the event condition to use for solving
-    const Shared<const GuidanceLaw> guidanceLaw = thrusterDynamics->getGuidanceLaw();
-
-    const std::function<Real(const State&)> thrustAccelerationNormEvaluator = [&guidanceLaw](const State& state) -> Real
-    {
-        const Vector3d positionCoordinates = state.getPosition().inMeters().accessCoordinates();
-        const Vector3d velocityCoordinates =
-            state.getVelocity().inUnit(Velocity::Unit::MeterPerSecond).accessCoordinates();
-
-        // Set the thrust acceleration to 1.0, as we're only interested to see if it's on or off.
-        const Vector3d thrustAcceleration = guidanceLaw->calculateThrustAccelerationAt(
-            state.accessInstant(), positionCoordinates, velocityCoordinates, 1.0, state.accessFrame()
-        );
-
-        return thrustAcceleration.norm();
-    };
-
-    // Use a threshold of 0.5 to determine if the thrust is on or off, as the thrust acceleration norm will either
-    // be 1.0 if on, or 0.0 if off.
-    const Shared<RealCondition> thrustOnCondition = std::make_shared<RealCondition>(
-        "Thrust On Condition", RealCondition::Criterion::StrictlyPositive, thrustAccelerationNormEvaluator, 0.5
-    );
-
-    // Solve the segment until the thrust is on
-    const Shared<EventCondition> combinedThrustOnCondition = std::make_shared<LogicalCondition>(
-        "Combined Event or Thrust On Condition",
-        LogicalCondition::Type::Or,
-        Array<Shared<EventCondition>> {eventCondition_, thrustOnCondition}
-    );
-
-    // std::cout << "Solving pre-coast for next maneuver from " << aState.getInstant().toString() << " to "
-    //           << maximumPropagationDuration.toString() << std::endl;
-
-    Segment::Solution coastSolution =
-        solveWithDynamics_(aState, maximumPropagationDuration, freeDynamicsArray_, combinedThrustOnCondition);
-
-    // As the event condition could have terminated due to the thruster on condition, we want to re-evaluate the
-    // segment event condition to see if it's satisfied.
-    // To do so, we can check the last state against the initial state to see if the event condition is satisfied.
-    coastSolution.conditionIsSatisfied = eventCondition_->isSatisfied(coastSolution.states.accessLast(), aState);
-    coastSolution.segmentType = Segment::Type::Coast;
-
-    std::cout << "coastSolution: " << coastSolution << std::endl;
-    std::cout << "coastSolution.states: " << coastSolution.states << std::endl;
-
-    return coastSolution;
 }
 
 Segment::Solution Segment::solveManeuverForInterval_(

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -131,7 +131,8 @@ Segment::ManeuverConstraints::ManeuverConstraints(
         // Minimum separation must be defined if maximum duty cycle is defined.
         if (!minimumSeparation.isDefined())
         {
-            throw ostk::core::error::RuntimeError("Minimum separation must be defined if maximum duty cycle is defined."
+            throw ostk::core::error::RuntimeError(
+                "Minimum separation must be defined if maximum duty cycle is defined."
             );
         }
     }
@@ -306,13 +307,15 @@ Segment::Solution::Solution(
     const Array<Shared<Dynamics>>& aDynamicsArray,
     const Array<State>& aStateArray,
     const bool& aConditionIsSatisfied,
-    const Segment::Type& aSegmentType
+    const Segment::Type& aSegmentType,
+    const Array<Interval>& aManeuverIntervals
 )
     : name(aName),
       dynamics(aDynamicsArray),
       states(aStateArray),
       conditionIsSatisfied(aConditionIsSatisfied),
-      segmentType(aSegmentType)
+      segmentType(aSegmentType),
+      maneuverIntervals(aManeuverIntervals)
 {
 }
 
@@ -493,6 +496,45 @@ Array<FlightManeuver> Segment::Solution::extractManeuvers(const Shared<const Fra
             maneuverBlockStartStopIndices.add(Pair<Size, Size>(blockStart, blockEnd));
         }
     }
+    // }
+    // else
+    // {
+    //     // Fall back to detecting maneuver blocks from acceleration on/off transitions
+    //     Integer maneuverStart = Integer::Undefined();
+    //     for (Size i = 0; i < numberOfStates; i++)
+    //     {
+    //         if (fullSegmentContributions.row(i).norm() != 0.0)  // If thrusting
+    //         {
+    //             // If a new block hasn't started yet, mark its start
+    //             if (!maneuverStart.isDefined())
+    //             {
+    //                 maneuverStart = i;
+    //             }
+
+    //             // If end of segment is thrusting, close last block
+    //             if (i == numberOfStates - 1)
+    //             {
+    //                 // Store stop index as i + 1 because you don't get a chance to "close this
+    //                 // block" by seeing the thrust go to zero on the next iteration, since the loop ends on this
+    //                 // iteration
+    //                 maneuverBlockStartStopIndices.add(Pair<Size, Size>(maneuverStart, i + 1));
+    //             }
+    //         }
+    //         else  // If not thrusting
+    //         {
+    //             // If we have reached the end of a block, save the start and end indices
+    //             // Include the current "off" state (i + 1 as exclusive end) because thrust was applied
+    //             // during the interval from the previous state to this state. The maneuver duration
+    //             // should span the full interval over which thrust was applied.
+    //             if (maneuverStart.isDefined())
+    //             {
+    //                 maneuverBlockStartStopIndices.add(Pair<Size, Size>(maneuverStart, i + 1));
+
+    //                 maneuverStart = Integer::Undefined();  // Close the block by marking the start as undefined
+    //             }
+    //         }
+    //     }
+    // }
 
     // If no thrusting has occured during this maneuvering segment (which is possible), return an empty array
     if (maneuverBlockStartStopIndices.isEmpty())
@@ -511,6 +553,11 @@ Array<FlightManeuver> Segment::Solution::extractManeuvers(const Shared<const Fra
     };
 
     Array<FlightManeuver> extractedManeuvers = Array<FlightManeuver>::Empty();
+
+    for (const auto& block : maneuverBlockStartStopIndices)
+    {
+        std::cout << "block: " << block.first << " " << block.second << std::endl;
+    }
     for (const Pair<Size, Size>& startStopPair : maneuverBlockStartStopIndices)
     {
         const Size blockLength = startStopPair.second - startStopPair.first;
@@ -530,11 +577,17 @@ Array<FlightManeuver> Segment::Solution::extractManeuvers(const Shared<const Fra
                 CartesianPosition::Default(),
                 CartesianVelocity::Default(),
             });
+
+            // Use the actual contribution values (including zero for the "off" state)
+            // The "off" state is included to enable accurate trapezoidal integration:
+            // the final interval contribution is (a_n-1 + 0) / 2 * dt
             coordinates.segment<3>(6) = maneuverContributionBlock.block<1, 3>(i, 0);
             coordinates(9) = fullSegmentContributions(startStopPair.first + i, 3);
 
             maneuverStatesBlock.add(stateBuilder.build(state.accessInstant(), coordinates));
         }
+
+        std::cout << "maneuverStatesBlock: " << maneuverStatesBlock << std::endl;
 
         extractedManeuvers.add(FlightManeuver(maneuverStatesBlock));
     }
@@ -613,10 +666,12 @@ MatrixXd Segment::Solution::getDynamicsContribution(
     {
         if (!dynamicsWriteCoordinateSubsets.contains(aCoordinateSubsetSPtr))
         {
-            throw ostk::core::error::RuntimeError(String::Format(
-                "Provided coordinate subset [{}] is not part of the dynamics write coordinate subsets.",
-                aCoordinateSubsetSPtr->getName()
-            ));
+            throw ostk::core::error::RuntimeError(
+                String::Format(
+                    "Provided coordinate subset [{}] is not part of the dynamics write coordinate subsets.",
+                    aCoordinateSubsetSPtr->getName()
+                )
+            );
         }
     }
 
@@ -674,7 +729,8 @@ MatrixXd Segment::Solution::getDynamicsAccelerationContribution(
     return this->getDynamicsContribution(aDynamicsSPtr, aFrameSPtr, {CartesianVelocity::Default()});
 }
 
-Map<Shared<Dynamics>, MatrixXd> Segment::Solution::getAllDynamicsContributions(const Shared<const Frame>& aFrameSPtr
+Map<Shared<Dynamics>, MatrixXd> Segment::Solution::getAllDynamicsContributions(
+    const Shared<const Frame>& aFrameSPtr
 ) const
 {
     // Each MatrixXd contains the contribution of a single dynamics for all the segment states
@@ -885,11 +941,14 @@ Segment::Solution Segment::solve(
     {
         if (previousManeuverInterval.getEnd() > aState.accessInstant())
         {
-            throw ostk::core::error::RuntimeError(String::Format(
-                "All maneuver intervals must be before the initial state instant. Maneuver interval [{}] ends after "
-                "the initial state instant.",
-                previousManeuverInterval.toString()
-            ));
+            throw ostk::core::error::RuntimeError(
+                String::Format(
+                    "All maneuver intervals must be before the initial state instant. Maneuver interval [{}] ends "
+                    "after "
+                    "the initial state instant.",
+                    previousManeuverInterval.toString()
+                )
+            );
         }
     }
 
@@ -939,8 +998,8 @@ Segment::Solution Segment::solve(
     };
 
     // Helper lambda to solve a single maneuver and extract results
-    const auto solveSingleManeuver = [&](const Shared<Thruster>& thrusterDynamics
-                                     ) -> std::pair<Segment::Solution, std::optional<FlightManeuver>>
+    const auto solveSingleManeuver =
+        [&](const Shared<Thruster>& thrusterDynamics) -> std::pair<Segment::Solution, std::optional<FlightManeuver>>
     {
         const State& lastState = segmentStates.accessLast();
         const Segment::Solution coastSolution = solveUntilThrusterOn_(lastState, maximumInstant, thrusterDynamics);
@@ -994,6 +1053,8 @@ Segment::Solution Segment::solve(
             return {maneuverSolution, std::nullopt};
         }
 
+        std::cout << "maneuverSolution: " << maneuverSolution << std::endl;
+
         const Array<FlightManeuver> maneuvers = maneuverSolution.extractManeuvers(aState.accessFrame());
 
         if (maneuvers.isEmpty())
@@ -1012,6 +1073,9 @@ Segment::Solution Segment::solve(
         {
             return maneuverSolution;
         }
+
+        // std::cout << "--------Constructing LOF compliant maneuver solution for maneuver: "
+        //           << maneuver.getInterval().toString() << "--------" << std::endl;
 
         return constructLOFCompliantManeuverSolution_(segmentStates.accessLast(), maneuver);
     };
@@ -1033,6 +1097,9 @@ Segment::Solution Segment::solve(
         std::make_shared<HeterogeneousGuidanceLaw>();
     const auto acceptManeuver = [&](const Segment::Solution& maneuverSolution, const FlightManeuver& maneuver) -> void
     {
+        // std::cout << "Accepting maneuver states from " << maneuverSolution.states[1].getInstant().toString() << " to
+        // "
+        //           << maneuverSolution.states.accessLast().getInstant().toString() << std::endl;
         segmentStates.add(Array<State>(maneuverSolution.states.begin() + 1, maneuverSolution.states.end()));
 
         segmentConditionIsSatisfied = maneuverSolution.conditionIsSatisfied;
@@ -1441,6 +1508,8 @@ Segment::Solution Segment::solve(
 
         const Interval candidateManeuverInterval = subsegmentManeuver->getInterval();
 
+        // std::cout << "candidateManeuverInterval: " << candidateManeuverInterval.toString() << std::endl;
+
         if (candidateManeuverInterval.getDuration() < shortManeuverThreshold)
         {
             segmentConditionIsSatisfied =
@@ -1528,20 +1597,27 @@ Segment::Solution Segment::solve(
             continue;
         }
 
-        // Candidate maneuver passed all constraints - accept it
-        const Segment::Solution maneuverLOFCompliantSolution =
-            constructLOFCompliantManeuverSolution(maneuverSubSegmentSolution, subsegmentManeuver.value());
-        acceptManeuver(maneuverLOFCompliantSolution, subsegmentManeuver.value());
+        else
+        {
+            // Candidate maneuver passed all constraints - accept it
+            const Segment::Solution maneuverLOFCompliantSolution =
+                constructLOFCompliantManeuverSolution(maneuverSubSegmentSolution, subsegmentManeuver.value());
+
+            // std::cout << "Accepting maneuver: " << subsegmentManeuver->getInterval().toString() << std::endl;
+            acceptManeuver(maneuverLOFCompliantSolution, subsegmentManeuver.value());
+        }
     }
 
     // Build final solution
     Array<Shared<Dynamics>> segmentDynamics = freeDynamicsArray_;
 
-    segmentDynamics.add(std::make_shared<Thruster>(
-        this->getThrusterDynamics()->getSatelliteSystem(),
-        segmentHeterogenousGuidanceLaw,
-        this->getThrusterDynamics()->getName() + " (Maneuvering Constraints)"
-    ));
+    segmentDynamics.add(
+        std::make_shared<Thruster>(
+            this->getThrusterDynamics()->getSatelliteSystem(),
+            segmentHeterogenousGuidanceLaw,
+            this->getThrusterDynamics()->getName() + " (Maneuvering Constraints)"
+        )
+    );
 
     return Segment::Solution(
         name_,
@@ -1675,6 +1751,16 @@ Segment::Solution Segment::solveWithDynamics_(
         states.add(stateBuilder.expand(state.inFrame(aState.accessFrame()), aState));
     }
 
+    // if (states.getSize() >= 3)
+    // {
+    //     std::cout << "third last state: " << states[states.getSize() - 3].getInstant().toString() << std::endl;
+    // }
+    // if (states.getSize() >= 2)
+    // {
+    //     std::cout << "second last state: " << states[states.getSize() - 2].getInstant().toString() << std::endl;
+    // }
+    // std::cout << "last state: " << states[states.getSize() - 1].getInstant().toString() << std::endl;
+
     return {
         name_,
         aDynamicsArray,
@@ -1709,8 +1795,9 @@ Array<State> Segment::propagateWithDynamics_(
     return states;
 }
 
-Segment::Solution Segment::constructLOFCompliantManeuverSolution_(const State& aState, const FlightManeuver& aManeuver)
-    const
+Segment::Solution Segment::constructLOFCompliantManeuverSolution_(
+    const State& aState, const FlightManeuver& aManeuver
+) const
 {
     const Shared<ConstantThrust> constantThrust = std::make_shared<ConstantThrust>(ConstantThrust::FromManeuver(
         aManeuver,
@@ -1735,8 +1822,9 @@ Segment::Solution Segment::solveCoast_(const State& aState, const Instant& anEnd
     return solution;
 }
 
-Shared<RealCondition> Segment::getThrusterToggleCondition_(const Shared<Thruster>& thrusterDynamics, const bool& isOn)
-    const
+Shared<RealCondition> Segment::getThrusterToggleCondition_(
+    const Shared<Thruster>& thrusterDynamics, const bool& isOn
+) const
 {
     const Shared<const GuidanceLaw> guidanceLaw = thrusterDynamics->getGuidanceLaw();
 
@@ -1812,6 +1900,60 @@ Segment::Solution Segment::solveUntilThrusterOn_(
     solution.segmentType = Segment::Type::Coast;
 
     return solution;
+}
+
+Segment::Solution Segment::solveTillThrusterOn_(
+    const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& thrusterDynamics
+) const
+{
+    std::cout << "solveTillThrusterOn_: " << aState.getInstant().toString() << " to "
+              << maximumPropagationDuration.toString() << std::endl;
+    // Determine the event condition to use for solving
+    const Shared<const GuidanceLaw> guidanceLaw = thrusterDynamics->getGuidanceLaw();
+
+    const std::function<Real(const State&)> thrustAccelerationNormEvaluator = [&guidanceLaw](const State& state) -> Real
+    {
+        const Vector3d positionCoordinates = state.getPosition().inMeters().accessCoordinates();
+        const Vector3d velocityCoordinates =
+            state.getVelocity().inUnit(Velocity::Unit::MeterPerSecond).accessCoordinates();
+
+        // Set the thrust acceleration to 1.0, as we're only interested to see if it's on or off.
+        const Vector3d thrustAcceleration = guidanceLaw->calculateThrustAccelerationAt(
+            state.accessInstant(), positionCoordinates, velocityCoordinates, 1.0, state.accessFrame()
+        );
+
+        return thrustAcceleration.norm();
+    };
+
+    // Use a threshold of 0.5 to determine if the thrust is on or off, as the thrust acceleration norm will either
+    // be 1.0 if on, or 0.0 if off.
+    const Shared<RealCondition> thrustOnCondition = std::make_shared<RealCondition>(
+        "Thrust On Condition", RealCondition::Criterion::StrictlyPositive, thrustAccelerationNormEvaluator, 0.5
+    );
+
+    // Solve the segment until the thrust is on
+    const Shared<EventCondition> combinedThrustOnCondition = std::make_shared<LogicalCondition>(
+        "Combined Event or Thrust On Condition",
+        LogicalCondition::Type::Or,
+        Array<Shared<EventCondition>> {eventCondition_, thrustOnCondition}
+    );
+
+    // std::cout << "Solving pre-coast for next maneuver from " << aState.getInstant().toString() << " to "
+    //           << maximumPropagationDuration.toString() << std::endl;
+
+    Segment::Solution coastSolution =
+        solveWithDynamics_(aState, maximumPropagationDuration, freeDynamicsArray_, combinedThrustOnCondition);
+
+    // As the event condition could have terminated due to the thruster on condition, we want to re-evaluate the
+    // segment event condition to see if it's satisfied.
+    // To do so, we can check the last state against the initial state to see if the event condition is satisfied.
+    coastSolution.conditionIsSatisfied = eventCondition_->isSatisfied(coastSolution.states.accessLast(), aState);
+    coastSolution.segmentType = Segment::Type::Coast;
+
+    std::cout << "coastSolution: " << coastSolution << std::endl;
+    std::cout << "coastSolution.states: " << coastSolution.states << std::endl;
+
+    return coastSolution;
 }
 
 Segment::Solution Segment::solveManeuverForInterval_(

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -1530,14 +1530,11 @@ Segment::Solution Segment::solve(
             continue;
         }
 
-        else
-        {
-            // Candidate maneuver passed all constraints - accept it
-            const Segment::Solution maneuverLOFCompliantSolution =
-                constructLOFCompliantManeuverSolution(maneuverSubSegmentSolution, subsegmentManeuver.value());
+        // Candidate maneuver passed all constraints - accept it
+        const Segment::Solution maneuverLOFCompliantSolution =
+            constructLOFCompliantManeuverSolution(maneuverSubSegmentSolution, subsegmentManeuver.value());
 
-            acceptManeuver(maneuverLOFCompliantSolution, subsegmentManeuver.value());
-        }
+        acceptManeuver(maneuverLOFCompliantSolution, subsegmentManeuver.value());
     }
 
     // Build final solution
@@ -1659,11 +1656,22 @@ Segment::Solution Segment::solveWithDynamics_(
     const State& aState,
     const Instant& anEndInstant,
     const Array<Shared<Dynamics>>& aDynamicsArray,
-    const Shared<EventCondition>& anEventCondition
+    const Shared<EventCondition>& anEventCondition,
+    const bool& limitMaxStepSize
 ) const
 {
+    // Use a solver with a max step size to ensure the integrator doesn't overshoot the thrust-on
+    // boundary. The thrust toggle condition is a step function that can be missed entirely if the
+    // adaptive stepper takes a step larger than the thrust window.
+    NumericalSolver numericalSolver = numericalSolver_;
+    if (limitMaxStepSize)
+    {
+        const Real maxStepSize = std::min(Real(120.0), (anEndInstant - aState.accessInstant()).inSeconds() / 10.0);
+        numericalSolver.setMaxStepSize(maxStepSize);
+    }
+
     const Propagator propagator = {
-        numericalSolver_,
+        numericalSolver,
         aDynamicsArray,
     };
 
@@ -1789,22 +1797,7 @@ Segment::Solution Segment::solveUntilThrusterOff_(
     // Use a solver with a max step size to ensure the integrator doesn't overshoot the thrust-off
     // boundary. The thrust toggle condition is a step function that can be missed entirely if the
     // adaptive stepper takes a step larger than the remaining thrust window.
-    NumericalSolver stepLimitedSolver = numericalSolver_;
-    stepLimitedSolver.setMaxStepSize((anEndInstant - aState.accessInstant()).inSeconds() / 10.0);
-
-    const Propagator propagator = {stepLimitedSolver, dynamicsArray};
-    const NumericalSolver::ConditionSolution conditionSolution =
-        propagator.calculateStateToCondition(aState, anEndInstant, *combinedCondition);
-
-    const StateBuilder stateBuilder = {aState};
-    Array<State> states = Array<State>::Empty();
-    states.reserve(propagator.accessNumericalSolver().accessObservedStates().getSize());
-    for (const State& state : propagator.accessNumericalSolver().accessObservedStates())
-    {
-        states.add(stateBuilder.expand(state.inFrame(aState.accessFrame()), aState));
-    }
-
-    Segment::Solution solution = {name_, dynamicsArray, states, conditionSolution.conditionIsSatisfied, type_};
+    Segment::Solution solution = solveWithDynamics_(aState, anEndInstant, dynamicsArray, combinedCondition, true);
 
     // As the event condition could have terminated due to the thruster off condition, we want to
     // re-evaluate the segment event condition to see if it's satisfied.
@@ -1831,22 +1824,7 @@ Segment::Solution Segment::solveUntilThrusterOn_(
     // Use a solver with a max step size to ensure the integrator doesn't overshoot the thrust-on
     // boundary. The thrust toggle condition is a step function that can be missed entirely if the
     // adaptive stepper takes a step larger than the thrust window.
-    NumericalSolver stepLimitedSolver = numericalSolver_;
-    stepLimitedSolver.setMaxStepSize((anEndInstant - aState.accessInstant()).inSeconds() / 10.0);
-
-    const Propagator propagator = {stepLimitedSolver, freeDynamicsArray_};
-    const NumericalSolver::ConditionSolution conditionSolution =
-        propagator.calculateStateToCondition(aState, anEndInstant, *combinedCondition);
-
-    const StateBuilder stateBuilder = {aState};
-    Array<State> states = Array<State>::Empty();
-    states.reserve(propagator.accessNumericalSolver().accessObservedStates().getSize());
-    for (const State& state : propagator.accessNumericalSolver().accessObservedStates())
-    {
-        states.add(stateBuilder.expand(state.inFrame(aState.accessFrame()), aState));
-    }
-
-    Segment::Solution solution = {name_, freeDynamicsArray_, states, conditionSolution.conditionIsSatisfied, type_};
+    Segment::Solution solution = solveWithDynamics_(aState, anEndInstant, freeDynamicsArray_, combinedCondition, true);
 
     // As the event condition could have terminated due to the thruster on condition, we want to
     // re-evaluate the segment event condition to see if it's satisfied.

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -144,8 +144,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTime(
 )
 {
     // Validate strategy is compatible with stepper
-    if (rootFindingStrategy_ == RootFindingStrategy::DenseOutput &&
-        stepperType_ != StepperType::RungeKuttaDopri5)
+    if (rootFindingStrategy_ == RootFindingStrategy::DenseOutput && stepperType_ != StepperType::RungeKuttaDopri5)
     {
         throw ostk::core::error::RuntimeError(
             "DenseOutput root finding strategy requires RungeKuttaDopri5 stepper type. "
@@ -238,8 +237,7 @@ NumericalSolver NumericalSolver::FixedStepSize(const NumericalSolver::StepperTyp
 }
 
 NumericalSolver NumericalSolver::DefaultConditional(
-    const std::function<void(const State&)>& stateLogger,
-    const RootFindingStrategy& aRootFindingStrategy
+    const std::function<void(const State&)>& stateLogger, const RootFindingStrategy& aRootFindingStrategy
 )
 {
     return NumericalSolver::Conditional(5.0, 1.0e-12, 1.0e-12, stateLogger, aRootFindingStrategy);
@@ -257,9 +255,9 @@ NumericalSolver NumericalSolver::Conditional(
         stateLogger != nullptr ? NumericalSolver::LogType::LogAdaptive : NumericalSolver::LogType::NoLog;
 
     // Choose stepper type based on strategy
-    const NumericalSolver::StepperType stepperType =
-        (aRootFindingStrategy == RootFindingStrategy::DenseOutput) ? NumericalSolver::StepperType::RungeKuttaDopri5
-                                                                   : NumericalSolver::StepperType::RungeKuttaFehlberg78;
+    const NumericalSolver::StepperType stepperType = (aRootFindingStrategy == RootFindingStrategy::DenseOutput)
+                                                       ? NumericalSolver::StepperType::RungeKuttaDopri5
+                                                       : NumericalSolver::StepperType::RungeKuttaFehlberg78;
 
     return {
         logType,
@@ -659,9 +657,9 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
         case RootFindingStrategy::Linear:
         {
             // Linear interpolation for root finding
-            const auto linearInterpolate =
-                [&previousStateVector, &currentStateVector, previousTime, currentTime](const double& t
-                ) -> NumericalSolver::StateVector
+            const auto linearInterpolate = [&previousStateVector, &currentStateVector, previousTime, currentTime](
+                                               const double& t
+                                           ) -> NumericalSolver::StateVector
             {
                 const double alpha = (t - previousTime) / (currentTime - previousTime);
                 return previousStateVector * (1.0 - alpha) + currentStateVector * alpha;
@@ -672,14 +670,14 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
                 const NumericalSolver::StateVector interpolatedCoords = linearInterpolate(aTime);
                 const State interpolatedState = createState(interpolatedCoords, aTime);
 
-                const bool isSatisfied = anEventCondition.isSatisfied(
-                    interpolatedState, createState(previousStateVector, previousTime)
-                );
+                const bool isSatisfied =
+                    anEventCondition.isSatisfied(interpolatedState, createState(previousStateVector, previousTime));
 
                 return isSatisfied ? 1.0 : -1.0;
             };
 
-            const RootSolver::Solution solution = rootSolver_.bisection(checkConditionLinear, previousTime, currentTime);
+            const RootSolver::Solution solution =
+                rootSolver_.bisection(checkConditionLinear, previousTime, currentTime);
             const NumericalSolver::StateVector solutionStateVector = linearInterpolate(solution.root);
             const State solutionState = createState(solutionStateVector, solution.root);
             observeState(solutionState);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -470,8 +470,11 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
 
         if (currentTime != finalTime)
         {
+            // Compute step size with correct sign for the direction from currentTime to finalTime.
+            // This handles the case where we overshot finalTime and need to integrate backwards.
+            const double adjustmentStepSize = (finalTime - currentTime) / 10.0;
             integrateToTime<Stepper>(
-                stepper, currentStateVector, currentTime, finalTime, signedTimeStep, aSystemOfEquations
+                stepper, currentStateVector, currentTime, finalTime, adjustmentStepSize, aSystemOfEquations
             );
         }
 
@@ -555,7 +558,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
             const RootSolver::Solution solution =
                 rootSolver.bisection(checkConditionPropagated, previousTime, currentTime);
 
-            const double solutionTime = static_cast<double>(solution.root);
+            const double solutionTime = solution.upperBound;
             const double subStepSize = (solutionTime - previousTime) / 10.0;
             NumericalSolver::StateVector solutionStateVector = previousStateVector;
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -26,6 +26,9 @@ using ostk::physics::time::Duration;
 using ostk::astrodynamics::RootSolver;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
+typedef runge_kutta4<NumericalSolver::StateVector> stepper_type_4;
+typedef runge_kutta_cash_karp54<NumericalSolver::StateVector> error_stepper_type_54;
+typedef runge_kutta_fehlberg78<NumericalSolver::StateVector> error_stepper_type_78;
 typedef runge_kutta_dopri5<NumericalSolver::StateVector> dense_stepper_type_5;
 
 NumericalSolver::NumericalSolver(
@@ -34,12 +37,14 @@ NumericalSolver::NumericalSolver(
     const Real& aTimeStep,
     const Real& aRelativeTolerance,
     const Real& anAbsoluteTolerance,
-    const RootSolver& aRootSolver
+    const RootSolver& aRootSolver,
+    const RootFindingStrategy& aRootFindingStrategy
 )
     : MathNumericalSolver(aLogType, aStepperType, aTimeStep, aRelativeTolerance, anAbsoluteTolerance),
       rootSolver_(aRootSolver),
       observedStates_(),
-      stateLogger_(nullptr)
+      stateLogger_(nullptr),
+      rootFindingStrategy_(aRootFindingStrategy)
 {
 }
 
@@ -66,6 +71,16 @@ RootSolver NumericalSolver::getRootSolver() const
 Array<State> NumericalSolver::getObservedStates() const
 {
     return accessObservedStates();
+}
+
+NumericalSolver::RootFindingStrategy NumericalSolver::getRootFindingStrategy() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("NumericalSolver");
+    }
+
+    return rootFindingStrategy_;
 }
 
 Array<State> NumericalSolver::integrateTime(
@@ -128,23 +143,19 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTime(
     const EventCondition& anEventCondition
 )
 {
-    if (stepperType_ != NumericalSolver::StepperType::RungeKuttaDopri5)
+    // Validate strategy is compatible with stepper
+    if (rootFindingStrategy_ == RootFindingStrategy::DenseOutput &&
+        stepperType_ != StepperType::RungeKuttaDopri5)
     {
-        throw ostk::core::error::runtime::ToBeImplemented(
-            "Integrating with conditions is only supported with RungeKuttaDopri5 stepper type."
+        throw ostk::core::error::RuntimeError(
+            "DenseOutput root finding strategy requires RungeKuttaDopri5 stepper type. "
+            "Use Linear, Propagated, or Boundary strategy for other steppers."
         );
     }
 
     observedStates_ = {aState};
 
-    const StateBuilder stateBuilder = {aState};
-
     const Real aDurationInSeconds = (anInstant - aState.accessInstant()).inSeconds();
-
-    const auto createState = [&stateBuilder, &aState](const VectorXd& aStateVector, const double& aTime) -> State
-    {
-        return stateBuilder.build(aState.accessInstant() + Duration::Seconds(aTime), aStateVector);
-    };
 
     // Check trivial cases
     if (aDurationInSeconds.isZero())
@@ -168,10 +179,164 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTime(
         };
     }
 
+    // Dispatch to appropriate helper based on strategy
+    if (rootFindingStrategy_ == RootFindingStrategy::DenseOutput)
+    {
+        return integrateTimeWithDenseOutput(aState, anInstant, aSystemOfEquations, anEventCondition);
+    }
+    else
+    {
+        return integrateTimeWithControlledStepper(aState, anInstant, aSystemOfEquations, anEventCondition);
+    }
+}
+
+NumericalSolver NumericalSolver::Undefined()
+{
+    return {
+        LogType::NoLog,
+        StepperType::RungeKuttaCashKarp54,
+        Real::Undefined(),
+        Real::Undefined(),
+        Real::Undefined(),
+        RootSolver::Default(),
+        nullptr,
+        RootFindingStrategy::DenseOutput,
+    };
+}
+
+NumericalSolver NumericalSolver::Default()
+{
+    return {
+        NumericalSolver::LogType::NoLog,
+        NumericalSolver::StepperType::RungeKuttaFehlberg78,
+        5.0,
+        1.0e-12,
+        1.0e-12,
+        RootSolver::Default(),
+        nullptr,
+        RootFindingStrategy::DenseOutput,
+    };
+}
+
+NumericalSolver NumericalSolver::FixedStepSize(const NumericalSolver::StepperType& aStepperType, const Real& aTimeStep)
+{
+    if (aStepperType != NumericalSolver::StepperType::RungeKutta4)
+    {
+        throw ostk::core::error::RuntimeError("Fixed step size is only supported with RungeKutta4 stepper type.");
+    }
+
+    return {
+        NumericalSolver::LogType::NoLog,
+        aStepperType,
+        aTimeStep,
+        1.0,
+        1.0,
+        RootSolver::Default(),
+        nullptr,
+        RootFindingStrategy::Boundary,  // RK4 doesn't support dense output, use Boundary as default
+    };
+}
+
+NumericalSolver NumericalSolver::DefaultConditional(
+    const std::function<void(const State&)>& stateLogger,
+    const RootFindingStrategy& aRootFindingStrategy
+)
+{
+    return NumericalSolver::Conditional(5.0, 1.0e-12, 1.0e-12, stateLogger, aRootFindingStrategy);
+}
+
+NumericalSolver NumericalSolver::Conditional(
+    const Real& aTimeStep,
+    const Real& aRelativeTolerance,
+    const Real& anAbsoluteTolerance,
+    const std::function<void(const State&)>& stateLogger,
+    const RootFindingStrategy& aRootFindingStrategy
+)
+{
+    const NumericalSolver::LogType logType =
+        stateLogger != nullptr ? NumericalSolver::LogType::LogAdaptive : NumericalSolver::LogType::NoLog;
+
+    // Choose stepper type based on strategy
+    const NumericalSolver::StepperType stepperType =
+        (aRootFindingStrategy == RootFindingStrategy::DenseOutput) ? NumericalSolver::StepperType::RungeKuttaDopri5
+                                                                   : NumericalSolver::StepperType::RungeKuttaFehlberg78;
+
+    return {
+        logType,
+        stepperType,
+        aTimeStep,
+        aRelativeTolerance,
+        anAbsoluteTolerance,
+        RootSolver::Default(),
+        stateLogger,
+        aRootFindingStrategy,
+    };
+}
+
+String NumericalSolver::StringFromRootFindingStrategy(const RootFindingStrategy& aStrategy)
+{
+    switch (aStrategy)
+    {
+        case RootFindingStrategy::DenseOutput:
+            return "DenseOutput";
+        case RootFindingStrategy::Linear:
+            return "Linear";
+        case RootFindingStrategy::Propagated:
+            return "Propagated";
+        case RootFindingStrategy::Boundary:
+            return "Boundary";
+        default:
+            throw ostk::core::error::runtime::Wrong("Root Finding Strategy");
+    }
+}
+
+NumericalSolver::NumericalSolver(
+    const NumericalSolver::LogType& aLogType,
+    const NumericalSolver::StepperType& aStepperType,
+    const Real& aTimeStep,
+    const Real& aRelativeTolerance,
+    const Real& anAbsoluteTolerance,
+    const RootSolver& aRootSolver,
+    const std::function<void(const State& aState)>& stateLogger,
+    const RootFindingStrategy& aRootFindingStrategy
+)
+    : MathNumericalSolver(aLogType, aStepperType, aTimeStep, aRelativeTolerance, anAbsoluteTolerance),
+      rootSolver_(aRootSolver),
+      observedStates_(),
+      stateLogger_(stateLogger),
+      rootFindingStrategy_(aRootFindingStrategy)
+{
+}
+
+void NumericalSolver::observeState(const State& aState)
+{
+    observedStates_.add(aState);
+
+    if (stateLogger_ != nullptr && getLogType() != NumericalSolver::LogType::NoLog)
+    {
+        stateLogger_(aState);
+    }
+}
+
+NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithDenseOutput(
+    const State& aState,
+    const Instant& anInstant,
+    const NumericalSolver::SystemOfEquationsWrapper& aSystemOfEquations,
+    const EventCondition& anEventCondition
+)
+{
+    const StateBuilder stateBuilder = {aState};
+
+    const Real aDurationInSeconds = (anInstant - aState.accessInstant()).inSeconds();
+
+    const auto createState = [&stateBuilder, &aState](const VectorXd& aStateVector, const double& aTime) -> State
+    {
+        return stateBuilder.build(aState.accessInstant() + Duration::Seconds(aTime), aStateVector);
+    };
+
     // Ensure that the time step is the correct sign
     const double signedTimeStep = getSignedTimeStep(aDurationInSeconds);
 
-    // TBI: Adapt this to any dense stepper type
     auto stepper = make_dense_output(absoluteTolerance_, relativeTolerance_, dense_stepper_type_5());
 
     // initialize stepper
@@ -198,6 +363,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTime(
 
     State currentState = State::Undefined();
     State previousState = aState;
+    bool conditionSatisfied = false;
 
     while (checkTimeLimit(currentTime) && !conditionSatisfied)
     {
@@ -271,99 +437,404 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTime(
     };
 }
 
-NumericalSolver NumericalSolver::Undefined()
+NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledStepper(
+    const State& aState,
+    const Instant& anInstant,
+    const NumericalSolver::SystemOfEquationsWrapper& aSystemOfEquations,
+    const EventCondition& anEventCondition
+)
 {
-    return {
-        LogType::NoLog,
-        StepperType::RungeKuttaCashKarp54,
-        Real::Undefined(),
-        Real::Undefined(),
-        Real::Undefined(),
-        RootSolver::Default(),
-        nullptr,
-    };
-}
+    const StateBuilder stateBuilder = {aState};
 
-NumericalSolver NumericalSolver::Default()
-{
-    return {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaFehlberg78,
-        5.0,
-        1.0e-12,
-        1.0e-12,
-        RootSolver::Default(),
-        nullptr,
-    };
-}
+    const Real aDurationInSeconds = (anInstant - aState.accessInstant()).inSeconds();
 
-NumericalSolver NumericalSolver::FixedStepSize(const NumericalSolver::StepperType& aStepperType, const Real& aTimeStep)
-{
-    if (aStepperType != NumericalSolver::StepperType::RungeKutta4)
+    const auto createState = [&stateBuilder, &aState](const VectorXd& aStateVector, const double& aTime) -> State
     {
-        throw ostk::core::error::RuntimeError("Fixed step size is only supported with RungeKutta4 stepper type.");
+        return stateBuilder.build(aState.accessInstant() + Duration::Seconds(aTime), aStateVector);
+    };
+
+    // Ensure that the time step is the correct sign
+    const double signedTimeStep = getSignedTimeStep(aDurationInSeconds);
+
+    // account for integration direction
+    std::function<bool(const double&)> checkTimeLimit;
+    if (aDurationInSeconds > 0.0)
+    {
+        checkTimeLimit = [&aDurationInSeconds](const double& aTime) -> bool
+        {
+            return aTime < aDurationInSeconds;
+        };
+    }
+    else
+    {
+        checkTimeLimit = [&aDurationInSeconds](const double& aTime) -> bool
+        {
+            return aTime > aDurationInSeconds;
+        };
     }
 
-    return {
-        NumericalSolver::LogType::NoLog,
-        aStepperType,
-        aTimeStep,
-        1.0,
-        1.0,
-        RootSolver::Default(),
-        nullptr,
-    };
-}
+    NumericalSolver::StateVector currentStateVector = aState.accessCoordinates();
+    NumericalSolver::StateVector previousStateVector = aState.accessCoordinates();
+    double previousTime = 0.0;
+    double currentTime = 0.0;
+    double dt = signedTimeStep;
+    State currentState = State::Undefined();
+    State previousState = aState;
+    bool conditionSatisfied = false;
 
-NumericalSolver NumericalSolver::DefaultConditional(const std::function<void(const State&)>& stateLogger)
-{
-    return NumericalSolver::Conditional(5.0, 1.0e-12, 1.0e-12, stateLogger);
-}
-
-NumericalSolver NumericalSolver::Conditional(
-    const Real& aTimeStep,
-    const Real& aRelativeTolerance,
-    const Real& anAbsoluteTolerance,
-    const std::function<void(const State&)>& stateLogger
-)
-{
-    const NumericalSolver::LogType logType =
-        stateLogger != nullptr ? NumericalSolver::LogType::LogAdaptive : NumericalSolver::LogType::NoLog;
-
-    return {
-        logType,
-        NumericalSolver::StepperType::RungeKuttaDopri5,
-        aTimeStep,
-        aRelativeTolerance,
-        anAbsoluteTolerance,
-        RootSolver::Default(),
-        stateLogger,
-    };
-}
-
-NumericalSolver::NumericalSolver(
-    const NumericalSolver::LogType& aLogType,
-    const NumericalSolver::StepperType& aStepperType,
-    const Real& aTimeStep,
-    const Real& aRelativeTolerance,
-    const Real& anAbsoluteTolerance,
-    const RootSolver& aRootSolver,
-    const std::function<void(const State& aState)>& stateLogger
-)
-    : MathNumericalSolver(aLogType, aStepperType, aTimeStep, aRelativeTolerance, anAbsoluteTolerance),
-      rootSolver_(aRootSolver),
-      observedStates_(),
-      stateLogger_(stateLogger)
-{
-}
-
-void NumericalSolver::observeState(const State& aState)
-{
-    observedStates_.add(aState);
-
-    if (stateLogger_ != nullptr && getLogType() != NumericalSolver::LogType::NoLog)
+    // Manual stepping loop - integrate step-by-step to allow early termination
+    switch (stepperType_)
     {
-        stateLogger_(aState);
+        case StepperType::RungeKutta4:
+        {
+            stepper_type_4 stepper;
+            while (checkTimeLimit(currentTime) && !conditionSatisfied)
+            {
+                previousStateVector = currentStateVector;
+                previousTime = currentTime;
+
+                stepper.do_step(aSystemOfEquations, currentStateVector, currentTime, dt);
+                currentTime += dt;
+
+                currentState = createState(currentStateVector, currentTime);
+                observeState(currentState);
+                conditionSatisfied = anEventCondition.isSatisfied(currentState, previousState);
+                previousState = currentState;
+            }
+            break;
+        }
+        case StepperType::RungeKuttaCashKarp54:
+        {
+            auto stepper = make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_54());
+            while (checkTimeLimit(currentTime) && !conditionSatisfied)
+            {
+                previousStateVector = currentStateVector;
+                previousTime = currentTime;
+
+                // Controlled steppers may reject steps, keep trying until step is accepted
+                while (stepper.try_step(aSystemOfEquations, currentStateVector, currentTime, dt) ==
+                       boost::numeric::odeint::controlled_step_result::fail)
+                {
+                }
+
+                currentState = createState(currentStateVector, currentTime);
+                observeState(currentState);
+                conditionSatisfied = anEventCondition.isSatisfied(currentState, previousState);
+                previousState = currentState;
+            }
+            break;
+        }
+        case StepperType::RungeKuttaFehlberg78:
+        {
+            auto stepper = make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_78());
+            while (checkTimeLimit(currentTime) && !conditionSatisfied)
+            {
+                previousStateVector = currentStateVector;
+                previousTime = currentTime;
+
+                // Controlled steppers may reject steps, keep trying until step is accepted
+                while (stepper.try_step(aSystemOfEquations, currentStateVector, currentTime, dt) ==
+                       boost::numeric::odeint::controlled_step_result::fail)
+                {
+                }
+
+                currentState = createState(currentStateVector, currentTime);
+                observeState(currentState);
+                conditionSatisfied = anEventCondition.isSatisfied(currentState, previousState);
+                previousState = currentState;
+            }
+            break;
+        }
+        case StepperType::RungeKuttaDopri5:
+        {
+            auto stepper = make_controlled(absoluteTolerance_, relativeTolerance_, dense_stepper_type_5());
+            while (checkTimeLimit(currentTime) && !conditionSatisfied)
+            {
+                previousStateVector = currentStateVector;
+                previousTime = currentTime;
+
+                // Controlled steppers may reject steps, keep trying until step is accepted
+                while (stepper.try_step(aSystemOfEquations, currentStateVector, currentTime, dt) ==
+                       boost::numeric::odeint::controlled_step_result::fail)
+                {
+                }
+
+                currentState = createState(currentStateVector, currentTime);
+                observeState(currentState);
+                conditionSatisfied = anEventCondition.isSatisfied(currentState, previousState);
+                previousState = currentState;
+            }
+            break;
+        }
+        default:
+            throw ostk::core::error::runtime::Wrong("Stepper type");
+    }
+
+    if (!conditionSatisfied)
+    {
+        // Need to integrate to exact end time
+        const double finalTime = static_cast<double>(aDurationInSeconds);
+        if (currentTime != finalTime)
+        {
+            // Integrate from current position to end
+            switch (stepperType_)
+            {
+                case StepperType::RungeKutta4:
+                {
+                    integrate_const(
+                        stepper_type_4(), aSystemOfEquations, currentStateVector, currentTime, finalTime, signedTimeStep
+                    );
+                    break;
+                }
+                case StepperType::RungeKuttaCashKarp54:
+                {
+                    integrate_adaptive(
+                        make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_54()),
+                        aSystemOfEquations,
+                        currentStateVector,
+                        currentTime,
+                        finalTime,
+                        signedTimeStep
+                    );
+                    break;
+                }
+                case StepperType::RungeKuttaFehlberg78:
+                {
+                    integrate_adaptive(
+                        make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_78()),
+                        aSystemOfEquations,
+                        currentStateVector,
+                        currentTime,
+                        finalTime,
+                        signedTimeStep
+                    );
+                    break;
+                }
+                case StepperType::RungeKuttaDopri5:
+                {
+                    integrate_adaptive(
+                        make_controlled(absoluteTolerance_, relativeTolerance_, dense_stepper_type_5()),
+                        aSystemOfEquations,
+                        currentStateVector,
+                        currentTime,
+                        finalTime,
+                        signedTimeStep
+                    );
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        const State finalState = createState(currentStateVector, finalTime);
+        observeState(finalState);
+        return {
+            finalState,
+            false,
+            0,
+            false,
+        };
+    }
+
+    // Remove the state that triggered the condition (we'll find the exact crossing)
+    observedStates_.pop_back();
+
+    // Handle root finding based on strategy
+    switch (rootFindingStrategy_)
+    {
+        case RootFindingStrategy::Boundary:
+        {
+            // Return the current state where condition was first satisfied
+            const State solutionState = createState(currentStateVector, currentTime);
+            observeState(solutionState);
+            return {
+                solutionState,
+                true,
+                0,
+                true,
+            };
+        }
+
+        case RootFindingStrategy::Linear:
+        {
+            // Linear interpolation for root finding
+            const auto linearInterpolate =
+                [&previousStateVector, &currentStateVector, previousTime, currentTime](const double& t
+                ) -> NumericalSolver::StateVector
+            {
+                const double alpha = (t - previousTime) / (currentTime - previousTime);
+                return previousStateVector * (1.0 - alpha) + currentStateVector * alpha;
+            };
+
+            const auto checkConditionLinear = [&](const double& aTime) -> double
+            {
+                const NumericalSolver::StateVector interpolatedCoords = linearInterpolate(aTime);
+                const State interpolatedState = createState(interpolatedCoords, aTime);
+
+                const bool isSatisfied = anEventCondition.isSatisfied(
+                    interpolatedState, createState(previousStateVector, previousTime)
+                );
+
+                return isSatisfied ? 1.0 : -1.0;
+            };
+
+            const RootSolver::Solution solution = rootSolver_.bisection(checkConditionLinear, previousTime, currentTime);
+            const NumericalSolver::StateVector solutionStateVector = linearInterpolate(solution.root);
+            const State solutionState = createState(solutionStateVector, solution.root);
+            observeState(solutionState);
+
+            return {
+                solutionState,
+                true,
+                solution.iterationCount,
+                solution.hasConverged,
+            };
+        }
+
+        case RootFindingStrategy::Propagated:
+        {
+            // Re-integrate from previousState to find exact crossing
+            const auto checkConditionPropagated = [&](const double& targetTime) -> double
+            {
+                NumericalSolver::StateVector tempStateVector = previousStateVector;
+
+                // Integrate from previousTime to targetTime
+                switch (stepperType_)
+                {
+                    case StepperType::RungeKutta4:
+                    {
+                        integrate_const(
+                            stepper_type_4(),
+                            aSystemOfEquations,
+                            tempStateVector,
+                            previousTime,
+                            targetTime,
+                            (targetTime - previousTime) / 10.0
+                        );
+                        break;
+                    }
+                    case StepperType::RungeKuttaCashKarp54:
+                    {
+                        integrate_adaptive(
+                            make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_54()),
+                            aSystemOfEquations,
+                            tempStateVector,
+                            previousTime,
+                            targetTime,
+                            (targetTime - previousTime) / 10.0
+                        );
+                        break;
+                    }
+                    case StepperType::RungeKuttaFehlberg78:
+                    {
+                        integrate_adaptive(
+                            make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_78()),
+                            aSystemOfEquations,
+                            tempStateVector,
+                            previousTime,
+                            targetTime,
+                            (targetTime - previousTime) / 10.0
+                        );
+                        break;
+                    }
+                    case StepperType::RungeKuttaDopri5:
+                    {
+                        integrate_adaptive(
+                            make_controlled(absoluteTolerance_, relativeTolerance_, dense_stepper_type_5()),
+                            aSystemOfEquations,
+                            tempStateVector,
+                            previousTime,
+                            targetTime,
+                            (targetTime - previousTime) / 10.0
+                        );
+                        break;
+                    }
+                    default:
+                        throw ostk::core::error::runtime::Wrong("Stepper type");
+                }
+
+                const State propagatedState = createState(tempStateVector, targetTime);
+                const bool isSatisfied =
+                    anEventCondition.isSatisfied(propagatedState, createState(previousStateVector, previousTime));
+
+                return isSatisfied ? 1.0 : -1.0;
+            };
+
+            const RootSolver::Solution solution =
+                rootSolver_.bisection(checkConditionPropagated, previousTime, currentTime);
+
+            // Final integration to the solution time
+            const double solutionTime = static_cast<double>(solution.root);
+            const double subStepSize = (solutionTime - previousTime) / 10.0;
+            NumericalSolver::StateVector solutionStateVector = previousStateVector;
+            switch (stepperType_)
+            {
+                case StepperType::RungeKutta4:
+                {
+                    integrate_const(
+                        stepper_type_4(),
+                        aSystemOfEquations,
+                        solutionStateVector,
+                        previousTime,
+                        solutionTime,
+                        subStepSize
+                    );
+                    break;
+                }
+                case StepperType::RungeKuttaCashKarp54:
+                {
+                    integrate_adaptive(
+                        make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_54()),
+                        aSystemOfEquations,
+                        solutionStateVector,
+                        previousTime,
+                        solutionTime,
+                        subStepSize
+                    );
+                    break;
+                }
+                case StepperType::RungeKuttaFehlberg78:
+                {
+                    integrate_adaptive(
+                        make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_78()),
+                        aSystemOfEquations,
+                        solutionStateVector,
+                        previousTime,
+                        solutionTime,
+                        subStepSize
+                    );
+                    break;
+                }
+                case StepperType::RungeKuttaDopri5:
+                {
+                    integrate_adaptive(
+                        make_controlled(absoluteTolerance_, relativeTolerance_, dense_stepper_type_5()),
+                        aSystemOfEquations,
+                        solutionStateVector,
+                        previousTime,
+                        solutionTime,
+                        subStepSize
+                    );
+                    break;
+                }
+                default:
+                    throw ostk::core::error::runtime::Wrong("Stepper type");
+            }
+
+            const State solutionState = createState(solutionStateVector, solutionTime);
+            observeState(solutionState);
+
+            return {
+                solutionState,
+                true,
+                solution.iterationCount,
+                solution.hasConverged,
+            };
+        }
+
+        default:
+            throw ostk::core::error::runtime::Wrong("Root Finding Strategy");
     }
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -176,6 +176,16 @@ NumericalSolver::RootFindingStrategy NumericalSolver::getRootFindingStrategy() c
     return rootFindingStrategy_;
 }
 
+Real NumericalSolver::getMaxStepSize() const
+{
+    return maxStepSize_;
+}
+
+void NumericalSolver::setMaxStepSize(const Real& aMaxStepSize)
+{
+    maxStepSize_ = aMaxStepSize;
+}
+
 Array<State> NumericalSolver::integrateTime(
     const State& aState,
     const Array<Instant>& anInstantArray,
@@ -500,7 +510,8 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
     const RootSolver& rootSolver,
     NumericalSolver::RootFindingStrategy rootFindingStrategy,
     Array<State>& observedStates,
-    const std::function<void(const State&)>& observeState
+    const std::function<void(const State&)>& observeState,
+    const Real& maxStepSize
 )
 {
     observedStates = {aState};
@@ -548,13 +559,15 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
         previousTime = currentTime;
 
         // Limit the step size to prevent massive overshoots past the target end time.
-        // Controlled/adaptive steppers can grow dt far beyond the remaining integration interval,
-        // leading to false event condition detections at states well beyond the intended interval.
-        // We cap dt to at most the remaining time plus one initial step size. This prevents large
-        // overshoots while still allowing small overshoots near the boundary (needed for detecting
-        // conditions that fire right at the end time).
+        // When a maxStepSize is specified, also enforce that as an upper bound. This is critical
+        // for detecting discrete/step-function events (e.g., thrust toggles) that can be missed
+        // entirely when the adaptive stepper grows its step too large.
         const double remaining = endTime - currentTime;
-        const double maxDt = std::abs(remaining) + std::abs(signedTimeStep);
+        double maxDt = std::abs(remaining) + std::abs(signedTimeStep);
+        if (maxStepSize.isDefined())
+        {
+            maxDt = std::min(maxDt, static_cast<double>(maxStepSize));
+        }
         dt = std::clamp(dt, -maxDt, maxDt);
 
         doStep(stepper, aSystemOfEquations, currentStateVector, currentTime, dt);
@@ -680,8 +693,8 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
     // Since previousState gets updated in the stepping loop, we need to reset it here
     previousState = createState(previousStateVector, previousTime);
 
-    const auto checkCondition =
-        [&anEventCondition, &createState, &previousState, &stateGenerator](const double& aTime) -> double
+    const auto checkCondition = [&anEventCondition, &createState, &previousState, &stateGenerator](const double& aTime
+                                ) -> double
     {
         const NumericalSolver::StateVector stateCoordinates = stateGenerator(aTime);
         const State interpolatedState = createState(stateCoordinates, aTime);
@@ -747,7 +760,8 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
                 rootSolver_,
                 rootFindingStrategy_,
                 observedStates_,
-                observer
+                observer,
+                maxStepSize_
             );
         }
         case StepperType::RungeKuttaCashKarp54:
@@ -765,7 +779,8 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
                 rootSolver_,
                 rootFindingStrategy_,
                 observedStates_,
-                observer
+                observer,
+                maxStepSize_
             );
         }
         case StepperType::RungeKuttaFehlberg78:
@@ -783,7 +798,8 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
                 rootSolver_,
                 rootFindingStrategy_,
                 observedStates_,
-                observer
+                observer,
+                maxStepSize_
             );
         }
         case StepperType::RungeKuttaDopri5:
@@ -801,13 +817,13 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
                 rootSolver_,
                 rootFindingStrategy_,
                 observedStates_,
-                observer
+                observer,
+                maxStepSize_
             );
         }
         case StepperType::AdamsBashforthMoulton5:
         {
-            auto stepper =
-                make_controlled_adam_bashforth_moulton<5>(absoluteTolerance_, relativeTolerance_);
+            auto stepper = make_controlled_adam_bashforth_moulton<5>(absoluteTolerance_, relativeTolerance_);
             return integrateTimeWithStepperImpl<decltype(stepper)>(
                 stepper,
                 aState,
@@ -818,13 +834,13 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
                 rootSolver_,
                 rootFindingStrategy_,
                 observedStates_,
-                observer
+                observer,
+                maxStepSize_
             );
         }
         case StepperType::AdamsBashforthMoulton8:
         {
-            auto stepper =
-                make_controlled_adam_bashforth_moulton<8>(absoluteTolerance_, relativeTolerance_);
+            auto stepper = make_controlled_adam_bashforth_moulton<8>(absoluteTolerance_, relativeTolerance_);
             return integrateTimeWithStepperImpl<decltype(stepper)>(
                 stepper,
                 aState,
@@ -835,13 +851,13 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
                 rootSolver_,
                 rootFindingStrategy_,
                 observedStates_,
-                observer
+                observer,
+                maxStepSize_
             );
         }
         case StepperType::BulirschStoer:
         {
-            auto stepper =
-                bulirsch_stoer<NumericalSolver::StateVector>(absoluteTolerance_, relativeTolerance_);
+            auto stepper = bulirsch_stoer<NumericalSolver::StateVector>(absoluteTolerance_, relativeTolerance_);
             return integrateTimeWithStepperImpl<decltype(stepper)>(
                 stepper,
                 aState,
@@ -852,7 +868,8 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
                 rootSolver_,
                 rootFindingStrategy_,
                 observedStates_,
-                observer
+                observer,
+                maxStepSize_
             );
         }
         default:

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -294,6 +294,8 @@ String NumericalSolver::StringFromRootFindingStrategy(const RootFindingStrategy&
             return "LinearInterpolation";
         case RootFindingStrategy::Skip:
             return "Skip";
+        case RootFindingStrategy::CubicInterpolation:
+            return "CubicInterpolation";
         default:
             throw ostk::core::error::runtime::Wrong("Root Finding Strategy");
     }
@@ -584,7 +586,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
                 }
             );
 
-            const Tabulated tabulated = Tabulated(states, Interpolator::Type::CubicSpline);
+            const Tabulated tabulated = Tabulated(states, Interpolator::Type::BarycentricRational);
 
             stateGenerator = [tabulated, &aState](const double& targetTime) -> NumericalSolver::StateVector
             {

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -1,6 +1,9 @@
 /// Apache License 2.0
 
+#include <algorithm>
+
 #include <boost/numeric/odeint.hpp>
+#include <boost/numeric/odeint/algebra/vector_space_algebra.hpp>
 #include <boost/numeric/odeint/external/eigen/eigen.hpp>
 
 #include <OpenSpaceToolkit/Core/Container/Pair.hpp>
@@ -13,6 +16,52 @@
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
+
+#include <Eigen/Core>
+
+namespace ostk
+{
+namespace astrodynamics
+{
+namespace trajectory
+{
+namespace state
+{
+
+using namespace boost::numeric::odeint;
+
+}  // namespace state
+}  // namespace trajectory
+}  // namespace astrodynamics
+}  // namespace ostk
+
+namespace boost
+{
+namespace numeric
+{
+namespace odeint
+{
+
+struct eigen_pid_algebra : public vector_space_algebra
+{
+    template <class S1, class S2, class Op>
+    static void for_each2(S1& s1, S2& s2, Op op)
+    {
+        for (int i = 0; i < s1.size(); ++i)
+            op(s1[i], s2[i]);
+    }
+
+    template <class S1, class S2, class S3, class S4, class Op>
+    static void for_each4(S1& s1, S2& s2, S3& s3, S4& s4, Op op)
+    {
+        for (int i = 0; i < s1.size(); ++i)
+            op(s1[i], s2[i], s3[i], s4[i]);
+    }
+};
+
+}  // namespace odeint
+}  // namespace numeric
+}  // namespace boost
 
 namespace ostk
 {
@@ -36,9 +85,24 @@ using ostk::astrodynamics::trajectory::model::Tabulated;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
 typedef runge_kutta4<NumericalSolver::StateVector> stepper_type_4;
-typedef runge_kutta_cash_karp54<NumericalSolver::StateVector> error_stepper_type_54;
-typedef runge_kutta_fehlberg78<NumericalSolver::StateVector> error_stepper_type_78;
-typedef runge_kutta_dopri5<NumericalSolver::StateVector> dense_stepper_type_5;
+
+template <size_t Order>
+auto make_controlled_adam_bashforth_moulton(double abs_tol, double rel_tol)
+{
+    // Define the underlying adaptive AdamsBashforthMoulton (using default template parameters)
+    typedef adaptive_adams_bashforth_moulton<Order, NumericalSolver::StateVector> adaptive_stepper_type;
+
+    // Define the Adjuster (where tolerances live)
+    typedef detail::
+        pid_step_adjuster<NumericalSolver::StateVector, double, NumericalSolver::StateVector, double, eigen_pid_algebra>
+            step_adjuster_type;
+
+    // Define the controlled stepper
+    typedef controlled_adams_bashforth_moulton<adaptive_stepper_type, step_adjuster_type> controlled_stepper_type;
+
+    // Return the fully constructed controlled stepper
+    return controlled_stepper_type(step_adjuster_type(abs_tol, rel_tol));
+}
 
 NumericalSolver::NumericalSolver(
     const NumericalSolver::LogType& aLogType,
@@ -477,10 +541,21 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
     bool conditionSatisfied = false;
 
     // Main stepping loop
+    const double endTime = static_cast<double>(aDurationInSeconds);
     while (checkTimeLimit(currentTime) && !conditionSatisfied)
     {
         previousStateVector = currentStateVector;
         previousTime = currentTime;
+
+        // Limit the step size to prevent massive overshoots past the target end time.
+        // Controlled/adaptive steppers can grow dt far beyond the remaining integration interval,
+        // leading to false event condition detections at states well beyond the intended interval.
+        // We cap dt to at most the remaining time plus one initial step size. This prevents large
+        // overshoots while still allowing small overshoots near the boundary (needed for detecting
+        // conditions that fire right at the end time).
+        const double remaining = endTime - currentTime;
+        const double maxDt = std::abs(remaining) + std::abs(signedTimeStep);
+        dt = std::clamp(dt, -maxDt, maxDt);
 
         doStep(stepper, aSystemOfEquations, currentStateVector, currentTime, dt);
 
@@ -579,6 +654,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
         {
             const Array<NumericalSolver::Solution> stateVectors =
                 integrateToTimes<Stepper>(stepper, previousStateVector, previousTime, currentTime, aSystemOfEquations);
+
             const Array<State> states = stateVectors.map<State>(
                 [&createState](const NumericalSolver::Solution& aSolution) -> State
                 {
@@ -604,8 +680,8 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
     // Since previousState gets updated in the stepping loop, we need to reset it here
     previousState = createState(previousStateVector, previousTime);
 
-    const auto checkCondition = [&anEventCondition, &createState, &previousState, &stateGenerator](const double& aTime
-                                ) -> double
+    const auto checkCondition =
+        [&anEventCondition, &createState, &previousState, &stateGenerator](const double& aTime) -> double
     {
         const NumericalSolver::StateVector stateCoordinates = stateGenerator(aTime);
         const State interpolatedState = createState(stateCoordinates, aTime);
@@ -676,7 +752,9 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
         }
         case StepperType::RungeKuttaCashKarp54:
         {
-            auto stepper = make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_54());
+            auto stepper = make_controlled(
+                absoluteTolerance_, relativeTolerance_, runge_kutta_cash_karp54<NumericalSolver::StateVector>()
+            );
             return integrateTimeWithStepperImpl<decltype(stepper)>(
                 stepper,
                 aState,
@@ -692,7 +770,9 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
         }
         case StepperType::RungeKuttaFehlberg78:
         {
-            auto stepper = make_controlled(absoluteTolerance_, relativeTolerance_, error_stepper_type_78());
+            auto stepper = make_controlled(
+                absoluteTolerance_, relativeTolerance_, runge_kutta_fehlberg78<NumericalSolver::StateVector>()
+            );
             return integrateTimeWithStepperImpl<decltype(stepper)>(
                 stepper,
                 aState,
@@ -708,7 +788,60 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
         }
         case StepperType::RungeKuttaDopri5:
         {
-            auto stepper = make_controlled(absoluteTolerance_, relativeTolerance_, dense_stepper_type_5());
+            auto stepper = make_controlled(
+                absoluteTolerance_, relativeTolerance_, runge_kutta_dopri5<NumericalSolver::StateVector>()
+            );
+            return integrateTimeWithStepperImpl<decltype(stepper)>(
+                stepper,
+                aState,
+                anInstant,
+                aSystemOfEquations,
+                anEventCondition,
+                signedTimeStep,
+                rootSolver_,
+                rootFindingStrategy_,
+                observedStates_,
+                observer
+            );
+        }
+        case StepperType::AdamsBashforthMoulton5:
+        {
+            auto stepper =
+                make_controlled_adam_bashforth_moulton<5>(absoluteTolerance_, relativeTolerance_);
+            return integrateTimeWithStepperImpl<decltype(stepper)>(
+                stepper,
+                aState,
+                anInstant,
+                aSystemOfEquations,
+                anEventCondition,
+                signedTimeStep,
+                rootSolver_,
+                rootFindingStrategy_,
+                observedStates_,
+                observer
+            );
+        }
+        case StepperType::AdamsBashforthMoulton8:
+        {
+            auto stepper =
+                make_controlled_adam_bashforth_moulton<8>(absoluteTolerance_, relativeTolerance_);
+            return integrateTimeWithStepperImpl<decltype(stepper)>(
+                stepper,
+                aState,
+                anInstant,
+                aSystemOfEquations,
+                anEventCondition,
+                signedTimeStep,
+                rootSolver_,
+                rootFindingStrategy_,
+                observedStates_,
+                observer
+            );
+        }
+        case StepperType::BulirschStoer:
+        {
+            auto stepper =
+                bulirsch_stoer<NumericalSolver::StateVector>(absoluteTolerance_, relativeTolerance_);
             return integrateTimeWithStepperImpl<decltype(stepper)>(
                 stepper,
                 aState,

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -481,7 +481,8 @@ inline Array<NumericalSolver::Solution> integrateToTimes_(
     Stepper& stepper, NumericalSolver::StateVector stateVector, double startTime, double endTime, const System& system
 )
 {
-    const int numberOfSteps = 20;
+    // Ensure at least 5 steps are taken, and no more than 20 second steps
+    const int numberOfSteps = std::max(5, static_cast<int>(std::floor((endTime - startTime) / 20.0)));
     const double stepSize = endTime / numberOfSteps;
     const VectorXd durations = VectorXd::LinSpaced(numberOfSteps, startTime, endTime);
 
@@ -675,7 +676,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
                 }
             );
 
-            const Tabulated tabulated = Tabulated(states, Interpolator::Type::BarycentricRational);
+            const Tabulated tabulated = Tabulated(states, Interpolator::Type::CubicSpline);
 
             stateGenerator = [tabulated, &aState](const double& targetTime) -> NumericalSolver::StateVector
             {
@@ -693,8 +694,8 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
     // Since previousState gets updated in the stepping loop, we need to reset it here
     previousState = createState(previousStateVector, previousTime);
 
-    const auto checkCondition = [&anEventCondition, &createState, &previousState, &stateGenerator](const double& aTime
-                                ) -> double
+    const auto checkCondition =
+        [&anEventCondition, &createState, &previousState, &stateGenerator](const double& aTime) -> double
     {
         const NumericalSolver::StateVector stateCoordinates = stateGenerator(aTime);
         const State interpolatedState = createState(stateCoordinates, aTime);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -6,7 +6,6 @@
 #include <boost/numeric/odeint/algebra/vector_space_algebra.hpp>
 #include <boost/numeric/odeint/external/eigen/eigen.hpp>
 
-#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
@@ -78,9 +77,6 @@ namespace state
 {
 
 using namespace boost::numeric::odeint;
-
-using ostk::core::container::Pair;
-using ostk::core::type::Shared;
 
 using ostk::physics::time::Duration;
 
@@ -410,14 +406,11 @@ inline typename std::enable_if<!IsFixedStepStepper<Stepper>::value>::type doStep
 ///        the multistep history (if any) remains valid.
 template <typename Stepper, typename System>
 inline void integrateToTime_(
-    Stepper& stepper,
-    NumericalSolver::StateVector& stateVector,
-    double startTime,
-    double endTime,
-    double stepSize,
-    const System& system
+    Stepper& stepper, NumericalSolver::StateVector& stateVector, double startTime, double endTime, const System& system
 )
 {
+    // Handles the sign of the step size
+    const double stepSize = (endTime - startTime) / 10.0;
     integrate_adaptive(stepper, system, stateVector, startTime, endTime, stepSize);
 }
 
@@ -459,7 +452,11 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl
     State previousState = aState;
     bool conditionSatisfied = false;
 
-    while (checkTimeLimit(currentTime) && !conditionSatisfied)
+    const double maxStepSizeDouble =
+        maxStepSize_.isDefined() ? static_cast<double>(maxStepSize_) : std::numeric_limits<double>::infinity();
+    const double stepSignAbs = std::abs(aSignedTimeStep);
+
+    while (true)
     {
         previousStateVector = currentStateVector;
         previousTime = currentTime;
@@ -468,32 +465,25 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl
         // When a maxStepSize is specified, also enforce that as an upper bound. This is critical
         // for detecting discrete/step-function events (e.g., thrust toggles) that can be missed
         // entirely when the adaptive stepper grows its step too large.
-        const double remaining = endTime - currentTime;
-        double maxDt = std::abs(remaining) + std::abs(aSignedTimeStep);
-        if (maxStepSize_.isDefined())
-        {
-            maxDt = std::min(maxDt, static_cast<double>(maxStepSize_));
-        }
+        const double remainingAbs = std::abs(endTime - currentTime);
+        const double maxDt = std::min(remainingAbs + stepSignAbs, maxStepSizeDouble);
         dt = std::clamp(dt, -maxDt, maxDt);
 
         doStep(aStepper, aSystemOfEquations, currentStateVector, currentTime, dt);
 
         currentState = createState(currentStateVector, currentTime);
 
-        observeState(currentState);
-
         conditionSatisfied = anEventCondition.isSatisfied(currentState, previousState);
 
-        if (conditionSatisfied)
+        if (conditionSatisfied || !checkTimeLimit(currentTime))
         {
             break;
         }
 
+        observeState(currentState);
+
         previousState = currentState;
     }
-
-    // Remove the state that triggered the condition (we'll find the exact crossing).
-    observedStates_.pop_back();
 
     if (!conditionSatisfied)
     {
@@ -502,12 +492,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl
         // integrate_adaptive with a zero-length window and have boost odeint reject the request.
         if (std::abs(endTime - currentTime) > 1e-12)
         {
-            // Compute step size with correct sign for the direction from currentTime to endTime.
-            // This handles the case where we overshot endTime and need to integrate backwards.
-            const double adjustmentStepSize = (endTime - currentTime) / 10.0;
-            integrateToTime_<Stepper>(
-                aStepper, currentStateVector, currentTime, endTime, adjustmentStepSize, aSystemOfEquations
-            );
+            integrateToTime_<Stepper>(aStepper, currentStateVector, currentTime, endTime, aSystemOfEquations);
         }
 
         const State finalState = createState(currentStateVector, endTime);
@@ -536,19 +521,14 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl
     const bool isBackward = stepSpan < 0.0;
 
     // Cubic Spline requires a atleast 5 samples.
-    const Size minIntervals = 5;
-    const double maxDt = 20.0;
-    const Size numIntervals =
-        static_cast<Size>(std::max(static_cast<double>(minIntervals), std::ceil(absStepSpan / maxDt)));
+    const Size numIntervals = std::max(5, static_cast<int>(std::ceil(absStepSpan / 20.0)));
     const Size numSamples = numIntervals + 1;
     const double signedSampleDt = stepSpan / static_cast<double>(numIntervals);
     const double absSampleDt = absStepSpan / static_cast<double>(numIntervals);
-
     VectorXd sampleTimes = VectorXd::LinSpaced(numSamples, previousTime, currentTime);
 
     const Size stateDim = previousStateVector.size();
     Eigen::MatrixXd sampleMatrix(numSamples, stateDim);
-
     Size sampleIdx = 0;
     const auto sampleObserver =
         [&sampleMatrix, &sampleIdx](const NumericalSolver::StateVector& aSampledState, const double& /*aTime*/)
@@ -584,7 +564,6 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl
         splines.add(CubicSpline(yColumn, splineX0, absSampleDt));
     }
 
-    NumericalSolver::StateVector interpolatedStateVector(previousStateVector.size());
     const auto stateGenerator = [&splines, stateDim](const double& aTime) -> NumericalSolver::StateVector
     {
         NumericalSolver::StateVector stateVectorAtTargetTime(stateDim);
@@ -595,12 +574,11 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl
         return stateVectorAtTargetTime;
     };
 
-    const auto checkCondition =
-        [&anEventCondition, &createState, &previousState, &stateGenerator, &interpolatedStateVector](const double& aTime
-        ) -> double
+    const auto checkCondition = [&anEventCondition, &createState, &previousState, &stateGenerator](const double& aTime
+                                ) -> double
     {
-        interpolatedStateVector = stateGenerator(aTime);
-        const State interpolatedState = createState(interpolatedStateVector, aTime);
+        const NumericalSolver::StateVector stateVectorAtTargetTime = stateGenerator(aTime);
+        const State interpolatedState = createState(stateVectorAtTargetTime, aTime);
         const bool isSatisfied = anEventCondition.isSatisfied(interpolatedState, previousState);
         return isSatisfied ? 1.0 : -1.0;
     };
@@ -639,7 +617,8 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl
     // Ensure that the solution time has crossed the condition
     const double solutionTime = (aSignedTimeStep > 0.0) ? solution.upperBound : solution.lowerBound;
 
-    const State solutionState = createState(interpolatedStateVector, solutionTime);
+    const NumericalSolver::StateVector stateVectorAtSolutionTime = stateGenerator(solutionTime);
+    const State solutionState = createState(stateVectorAtSolutionTime, solutionTime);
 
     // If the solution state is not the same as the initial state, add it to the observed states
     if (solutionState.accessInstant() != aState.accessInstant())

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -704,7 +704,33 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
 
     // Condition at previousTime => False
     // Condition at currentTime => True
-    // Search for the exact time of the condition change
+    // Search for the exact time of the condition change.
+    //
+    // When the adaptive stepper accepts an extremely small step that triggers the crossing,
+    // re-evaluating the condition through `stateGenerator` (which re-integrates or re-interpolates
+    // the same interval) may not reproduce the same crossing due to roundoff in the cartesian
+    // state and the non-linear conversion to whatever quantity the event condition measures
+    // (e.g. Brouwer-Lyddane mean SMA). In that case `f(previousTime)` and `f(currentTime)` end up
+    // with the same sign and `boost::math::tools::bisect` throws `evaluation_error`. The forward
+    // integration already detected the crossing, so accept `currentState` as the solution rather
+    // than aborting.
+    if (checkCondition(previousTime) * checkCondition(currentTime) > 0.0)
+    {
+        const State solutionState = createState(currentStateVector, currentTime);
+
+        if (solutionState.accessInstant() != aState.accessInstant())
+        {
+            observeState(solutionState);
+        }
+
+        return {
+            solutionState,
+            true,
+            0,
+            false,
+        };
+    }
+
     const RootSolver::Solution solution = rootSolver.bisection(checkCondition, previousTime, currentTime);
 
     // Ensure that the solution time has crossed the condition

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -10,10 +10,9 @@
 #include <OpenSpaceToolkit/Core/Error.hpp>
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
-#include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp>
+#include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/CubicSpline.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/RootSolver.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
@@ -47,21 +46,27 @@ struct eigen_pid_algebra : public vector_space_algebra
     template <class S1, class S2, class Op>
     static void for_each2(S1& s1, S2& s2, Op op)
     {
-        for (int i = 0; i < s1.size(); ++i)
-            op(s1[i], s2[i]);
+        for (Eigen::Index i = 0; i < s1.size(); ++i)
+        {
+            op(s1.coeffRef(i), s2.coeffRef(i));
+        }
     }
 
     template <class S1, class S2, class S3, class S4, class Op>
     static void for_each4(S1& s1, S2& s2, S3& s3, S4& s4, Op op)
     {
-        for (int i = 0; i < s1.size(); ++i)
-            op(s1[i], s2[i], s3[i], s4[i]);
+        for (Eigen::Index i = 0; i < s1.size(); ++i)
+        {
+            op(s1.coeffRef(i), s2.coeffRef(i), s3.coeffRef(i), s4.coeffRef(i));
+        }
     }
 };
 
 }  // namespace odeint
 }  // namespace numeric
 }  // namespace boost
+
+using ostk::mathematics::curvefitting::interpolator::CubicSpline;
 
 namespace ostk
 {
@@ -75,33 +80,30 @@ namespace state
 using namespace boost::numeric::odeint;
 
 using ostk::core::container::Pair;
-
-using ostk::mathematics::curvefitting::Interpolator;
+using ostk::core::type::Shared;
 
 using ostk::physics::time::Duration;
 
 using ostk::astrodynamics::RootSolver;
-using ostk::astrodynamics::trajectory::model::Tabulated;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
-typedef runge_kutta4<NumericalSolver::StateVector> stepper_type_4;
+using stepper_type_4 = runge_kutta4<NumericalSolver::StateVector>;
 
 template <size_t Order>
 auto make_controlled_adam_bashforth_moulton(double abs_tol, double rel_tol)
 {
-    // Define the underlying adaptive AdamsBashforthMoulton (using default template parameters)
-    typedef adaptive_adams_bashforth_moulton<Order, NumericalSolver::StateVector> adaptive_stepper_type;
+    using AdaptiveStepperType = adaptive_adams_bashforth_moulton<Order, NumericalSolver::StateVector>;
 
-    // Define the Adjuster (where tolerances live)
-    typedef detail::
-        pid_step_adjuster<NumericalSolver::StateVector, double, NumericalSolver::StateVector, double, eigen_pid_algebra>
-            step_adjuster_type;
+    using StepAdjusterType = detail::pid_step_adjuster<
+        NumericalSolver::StateVector,
+        double,
+        NumericalSolver::StateVector,
+        double,
+        eigen_pid_algebra>;
 
-    // Define the controlled stepper
-    typedef controlled_adams_bashforth_moulton<adaptive_stepper_type, step_adjuster_type> controlled_stepper_type;
+    using ControlledStepperType = controlled_adams_bashforth_moulton<AdaptiveStepperType, StepAdjusterType>;
 
-    // Return the fully constructed controlled stepper
-    return controlled_stepper_type(step_adjuster_type(abs_tol, rel_tol));
+    return ControlledStepperType(StepAdjusterType(abs_tol, rel_tol));
 }
 
 NumericalSolver::NumericalSolver(
@@ -112,32 +114,10 @@ NumericalSolver::NumericalSolver(
     const Real& anAbsoluteTolerance,
     const RootSolver& aRootSolver
 )
-    : NumericalSolver(
-          aLogType,
-          aStepperType,
-          aTimeStep,
-          aRelativeTolerance,
-          anAbsoluteTolerance,
-          aRootSolver,
-          RootFindingStrategy::Integration
-      )
-{
-}
-
-NumericalSolver::NumericalSolver(
-    const NumericalSolver::LogType& aLogType,
-    const NumericalSolver::StepperType& aStepperType,
-    const Real& aTimeStep,
-    const Real& aRelativeTolerance,
-    const Real& anAbsoluteTolerance,
-    const RootSolver& aRootSolver,
-    const RootFindingStrategy& aRootFindingStrategy
-)
     : MathNumericalSolver(aLogType, aStepperType, aTimeStep, aRelativeTolerance, anAbsoluteTolerance),
       rootSolver_(aRootSolver),
       observedStates_(),
-      stateLogger_(nullptr),
-      rootFindingStrategy_(aRootFindingStrategy)
+      stateLogger_(nullptr)
 {
 }
 
@@ -166,18 +146,13 @@ Array<State> NumericalSolver::getObservedStates() const
     return accessObservedStates();
 }
 
-NumericalSolver::RootFindingStrategy NumericalSolver::getRootFindingStrategy() const
+Real NumericalSolver::getMaxStepSize() const
 {
     if (!this->isDefined())
     {
         throw ostk::core::error::runtime::Undefined("NumericalSolver");
     }
 
-    return rootFindingStrategy_;
-}
-
-Real NumericalSolver::getMaxStepSize() const
-{
     return maxStepSize_;
 }
 
@@ -246,6 +221,21 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTime(
     const EventCondition& anEventCondition
 )
 {
+    // Multistep Adams-Bashforth-Moulton steppers are not supported with event conditions.
+    // The conditional path samples the post-crossing bracket via `integrate_times` on a fresh
+    // (multistep-history-cleared) copy of the stepper, which forces ABM to warm up from scratch
+    // at every bracket. Combined with tight integration tolerances and discontinuous dynamics
+    // (e.g. thrust events) this drives the accepted step size near zero and makes the run
+    // effectively non-terminating. Callers should select a Runge-Kutta or Bulirsch-Stoer stepper.
+    if (stepperType_ == StepperType::AdamsBashforthMoulton5 || stepperType_ == StepperType::AdamsBashforthMoulton8)
+    {
+        throw ostk::core::error::RuntimeError(
+            "Conditional integration is not supported with Adams-Bashforth-Moulton steppers "
+            "(AdamsBashforthMoulton5, AdamsBashforthMoulton8). Use a Runge-Kutta or Bulirsch-Stoer "
+            "stepper instead."
+        );
+    }
+
     observedStates_ = {aState};
 
     const Real aDurationInSeconds = (anInstant - aState.accessInstant()).inSeconds();
@@ -285,7 +275,6 @@ NumericalSolver NumericalSolver::Undefined()
         Real::Undefined(),
         RootSolver::Default(),
         nullptr,
-        RootFindingStrategy::Integration,
     };
 }
 
@@ -299,7 +288,6 @@ NumericalSolver NumericalSolver::Default()
         1.0e-12,
         RootSolver::Default(),
         nullptr,
-        RootFindingStrategy::Integration,
     };
 }
 
@@ -318,7 +306,6 @@ NumericalSolver NumericalSolver::FixedStepSize(const NumericalSolver::StepperTyp
         1.0,
         RootSolver::Default(),
         nullptr,
-        RootFindingStrategy::Integration,
     };
 }
 
@@ -332,7 +319,6 @@ NumericalSolver NumericalSolver::DefaultConditional(const std::function<void(con
         1.0e-12,
         RootSolver::Default(),
         stateLogger,
-        RootFindingStrategy::Integration,
     };
 }
 
@@ -354,25 +340,7 @@ NumericalSolver NumericalSolver::Conditional(
         anAbsoluteTolerance,
         RootSolver::Default(),
         stateLogger,
-        RootFindingStrategy::Integration,
     };
-}
-
-String NumericalSolver::StringFromRootFindingStrategy(const RootFindingStrategy& aStrategy)
-{
-    switch (aStrategy)
-    {
-        case RootFindingStrategy::Integration:
-            return "Integration";
-        case RootFindingStrategy::LinearInterpolation:
-            return "LinearInterpolation";
-        case RootFindingStrategy::First:
-            return "First";
-        case RootFindingStrategy::CubicInterpolation:
-            return "CubicInterpolation";
-        default:
-            throw ostk::core::error::runtime::Wrong("Root Finding Strategy");
-    }
 }
 
 NumericalSolver::NumericalSolver(
@@ -384,34 +352,10 @@ NumericalSolver::NumericalSolver(
     const RootSolver& aRootSolver,
     const std::function<void(const State& aState)>& stateLogger
 )
-    : NumericalSolver(
-          aLogType,
-          aStepperType,
-          aTimeStep,
-          aRelativeTolerance,
-          anAbsoluteTolerance,
-          aRootSolver,
-          stateLogger,
-          RootFindingStrategy::Integration
-      )
-{
-}
-
-NumericalSolver::NumericalSolver(
-    const NumericalSolver::LogType& aLogType,
-    const NumericalSolver::StepperType& aStepperType,
-    const Real& aTimeStep,
-    const Real& aRelativeTolerance,
-    const Real& anAbsoluteTolerance,
-    const RootSolver& aRootSolver,
-    const std::function<void(const State& aState)>& stateLogger,
-    const RootFindingStrategy& aRootFindingStrategy
-)
     : MathNumericalSolver(aLogType, aStepperType, aTimeStep, aRelativeTolerance, anAbsoluteTolerance),
       rootSolver_(aRootSolver),
       observedStates_(),
-      stateLogger_(stateLogger),
-      rootFindingStrategy_(aRootFindingStrategy)
+      stateLogger_(stateLogger)
 {
 }
 
@@ -461,7 +405,9 @@ inline typename std::enable_if<!IsFixedStepStepper<Stepper>::value>::type doStep
     }
 }
 
-/// @brief Integrate to a target time with a stepper
+/// @brief Integrate adaptively to a target time. Used for the trim integration after the main
+///        loop exits without finding the event, where direction is the same as the main loop and
+///        the multistep history (if any) remains valid.
 template <typename Stepper, typename System>
 inline void integrateToTime_(
     Stepper& stepper,
@@ -475,85 +421,44 @@ inline void integrateToTime_(
     integrate_adaptive(stepper, system, stateVector, startTime, endTime, stepSize);
 }
 
-/// @brief Integrate to a target times with a stepper
-template <typename Stepper, typename System>
-inline Array<NumericalSolver::Solution> integrateToTimes_(
-    Stepper& stepper, NumericalSolver::StateVector stateVector, double startTime, double endTime, const System& system
-)
-{
-    // Ensure at least 5 steps are taken, and no more than 20 second steps
-    const int numberOfSteps = std::max(5, static_cast<int>(std::floor((endTime - startTime) / 20.0)));
-    const double stepSize = endTime / numberOfSteps;
-    const VectorXd durations = VectorXd::LinSpaced(numberOfSteps, startTime, endTime);
-
-    Array<NumericalSolver::Solution> stateVectors = Array<NumericalSolver::Solution>::Empty();
-    stateVectors.reserve(numberOfSteps);
-    const auto observer = [&stateVectors](const VectorXd& aStateVector, const double& aTime) -> void
-    {
-        stateVectors.add(NumericalSolver::Solution(aStateVector, aTime));
-    };
-    integrate_times(stepper, system, stateVector, durations.begin(), durations.end(), stepSize, observer);
-
-    return stateVectors;
-}
-
 }  // namespace
 
-/// @brief Templated implementation of conditional integration
 template <typename Stepper>
-NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
-    Stepper& stepper,
+NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl_(
+    Stepper& aStepper,
     const State& aState,
     const Instant& anInstant,
     const NumericalSolver::SystemOfEquationsWrapper& aSystemOfEquations,
     const EventCondition& anEventCondition,
-    double signedTimeStep,
-    const RootSolver& rootSolver,
-    NumericalSolver::RootFindingStrategy rootFindingStrategy,
-    Array<State>& observedStates,
-    const std::function<void(const State&)>& observeState,
-    const Real& maxStepSize
+    double aSignedTimeStep
 )
 {
-    observedStates = {aState};
+    observedStates_ = {aState};
 
     const StateBuilder stateBuilder = {aState};
 
-    const Real aDurationInSeconds = (anInstant - aState.accessInstant()).inSeconds();
+    const double endTime = (anInstant - aState.accessInstant()).inSeconds();
 
     const auto createState = [&stateBuilder, &aState](const VectorXd& aStateVector, const double& aTime) -> State
     {
         return stateBuilder.build(aState.accessInstant() + Duration::Seconds(aTime), aStateVector);
     };
 
-    std::function<bool(const double&)> checkTimeLimit;
-    if (aDurationInSeconds > 0.0)
+    const auto checkTimeLimit = [aSignedTimeStep, endTime](double aTime) -> bool
     {
-        checkTimeLimit = [&aDurationInSeconds](const double& aTime) -> bool
-        {
-            return aTime < aDurationInSeconds;
-        };
-    }
-    else
-    {
-        checkTimeLimit = [&aDurationInSeconds](const double& aTime) -> bool
-        {
-            return aTime > aDurationInSeconds;
-        };
-    }
+        return aSignedTimeStep > 0.0 ? aTime < endTime : aTime > endTime;
+    };
 
     NumericalSolver::StateVector currentStateVector = aState.accessCoordinates();
     NumericalSolver::StateVector previousStateVector = aState.accessCoordinates();
 
     double previousTime = 0.0;
     double currentTime = 0.0;
-    double dt = signedTimeStep;
+    double dt = aSignedTimeStep;
     State currentState = State::Undefined();
     State previousState = aState;
     bool conditionSatisfied = false;
 
-    // Main stepping loop
-    const double endTime = static_cast<double>(aDurationInSeconds);
     while (checkTimeLimit(currentTime) && !conditionSatisfied)
     {
         previousStateVector = currentStateVector;
@@ -564,14 +469,14 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
         // for detecting discrete/step-function events (e.g., thrust toggles) that can be missed
         // entirely when the adaptive stepper grows its step too large.
         const double remaining = endTime - currentTime;
-        double maxDt = std::abs(remaining) + std::abs(signedTimeStep);
-        if (maxStepSize.isDefined())
+        double maxDt = std::abs(remaining) + std::abs(aSignedTimeStep);
+        if (maxStepSize_.isDefined())
         {
-            maxDt = std::min(maxDt, static_cast<double>(maxStepSize));
+            maxDt = std::min(maxDt, static_cast<double>(maxStepSize_));
         }
         dt = std::clamp(dt, -maxDt, maxDt);
 
-        doStep(stepper, aSystemOfEquations, currentStateVector, currentTime, dt);
+        doStep(aStepper, aSystemOfEquations, currentStateVector, currentTime, dt);
 
         currentState = createState(currentStateVector, currentTime);
 
@@ -579,29 +484,42 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
 
         conditionSatisfied = anEventCondition.isSatisfied(currentState, previousState);
 
+        if (conditionSatisfied)
+        {
+            break;
+        }
+
         previousState = currentState;
     }
 
-    // Remove the state that triggered the condition (we'll find the exact crossing)
-    observedStates.pop_back();
+    // Remove the state that triggered the condition (we'll find the exact crossing).
+    observedStates_.pop_back();
 
     if (!conditionSatisfied)
     {
-        const double finalTime = static_cast<double>(aDurationInSeconds);
-
-        if (currentTime != finalTime)
+        // Use a relative tolerance when comparing currentTime to endTime: the running accumulator
+        // can land epsilon-short of endTime, in which case a strict `!=` check would call
+        // integrate_adaptive with a zero-length window and have boost odeint reject the request.
+        if (std::abs(endTime - currentTime) > 1e-12)
         {
-            // Compute step size with correct sign for the direction from currentTime to finalTime.
-            // This handles the case where we overshot finalTime and need to integrate backwards.
-            const double adjustmentStepSize = (finalTime - currentTime) / 10.0;
+            // Compute step size with correct sign for the direction from currentTime to endTime.
+            // This handles the case where we overshot endTime and need to integrate backwards.
+            const double adjustmentStepSize = (endTime - currentTime) / 10.0;
             integrateToTime_<Stepper>(
-                stepper, currentStateVector, currentTime, finalTime, adjustmentStepSize, aSystemOfEquations
+                aStepper, currentStateVector, currentTime, endTime, adjustmentStepSize, aSystemOfEquations
             );
         }
 
-        const State finalState = createState(currentStateVector, finalTime);
+        const State finalState = createState(currentStateVector, endTime);
 
-        observeState(finalState);
+        // Append finalState only if it preserves the strict monotonicity of observedStates_:
+        // the trim integration above can produce a state at the exact same instant as the
+        // last observed entry (e.g. when currentTime already coincided with endTime within
+        // tolerance), and emitting a duplicate would silently regress monotonicity downstream.
+        if (observedStates_.isEmpty() || finalState.accessInstant() != observedStates_.accessLast().accessInstant())
+        {
+            observeState(finalState);
+        }
 
         return {
             finalState,
@@ -611,94 +529,78 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
         };
     }
 
-    std::function<NumericalSolver::StateVector(const double&)> stateGenerator;
+    const double stepSpan = currentTime - previousTime;
 
-    // Handle root finding based on strategy
-    switch (rootFindingStrategy)
+    // Fixed-step sampling + per-dimension CubicSpline interpolation.
+    const double absStepSpan = std::abs(stepSpan);
+    const bool isBackward = stepSpan < 0.0;
+
+    // Cubic Spline requires a atleast 5 samples.
+    const Size minIntervals = 5;
+    const double maxDt = 20.0;
+    const Size numIntervals =
+        static_cast<Size>(std::max(static_cast<double>(minIntervals), std::ceil(absStepSpan / maxDt)));
+    const Size numSamples = numIntervals + 1;
+    const double signedSampleDt = stepSpan / static_cast<double>(numIntervals);
+    const double absSampleDt = absStepSpan / static_cast<double>(numIntervals);
+
+    VectorXd sampleTimes = VectorXd::LinSpaced(numSamples, previousTime, currentTime);
+
+    const Size stateDim = previousStateVector.size();
+    Eigen::MatrixXd sampleMatrix(numSamples, stateDim);
+
+    Size sampleIdx = 0;
+    const auto sampleObserver =
+        [&sampleMatrix, &sampleIdx](const NumericalSolver::StateVector& aSampledState, const double& /*aTime*/)
     {
-        case NumericalSolver::RootFindingStrategy::First:
-        {
-            const State solutionState = createState(currentStateVector, currentTime);
-            observeState(solutionState);
-            return {
-                solutionState,
-                true,
-                0,
-                true,
-            };
-        }
+        sampleMatrix.row(sampleIdx++) = aSampledState.transpose();
+    };
 
-        case NumericalSolver::RootFindingStrategy::LinearInterpolation:
-        {
-            stateGenerator = [&previousStateVector, &currentStateVector, previousTime, currentTime](
-                                 const double& targetTime
-                             ) -> NumericalSolver::StateVector
-            {
-                const double alpha = (targetTime - previousTime) / (currentTime - previousTime);
-                return previousStateVector * (1.0 - alpha) + currentStateVector * alpha;
-            };
+    const double initialDt = signedSampleDt / 10.0;
+    integrate_times(
+        aStepper,
+        aSystemOfEquations,
+        previousStateVector,
+        sampleTimes.begin(),
+        sampleTimes.end(),
+        initialDt,
+        sampleObserver
+    );
 
-            break;
-        }
-
-        case NumericalSolver::RootFindingStrategy::Integration:
-        {
-            stateGenerator = [&stepper,
-                              &aSystemOfEquations,
-                              &anEventCondition,
-                              &createState,
-                              &previousStateVector,
-                              &previousTime,
-                              &previousState](const double& targetTime) -> NumericalSolver::StateVector
-            {
-                NumericalSolver::StateVector stateVectorAtTargetTime = previousStateVector;
-                const double subStepSize = (targetTime - previousTime) / 10.0;
-
-                integrateToTime_<Stepper>(
-                    stepper, stateVectorAtTargetTime, previousTime, targetTime, subStepSize, aSystemOfEquations
-                );
-
-                return stateVectorAtTargetTime;
-            };
-
-            break;
-        }
-
-        case NumericalSolver::RootFindingStrategy::CubicInterpolation:
-        {
-            const Array<NumericalSolver::Solution> stateVectors =
-                integrateToTimes_<Stepper>(stepper, previousStateVector, previousTime, currentTime, aSystemOfEquations);
-
-            const Array<State> states = stateVectors.map<State>(
-                [&createState](const NumericalSolver::Solution& aSolution) -> State
-                {
-                    return createState(aSolution.first, aSolution.second);
-                }
-            );
-
-            const Tabulated tabulated = Tabulated(states, Interpolator::Type::CubicSpline);
-
-            stateGenerator = [tabulated, &aState](const double& targetTime) -> NumericalSolver::StateVector
-            {
-                const Instant instant = aState.accessInstant() + Duration::Seconds(targetTime);
-                return tabulated.calculateStateAt(instant).accessCoordinates();
-            };
-
-            break;
-        }
-
-        default:
-            throw ostk::core::error::runtime::Wrong("Root Finding Strategy");
+    // CubicSpline (boost cardinal_cubic_b_spline) requires h > 0 and ascending x. For backward
+    // integration the samples are in descending time order — reverse them so the spline sees an
+    // ascending axis with positive spacing.
+    const double splineX0 = isBackward ? currentTime : previousTime;
+    if (isBackward)
+    {
+        sampleMatrix = sampleMatrix.colwise().reverse().eval();
     }
 
-    // Since previousState gets updated in the stepping loop, we need to reset it here
-    previousState = createState(previousStateVector, previousTime);
+    Array<CubicSpline> splines;
+    splines.reserve(stateDim);
+    for (Index idx = 0; idx < stateDim; ++idx)
+    {
+        const ostk::mathematics::object::VectorXd yColumn = sampleMatrix.col(idx);
+        splines.add(CubicSpline(yColumn, splineX0, absSampleDt));
+    }
+
+    NumericalSolver::StateVector interpolatedStateVector(previousStateVector.size());
+    const auto stateGenerator = [&splines, stateDim](const double& aTime) -> NumericalSolver::StateVector
+    {
+        NumericalSolver::StateVector stateVectorAtTargetTime(stateDim);
+        for (Index idx = 0; idx < stateDim; ++idx)
+        {
+            stateVectorAtTargetTime(idx) = splines[idx].evaluate(aTime);
+        }
+        return stateVectorAtTargetTime;
+    };
 
     const auto checkCondition =
-        [&anEventCondition, &createState, &previousState, &stateGenerator](const double& aTime) -> double
+        [&anEventCondition, &createState, &previousState, &stateGenerator, &interpolatedStateVector](const double& aTime
+        ) -> double
     {
-        const NumericalSolver::StateVector stateCoordinates = stateGenerator(aTime);
-        const State interpolatedState = createState(stateCoordinates, aTime);
+        interpolatedStateVector = stateGenerator(aTime);
+        const State interpolatedState = createState(interpolatedStateVector, aTime);
         const bool isSatisfied = anEventCondition.isSatisfied(interpolatedState, previousState);
         return isSatisfied ? 1.0 : -1.0;
     };
@@ -708,13 +610,13 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
     // Search for the exact time of the condition change.
     //
     // When the adaptive stepper accepts an extremely small step that triggers the crossing,
-    // re-evaluating the condition through `stateGenerator` (which re-integrates or re-interpolates
-    // the same interval) may not reproduce the same crossing due to roundoff in the cartesian
-    // state and the non-linear conversion to whatever quantity the event condition measures
-    // (e.g. Brouwer-Lyddane mean SMA). In that case `f(previousTime)` and `f(currentTime)` end up
-    // with the same sign and `boost::math::tools::bisect` throws `evaluation_error`. The forward
-    // integration already detected the crossing, so accept `currentState` as the solution rather
-    // than aborting.
+    // re-evaluating the condition through `stateGenerator` (which re-interpolates the same
+    // interval) may not reproduce the same crossing due to roundoff in the cartesian state and
+    // the non-linear conversion to whatever quantity the event condition measures
+    // (e.g. Brouwer-Lyddane mean SMA). In that case `f(previousTime)` and `f(currentTime)` end
+    // up with the same sign and `boost::math::tools::bisect` throws `evaluation_error`. The
+    // forward integration already detected the crossing, so accept `currentState` as the
+    // solution rather than aborting.
     if (checkCondition(previousTime) * checkCondition(currentTime) > 0.0)
     {
         const State solutionState = createState(currentStateVector, currentTime);
@@ -732,18 +634,12 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
         };
     }
 
-    const RootSolver::Solution solution = rootSolver.bisection(checkCondition, previousTime, currentTime);
+    const RootSolver::Solution solution = rootSolver_.bisection(checkCondition, previousTime, currentTime);
 
     // Ensure that the solution time has crossed the condition
-    const double solutionTime = (signedTimeStep > 0.0) ? solution.upperBound : solution.lowerBound;
-    const double subStepSize = (solutionTime - previousTime) / 10.0;
-    NumericalSolver::StateVector solutionStateVector = previousStateVector;
+    const double solutionTime = (aSignedTimeStep > 0.0) ? solution.upperBound : solution.lowerBound;
 
-    integrateToTime_<Stepper>(
-        stepper, solutionStateVector, previousTime, solutionTime, subStepSize, aSystemOfEquations
-    );
-
-    const State solutionState = createState(solutionStateVector, solutionTime);
+    const State solutionState = createState(interpolatedStateVector, solutionTime);
 
     // If the solution state is not the same as the initial state, add it to the observed states
     if (solutionState.accessInstant() != aState.accessInstant())
@@ -766,141 +662,39 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
     const EventCondition& anEventCondition
 )
 {
-    const auto observer = [this](const State& state)
-    {
-        this->observeState(state);
-    };
-
     const Real aDurationInSeconds = (anInstant - aState.accessInstant()).inSeconds();
     const double signedTimeStep = getSignedTimeStep(aDurationInSeconds);
+
+    auto dispatch = [&](auto&& aStepper) -> NumericalSolver::ConditionSolution
+    {
+        using DispatchStepperType = std::decay_t<decltype(aStepper)>;
+        return integrateTimeWithStepperImpl_<DispatchStepperType>(
+            aStepper, aState, anInstant, aSystemOfEquations, anEventCondition, signedTimeStep
+        );
+    };
 
     switch (stepperType_)
     {
         case StepperType::RungeKutta4:
-        {
-            stepper_type_4 stepper;
-            return integrateTimeWithStepperImpl_<stepper_type_4>(
-                stepper,
-                aState,
-                anInstant,
-                aSystemOfEquations,
-                anEventCondition,
-                signedTimeStep,
-                rootSolver_,
-                rootFindingStrategy_,
-                observedStates_,
-                observer,
-                maxStepSize_
-            );
-        }
+            return dispatch(stepper_type_4 {});
         case StepperType::RungeKuttaCashKarp54:
-        {
-            auto stepper = make_controlled(
+            return dispatch(make_controlled(
                 absoluteTolerance_, relativeTolerance_, runge_kutta_cash_karp54<NumericalSolver::StateVector>()
-            );
-            return integrateTimeWithStepperImpl_<decltype(stepper)>(
-                stepper,
-                aState,
-                anInstant,
-                aSystemOfEquations,
-                anEventCondition,
-                signedTimeStep,
-                rootSolver_,
-                rootFindingStrategy_,
-                observedStates_,
-                observer,
-                maxStepSize_
-            );
-        }
+            ));
         case StepperType::RungeKuttaFehlberg78:
-        {
-            auto stepper = make_controlled(
+            return dispatch(make_controlled(
                 absoluteTolerance_, relativeTolerance_, runge_kutta_fehlberg78<NumericalSolver::StateVector>()
-            );
-            return integrateTimeWithStepperImpl_<decltype(stepper)>(
-                stepper,
-                aState,
-                anInstant,
-                aSystemOfEquations,
-                anEventCondition,
-                signedTimeStep,
-                rootSolver_,
-                rootFindingStrategy_,
-                observedStates_,
-                observer,
-                maxStepSize_
-            );
-        }
+            ));
         case StepperType::RungeKuttaDopri5:
-        {
-            auto stepper = make_controlled(
+            return dispatch(make_controlled(
                 absoluteTolerance_, relativeTolerance_, runge_kutta_dopri5<NumericalSolver::StateVector>()
-            );
-            return integrateTimeWithStepperImpl_<decltype(stepper)>(
-                stepper,
-                aState,
-                anInstant,
-                aSystemOfEquations,
-                anEventCondition,
-                signedTimeStep,
-                rootSolver_,
-                rootFindingStrategy_,
-                observedStates_,
-                observer,
-                maxStepSize_
-            );
-        }
+            ));
         case StepperType::AdamsBashforthMoulton5:
-        {
-            auto stepper = make_controlled_adam_bashforth_moulton<5>(absoluteTolerance_, relativeTolerance_);
-            return integrateTimeWithStepperImpl_<decltype(stepper)>(
-                stepper,
-                aState,
-                anInstant,
-                aSystemOfEquations,
-                anEventCondition,
-                signedTimeStep,
-                rootSolver_,
-                rootFindingStrategy_,
-                observedStates_,
-                observer,
-                maxStepSize_
-            );
-        }
+            return dispatch(make_controlled_adam_bashforth_moulton<5>(absoluteTolerance_, relativeTolerance_));
         case StepperType::AdamsBashforthMoulton8:
-        {
-            auto stepper = make_controlled_adam_bashforth_moulton<8>(absoluteTolerance_, relativeTolerance_);
-            return integrateTimeWithStepperImpl_<decltype(stepper)>(
-                stepper,
-                aState,
-                anInstant,
-                aSystemOfEquations,
-                anEventCondition,
-                signedTimeStep,
-                rootSolver_,
-                rootFindingStrategy_,
-                observedStates_,
-                observer,
-                maxStepSize_
-            );
-        }
+            return dispatch(make_controlled_adam_bashforth_moulton<8>(absoluteTolerance_, relativeTolerance_));
         case StepperType::BulirschStoer:
-        {
-            auto stepper = bulirsch_stoer<NumericalSolver::StateVector>(absoluteTolerance_, relativeTolerance_);
-            return integrateTimeWithStepperImpl_<decltype(stepper)>(
-                stepper,
-                aState,
-                anInstant,
-                aSystemOfEquations,
-                anEventCondition,
-                signedTimeStep,
-                rootSolver_,
-                rootFindingStrategy_,
-                observedStates_,
-                observer,
-                maxStepSize_
-            );
-        }
+            return dispatch(bulirsch_stoer<NumericalSolver::StateVector>(absoluteTolerance_, relativeTolerance_));
         default:
             throw ostk::core::error::runtime::Wrong("Stepper type");
     }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -119,7 +119,7 @@ NumericalSolver::NumericalSolver(
           aRelativeTolerance,
           anAbsoluteTolerance,
           aRootSolver,
-          RootFindingStrategy::Propagated
+          RootFindingStrategy::Integration
       )
 {
 }
@@ -285,7 +285,7 @@ NumericalSolver NumericalSolver::Undefined()
         Real::Undefined(),
         RootSolver::Default(),
         nullptr,
-        RootFindingStrategy::Propagated,
+        RootFindingStrategy::Integration,
     };
 }
 
@@ -299,7 +299,7 @@ NumericalSolver NumericalSolver::Default()
         1.0e-12,
         RootSolver::Default(),
         nullptr,
-        RootFindingStrategy::Propagated,
+        RootFindingStrategy::Integration,
     };
 }
 
@@ -318,7 +318,7 @@ NumericalSolver NumericalSolver::FixedStepSize(const NumericalSolver::StepperTyp
         1.0,
         RootSolver::Default(),
         nullptr,
-        RootFindingStrategy::Propagated,
+        RootFindingStrategy::Integration,
     };
 }
 
@@ -332,7 +332,7 @@ NumericalSolver NumericalSolver::DefaultConditional(const std::function<void(con
         1.0e-12,
         RootSolver::Default(),
         stateLogger,
-        RootFindingStrategy::Propagated,
+        RootFindingStrategy::Integration,
     };
 }
 
@@ -354,7 +354,7 @@ NumericalSolver NumericalSolver::Conditional(
         anAbsoluteTolerance,
         RootSolver::Default(),
         stateLogger,
-        RootFindingStrategy::Propagated,
+        RootFindingStrategy::Integration,
     };
 }
 
@@ -362,12 +362,12 @@ String NumericalSolver::StringFromRootFindingStrategy(const RootFindingStrategy&
 {
     switch (aStrategy)
     {
-        case RootFindingStrategy::Propagated:
-            return "Propagated";
+        case RootFindingStrategy::Integration:
+            return "Integration";
         case RootFindingStrategy::LinearInterpolation:
             return "LinearInterpolation";
-        case RootFindingStrategy::Skip:
-            return "Skip";
+        case RootFindingStrategy::First:
+            return "First";
         case RootFindingStrategy::CubicInterpolation:
             return "CubicInterpolation";
         default:
@@ -392,7 +392,7 @@ NumericalSolver::NumericalSolver(
           anAbsoluteTolerance,
           aRootSolver,
           stateLogger,
-          RootFindingStrategy::Propagated
+          RootFindingStrategy::Integration
       )
 {
 }
@@ -463,7 +463,7 @@ inline typename std::enable_if<!IsFixedStepStepper<Stepper>::value>::type doStep
 
 /// @brief Integrate to a target time with a stepper
 template <typename Stepper, typename System>
-inline void integrateToTime(
+inline void integrateToTime_(
     Stepper& stepper,
     NumericalSolver::StateVector& stateVector,
     double startTime,
@@ -477,7 +477,7 @@ inline void integrateToTime(
 
 /// @brief Integrate to a target times with a stepper
 template <typename Stepper, typename System>
-inline Array<NumericalSolver::Solution> integrateToTimes(
+inline Array<NumericalSolver::Solution> integrateToTimes_(
     Stepper& stepper, NumericalSolver::StateVector stateVector, double startTime, double endTime, const System& system
 )
 {
@@ -500,7 +500,7 @@ inline Array<NumericalSolver::Solution> integrateToTimes(
 
 /// @brief Templated implementation of conditional integration
 template <typename Stepper>
-NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
+NumericalSolver::ConditionSolution integrateTimeWithStepperImpl_(
     Stepper& stepper,
     const State& aState,
     const Instant& anInstant,
@@ -593,7 +593,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
             // Compute step size with correct sign for the direction from currentTime to finalTime.
             // This handles the case where we overshot finalTime and need to integrate backwards.
             const double adjustmentStepSize = (finalTime - currentTime) / 10.0;
-            integrateToTime<Stepper>(
+            integrateToTime_<Stepper>(
                 stepper, currentStateVector, currentTime, finalTime, adjustmentStepSize, aSystemOfEquations
             );
         }
@@ -615,7 +615,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
     // Handle root finding based on strategy
     switch (rootFindingStrategy)
     {
-        case NumericalSolver::RootFindingStrategy::Skip:
+        case NumericalSolver::RootFindingStrategy::First:
         {
             const State solutionState = createState(currentStateVector, currentTime);
             observeState(solutionState);
@@ -640,7 +640,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
             break;
         }
 
-        case NumericalSolver::RootFindingStrategy::Propagated:
+        case NumericalSolver::RootFindingStrategy::Integration:
         {
             stateGenerator = [&stepper,
                               &aSystemOfEquations,
@@ -653,7 +653,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
                 NumericalSolver::StateVector stateVectorAtTargetTime = previousStateVector;
                 const double subStepSize = (targetTime - previousTime) / 10.0;
 
-                integrateToTime<Stepper>(
+                integrateToTime_<Stepper>(
                     stepper, stateVectorAtTargetTime, previousTime, targetTime, subStepSize, aSystemOfEquations
                 );
 
@@ -666,7 +666,7 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
         case NumericalSolver::RootFindingStrategy::CubicInterpolation:
         {
             const Array<NumericalSolver::Solution> stateVectors =
-                integrateToTimes<Stepper>(stepper, previousStateVector, previousTime, currentTime, aSystemOfEquations);
+                integrateToTimes_<Stepper>(stepper, previousStateVector, previousTime, currentTime, aSystemOfEquations);
 
             const Array<State> states = stateVectors.map<State>(
                 [&createState](const NumericalSolver::Solution& aSolution) -> State
@@ -738,7 +738,9 @@ NumericalSolver::ConditionSolution integrateTimeWithStepperImpl(
     const double subStepSize = (solutionTime - previousTime) / 10.0;
     NumericalSolver::StateVector solutionStateVector = previousStateVector;
 
-    integrateToTime<Stepper>(stepper, solutionStateVector, previousTime, solutionTime, subStepSize, aSystemOfEquations);
+    integrateToTime_<Stepper>(
+        stepper, solutionStateVector, previousTime, solutionTime, subStepSize, aSystemOfEquations
+    );
 
     const State solutionState = createState(solutionStateVector, solutionTime);
 
@@ -776,7 +778,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
         case StepperType::RungeKutta4:
         {
             stepper_type_4 stepper;
-            return integrateTimeWithStepperImpl<stepper_type_4>(
+            return integrateTimeWithStepperImpl_<stepper_type_4>(
                 stepper,
                 aState,
                 anInstant,
@@ -795,7 +797,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
             auto stepper = make_controlled(
                 absoluteTolerance_, relativeTolerance_, runge_kutta_cash_karp54<NumericalSolver::StateVector>()
             );
-            return integrateTimeWithStepperImpl<decltype(stepper)>(
+            return integrateTimeWithStepperImpl_<decltype(stepper)>(
                 stepper,
                 aState,
                 anInstant,
@@ -814,7 +816,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
             auto stepper = make_controlled(
                 absoluteTolerance_, relativeTolerance_, runge_kutta_fehlberg78<NumericalSolver::StateVector>()
             );
-            return integrateTimeWithStepperImpl<decltype(stepper)>(
+            return integrateTimeWithStepperImpl_<decltype(stepper)>(
                 stepper,
                 aState,
                 anInstant,
@@ -833,7 +835,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
             auto stepper = make_controlled(
                 absoluteTolerance_, relativeTolerance_, runge_kutta_dopri5<NumericalSolver::StateVector>()
             );
-            return integrateTimeWithStepperImpl<decltype(stepper)>(
+            return integrateTimeWithStepperImpl_<decltype(stepper)>(
                 stepper,
                 aState,
                 anInstant,
@@ -850,7 +852,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
         case StepperType::AdamsBashforthMoulton5:
         {
             auto stepper = make_controlled_adam_bashforth_moulton<5>(absoluteTolerance_, relativeTolerance_);
-            return integrateTimeWithStepperImpl<decltype(stepper)>(
+            return integrateTimeWithStepperImpl_<decltype(stepper)>(
                 stepper,
                 aState,
                 anInstant,
@@ -867,7 +869,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
         case StepperType::AdamsBashforthMoulton8:
         {
             auto stepper = make_controlled_adam_bashforth_moulton<8>(absoluteTolerance_, relativeTolerance_);
-            return integrateTimeWithStepperImpl<decltype(stepper)>(
+            return integrateTimeWithStepperImpl_<decltype(stepper)>(
                 stepper,
                 aState,
                 anInstant,
@@ -884,7 +886,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithControlledS
         case StepperType::BulirschStoer:
         {
             auto stepper = bulirsch_stoer<NumericalSolver::StateVector>(absoluteTolerance_, relativeTolerance_);
-            return integrateTimeWithStepperImpl<decltype(stepper)>(
+            return integrateTimeWithStepperImpl_<decltype(stepper)>(
                 stepper,
                 aState,
                 anInstant,

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -779,10 +779,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Calcula
         EXPECT_EQ(coordinates1.size(), coordinates2.size());
 
         // Check that each element of the two vectors is close
-        for (int i = 0; i < coordinates1.size(); ++i)
-        {
-            EXPECT_NEAR(coordinates1(i), coordinates2(i), 1e-5);
-        }
+        EXPECT_VECTORS_ALMOST_EQUAL(coordinates1, coordinates2, 5e-5);
     }
 
     {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -845,10 +845,10 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Segment : public ::testing::Test
 
     const NumericalSolver defaultNumericalSolver_ = {
         NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaDopri5,
+        NumericalSolver::StepperType::RungeKuttaFehlberg78,
         5.0,
-        1.0e-8,  // Reducing tolerances so that the solving doesn't take forever
-        1.0e-8,  // Reducing tolerances so that the solving doesn't take forever
+        1.0e-12,
+        1.0e-12,
     };
 
     const NumericalSolver defaultHighPrecisionNumericalSolver_ = {
@@ -3220,7 +3220,8 @@ TEST_F(
 }
 
 TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_ManeuverDurationBelowMinimum_ConditionSatisfiedWithManeuver
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Segment,
+    Solve_ManeuverDurationBelowMinimum_ConditionSatisfiedWithManeuver
 )
 {
     const Segment::ManeuverConstraints constraints(
@@ -3244,21 +3245,26 @@ TEST_F(
             initialStateWithMass_.accessInstant() + Duration::Minutes(30.0)
         ),
     };
+
+    for (const Interval& interval : guidanceLawIntervals)
+    {
+        std::cout << "guidanceLawInterval: " << interval.toString() << std::endl;
+    }
+
     const Shared<Thruster> customThrusterDynamics =
-        std::make_shared<Thruster>(defaultSatelliteSystem_, std::make_shared<CustomGuidanceLaw>(guidanceLawIntervals));
+        std::make_shared<Thruster>(defaultSatelliteSystem_,
+        std::make_shared<CustomGuidanceLaw>(guidanceLawIntervals));
 
     const Segment maneuverSegment = Segment::Maneuver(
         defaultName_,
         durationCondition,
         customThrusterDynamics,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,  // Have to use high precision numerical solver to get a precise duration
-        constraints
+        defaultHighPrecisionNumericalSolver_,  // Have to use high precision numerical solver to get a precise
+        duration constraints
     );
 
     const Segment::Solution solution = maneuverSegment.solve(initialStateWithMass_, Duration::Minutes(35.0));
-
-    ASSERT_STATES_ARE_STRICTLY_MONOTONIC(solution.states);
 
     // first maneuver will be skipped due to minimum duration constraint
     const Array<Maneuver> maneuvers = solution.extractManeuvers(defaultFrameSPtr_);
@@ -3298,6 +3304,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_ManeuverDuration
     EXPECT_GT(maneuvers.getSize(), 0);
     for (const Maneuver& maneuver : maneuvers)
     {
+        std::cout << "TEST MANEUVER: " << maneuver.getInterval().toString() << std::endl;
         EXPECT_LE(maneuver.getInterval().getDuration(), constraints.maximumDuration);
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -686,10 +686,9 @@ INSTANTIATE_TEST_SUITE_P(
         },
         IntervalHasValidMaximumDutyCycleParams {
             "PreviousManeuversSaturatedDutyCycle_NoRoomForCandidateManeuver",
-            Array<Pair<Duration, Duration>> {
-                // Previous maneuvers have saturated the duty cycle (40 min total)
-                Pair<Duration, Duration> {Duration::Minutes(0), Duration::Minutes(10.0)},
-                Pair<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(50.0)}
+            Array<Pair<Duration, Duration>> {// Previous maneuvers have saturated the duty cycle (40 min total)
+                                             Pair<Duration, Duration> {Duration::Minutes(0), Duration::Minutes(10.0)},
+                                             Pair<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(50.0)}
             },
             Pair<Duration, Duration> {Duration::Minutes(60.0), Duration::Minutes(70.0)},
             false,
@@ -706,10 +705,9 @@ INSTANTIATE_TEST_SUITE_P(
         },
         IntervalHasValidMaximumDutyCycleParams {
             "PreviousManeuversOverSaturatedDutyCycle_NoRoomForCandidateManeuver_1",
-            Array<Pair<Duration, Duration>> {
-                // Previous maneuvers have over-saturated the duty cycle (45 min total)
-                Pair<Duration, Duration> {Duration::Minutes(0), Duration::Minutes(15.0)},
-                Pair<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(50.0)}
+            Array<Pair<Duration, Duration>> {// Previous maneuvers have over-saturated the duty cycle (45 min total)
+                                             Pair<Duration, Duration> {Duration::Minutes(0), Duration::Minutes(15.0)},
+                                             Pair<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(50.0)}
             },
             Pair<Duration, Duration> {Duration::Minutes(60.0), Duration::Minutes(70.0)},
             false,
@@ -1286,18 +1284,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Extrac
 
         // Check that metrics from the maneuvering segment solution are the same as the ones from the extracted maneuver
         EXPECT_NEAR(
-            maneuveringSegmentSolution.computeDeltaV(
-                defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()
+            maneuveringSegmentSolution.computeDeltaV(defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()
             ),
             maneuvers[0].calculateDeltaV(),
-            1e-10 * maneuveringSegmentSolution.computeDeltaV(
-                        defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()  // Scale to relative error
-                    )
+            1e-8 * maneuveringSegmentSolution.computeDeltaV(
+                       defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()  // Scale to relative error
+                   )
         );
         EXPECT_NEAR(
             maneuveringSegmentSolution.computeDeltaMass().inKilograms(),
             maneuvers[0].calculateDeltaMass().inKilograms(),
-            1e-10 * maneuveringSegmentSolution.computeDeltaMass().inKilograms()  // Scale to relative error
+            1e-8 * maneuveringSegmentSolution.computeDeltaMass().inKilograms()  // Scale to relative error
         );
 
         // These are not as close as the dV and dM above likely due to the midpoint trapezoidal rule used to calculate
@@ -1305,13 +1302,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Extrac
         EXPECT_NEAR(
             defaultSatelliteSystem_.getPropulsionSystem().getThrust(),
             maneuvers[0].calculateAverageThrust(initialWetMass),
-            5e-6 * defaultSatelliteSystem_.getPropulsionSystem().getThrust()  // Scale to relative error
+            5e-5 * defaultSatelliteSystem_.getPropulsionSystem().getThrust()  // Scale to relative error
         );
 
         EXPECT_NEAR(
             defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse(),
             maneuvers[0].calculateAverageSpecificImpulse(initialWetMass),
-            5e-6 * defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()  // Scale to relative error
+            5e-5 * defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()  // Scale to relative error
         );
     }
 
@@ -1819,16 +1816,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Maneuver)
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, ConstantLocalOrbitalFrameDirectionManeuver)
 {
     {
-        EXPECT_NO_THROW(
-            Segment::ConstantLocalOrbitalFrameDirectionManeuver(
-                defaultName_,
-                defaultInstantCondition_,
-                defaultThrusterDynamicsSPtr_,
-                defaultDynamics_,
-                defaultNumericalSolver_,
-                defaultLocalOrbitalFrameFactorySPtr_
-            )
-        );
+        EXPECT_NO_THROW(Segment::ConstantLocalOrbitalFrameDirectionManeuver(
+            defaultName_,
+            defaultInstantCondition_,
+            defaultThrusterDynamicsSPtr_,
+            defaultDynamics_,
+            defaultNumericalSolver_,
+            defaultLocalOrbitalFrameFactorySPtr_
+        ));
     }
 }
 
@@ -2632,30 +2627,25 @@ INSTANTIATE_TEST_SUITE_P(
                 Tuple<Duration, Duration> {Duration::Minutes(-1.0), Duration::Minutes(1.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(0.0), Duration::Minutes(1.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(0.0), Duration::Minutes(1.0)}
             }
         },
         // Middle maneuver
         SolveTestParams {
             "Middle",
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(1.0), Duration::Minutes(2.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(1.0), Duration::Minutes(2.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(1.0), Duration::Minutes(2.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(1.0), Duration::Minutes(2.0)}
             }
         },
         // Trailing edge maneuver
         SolveTestParams {
             "TrailingEdge",
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(7.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(7.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(6.0)}
             }
         },
         // Maneuver spans entire interval
@@ -2665,19 +2655,16 @@ INSTANTIATE_TEST_SUITE_P(
                 Tuple<Duration, Duration> {Duration::Minutes(-1.0), Duration::Minutes(7.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(0.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(0.0), Duration::Minutes(6.0)}
             }
         },
         // Maneuver ends at condition time
         SolveTestParams {
             "EndsAtCondition",
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(3.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(3.0), Duration::Minutes(6.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(3.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(3.0), Duration::Minutes(6.0)}
             }
         },
         // Leading edge + middle maneuvers
@@ -2714,8 +2701,7 @@ INSTANTIATE_TEST_SUITE_P(
                 Tuple<Duration, Duration> {Duration::Minutes(8.0), Duration::Minutes(9.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {
-                Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(6.0)}
             }
         }
     ),
@@ -2751,11 +2737,9 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment_Solve_Parameterized, Ma
     Array<Interval> guidanceLawIntervals = Array<Interval>::Empty();
     for (const auto& durationTuple : params.maneuverIntervals)
     {
-        guidanceLawIntervals.add(
-            Interval::Closed(
-                referenceInstant + std::get<0>(durationTuple), referenceInstant + std::get<1>(durationTuple)
-            )
-        );
+        guidanceLawIntervals.add(Interval::Closed(
+            referenceInstant + std::get<0>(durationTuple), referenceInstant + std::get<1>(durationTuple)
+        ));
     }
 
     const Shared<Thruster> customThrusterDynamics =
@@ -2775,11 +2759,9 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment_Solve_Parameterized, Ma
     Array<Interval> expectedManeuverIntervals = Array<Interval>::Empty();
     for (const auto& durationTuple : params.expectedManeuverIntervals)
     {
-        expectedManeuverIntervals.add(
-            Interval::Closed(
-                referenceInstant + std::get<0>(durationTuple), referenceInstant + std::get<1>(durationTuple)
-            )
-        );
+        expectedManeuverIntervals.add(Interval::Closed(
+            referenceInstant + std::get<0>(durationTuple), referenceInstant + std::get<1>(durationTuple)
+        ));
     }
 
     ASSERT_FALSE(solution.states.isEmpty());
@@ -2794,8 +2776,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment_Solve_Parameterized, Ma
 
     for (Size idx = 0; idx < expectedManeuverIntervals.getSize(); ++idx)
     {
-        EXPECT_TRUE(
-            expectedManeuverIntervals[idx].getStart().isNear(maneuvers[idx].getInterval().getStart(), tolerance)
+        EXPECT_TRUE(expectedManeuverIntervals[idx].getStart().isNear(maneuvers[idx].getInterval().getStart(), tolerance)
         );
         EXPECT_TRUE(expectedManeuverIntervals[idx].getEnd().isNear(maneuvers[idx].getInterval().getEnd(), tolerance));
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -853,7 +853,7 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Segment : public ::testing::Test
 
     const NumericalSolver defaultHighPrecisionNumericalSolver_ = {
         NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaDopri5,
+        NumericalSolver::StepperType::RungeKuttaFehlberg78,
         5.0,
         1.0e-12,
         1.0e-12,
@@ -3246,11 +3246,6 @@ TEST_F(
         ),
     };
 
-    for (const Interval& interval : guidanceLawIntervals)
-    {
-        std::cout << "guidanceLawInterval: " << interval.toString() << std::endl;
-    }
-
     const Shared<Thruster> customThrusterDynamics =
         std::make_shared<Thruster>(defaultSatelliteSystem_,
         std::make_shared<CustomGuidanceLaw>(guidanceLawIntervals));
@@ -3261,7 +3256,7 @@ TEST_F(
         customThrusterDynamics,
         defaultDynamics_,
         defaultHighPrecisionNumericalSolver_,  // Have to use high precision numerical solver to get a precise
-        duration constraints
+        constraints
     );
 
     const Segment::Solution solution = maneuverSegment.solve(initialStateWithMass_, Duration::Minutes(35.0));
@@ -3304,7 +3299,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_ManeuverDuration
     EXPECT_GT(maneuvers.getSize(), 0);
     for (const Maneuver& maneuver : maneuvers)
     {
-        std::cout << "TEST MANEUVER: " << maneuver.getInterval().toString() << std::endl;
         EXPECT_LE(maneuver.getInterval().getDuration(), constraints.maximumDuration);
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -125,6 +125,7 @@ using ostk::astrodynamics::flight::system::SatelliteSystem;
 using ostk::astrodynamics::guidancelaw::ConstantThrust;
 using ostk::astrodynamics::guidancelaw::HeterogeneousGuidanceLaw;
 using ostk::astrodynamics::guidancelaw::QLaw;
+using ostk::astrodynamics::RootSolver;
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameDirection;
 using ostk::astrodynamics::trajectory::LocalOrbitalFrameFactory;
 using ostk::astrodynamics::trajectory::orbit::model::blm::BrouwerLyddaneMeanLong;
@@ -849,6 +850,8 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Segment : public ::testing::Test
         5.0,
         1.0e-12,
         1.0e-12,
+        RootSolver::Default(),
+        NumericalSolver::RootFindingStrategy::CubicInterpolation,
     };
 
     const NumericalSolver defaultHighPrecisionNumericalSolver_ = {
@@ -857,6 +860,8 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Segment : public ::testing::Test
         5.0,
         1.0e-12,
         1.0e-12,
+        RootSolver::Default(),
+        NumericalSolver::RootFindingStrategy::CubicInterpolation,
     };
 
     const Shared<InstantCondition> defaultInstantCondition_ = std::make_shared<InstantCondition>(
@@ -2512,7 +2517,7 @@ TEST_F(
         // The second maneuver interval is expected to be similar but not very close as the trajectory (after the first
         // maneuver) has changed
         EXPECT_INTERVALS_ALMOST_EQUAL(
-            maneuvers[1].getInterval(), constraintedManeuvers[1].getInterval(), Duration::Seconds(0.5)
+            maneuvers[1].getInterval(), constraintedManeuvers[1].getInterval(), Duration::Seconds(1.0)
         );
     }
 }
@@ -3220,8 +3225,7 @@ TEST_F(
 }
 
 TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_Segment,
-    Solve_ManeuverDurationBelowMinimum_ConditionSatisfiedWithManeuver
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_ManeuverDurationBelowMinimum_ConditionSatisfiedWithManeuver
 )
 {
     const Segment::ManeuverConstraints constraints(
@@ -3247,8 +3251,7 @@ TEST_F(
     };
 
     const Shared<Thruster> customThrusterDynamics =
-        std::make_shared<Thruster>(defaultSatelliteSystem_,
-        std::make_shared<CustomGuidanceLaw>(guidanceLawIntervals));
+        std::make_shared<Thruster>(defaultSatelliteSystem_, std::make_shared<CustomGuidanceLaw>(guidanceLawIntervals));
 
     const Segment maneuverSegment = Segment::Maneuver(
         defaultName_,

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -686,9 +686,10 @@ INSTANTIATE_TEST_SUITE_P(
         },
         IntervalHasValidMaximumDutyCycleParams {
             "PreviousManeuversSaturatedDutyCycle_NoRoomForCandidateManeuver",
-            Array<Pair<Duration, Duration>> {// Previous maneuvers have saturated the duty cycle (40 min total)
-                                             Pair<Duration, Duration> {Duration::Minutes(0), Duration::Minutes(10.0)},
-                                             Pair<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(50.0)}
+            Array<Pair<Duration, Duration>> {
+                // Previous maneuvers have saturated the duty cycle (40 min total)
+                Pair<Duration, Duration> {Duration::Minutes(0), Duration::Minutes(10.0)},
+                Pair<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(50.0)}
             },
             Pair<Duration, Duration> {Duration::Minutes(60.0), Duration::Minutes(70.0)},
             false,
@@ -705,9 +706,10 @@ INSTANTIATE_TEST_SUITE_P(
         },
         IntervalHasValidMaximumDutyCycleParams {
             "PreviousManeuversOverSaturatedDutyCycle_NoRoomForCandidateManeuver_1",
-            Array<Pair<Duration, Duration>> {// Previous maneuvers have over-saturated the duty cycle (45 min total)
-                                             Pair<Duration, Duration> {Duration::Minutes(0), Duration::Minutes(15.0)},
-                                             Pair<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(50.0)}
+            Array<Pair<Duration, Duration>> {
+                // Previous maneuvers have over-saturated the duty cycle (45 min total)
+                Pair<Duration, Duration> {Duration::Minutes(0), Duration::Minutes(15.0)},
+                Pair<Duration, Duration> {Duration::Minutes(20.0), Duration::Minutes(50.0)}
             },
             Pair<Duration, Duration> {Duration::Minutes(60.0), Duration::Minutes(70.0)},
             false,
@@ -1254,13 +1256,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Extrac
             durationCondition,
             defaultThrusterDynamicsSPtr_,
             defaultDynamics_,
-            {
-                NumericalSolver::LogType::NoLog,
-                NumericalSolver::StepperType::RungeKuttaDopri5,
-                5.0,
-                1.0e-12,
-                1.0e-12,
-            }
+            defaultNumericalSolver_
         );
 
         const Mass initialWetMass = Mass::Kilograms(200.0);
@@ -1290,7 +1286,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Extrac
 
         // Check that metrics from the maneuvering segment solution are the same as the ones from the extracted maneuver
         EXPECT_NEAR(
-            maneuveringSegmentSolution.computeDeltaV(defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()
+            maneuveringSegmentSolution.computeDeltaV(
+                defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()
             ),
             maneuvers[0].calculateDeltaV(),
             1e-10 * maneuveringSegmentSolution.computeDeltaV(
@@ -1822,14 +1819,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Maneuver)
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, ConstantLocalOrbitalFrameDirectionManeuver)
 {
     {
-        EXPECT_NO_THROW(Segment::ConstantLocalOrbitalFrameDirectionManeuver(
-            defaultName_,
-            defaultInstantCondition_,
-            defaultThrusterDynamicsSPtr_,
-            defaultDynamics_,
-            defaultNumericalSolver_,
-            defaultLocalOrbitalFrameFactorySPtr_
-        ));
+        EXPECT_NO_THROW(
+            Segment::ConstantLocalOrbitalFrameDirectionManeuver(
+                defaultName_,
+                defaultInstantCondition_,
+                defaultThrusterDynamicsSPtr_,
+                defaultDynamics_,
+                defaultNumericalSolver_,
+                defaultLocalOrbitalFrameFactorySPtr_
+            )
+        );
     }
 }
 
@@ -1951,14 +1950,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve)
 
     // No maneuvers should be produced
     {
-        const NumericalSolver numericalSolver = {
-            NumericalSolver::LogType::NoLog,
-            NumericalSolver::StepperType::RungeKuttaDopri5,
-            1.0,
-            1.0e-12,
-            1.0e-12,
-        };
-
         VectorXd initialCoordinates(7);
         initialCoordinates << 7000000.0, 0.0, 0.0, 0.0, 7546.05329, 0.0, 200.0;
         const State initialState = {Instant::J2000(), initialCoordinates, Frame::GCRF(), thrustCoordinateBrokerSPtr_};
@@ -1978,7 +1969,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve)
             eventCondition,
             customThrusterDynamics,
             defaultDynamics_,
-            numericalSolver
+            defaultNumericalSolver_
         );
 
         {
@@ -2058,14 +2049,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SolveWithPreviousManeu
 
     // No maneuvers should be produced
     {
-        const NumericalSolver numericalSolver = {
-            NumericalSolver::LogType::NoLog,
-            NumericalSolver::StepperType::RungeKuttaDopri5,
-            1.0,
-            1.0e-12,
-            1.0e-12,
-        };
-
         VectorXd initialCoordinates(7);
         initialCoordinates << 7000000.0, 0.0, 0.0, 0.0, 7546.05329, 0.0, 200.0;
         const State initialState = {Instant::J2000(), initialCoordinates, Frame::GCRF(), thrustCoordinateBrokerSPtr_};
@@ -2085,7 +2068,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SolveWithPreviousManeu
             eventCondition,
             customThrusterDynamics,
             defaultDynamics_,
-            numericalSolver
+            defaultNumericalSolver_
         );
 
         {
@@ -2649,25 +2632,30 @@ INSTANTIATE_TEST_SUITE_P(
                 Tuple<Duration, Duration> {Duration::Minutes(-1.0), Duration::Minutes(1.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(0.0), Duration::Minutes(1.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(0.0), Duration::Minutes(1.0)}
             }
         },
         // Middle maneuver
         SolveTestParams {
             "Middle",
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(1.0), Duration::Minutes(2.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(1.0), Duration::Minutes(2.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(1.0), Duration::Minutes(2.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(1.0), Duration::Minutes(2.0)}
             }
         },
         // Trailing edge maneuver
         SolveTestParams {
             "TrailingEdge",
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(7.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(7.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(6.0)}
             }
         },
         // Maneuver spans entire interval
@@ -2677,16 +2665,19 @@ INSTANTIATE_TEST_SUITE_P(
                 Tuple<Duration, Duration> {Duration::Minutes(-1.0), Duration::Minutes(7.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(0.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(0.0), Duration::Minutes(6.0)}
             }
         },
         // Maneuver ends at condition time
         SolveTestParams {
             "EndsAtCondition",
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(3.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(3.0), Duration::Minutes(6.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(3.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(3.0), Duration::Minutes(6.0)}
             }
         },
         // Leading edge + middle maneuvers
@@ -2723,7 +2714,8 @@ INSTANTIATE_TEST_SUITE_P(
                 Tuple<Duration, Duration> {Duration::Minutes(8.0), Duration::Minutes(9.0)}
             },
             Duration::Minutes(6.0),
-            Array<Tuple<Duration, Duration>> {Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(6.0)}
+            Array<Tuple<Duration, Duration>> {
+                Tuple<Duration, Duration> {Duration::Minutes(5.0), Duration::Minutes(6.0)}
             }
         }
     ),
@@ -2739,7 +2731,7 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment_Solve_Parameterized, Ma
 
     const NumericalSolver numericalSolver = {
         NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaDopri5,
+        NumericalSolver::StepperType::RungeKuttaFehlberg78,
         1.0,
         1.0e-12,
         1.0e-12,
@@ -2759,9 +2751,11 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment_Solve_Parameterized, Ma
     Array<Interval> guidanceLawIntervals = Array<Interval>::Empty();
     for (const auto& durationTuple : params.maneuverIntervals)
     {
-        guidanceLawIntervals.add(Interval::Closed(
-            referenceInstant + std::get<0>(durationTuple), referenceInstant + std::get<1>(durationTuple)
-        ));
+        guidanceLawIntervals.add(
+            Interval::Closed(
+                referenceInstant + std::get<0>(durationTuple), referenceInstant + std::get<1>(durationTuple)
+            )
+        );
     }
 
     const Shared<Thruster> customThrusterDynamics =
@@ -2781,9 +2775,11 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment_Solve_Parameterized, Ma
     Array<Interval> expectedManeuverIntervals = Array<Interval>::Empty();
     for (const auto& durationTuple : params.expectedManeuverIntervals)
     {
-        expectedManeuverIntervals.add(Interval::Closed(
-            referenceInstant + std::get<0>(durationTuple), referenceInstant + std::get<1>(durationTuple)
-        ));
+        expectedManeuverIntervals.add(
+            Interval::Closed(
+                referenceInstant + std::get<0>(durationTuple), referenceInstant + std::get<1>(durationTuple)
+            )
+        );
     }
 
     ASSERT_FALSE(solution.states.isEmpty());
@@ -2798,7 +2794,8 @@ TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment_Solve_Parameterized, Ma
 
     for (Size idx = 0; idx < expectedManeuverIntervals.getSize(); ++idx)
     {
-        EXPECT_TRUE(expectedManeuverIntervals[idx].getStart().isNear(maneuvers[idx].getInterval().getStart(), tolerance)
+        EXPECT_TRUE(
+            expectedManeuverIntervals[idx].getStart().isNear(maneuvers[idx].getInterval().getStart(), tolerance)
         );
         EXPECT_TRUE(expectedManeuverIntervals[idx].getEnd().isNear(maneuvers[idx].getInterval().getEnd(), tolerance));
     }
@@ -4966,14 +4963,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Regression_Solve_Dupli
     const Environment environment(initialInstant, {earthSPtr});
     const Array<Shared<Dynamics>> dynamics = Dynamics::FromEnvironment(environment);
 
-    const NumericalSolver numericalSolver = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaDopri5,
-        5.0,
-        1.0e-12,
-        1.0e-12,
-    };
-
     const BrouwerLyddaneMeanLong blm = BrouwerLyddaneMeanLong::Cartesian(
         {initialState.getPosition(), initialState.getVelocity()},
         EarthGravitationalModel::EGM2008.gravitationalParameter_
@@ -5046,7 +5035,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Regression_Solve_Dupli
         endConditionSPtr,
         thrusterSPtr,
         dynamics,
-        numericalSolver,
+        defaultNumericalSolver_,
         {Duration::Minutes(16.0),
          Duration::Minutes(16.0),
          Duration::Minutes(26.0),
@@ -5113,14 +5102,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Regression_Solve_Maneu
     const Environment environment(earthSPtr, {std::make_shared<Sun>(Sun::Default())}, initialInstant);
     const Array<Shared<Dynamics>> dynamics = Dynamics::FromEnvironment(environment);
 
-    const NumericalSolver numericalSolver = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaDopri5,
-        10.0,
-        1.0e-12,
-        1.0e-12,
-    };
-
     const COE targetCOE = {
         Length::Meters(10.0e10),
         0.0,                    // eccentricity
@@ -5170,7 +5151,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Regression_Solve_Maneu
         endConditionSPtr,
         thrusterSPtr,
         dynamics,
-        numericalSolver,
+        defaultNumericalSolver_,
         tnwFactorySPtr,
         Angle::Undefined(),
         {Duration::Minutes(10.0),

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -851,17 +851,6 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Segment : public ::testing::Test
         1.0e-12,
         1.0e-12,
         RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::CubicInterpolation,
-    };
-
-    const NumericalSolver defaultHighPrecisionNumericalSolver_ = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaFehlberg78,
-        5.0,
-        1.0e-12,
-        1.0e-12,
-        RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::CubicInterpolation,
     };
 
     const Shared<InstantCondition> defaultInstantCondition_ = std::make_shared<InstantCondition>(
@@ -1287,14 +1276,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, SegmentSolution_Extrac
             maneuveringSegmentSolution.computeDeltaV(defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()
             ),
             maneuvers[0].calculateDeltaV(),
-            1e-8 * maneuveringSegmentSolution.computeDeltaV(
-                       defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()  // Scale to relative error
-                   )
+            5e-10 * maneuveringSegmentSolution.computeDeltaV(
+                        defaultSatelliteSystem_.getPropulsionSystem().getSpecificImpulse()  // Scale to relative error
+                    )
         );
         EXPECT_NEAR(
             maneuveringSegmentSolution.computeDeltaMass().inKilograms(),
             maneuvers[0].calculateDeltaMass().inKilograms(),
-            1e-8 * maneuveringSegmentSolution.computeDeltaMass().inKilograms()  // Scale to relative error
+            5e-10 * maneuveringSegmentSolution.computeDeltaMass().inKilograms()  // Scale to relative error
         );
 
         // These are not as close as the dV and dM above likely due to the midpoint trapezoidal rule used to calculate
@@ -2495,7 +2484,7 @@ TEST_F(
         // The second maneuver interval is expected to be similar but not very close as the trajectory (after the first
         // maneuver) has changed
         EXPECT_INTERVALS_ALMOST_EQUAL(
-            maneuvers[1].getInterval(), constraintedManeuvers[1].getInterval(), Duration::Seconds(1.0)
+            maneuvers[1].getInterval(), constraintedManeuvers[1].getInterval(), Duration::Seconds(1.5)
         );
     }
 }
@@ -3232,15 +3221,11 @@ TEST_F(
         std::make_shared<Thruster>(defaultSatelliteSystem_, std::make_shared<CustomGuidanceLaw>(guidanceLawIntervals));
 
     const Segment maneuverSegment = Segment::Maneuver(
-        defaultName_,
-        durationCondition,
-        customThrusterDynamics,
-        defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,  // Have to use high precision numerical solver to get a precise
-        constraints
+        defaultName_, durationCondition, customThrusterDynamics, defaultDynamics_, defaultNumericalSolver_, constraints
     );
 
     const Segment::Solution solution = maneuverSegment.solve(initialStateWithMass_, Duration::Minutes(35.0));
+    ASSERT_STATES_ARE_STRICTLY_MONOTONIC(solution.states);
 
     // first maneuver will be skipped due to minimum duration constraint
     const Array<Maneuver> maneuvers = solution.extractManeuvers(defaultFrameSPtr_);
@@ -3268,7 +3253,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_ManeuverDuration
         durationCondition,
         defaultThrusterDynamicsSPtr_,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         constraints
     );
 
@@ -3422,7 +3407,7 @@ TEST_F(
         durationCondition,
         defaultThrusterDynamicsSPtr_,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         constraints
     );
 
@@ -3512,7 +3497,7 @@ TEST_F(
         durationCondition,
         defaultThrusterDynamicsSPtr_,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         constraints
     );
 
@@ -3561,7 +3546,7 @@ TEST_F(
         eventCondition,
         defaultThrusterDynamicsSPtr_,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         constraints
     );
 
@@ -3600,7 +3585,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_ManeuverDuration
         durationCondition,
         defaultThrusterDynamicsSPtr_,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         constraints
     );
 
@@ -3690,7 +3675,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_ManeuverDuration
         durationCondition,
         defaultThrusterDynamicsSPtr_,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         constraints
     );
 
@@ -4398,7 +4383,7 @@ TEST_P(
         durationCondition,
         defaultThrusterDynamicsSPtr_,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         constraints
     );
 
@@ -4501,7 +4486,7 @@ TEST_P(
         durationCondition,
         defaultThrusterDynamicsSPtr_,
         defaultDynamics_,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         constraints
     );
 
@@ -4730,7 +4715,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Regression_Solve_Singl
         endConditionSPtr,
         thrusterSPtr,
         dynamics,
-        defaultHighPrecisionNumericalSolver_,
+        defaultNumericalSolver_,
         lofFactorySPtr,
         Angle::Undefined(),
         constraints

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
@@ -1003,7 +1003,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, Solve_3)
                 {segmentSolution.states.accessLast().getPosition(), segmentSolution.states.accessLast().getVelocity()},
                 EarthGravitationalModel::EGM2008.gravitationalParameter_
             );
-            EXPECT_NEAR(coe.getTrueAnomaly().inDegrees() - initialCOE.getTrueAnomaly().inDegrees(), 5.0, 1e-5);
+            EXPECT_NEAR(coe.getTrueAnomaly().inDegrees() - initialCOE.getTrueAnomaly().inDegrees(), 5.0, 1e-4);
             initialCOE = coe;
         }
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Sequence.test.cpp
@@ -1003,7 +1003,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Sequence, Solve_3)
                 {segmentSolution.states.accessLast().getPosition(), segmentSolution.states.accessLast().getVelocity()},
                 EarthGravitationalModel::EGM2008.gravitationalParameter_
             );
-            EXPECT_NEAR(coe.getTrueAnomaly().inDegrees() - initialCOE.getTrueAnomaly().inDegrees(), 5.0, 1e-4);
+            EXPECT_NEAR(coe.getTrueAnomaly().inDegrees() - initialCOE.getTrueAnomaly().inDegrees(), 5.0, 2e-5);
             initialCOE = coe;
         }
     }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -564,7 +564,7 @@ TEST_F(
 
     const State state = getStateVector(defaultStartInstant_);
     const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
-    const InstantCondition condition = InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
+    const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
 
     const NumericalSolver::ConditionSolution conditionSolution =
         solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
@@ -590,7 +590,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
 
     const State state = getStateVector(defaultStartInstant_);
     const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
-    const InstantCondition condition = InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
+    const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
 
     const NumericalSolver::ConditionSolution conditionSolution =
         solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
@@ -618,7 +618,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
 
     const State state = getStateVector(defaultStartInstant_);
     const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
-    const InstantCondition condition = InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
+    const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
 
     const NumericalSolver::ConditionSolution conditionSolution =
         solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -218,20 +218,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
 {
     const State state = getStateVector(defaultStartInstant_);
 
-    {
-        EXPECT_TRUE(defaultRKD5_.getObservedStates().isEmpty());
-
-        EXPECT_THROW(
-            defaultRK54_.integrateTime(
-                state,
-                defaultStartInstant_,
-                systemOfEquations_,
-                InstantCondition(RealCondition::Criterion::AnyCrossing, state.accessInstant())
-            ),
-            ostk::core::error::RuntimeError
-        );
-    }
-
     // trivial case, zero second integration
     {
         NumericalSolver::ConditionSolution solution = defaultRKD5_.integrateTime(

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -141,7 +141,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Getters)
     {
         EXPECT_NO_THROW(defaultRKD5_.getRootFindingStrategy());
         EXPECT_THROW(NumericalSolver::Undefined().getRootFindingStrategy(), ostk::core::error::runtime::Undefined);
-        EXPECT_EQ(defaultRKD5_.getRootFindingStrategy(), NumericalSolver::RootFindingStrategy::DenseOutput);
+        EXPECT_EQ(defaultRKD5_.getRootFindingStrategy(), NumericalSolver::RootFindingStrategy::Propagated);
     }
 }
 
@@ -549,10 +549,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, StringFr
 {
     {
         EXPECT_EQ(
-            "DenseOutput",
-            NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::DenseOutput)
-        );
-        EXPECT_EQ(
             "Linear", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Linear)
         );
         EXPECT_EQ(
@@ -643,30 +639,4 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
     EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
     EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
     EXPECT_EQ(conditionSolution.iterationCount, 0);  // No root finding iterations for Boundary
-}
-
-TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver,
-    IntegrateTime_Conditions_DenseOutputWithNonRKDP5Throws
-)
-{
-    // Test that DenseOutput strategy with non-RKDP5 stepper throws
-    NumericalSolver solverInvalid = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaCashKarp54,
-        1e-3,
-        1.0e-12,
-        1.0e-12,
-        RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::DenseOutput,
-    };
-
-    const State state = getStateVector(defaultStartInstant_);
-    const InstantCondition condition =
-        InstantCondition(defaultStartInstant_ + defaultDuration_ / 2.0, RealCondition::Criterion::AnyCrossing);
-
-    EXPECT_THROW(
-        solverInvalid.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition),
-        ostk::core::error::RuntimeError
-    );
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -552,9 +552,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, StringFr
             "DenseOutput",
             NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::DenseOutput)
         );
-        EXPECT_EQ("Linear", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Linear));
         EXPECT_EQ(
-            "Propagated", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Propagated)
+            "Linear", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Linear)
+        );
+        EXPECT_EQ(
+            "Propagated",
+            NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Propagated)
         );
         EXPECT_EQ(
             "Boundary", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Boundary)
@@ -577,8 +580,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
 
     const State state = getStateVector(defaultStartInstant_);
     const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
-    const InstantCondition condition =
-        InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
+    const InstantCondition condition = InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
 
     const NumericalSolver::ConditionSolution conditionSolution =
         solverLinear.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
@@ -604,8 +606,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
 
     const State state = getStateVector(defaultStartInstant_);
     const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
-    const InstantCondition condition =
-        InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
+    const InstantCondition condition = InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
 
     const NumericalSolver::ConditionSolution conditionSolution =
         solverPropagated.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
@@ -633,8 +634,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
 
     const State state = getStateVector(defaultStartInstant_);
     const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
-    const InstantCondition condition =
-        InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
+    const InstantCondition condition = InstantCondition(targetInstant, RealCondition::Criterion::AnyCrossing);
 
     const NumericalSolver::ConditionSolution conditionSolution =
         solverBoundary.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
@@ -645,7 +645,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
     EXPECT_EQ(conditionSolution.iterationCount, 0);  // No root finding iterations for Boundary
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_DenseOutputWithNonRKDP5Throws)
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver,
+    IntegrateTime_Conditions_DenseOutputWithNonRKDP5Throws
+)
 {
     // Test that DenseOutput strategy with non-RKDP5 stepper throws
     NumericalSolver solverInvalid = {

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -139,9 +139,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Getters)
     }
 
     {
-        EXPECT_NO_THROW(defaultRKD5_.getRootFindingStrategy());
-        EXPECT_THROW(NumericalSolver::Undefined().getRootFindingStrategy(), ostk::core::error::runtime::Undefined);
-        EXPECT_EQ(defaultRKD5_.getRootFindingStrategy(), NumericalSolver::RootFindingStrategy::Integration);
+        // Defined solver: no throw, returns the configured (initially Undefined) max step size
+        EXPECT_NO_THROW(defaultRKD5_.getMaxStepSize());
+        EXPECT_FALSE(defaultRKD5_.getMaxStepSize().isDefined());
+
+        // Undefined solver: throws like the other getters
+        EXPECT_THROW(NumericalSolver::Undefined().getMaxStepSize(), ostk::core::error::runtime::Undefined);
+
+        // Round-trip via setter
+        NumericalSolver solver = defaultRKD5_;
+        solver.setMaxStepSize(10.0);
+        EXPECT_EQ(solver.getMaxStepSize(), 10.0);
     }
 }
 
@@ -375,43 +383,29 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
 
     {
         const Array<Tuple<Real, Real, RealCondition::Criterion, Real, bool>> testCases = {
-            {Real::TwoPi(),
-             1.0,
-             RealCondition::Criterion::AnyCrossing,
-             Real::TwoPi(),
-             false},  // Almost meets the condition, but never does (forwards)
-            {
-                -Real::TwoPi(), 1.0, RealCondition::Criterion::AnyCrossing, -Real::TwoPi(), false
+            {Real::TwoPi(), 1.0, RealCondition::Criterion::AnyCrossing, Real::TwoPi(), false
+            },  // Almost meets the condition, but never does (forwards)
+            {-Real::TwoPi(), 1.0, RealCondition::Criterion::AnyCrossing, -Real::TwoPi(), false
             },  // Almost meets the condition, but never does (backwards)
-            {
-                Real::TwoPi(), 0.5, RealCondition::Criterion::AnyCrossing, std::asin(0.5), true
+            {Real::TwoPi(), 0.5, RealCondition::Criterion::AnyCrossing, std::asin(0.5), true
             },  // Any crossing (forwards)
-            {
-                -Real::TwoPi(), 0.5, RealCondition::Criterion::AnyCrossing, -Real::Pi() - std::asin(0.5), true
+            {-Real::TwoPi(), 0.5, RealCondition::Criterion::AnyCrossing, -Real::Pi() - std::asin(0.5), true
             },  // Any crossing (backwards)
-            {
-                Real::TwoPi(), 0.5, RealCondition::Criterion::NegativeCrossing, Real::Pi() - std::asin(0.5), true
+            {Real::TwoPi(), 0.5, RealCondition::Criterion::NegativeCrossing, Real::Pi() - std::asin(0.5), true
             },  // Negative crossing (forwards)
-            {
-                -Real::TwoPi(), 0.5, RealCondition::Criterion::NegativeCrossing, -Real::TwoPi() + std::asin(0.5), true
+            {-Real::TwoPi(), 0.5, RealCondition::Criterion::NegativeCrossing, -Real::TwoPi() + std::asin(0.5), true
             },  // Negative crossing (backwards)
-            {
-                Real::TwoPi(), -0.5, RealCondition::Criterion::PositiveCrossing, Real::TwoPi() - std::asin(0.5), true
+            {Real::TwoPi(), -0.5, RealCondition::Criterion::PositiveCrossing, Real::TwoPi() - std::asin(0.5), true
             },  // Positive crossing (forwards)
-            {
-                -Real::TwoPi(), -0.5, RealCondition::Criterion::PositiveCrossing, -Real::Pi() + std::asin(0.5), true
+            {-Real::TwoPi(), -0.5, RealCondition::Criterion::PositiveCrossing, -Real::Pi() + std::asin(0.5), true
             },  // Positive crossing (backwards)
-            {
-                Real::TwoPi(), -0.5, RealCondition::Criterion::StrictlyNegative, Real::Pi() + std::asin(0.5), true
+            {Real::TwoPi(), -0.5, RealCondition::Criterion::StrictlyNegative, Real::Pi() + std::asin(0.5), true
             },  // Strictly negative (forwards)
-            {
-                -Real::TwoPi(), -0.5, RealCondition::Criterion::StrictlyNegative, -std::asin(0.5), true
+            {-Real::TwoPi(), -0.5, RealCondition::Criterion::StrictlyNegative, -std::asin(0.5), true
             },  // Strictly negative (backwards)
-            {
-                Real::TwoPi(), 0.5, RealCondition::Criterion::StrictlyPositive, std::asin(0.5), true
+            {Real::TwoPi(), 0.5, RealCondition::Criterion::StrictlyPositive, std::asin(0.5), true
             },  // Strictly positive (forwards)
-            {
-                -Real::TwoPi(), 0.5, RealCondition::Criterion::StrictlyPositive, -Real::Pi() - std::asin(0.5), true
+            {-Real::TwoPi(), 0.5, RealCondition::Criterion::StrictlyPositive, -Real::Pi() - std::asin(0.5), true
             },  // Strictly positive (backwards)
         };
 
@@ -545,57 +539,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
     EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - targetInstant).inSeconds()), 1e-6);
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, StringFromRootFindingStrategy)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_Refinement)
 {
-    {
-        EXPECT_EQ(
-            "LinearInterpolation",
-            NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::LinearInterpolation)
-        );
-        EXPECT_EQ(
-            "Integration",
-            NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Integration)
-        );
-        EXPECT_EQ("First", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::First));
-        EXPECT_EQ(
-            "CubicInterpolation",
-            NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::CubicInterpolation)
-        );
-    }
-}
-
-TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver,
-    IntegrateTime_Conditions_LinearInterpolationStrategy
-)
-{
-    // Test Linear strategy with CashKarp54 stepper
-    NumericalSolver solver = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKuttaCashKarp54,
-        1e-3,
-        1.0e-12,
-        1.0e-12,
-        RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::LinearInterpolation,
-    };
-
-    const State state = getStateVector(defaultStartInstant_);
-    const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
-    const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
-
-    const NumericalSolver::ConditionSolution conditionSolution =
-        solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
-
-    // Linear interpolation should find the crossing, but with less precision
-    EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
-    EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
-    EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - targetInstant).inSeconds()), 1e-3);
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_IntegrationStrategy)
-{
-    // Test Integration strategy with Fehlberg78 stepper
+    // Test the unified dense-output refinement with Fehlberg78 stepper.
     NumericalSolver solver = {
         NumericalSolver::LogType::NoLog,
         NumericalSolver::StepperType::RungeKuttaFehlberg78,
@@ -603,7 +549,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
         1.0e-12,
         1.0e-12,
         RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::Integration,
     };
 
     const State state = getStateVector(defaultStartInstant_);
@@ -613,64 +558,178 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
     const NumericalSolver::ConditionSolution conditionSolution =
         solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
 
-    // Integration should be very accurate
+    // Dense-output refinement should be very accurate.
     EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
     EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
     EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - targetInstant).inSeconds()), 1e-6);
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_FirstStrategy)
+class OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver_StepperConditional
+    : public OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver,
+      public ::testing::WithParamInterface<NumericalSolver::StepperType>
 {
-    // Test First strategy with RK4 stepper
-    // Use 1.1e-3 step size to avoid landing exactly on target (which would make evaluate=0.0
-    // and fail the AnyCrossing comparator that uses strict inequalities)
-    NumericalSolver solver = {
-        NumericalSolver::LogType::NoLog,
-        NumericalSolver::StepperType::RungeKutta4,
-        1.1e-3,
-        1.0,
-        1.0,
-        RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::First,
-    };
+};
 
-    const State state = getStateVector(defaultStartInstant_);
-    const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
-    const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
-
-    const NumericalSolver::ConditionSolution conditionSolution =
-        solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
-
-    // First returns step boundary, so precision depends on step size
-    EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
-    EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
-    EXPECT_EQ(conditionSolution.iterationCount, 0);  // No root finding iterations for First
-}
-
-TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_CubicInterpolationStrategy
-)
-{
-    // Test CubicInterpolation strategy with CashKarp54 stepper
-    NumericalSolver solver = {
-        NumericalSolver::LogType::NoLog,
+INSTANTIATE_TEST_SUITE_P(
+    AllSteppers,
+    OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver_StepperConditional,
+    ::testing::Values(
+        // Adams-Bashforth-Moulton steppers are excluded — conditional integration is not
+        // supported with multistep methods. See `IntegrateTime_Conditions_ABM_Rejected`.
         NumericalSolver::StepperType::RungeKuttaCashKarp54,
+        NumericalSolver::StepperType::RungeKuttaFehlberg78,
+        NumericalSolver::StepperType::RungeKuttaDopri5,
+        NumericalSolver::StepperType::BulirschStoer
+    )
+);
+
+TEST_P(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver_StepperConditional, ForwardAndBackwardCrossing)
+{
+    // Exercise every stepper with the unified dense-output refinement, in both directions. The
+    // forward case is the canonical conditional integration; the backward case is critical
+    // regression coverage for the multistep (ABM) fallback path and for the sign-handling in the
+    // root refinement helpers, which historically had bugs masked by tolerance-friendly forward
+    // runs.
+    const NumericalSolver::StepperType stepperType = GetParam();
+
+    NumericalSolver solver = {
+        NumericalSolver::LogType::NoLog,
+        stepperType,
         1e-3,
         1.0e-12,
         1.0e-12,
         RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::CubicInterpolation,
     };
 
     const State state = getStateVector(defaultStartInstant_);
-    const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
+
+    for (const Real durationSeconds : {Real(1.0), Real(-1.0)})
+    {
+        const Duration duration = Duration::Seconds(durationSeconds);
+        const Instant endInstant = defaultStartInstant_ + duration;
+        const Instant targetInstant = defaultStartInstant_ + duration / 2.0;
+        const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
+
+        const NumericalSolver::ConditionSolution conditionSolution =
+            solver.integrateTime(state, endInstant, systemOfEquations_, condition);
+
+        EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
+        EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
+        EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - targetInstant).inSeconds()), 1e-3);
+
+        // Sanity: observed states are non-empty and last entry matches the solution state.
+        EXPECT_FALSE(solver.getObservedStates().isEmpty());
+        EXPECT_EQ(conditionSolution.state, solver.getObservedStates().accessLast());
+    }
+}
+
+TEST_P(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver_StepperConditional, ConditionNeverSatisfiedMonotonic
+)
+{
+    // when the condition is never satisfied, the trim back to endTime
+    // must keep observedStates_ monotonic in time. Run forward and backward to exercise both
+    // sign branches of the trim integration.
+    const NumericalSolver::StepperType stepperType = GetParam();
+
+    NumericalSolver solver = {
+        NumericalSolver::LogType::NoLog,
+        stepperType,
+        1e-3,
+        1.0e-12,
+        1.0e-12,
+        RootSolver::Default(),
+    };
+
+    const State state = getStateVector(defaultStartInstant_);
+
+    for (const Real durationSeconds : {Real(1.0), Real(-1.0)})
+    {
+        const Duration duration = Duration::Seconds(durationSeconds);
+        const Instant endInstant = defaultStartInstant_ + duration;
+
+        // Place the condition target *outside* [start, end] so it is never reached.
+        const Instant outsideTarget = defaultStartInstant_ + duration * Real(2.0);
+        const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, outsideTarget);
+
+        const NumericalSolver::ConditionSolution conditionSolution =
+            solver.integrateTime(state, endInstant, systemOfEquations_, condition);
+
+        EXPECT_FALSE(conditionSolution.conditionIsSatisfied);
+        EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - endInstant).inSeconds()), 1e-9);
+
+        const Array<State> observed = solver.getObservedStates();
+        ASSERT_GE(observed.getSize(), 2u);
+
+        // Strict monotonicity in the integration direction.
+        for (size_t i = 1; i < observed.getSize(); ++i)
+        {
+            const double dt = (observed[i].accessInstant() - observed[i - 1].accessInstant()).inSeconds();
+            if (durationSeconds > 0.0)
+            {
+                EXPECT_GT(dt, 0.0) << "Forward integration produced non-monotonic observed states at index " << i;
+            }
+            else
+            {
+                EXPECT_LT(dt, 0.0) << "Backward integration produced non-monotonic observed states at index " << i;
+            }
+        }
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_BackwardIntegration)
+{
+    // Regression coverage for signedTimeStep < 0 (backward integration) to a known event.
+    // Confirms the dense-output refinement and the bisection lower-bound selection produce the
+    // correct crossing time when integrating in reverse.
+    NumericalSolver solver = {
+        NumericalSolver::LogType::NoLog,
+        NumericalSolver::StepperType::RungeKuttaDopri5,
+        1e-3,
+        1.0e-12,
+        1.0e-12,
+        RootSolver::Default(),
+    };
+
+    const State state = getStateVector(defaultStartInstant_);
+    const Duration duration = -defaultDuration_;
+    const Instant endInstant = defaultStartInstant_ + duration;
+    const Instant targetInstant = defaultStartInstant_ + duration / 2.0;
     const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
 
     const NumericalSolver::ConditionSolution conditionSolution =
-        solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
+        solver.integrateTime(state, endInstant, systemOfEquations_, condition);
 
-    // Cubic interpolation should be very accurate
     EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
     EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
     EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - targetInstant).inSeconds()), 1e-6);
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_ABM_Rejected)
+{
+    // Multistep Adams-Bashforth-Moulton steppers are not supported for conditional integration.
+    // Both AdamsBashforthMoulton5 and AdamsBashforthMoulton8 must raise a RuntimeError up-front
+    // rather than silently falling through to a path that would warm-up multistep history on
+    // every bracket and stall under tight tolerances.
+    const State state = getStateVector(defaultStartInstant_);
+    const Instant endInstant = defaultStartInstant_ + defaultDuration_;
+    const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
+    const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
+
+    for (const NumericalSolver::StepperType stepperType :
+         {NumericalSolver::StepperType::AdamsBashforthMoulton5, NumericalSolver::StepperType::AdamsBashforthMoulton8})
+    {
+        NumericalSolver solver = {
+            NumericalSolver::LogType::NoLog,
+            stepperType,
+            1e-3,
+            1.0e-12,
+            1.0e-12,
+            RootSolver::Default(),
+        };
+
+        EXPECT_THROW(
+            solver.integrateTime(state, endInstant, systemOfEquations_, condition), ostk::core::error::RuntimeError
+        );
+    }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -141,7 +141,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Getters)
     {
         EXPECT_NO_THROW(defaultRKD5_.getRootFindingStrategy());
         EXPECT_THROW(NumericalSolver::Undefined().getRootFindingStrategy(), ostk::core::error::runtime::Undefined);
-        EXPECT_EQ(defaultRKD5_.getRootFindingStrategy(), NumericalSolver::RootFindingStrategy::Propagated);
+        EXPECT_EQ(defaultRKD5_.getRootFindingStrategy(), NumericalSolver::RootFindingStrategy::Integration);
     }
 }
 
@@ -539,10 +539,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, StringFr
             NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::LinearInterpolation)
         );
         EXPECT_EQ(
-            "Propagated",
-            NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Propagated)
+            "Integration",
+            NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Integration)
         );
-        EXPECT_EQ("Skip", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Skip));
+        EXPECT_EQ("First", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::First));
     }
 }
 
@@ -585,7 +585,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
         1.0e-12,
         1.0e-12,
         RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::Propagated,
+        NumericalSolver::RootFindingStrategy::Integration,
     };
 
     const State state = getStateVector(defaultStartInstant_);
@@ -613,7 +613,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
         1.0,
         1.0,
         RootSolver::Default(),
-        NumericalSolver::RootFindingStrategy::Skip,
+        NumericalSolver::RootFindingStrategy::First,
     };
 
     const State state = getStateVector(defaultStartInstant_);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.test.cpp
@@ -375,29 +375,43 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
 
     {
         const Array<Tuple<Real, Real, RealCondition::Criterion, Real, bool>> testCases = {
-            {Real::TwoPi(), 1.0, RealCondition::Criterion::AnyCrossing, Real::TwoPi(), false
-            },  // Almost meets the condition, but never does (forwards)
-            {-Real::TwoPi(), 1.0, RealCondition::Criterion::AnyCrossing, -Real::TwoPi(), false
+            {Real::TwoPi(),
+             1.0,
+             RealCondition::Criterion::AnyCrossing,
+             Real::TwoPi(),
+             false},  // Almost meets the condition, but never does (forwards)
+            {
+                -Real::TwoPi(), 1.0, RealCondition::Criterion::AnyCrossing, -Real::TwoPi(), false
             },  // Almost meets the condition, but never does (backwards)
-            {Real::TwoPi(), 0.5, RealCondition::Criterion::AnyCrossing, std::asin(0.5), true
+            {
+                Real::TwoPi(), 0.5, RealCondition::Criterion::AnyCrossing, std::asin(0.5), true
             },  // Any crossing (forwards)
-            {-Real::TwoPi(), 0.5, RealCondition::Criterion::AnyCrossing, -Real::Pi() - std::asin(0.5), true
+            {
+                -Real::TwoPi(), 0.5, RealCondition::Criterion::AnyCrossing, -Real::Pi() - std::asin(0.5), true
             },  // Any crossing (backwards)
-            {Real::TwoPi(), 0.5, RealCondition::Criterion::NegativeCrossing, Real::Pi() - std::asin(0.5), true
+            {
+                Real::TwoPi(), 0.5, RealCondition::Criterion::NegativeCrossing, Real::Pi() - std::asin(0.5), true
             },  // Negative crossing (forwards)
-            {-Real::TwoPi(), 0.5, RealCondition::Criterion::NegativeCrossing, -Real::TwoPi() + std::asin(0.5), true
+            {
+                -Real::TwoPi(), 0.5, RealCondition::Criterion::NegativeCrossing, -Real::TwoPi() + std::asin(0.5), true
             },  // Negative crossing (backwards)
-            {Real::TwoPi(), -0.5, RealCondition::Criterion::PositiveCrossing, Real::TwoPi() - std::asin(0.5), true
+            {
+                Real::TwoPi(), -0.5, RealCondition::Criterion::PositiveCrossing, Real::TwoPi() - std::asin(0.5), true
             },  // Positive crossing (forwards)
-            {-Real::TwoPi(), -0.5, RealCondition::Criterion::PositiveCrossing, -Real::Pi() + std::asin(0.5), true
+            {
+                -Real::TwoPi(), -0.5, RealCondition::Criterion::PositiveCrossing, -Real::Pi() + std::asin(0.5), true
             },  // Positive crossing (backwards)
-            {Real::TwoPi(), -0.5, RealCondition::Criterion::StrictlyNegative, Real::Pi() + std::asin(0.5), true
+            {
+                Real::TwoPi(), -0.5, RealCondition::Criterion::StrictlyNegative, Real::Pi() + std::asin(0.5), true
             },  // Strictly negative (forwards)
-            {-Real::TwoPi(), -0.5, RealCondition::Criterion::StrictlyNegative, -std::asin(0.5), true
+            {
+                -Real::TwoPi(), -0.5, RealCondition::Criterion::StrictlyNegative, -std::asin(0.5), true
             },  // Strictly negative (backwards)
-            {Real::TwoPi(), 0.5, RealCondition::Criterion::StrictlyPositive, std::asin(0.5), true
+            {
+                Real::TwoPi(), 0.5, RealCondition::Criterion::StrictlyPositive, std::asin(0.5), true
             },  // Strictly positive (forwards)
-            {-Real::TwoPi(), 0.5, RealCondition::Criterion::StrictlyPositive, -Real::Pi() - std::asin(0.5), true
+            {
+                -Real::TwoPi(), 0.5, RealCondition::Criterion::StrictlyPositive, -Real::Pi() - std::asin(0.5), true
             },  // Strictly positive (backwards)
         };
 
@@ -543,6 +557,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, StringFr
             NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::Integration)
         );
         EXPECT_EQ("First", NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::First));
+        EXPECT_EQ(
+            "CubicInterpolation",
+            NumericalSolver::StringFromRootFindingStrategy(NumericalSolver::RootFindingStrategy::CubicInterpolation)
+        );
     }
 }
 
@@ -575,9 +593,9 @@ TEST_F(
     EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - targetInstant).inSeconds()), 1e-3);
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_PropagatedStrategy)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_IntegrationStrategy)
 {
-    // Test Propagated strategy with Fehlberg78 stepper
+    // Test Integration strategy with Fehlberg78 stepper
     NumericalSolver solver = {
         NumericalSolver::LogType::NoLog,
         NumericalSolver::StepperType::RungeKuttaFehlberg78,
@@ -595,15 +613,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
     const NumericalSolver::ConditionSolution conditionSolution =
         solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
 
-    // Propagated should be very accurate
+    // Integration should be very accurate
     EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
     EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
     EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - targetInstant).inSeconds()), 1e-6);
 }
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_SkipStrategy)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_FirstStrategy)
 {
-    // Test Skip strategy with RK4 stepper
+    // Test First strategy with RK4 stepper
     // Use 1.1e-3 step size to avoid landing exactly on target (which would make evaluate=0.0
     // and fail the AnyCrossing comparator that uses strict inequalities)
     NumericalSolver solver = {
@@ -623,8 +641,36 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, Integrat
     const NumericalSolver::ConditionSolution conditionSolution =
         solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
 
-    // Skip returns step boundary, so precision depends on step size
+    // First returns step boundary, so precision depends on step size
     EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
     EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
-    EXPECT_EQ(conditionSolution.iterationCount, 0);  // No root finding iterations for Skip
+    EXPECT_EQ(conditionSolution.iterationCount, 0);  // No root finding iterations for First
+}
+
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_State_NumericalSolver, IntegrateTime_Conditions_CubicInterpolationStrategy
+)
+{
+    // Test CubicInterpolation strategy with CashKarp54 stepper
+    NumericalSolver solver = {
+        NumericalSolver::LogType::NoLog,
+        NumericalSolver::StepperType::RungeKuttaCashKarp54,
+        1e-3,
+        1.0e-12,
+        1.0e-12,
+        RootSolver::Default(),
+        NumericalSolver::RootFindingStrategy::CubicInterpolation,
+    };
+
+    const State state = getStateVector(defaultStartInstant_);
+    const Instant targetInstant = defaultStartInstant_ + defaultDuration_ / 2.0;
+    const InstantCondition condition = InstantCondition(RealCondition::Criterion::AnyCrossing, targetInstant);
+
+    const NumericalSolver::ConditionSolution conditionSolution =
+        solver.integrateTime(state, defaultStartInstant_ + defaultDuration_, systemOfEquations_, condition);
+
+    // Cubic interpolation should be very accurate
+    EXPECT_TRUE(conditionSolution.conditionIsSatisfied);
+    EXPECT_TRUE(conditionSolution.rootSolverHasConverged);
+    EXPECT_LT(std::abs((conditionSolution.state.accessInstant() - targetInstant).inSeconds()), 1e-6);
 }

--- a/validation/OpenSpaceToolkit/Astrodynamics/Parser.cpp
+++ b/validation/OpenSpaceToolkit/Astrodynamics/Parser.cpp
@@ -207,7 +207,7 @@ Sequence Parser::CreateSequence(
     {
         numericalSolver = NumericalSolver(
             NumericalSolver::LogType::NoLog,
-            NumericalSolver::StepperType::RungeKuttaDopri5,
+            NumericalSolver::StepperType::RungeKuttaFehlberg78,
             aDictionary["data"]["sequence"]["propagator"]["data"]["initial-step"].accessReal(),
             aDictionary["data"]["sequence"]["propagator"]["data"]["relative-tolerance"].accessReal(),
             aDictionary["data"]["sequence"]["propagator"]["data"]["absolute-tolerance"].accessReal()


### PR DESCRIPTION
Leverage the provided numerical solver to compute the Event Crossings. Previously, only dense steppers are supported. Now, instead of leveraging the dense interpolant, integration is performed between the previous step and the current step (post crossing step), and a CubicSpline interpolant is used to solve for the event crossing efficiently.
This unlocks using RK78 for various applications (such as within the Segment solver).

The segment benchmark with this reads:
| Benchmark                                                             | Time    | duration_h | final_sma_difference | maneuvers | max_step_s | min_step_s |
|-----------------------------------------------------------------------|---------|------------|----------------------|-----------|------------|------------|
| BM_Segment_ConstantThrust_Intrack_550_to_580/iterations:1             | 1.46 |  16.0027    | 4.65661n            | 20        | 94.7937    | 0.129444    |
| BM_Segment_QLaw_Analytical_SMA_550_to_580/iterations:1                | 5.29 |  30.8055    | 931.323p            | 20        | 94.9888    | 0.0183992   |
| BM_Segment_QLaw_FiniteDifference_SMA_550_to_580/iterations:1          | 11.7 |  30.8053    | 2.79397n            | 20        | 94.9887    | 0.765134    |
| BM_Segment_QLaw_Analytical_Frozen_550_to_580/iterations:1             | 8.06 |  40.6546    | 3.72529n            | 45        | 94.6473    | 1.33437m    |
| BM_Segment_ConstantThrust_Intrack_DutyCycle_550_to_580/iterations:1   | 11.4 |  48         | -23.8683k           | 4         | 94.2705    | 5           |

A huge speed up compared to main:
| Benchmark                                                             | Time    | duration_h | final_sma_difference | maneuvers | max_step_s | min_step_s |
|-----------------------------------------------------------------------|---------|------------|----------------------|-----------|------------|------------|
| BM_Segment_ConstantThrust_Intrack_550_to_580/iterations:1             | 5.04 |  16.0027    | 5.58794n            | 20        | 13.6413    | 0.315719   |
| BM_Segment_QLaw_Analytical_SMA_550_to_580/iterations:1                | 19.7 |  30.8056    | 4.65661n            | 20        | 13.6803    | 671.847u   |
| BM_Segment_QLaw_FiniteDifference_SMA_550_to_580/iterations:1          | 41.7 |  30.8056    | 931.323p            | 20        | 13.6804    | 303.349u   |
| BM_Segment_QLaw_Analytical_Frozen_550_to_580/iterations:1             | 142  |  40.6558    | 1.86265n            | 45        | 13.6921    | 20.212u    |
| BM_Segment_ConstantThrust_Intrack_DutyCycle_550_to_580/iterations:1   | 46.9 |  48         | -23.8683k           | 4         | 13.6573    | 0.469988   |