### PR TITLE
Add output frame parameter to SGP4 model

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Estimator/TLESolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Estimator/TLESolver.cpp
@@ -91,7 +91,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Estimator_TLESolver(pybind11::module
             arg("international_designator") = "00001A",
             arg("revolution_number") = 0,
             arg("estimate_b_star") = true,
-            arg_v("estimation_frame", Frame::GCRF(), "Frame.GCRF()"),
+            arg_v("estimation_frame", Frame::TEME(), "Frame.TEME()"),
             R"doc(
                 Construct a new TLESolver object.
 
@@ -101,7 +101,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Estimator_TLESolver(pybind11::module
                     international_designator (str, optional): International designator for TLE. Defaults to "00001A".
                     revolution_number (int, optional): Revolution number. Defaults to 0.
                     estimate_b_star (bool, optional): Whether to also estimate the B* parameter. Defaults to True.
-                    estimation_frame (Frame, optional): Frame for estimation. Defaults to GCRF.
+                    estimation_frame (Frame, optional): Frame for estimation. Defaults to TEME.
             )doc"
         )
         .def(
@@ -212,6 +212,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Estimator_TLESolver(pybind11::module
 
                 Returns:
                     bool: whether to estimate B*.
+            )doc"
+        )
+        .def(
+            "access_estimation_frame",
+            &TLESolver::accessEstimationFrame,
+            return_value_policy::reference_internal,
+            R"doc(
+                Access the estimation frame.
+
+                Returns:
+                    Frame: The estimation frame.
             )doc"
         )
         .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
@@ -8,6 +8,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 {
     using namespace pybind11;
 
+    using ostk::core::type::Shared;
+
+    using ostk::physics::coordinate::Frame;
+
     using ostk::astrodynamics::trajectory::orbit::model::SGP4;
     using ostk::astrodynamics::trajectory::orbit::model::sgp4::TLE;
 
@@ -36,6 +40,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
             )
 
             .def(
+                init<TLE, Shared<const Frame>>(),
+                R"doc(
+                    Constructor with output frame.
+
+                    Args:
+                        tle (TLE): The TLE.
+                        output_frame (Frame): The output state frame. Defaults to GCRF.
+
+                )doc",
+                arg("tle"),
+                arg("output_frame")
+            )
+
+            .def(
                 "is_defined",
                 &SGP4::isDefined,
                 R"doc(
@@ -55,6 +73,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 
                     Returns:
                         TLE: The TLE.
+
+                )doc"
+            )
+
+            .def(
+                "get_output_frame",
+                &SGP4::getOutputFrame,
+                R"doc(
+                    Get the output frame of the `SGP4` model.
+
+                    Returns:
+                        Frame: The output frame.
 
                 )doc"
             )

--- a/bindings/python/test/estimator/test_tle_solver.py
+++ b/bindings/python/test/estimator/test_tle_solver.py
@@ -79,6 +79,7 @@ class TestTLESolver:
         assert solver.access_international_designator() == "00001A"
         assert solver.access_revolution_number() == 0
         assert solver.access_estimate_b_star() is True
+        assert solver.access_estimation_frame() == Frame.TEME()
 
     def test_access_methods(self, tle_solver: TLESolver):
         assert isinstance(tle_solver.access_solver(), LeastSquaresSolver)

--- a/bindings/python/test/trajectory/orbit/models/test_sgp4.py
+++ b/bindings/python/test/trajectory/orbit/models/test_sgp4.py
@@ -1,1 +1,55 @@
 # Apache License 2.0
