### PR TITLE
perf: improve Segment Chunk strategy performance

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -793,8 +793,11 @@ Segment::Solution Segment::solve(
         if (maneuverConstraints_.maximumDuration.isDefined() &&
             maneuverConstraints_.maximumDurationStrategy == MaximumManeuverDurationViolationStrategy::Chunk)
         {
-            // Since we know that the burn is about to start, we can foresee the maximum maneuver solution
-            // instant the Chunk strategy. This prevents unnecessary solving and trimming, improving performance.
+            // Performance when considering a maximum maneuver duration constraint for the "Chunk" strategy
+            // can be optimized by eliminating redundant solver iterations and unnecessary trimming.
+            //
+            // Since the "Chunk" strategy does not need to know when the burn is going to end, we can safely
+            // assume that the burn (or chunk for that matter) should not take longer than said maximum duration.
             maximumManeuverSolutionInstant = std::min(
                 segmentStates.accessLast().accessInstant() + maneuverConstraints_.maximumDuration,
                 maximumManeuverSolutionInstant


### PR DESCRIPTION
This MR improves the performance when using the Chunk maximum maneuver duration violation strategy. It does so by preemptively trimming the maximum maneuver instant during maneuver sub-segments.

See below an illustrative example:

Let's assume we have a long solving span with thruster dynamics that are currently on.
We have a maximum maneuver duration constraint, minimum maneuver separation, and we're using the "Chunk" strategy.

```
------> Time

Unconstrained solution (thruster always on):
                           
***************************************************************************

Constrained solution:
                           
****------****------****------****------****------****------****------****-

* = thrust on
_ = thrust off
``` 


**Before**

These is what the solve iterations looked like before...

```
ITERATION 1:

Solving...
***************************************************************************
Accepted states:
****------

ITERATION 2:

Solving...
          *****************************************************************

Accepted states:
****------****------

ITERATION 3:

Solving...
                    *******************************************************

Accepted states:
****------****------****------

ETC.
``` 

...which were unnecessarily solving over the entire segment multiple times.

**Now**

These is what the solve iterations look like now...

```
ITERATION 1:

Solving...
****

Accepted states:
****------

ITERATION 2:

Solving...
          ****

Accepted states:
****------****------

ITERATION 3:

Solving...
                    ****

Accepted states:
****------****------****------

ETC.
``` 

...which avoid unnecessary solves over parts of the segment that we know will be trimmed down and solved at a later iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved maneuver-solving performance when a maximum maneuver duration is set, allowing earlier termination of planning steps to avoid unnecessary computation and trimming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->