### PR TITLE
fix: amend Jupyter debug image GLIBCXX issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ debug-jupyter: build-release-image-jupyter ## Debug jupyter notebook using the o
 		--volume="$(CURDIR)/build/bindings/python/OpenSpaceToolkit${project_name_camel_case}Py-python-package-$(jupyter_python_version):/opt/conda/lib/python$(jupyter_python_version)/site-packages/ostk/$(project_name)" \
 		--workdir="/home/jovyan" \
 		$(docker_release_image_jupyter_repository):$(docker_image_version) \
-		/bin/bash -c "chown -R jovyan:users /home/jovyan ; python$(jupyter_python_version) -m pip install /opt/conda/lib/python$(jupyter_python_version)/site-packages/ostk/$(project_name)/ --force-reinstall ; start-notebook.sh --ServerApp.token=''"
+		/bin/bash -c "rm -f /opt/conda/lib/libstdc++.so* ; chown -R jovyan:users /home/jovyan ; python$(jupyter_python_version) -m pip install /opt/conda/lib/python$(jupyter_python_version)/site-packages/ostk/$(project_name)/ --force-reinstall ; start-notebook.sh --ServerApp.token=''"
 
 	@ sudo chown -R $(shell id -u):$(shell id -g) $(CURDIR)
 


### PR DESCRIPTION
I've been hitting this error consistently when building the Jupyter debug image, e.g. `make debug-jupyter-rebuild`

<img width="842" height="405" alt="image" src="https://github.com/user-attachments/assets/9e94a272-94c6-44bd-8e90-1651fb4e182e" />

After the changes, it's fine:

<img width="480" height="117" alt="image" src="https://github.com/user-attachments/assets/8f9aa562-6fa8-4b84-ad29-e7b0de6b6c75" />


Note: the previous way I had to fix it was running `conda install -c conda-forge libstdcxx-ng --update-deps` once I had started the debug image, then restarting the kernel. But that was just a workaround, it had to be done every time, and it took forever...




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved library dependency issues in the debug environment setup process to ensure proper package installation and notebook server initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->