### PR TITLE
docs: add units to seconds based timesteps

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -101,7 +101,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Args:
                         log_type (NumericalSolver.LogType): The type of logging.
                         stepper_type (NumericalSolver.StepperType): The type of stepper.
-                        time_step (float): The time step.
+                        time_step (float): The time step (in seconds).
                         relative_tolerance (float): The relative tolerance.
                         absolute_tolerance (float): The absolute tolerance.
                         root_solver (RootSolver, optional): The root solver. Defaults to RootSolver.Default().
@@ -292,7 +292,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
 
                     Args:
                         stepper_type (NumericalSolver.StepperType): The type of stepper.
-                        time_step (float): The time step.
+                        time_step (float): The time step (in seconds).
 
                     Returns:
                         NumericalSolver: The numerical solver.
@@ -321,7 +321,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Return a conditional numerical solver.
 
                     Args:
-                        time_step (float): The time step.
+                        time_step (float): The time step (in seconds).
                         relative_tolerance (float): The relative tolerance.
                         absolute_tolerance (float): The absolute tolerance.
                         state_logger (StateLogger, optional): The state logger. Defaults to None.

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -56,7 +56,7 @@ class NumericalSolver : public MathNumericalSolver
     ///                  numerical integration
     /// @param aStepperType An enum indicating the type of numerical stepper used to perform
     ///                  integration
-    /// @param aTimeStep A number indicating the initial guess time step the numerical solver will
+    /// @param aTimeStep A number indicating the initial guess time step (in seconds) the numerical solver will
     ///                  take
     /// @param aRelativeTolerance A number indicating the relative integration tolerance
     /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance
@@ -144,7 +144,7 @@ class NumericalSolver : public MathNumericalSolver
 
     /// @brief Create a fixed step size numerical solver.
     ///
-    /// @param aTimeStep The time step to use for integration.
+    /// @param aTimeStep The time step (in seconds) to use for integration.
     /// @param aSystemOfEquations System of equations to integrate.
     ///
     /// @return A fixed step size numerical solver.
@@ -158,7 +158,7 @@ class NumericalSolver : public MathNumericalSolver
 
     /// @brief Create a conditional numerical solver.
     ///
-    /// @param aTimeStep The initial time step to use.
+    /// @param aTimeStep The initial time step (in seconds) to use.
     /// @param aRelativeTolerance The relative tolerance to use.
     /// @param anAbsoluteTolerance The absolute tolerance to use.
     /// @param stateLogger A function that takes a `State` object and logs.
@@ -218,7 +218,7 @@ class NumericalSolver : public MathNumericalSolver
     ///                  numerical integration
     /// @param aStepperType An enum indicating the type of numerical stepper used to perform
     ///                  integration
-    /// @param aTimeStep A number indicating the initial guess time step the numerical solver will
+    /// @param aTimeStep A number indicating the initial guess time step (in seconds) the numerical solver will
     ///                  take
     /// @param aRelativeTolerance A number indicating the relative integration tolerance
     /// @param anAbsoluteTolerance A number indicating the absolute integration tolerance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for the time_step parameter in numerical solver functions, clarifying that values must be specified in seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->