+
+import pytest
+
+from ostk.physics.coordinate import Frame
+
+from ostk.astrodynamics.trajectory.orbit.model import SGP4
+from ostk.astrodynamics.trajectory.orbit.model.sgp4 import TLE
+
+
+@pytest.fixture
+def tle() -> TLE:
+    return TLE(
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    )
+
+
+class TestSGP4:
+    def test_constructor_default(self, tle: TLE):
+        sgp4 = SGP4(tle)
+        assert sgp4.is_defined()
+        assert sgp4.get_output_frame() == Frame.GCRF()
+
+    def test_constructor_with_output_frame(self, tle: TLE):
+        sgp4_teme = SGP4(tle, Frame.TEME())
+        assert sgp4_teme.is_defined()
+        assert sgp4_teme.get_output_frame() == Frame.TEME()
+
+        sgp4_gcrf = SGP4(tle, Frame.GCRF())
+        assert sgp4_gcrf.is_defined()
+        assert sgp4_gcrf.get_output_frame() == Frame.GCRF()
+
+    def test_calculate_state_at_output_frame(self, tle: TLE):
+        sgp4_default = SGP4(tle)
+        sgp4_teme = SGP4(tle, Frame.TEME())
+
+        instant = tle.get_epoch()
+
+        state_default = sgp4_default.calculate_state_at(instant)
+        state_teme = sgp4_teme.calculate_state_at(instant)
+
+        # Default outputs GCRF
+        assert state_default.get_frame() == Frame.GCRF()
+
+        # TEME constructor outputs TEME
+        assert state_teme.get_frame() == Frame.TEME()
+
+        # Both should give same position when converted to same frame
+        state_teme_in_gcrf = state_teme.in_frame(Frame.GCRF())
+        pos_diff = (
+            state_default.get_position().get_coordinates()
+            - state_teme_in_gcrf.get_position().get_coordinates()
+        )
+        assert pos_diff.norm() < 1e-6

--- a/include/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.hpp
@@ -91,14 +91,14 @@ class TLESolver
     /// @param anInternationalDesignator International designator for TLE, defaults to "00001A"
     /// @param aRevolutionNumber Revolution number, defaults to 0
     /// @param anEstimateBStar Whether to also estimate the B* parameter, defaults to true
-    /// @param anEstimationFrameSPtr Estimation frame, defaults to GCRF
+    /// @param anEstimationFrameSPtr Estimation frame, defaults to TEME
     TLESolver(
         const LeastSquaresSolver& aSolver = LeastSquaresSolver::Default(),
         const Integer& aSatelliteNumber = 0,
         const String& anInternationalDesignator = "00001A",
         const Integer& aRevolutionNumber = 0,
         const bool anEstimateBStar = true,
-        const Shared<const Frame>& anEstimationFrameSPtr = Frame::GCRF()
+        const Shared<const Frame>& anEstimationFrameSPtr = Frame::TEME()
     );
 
     /// @brief Access solver

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
@@ -5,9 +5,11 @@
 
 #include <OpenSpaceToolkit/Core/Type/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
+#include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 #include <OpenSpaceToolkit/Core/Type/Unique.hpp>
 
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
@@ -30,8 +32,11 @@ namespace model
 
 using ostk::core::type::Integer;
 using ostk::core::type::Real;
+using ostk::core::type::Shared;
 using ostk::core::type::String;
 using ostk::core::type::Unique;
+
+using ostk::physics::coordinate::Frame;
 
 using ostk::physics::environment::object::Celestial;
 using ostk::physics::time::Instant;
@@ -45,6 +50,8 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
 {
    public:
     SGP4(const TLE& aTle);
+
+    SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr);
 
     SGP4(const SGP4& aSGP4Model);
 
@@ -64,6 +71,8 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
 
     TLE getTle() const;
 
+    Shared<const Frame> getOutputFrame() const;
+
     virtual Instant getEpoch() const override;
 
     virtual Integer getRevolutionNumberAtEpoch() const override;
@@ -81,6 +90,7 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     class Impl;
 
     TLE tle_;
+    Shared<const Frame> outputFrameSPtr_;
 
     Unique<SGP4::Impl> implUPtr_;
 };

