### PR TITLE
refactor: use boost::regex for thread safety

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.cpp
@@ -608,7 +608,7 @@ TLE TLE::Construct(
         throw ostk::core::error::runtime::Wrong("International designator", anInternationalDesignator);
     }
 
-    if (!boost::regex_match(anInternationalDesignator, std::regex("^\\d{2}\\d{3}\\w{1,3}$")))
+    if (!boost::regex_match(anInternationalDesignator, boost::regex("^\\d{2}\\d{3}\\w{1,3}$")))
     {
         throw ostk::core::error::runtime::Wrong("International designator", anInternationalDesignator);
     }


### PR DESCRIPTION
https://github.com/open-space-collective/open-space-toolkit-physics/issues/356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal TLE parsing and validation for International designators, enhancing reliability and robustness of orbit data processing while preserving existing behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->