### PR TITLE
fix: build packages in main branch environment

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -1,6 +1,7 @@
 /// Apache License 2.0
 
 #include <numeric>
+#include <optional>
 
 #include <OpenSpaceToolkit/Core/Error/Runtime/Wrong.hpp>
 


### PR DESCRIPTION
Main branch build package jobs have been failing since this MR: https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/633

(MR branches are still fine)

I believe it had to do with using optional straight away in Segment.cpp. Explicitly importing may do the trick based on the error messages we're seeing?

<img width="436" height="175" alt="image" src="https://github.com/user-attachments/assets/0d6a17b2-ce7b-492a-82d8-ddd75deeccce" />

https://github.com/open-space-collective/open-space-toolkit-astrodynamics/actions/runs/21233154507/job/61096585638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->