--- a/src/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.cpp
@@ -223,14 +223,14 @@ TLESolver::Analysis TLESolver::estimate(
     const auto stateGenerator = [this](const State& aState, const Array<Instant>& anInstantArray) -> Array<State>
     {
         const TLE tle = TLEStateToTLE(aState);
-        const SGP4 sgp4(tle);
+        const SGP4 sgp4(tle, estimationFrameSPtr_);
 
         Array<State> states;
         states.reserve(anInstantArray.getSize());
 
         for (const Instant& instant : anInstantArray)
         {
-            states.add(sgp4.calculateStateAt(instant).inFrame(estimationFrameSPtr_));
+            states.add(sgp4.calculateStateAt(instant));
         }
 
         return states;
@@ -261,8 +261,8 @@ Orbit TLESolver::estimateOrbit(
 
 State TLESolver::TLEToTLEState(const TLE& aTLE) const
 {
-    const SGP4 sgp4(aTLE);
-    const State state = sgp4.calculateStateAt(aTLE.getEpoch()).inFrame(tleStateBuilder_.getFrame());
+    const SGP4 sgp4(aTLE, tleStateBuilder_.getFrame());
+    const State state = sgp4.calculateStateAt(aTLE.getEpoch());
 
     const ModifiedEquinoctial modifiedEquinoctial = ModifiedEquinoctial::Cartesian(
         {state.getPosition(), state.getVelocity()}, EarthGravitationalModel::EGM2008.gravitationalParameter_

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
@@ -27,7 +27,7 @@ using ostk::physics::coordinate::Transform;
 class SGP4::Impl
 {
    public:
-    Impl(const TLE& aTle);
+    Impl(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr);
 
     Impl(const SGP4::Impl& anImpl) = delete;
 
@@ -37,13 +37,15 @@ class SGP4::Impl
 
    private:
     const TLE& tle_;
+    const Shared<const Frame>& outputFrameSPtr_;
     libsgp4::SGP4 sgp4_;
 
     Shared<const Frame> temeFrameOfEpochSPtr_;
 };
 
-SGP4::Impl::Impl(const TLE& aTle)
+SGP4::Impl::Impl(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr)
     : tle_(aTle),
+      outputFrameSPtr_(anOutputFrameSPtr),
       sgp4_(libsgp4::Tle(tle_.getSatelliteName(), tle_.getFirstLine(), tle_.getSecondLine())),
       temeFrameOfEpochSPtr_(Frame::TEME())
 {
@@ -70,20 +72,30 @@ State SGP4::Impl::calculateStateAt(const Instant& anInstant) const
 
     const State state_TEME = {anInstant, position_TEME, velocity_TEME};
 
-    return state_TEME.inFrame(Frame::GCRF());
+    return state_TEME.inFrame(this->outputFrameSPtr_);
 }
 
 SGP4::SGP4(const TLE& aTle)
     : Model(),
       tle_(aTle),
-      implUPtr_(std::make_unique<SGP4::Impl>(tle_))
+      outputFrameSPtr_(Frame::GCRF()),
+      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_))
+{
+}
+
+SGP4::SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr)
+    : Model(),
+      tle_(aTle),
+      outputFrameSPtr_(anOutputFrameSPtr),
+      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_))
 {
 }
 
 SGP4::SGP4(const SGP4& aSGP4Model)
     : Model(aSGP4Model),
       tle_(aSGP4Model.tle_),
-      implUPtr_(std::make_unique<SGP4::Impl>(tle_))
+      outputFrameSPtr_(aSGP4Model.outputFrameSPtr_),
+      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_))
 {
 }
 
@@ -96,8 +108,9 @@ SGP4& SGP4::operator=(const SGP4& aSGP4Model)
         Model::operator=(aSGP4Model);
 
         this->tle_ = aSGP4Model.tle_;
+        this->outputFrameSPtr_ = aSGP4Model.outputFrameSPtr_;
 
-        this->implUPtr_ = std::make_unique<SGP4::Impl>(tle_);
+        this->implUPtr_ = std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_);
     }
 
     return *this;
@@ -115,7 +128,7 @@ bool SGP4::operator==(const SGP4& aSGP4Model) const
         return false;
     }
 
-    return this->tle_ == aSGP4Model.tle_;
+    return (this->tle_ == aSGP4Model.tle_) && (this->outputFrameSPtr_ == aSGP4Model.outputFrameSPtr_);
 }
 
 bool SGP4::operator!=(const SGP4& aSGP4Model) const
