### PR TITLE
fix: maneuver segments not solved precisely at provided intervals

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -472,6 +472,17 @@ class Segment
     Segment::Solution solveSingleManeuver_(
         const State& aState, const Duration& maximumPropagationDuration, const Shared<Thruster>& thrusterDynamics
     ) const;
+
+    /// @brief Propagate the segment with the provided dynamics and event condition. This method is used to propagate
+    /// the segment until a given instant.
+    ///
+    /// @param aState The initial state of the segment
+    /// @param anEndInstant The end instant
+    /// @param aDynamicsArray The dynamics array
+    /// @return States
+    Array<State> propagateWithDynamics_(
+        const State& aState, const Instant& anEndInstant, const Array<Shared<Dynamics>>& aDynamicsArray
+    ) const;
 };
 
 }  // namespace trajectory

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.test.cpp
@@ -2876,7 +2876,7 @@ TEST_F(
     EXPECT_EQ(maneuvers.getSize(), 3);
     for (const Maneuver& maneuver : maneuvers)
     {
-        EXPECT_LE(maneuver.getInterval().getDuration(), constraints.maximumDuration);
+        EXPECT_LE(maneuver.getInterval().getDuration(), constraints.maximumDuration + Duration::Nanoseconds(10));
     }
 
     // Candidate:   0--------------15-----------------30
@@ -2884,21 +2884,24 @@ TEST_F(
     // Candidate:                       17.6-----------30
     // Maneuver 2                          21.6---26.6
     // ...
+
     EXPECT_TRUE(maneuvers[0].getInterval().getStart().isNear(
-        initialStateWithMass_.accessInstant() + Duration::Minutes(12.5), Duration::Seconds(1e-1)
+        initialStateWithMass_.accessInstant() + Duration::Minutes(12.5), Duration::Nanoseconds(10)
     ));
-    EXPECT_TRUE(maneuvers[0].getInterval().getDuration().isNear(Duration::Minutes(5.0), Duration::Seconds(1e-1)));
+    EXPECT_TRUE(maneuvers[0].getInterval().getDuration().isNear(constraints.maximumDuration, Duration::Nanoseconds(10))
+    );
     EXPECT_TRUE(maneuvers[1].getInterval().getStart().isNear(
         initialStateWithMass_.accessInstant() + Duration::Minutes(21.0) + Duration::Seconds(20.0),
-        Duration::Seconds(1e-1)
+        Duration::Nanoseconds(10)
     ));
-    EXPECT_TRUE(maneuvers[1].getInterval().getDuration().isNear(Duration::Minutes(5.0), Duration::Seconds(1e-1)));
+    EXPECT_TRUE(maneuvers[1].getInterval().getDuration().isNear(constraints.maximumDuration, Duration::Nanoseconds(10))
+    );
     EXPECT_TRUE(maneuvers[2].getInterval().getStart().isNear(
         initialStateWithMass_.accessInstant() + Duration::Minutes(26.0) + Duration::Seconds(30.0),
-        Duration::Seconds(1e-1)
+        Duration::Nanoseconds(10)
     ));
     EXPECT_TRUE(maneuvers[2].getInterval().getEnd().isNear(
-        initialStateWithMass_.accessInstant() + Duration::Minutes(30.0), Duration::Seconds(1e-1)
+        initialStateWithMass_.accessInstant() + Duration::Minutes(30.0), Duration::Nanoseconds(10)
     ));
 }
 
@@ -3026,8 +3029,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_SinglePointManeu
     const Environment environment = {initialInstant, {earthSPtr}};
     const Array<Shared<Dynamics>> dynamics = Dynamics::FromEnvironment(environment);
 
-    const NumericalSolver numericalSolver = NumericalSolver::DefaultConditional();
-
     const BrouwerLyddaneMeanLong blm = BrouwerLyddaneMeanLong::Cartesian(
         {initialState.getPosition(), initialState.getVelocity()},
         EarthGravitationalModel::EGM2008.gravitationalParameter_
@@ -3088,7 +3089,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Segment, Solve_SinglePointManeu
         endConditionSPtr,
         thrusterSPtr,
         dynamics,
-        numericalSolver,
+        defaultHighPrecisionNumericalSolver_,
         lofFactorySPtr,
         Angle::Undefined(),
         constraints


### PR DESCRIPTION
Came across this bug while going through some tests on another branch.
The fix addresses a timing precision issue in the Segment::solve() method where maneuvers with duration constraints were not starting and ending at their exact computed intervals, but instead at whatever times the numerical integrator happened to step to.

## Problem

When solving a maneuver segment with constraints (like maximumDuration), the system computes a validManeuverInterval that defines the exact time window for the maneuver. However, the original implementation used the general solveManeuver() method which propagates using event conditions and variable step sizes.

### Original Flow
Timeline:
```
  ├─────────────────────────────────────────────────────────────────────┤
  0                                                                    30 min

  Last accumulated state is at some arbitrary solver step:
                     ▼
  ├──────────────────┼──────────────────────────────────────────────────┤
                  11.8 min

  Computed validManeuverInterval = [12.5 min, 17.5 min]:
                        ├─────────────────────────┤
                      12.5                      17.5

  But solver steps forward with its own step sizes:
                     ▼     ▼     ▼     ▼     ▼     ▼     ▼
  ├──────────────────┼─────┼─────┼─────┼─────┼─────┼─────┼───────────────┤
```
Maneuver starts at 12.3 or 12.8 instead of exactly 12.5!

The numerical solver doesn't know about the precise interval boundaries. It uses:
- Variable step sizes based on error tolerances
- Event condition detection (which has its own tolerances)

###  What Actually Happens
```
  Expected Maneuver:    |=========BURN=========|
                      12.5                    17.5

  Actual (Old Code):        |=========BURN=========|
                          12.8                    17.8
                            ↑                       ↑
                       ~0.3min error          ~0.3min error
```

The test previously allowed tolerances of 100 milliseconds (Duration::Seconds(1e-1)) because the solver couldn't hit the exact times

## Solution
```
 Timeline with precise intervals:
  ├─────────────────────────────────────────────────────────────────────┤
  0                                                                    30 min

  Step 1: Last state at arbitrary solver step
                     ▼
  ├──────────────────┼──────────────────────────────────────────────────┤
                   11.8

  Step 2: Coast (no thrust) to EXACT maneuver start
                     ▼──────▶▼
  ├──────────────────┼───────┼──────────────────────────────────────────┤
                   11.8    12.5  ← propagateWithDynamics_() to exact instant

  Step 3: Burn to EXACT maneuver end
                             ▼════════════════════▶▼
  ├──────────────────────────┼═════════════════════┼────────────────────┤
                           12.5   (THRUSTING)     17.5
                             └─────────────────────┘
                             Exact interval boundaries!
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced interval-aware maneuver propagation in trajectory segments for improved computation accuracy.

* **Tests**
  * Updated test suite with increased numerical precision validation for maneuver interval measurements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->