@@ -143,6 +156,16 @@ TLE SGP4::getTle() const
     }
 
     return this->tle_;
+}
+
+Shared<const Frame> SGP4::getOutputFrame() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("SGP4");
+    }
+
+    return this->outputFrameSPtr_;
 }
 
 Instant SGP4::getEpoch() const

--- a/test/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.test.cpp
@@ -210,7 +210,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Estimation_TLESolver, Accessors)
         EXPECT_EQ(tleSolver_.accessInternationalDesignator(), "00001A");
         EXPECT_EQ(tleSolver_.accessRevolutionNumber(), 0);
         EXPECT_EQ(tleSolver_.accessEstimateBStar(), true);
-        EXPECT_EQ(tleSolver_.accessEstimationFrame(), Frame::GCRF());
+        EXPECT_EQ(tleSolver_.accessEstimationFrame(), Frame::TEME());
         EXPECT_EQ(tleSolver_.accessDefaultBStar(), 0.0);
         EXPECT_EQ(tleSolver_.accessFirstDerivativeMeanMotionDividedBy2(), 0.0);
         EXPECT_EQ(tleSolver_.accessSecondDerivativeMeanMotionDividedBy6(), 0.0);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
@@ -26,37 +26,94 @@
 
 #include <Global.test.hpp>
 
+using ostk::core::container::Array;
+using ostk::core::container::Table;
+using ostk::core::filesystem::File;
+using ostk::core::filesystem::Path;
+using ostk::core::type::Real;
+using ostk::core::type::Shared;
+
+using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
+using ostk::mathematics::geometry::d3::transformation::rotation::RotationVector;
+using ostk::mathematics::object::Vector3d;
+
+using ostk::physics::coordinate::Frame;
+using ostk::physics::coordinate::Position;
+using ostk::physics::coordinate::Velocity;
+using ostk::physics::Environment;
+using ostk::physics::environment::object::celestial::Earth;
+using ostk::physics::time::DateTime;
+using ostk::physics::time::Duration;
+using ostk::physics::time::Instant;
+using ostk::physics::time::Interval;
+using ostk::physics::time::Scale;
+using ostk::physics::unit::Angle;
+using ostk::physics::unit::Derived;
+using ostk::physics::unit::Length;
+
+using ostk::astrodynamics::trajectory::Orbit;
+using ostk::astrodynamics::trajectory::orbit::model::SGP4;
+using ostk::astrodynamics::trajectory::orbit::model::sgp4::TLE;
+using ostk::astrodynamics::trajectory::State;
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
+{
+    {
+        const TLE tle = TLE::Load(File::Path(
+            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite.tle")
+        ));
+
+        // Default constructor (GCRF output)
+        const SGP4 sgp4Default(tle);
+        EXPECT_TRUE(sgp4Default.isDefined());
+        EXPECT_EQ(*sgp4Default.getOutputFrame(), *Frame::GCRF());
+
+        // Constructor with output frame
+        const SGP4 sgp4Teme(tle, Frame::TEME());
+        EXPECT_TRUE(sgp4Teme.isDefined());
+        EXPECT_EQ(*sgp4Teme.getOutputFrame(), *Frame::TEME());
+
+        const SGP4 sgp4Gcrf(tle, Frame::GCRF());
+        EXPECT_TRUE(sgp4Gcrf.isDefined());
+        EXPECT_EQ(*sgp4Gcrf.getOutputFrame(), *Frame::GCRF());
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStateAt_OutputFrame)
+{
+    {
+        const TLE tle = TLE::Load(File::Path(
+            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite.tle")
+        ));
+
+        const SGP4 sgp4Default(tle);
+        const SGP4 sgp4Teme(tle, Frame::TEME());
+        const SGP4 sgp4Gcrf(tle, Frame::GCRF());
+
+        const Instant instant = tle.getEpoch();
+
+        const State stateDefault = sgp4Default.calculateStateAt(instant);
+        const State stateTeme = sgp4Teme.calculateStateAt(instant);
+        const State stateGcrf = sgp4Gcrf.calculateStateAt(instant);
+
+        // Default should be GCRF
+        EXPECT_EQ(*Frame::GCRF(), *stateDefault.getPosition().accessFrame());
+
+        // TEME constructor should output TEME
+        EXPECT_EQ(*Frame::TEME(), *stateTeme.getPosition().accessFrame());
+
+        // GCRF constructor should output GCRF
+        EXPECT_EQ(*Frame::GCRF(), *stateGcrf.getPosition().accessFrame());
+
+        // All should give the same position when converted to same frame
+        const State stateTemelInGcrf = stateTeme.inFrame(Frame::GCRF());
+        EXPECT_GT(1e-6, (stateDefault.getPosition().getCoordinates() - stateTemelInGcrf.getPosition().getCoordinates()).norm());
+        EXPECT_GT(1e-6, (stateDefault.getVelocity().getCoordinates() - stateTemelInGcrf.getVelocity().getCoordinates()).norm());
+    }
+}
+
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
 {
-    using ostk::core::container::Array;
-    using ostk::core::container::Table;
-    using ostk::core::filesystem::File;
-    using ostk::core::filesystem::Path;
-    using ostk::core::type::Real;
-    using ostk::core::type::Shared;
-
-    using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
-    using ostk::mathematics::geometry::d3::transformation::rotation::RotationVector;
-    using ostk::mathematics::object::Vector3d;
-
-    using ostk::physics::coordinate::Frame;
-    using ostk::physics::coordinate::Position;
-    using ostk::physics::coordinate::Velocity;
-    using ostk::physics::Environment;
-    using ostk::physics::environment::object::celestial::Earth;
-    using ostk::physics::time::DateTime;
-    using ostk::physics::time::Duration;
-    using ostk::physics::time::Instant;
-    using ostk::physics::time::Interval;
-    using ostk::physics::time::Scale;
-    using ostk::physics::unit::Angle;
-    using ostk::physics::unit::Derived;
-    using ostk::physics::unit::Length;
-
-    using ostk::astrodynamics::trajectory::Orbit;
-    using ostk::astrodynamics::trajectory::orbit::model::SGP4;
-    using ostk::astrodynamics::trajectory::orbit::model::sgp4::TLE;
-    using ostk::astrodynamics::trajectory::State;
 
     {
         // Environment setup


### PR DESCRIPTION
## Summary
This PR adds support for configurable output frames in the SGP4 propagation model. Previously, SGP4 always output states in the GCRF frame. Now users can specify an output frame (defaulting to GCRF for backward compatibility), allowing direct propagation in alternative frames like TEME without requiring frame transformations.

## Key Changes

- **SGP4 Model Enhancement**:
  - Added new constructor overload accepting an output frame parameter: `SGP4(const TLE&, const Shared<const Frame>&)`
  - Default constructor maintains backward compatibility by defaulting to GCRF output
  - Added `getOutputFrame()` accessor method
  - Modified internal state calculation to transform to the specified output frame instead of always using GCRF
  - Updated equality operator to compare output frames

- **TLESolver Integration**:
  - Updated TLESolver to pass its estimation frame directly to SGP4 constructor, eliminating redundant frame transformations
  - Changed default estimation frame from GCRF to TEME (more natural for TLE-based propagation)
  - Added `accessEstimationFrame()` method to Python bindings

- **Test Coverage**:
  - Added comprehensive C++ tests for SGP4 constructor variants and output frame behavior
  - Added Python tests validating constructor options and frame transformations
  - Verified that states in different output frames transform correctly to common reference frames

## Implementation Details

- The output frame is stored as a member variable and passed to the internal Impl class
- Frame transformation now occurs at the end of state calculation using the configured output frame
- All copy/assignment operations properly handle the output frame member
- Python bindings expose both constructor variants and the new accessor method

https://claude.ai/code/session_01Ecity98uQmPS6U31QpPNte