### PR TITLE
feat: expand SGP4 to support propagating across multiple TLEs

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
@@ -112,11 +112,14 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
                 "get_tle",
                 &SGP4::getTle,
                 R"doc(
-                    Get the TLE of the `SGP4` model. For multi-TLE models, returns the TLE with the earliest epoch.
+                    Get the TLE of the `SGP4` model.
+                    
 
                     Returns:
                         TLE: The TLE.
 
+                    Raises:
+                        RuntimeError: If the model contains multiple TLEs. Use `get_tles()` instead.
                 )doc"
             )
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
@@ -1,6 +1,9 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
+
+#include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp>
 
@@ -11,10 +14,12 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
     using namespace pybind11;
 
     using ostk::core::container::Array;
+    using ostk::core::container::Pair;
     using ostk::core::type::Shared;
 
     using ostk::physics::coordinate::Frame;
     using ostk::physics::time::Instant;
+    using ostk::physics::time::Interval;
 
     using ostk::astrodynamics::trajectory::orbit::model::SGP4;
     using ostk::astrodynamics::trajectory::orbit::model::sgp4::TLE;
@@ -60,55 +65,31 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
             )
 
             .def(
-                init(
-                    [](const list& aTleList) -> SGP4
-                    {
-                        Array<TLE> tleArray = Array<TLE>::Empty();
-                        for (auto item : aTleList)
-                        {
-                            tleArray.add(item.cast<TLE>());
-                        }
-                        return SGP4(tleArray);
-                    }
-                ),
+                init<Array<TLE>, Shared<const Frame>>(),
                 R"doc(
-                    Construct an SGP4 model from an array of TLEs.
-
-                    When multiple TLEs are provided, the model will use the TLE whose epoch is closest
-                    to the requested instant for state calculations.
+                    Constructor with output frame. If TEME, the runtime is faster as no frame
+                    transformations are needed. In other frames, the runtime will be slower as frame transformations are needed.
 
                     Args:
-                        tle_array (list[TLE]): An array of TLEs.
-
+                        tles (list[TLE]): The array of TLEs.
+                        output_frame (Frame): The output frame for state calculations. Defaults to TEME.
                 )doc",
-                arg("tle_array")
+                arg("tles"),
+                arg_v("output_frame", Frame::TEME(), "Frame.TEME()")
             )
 
             .def(
-                init(
-                    [](const list& aTleList, const Shared<const Frame>& anOutputFrameSPtr) -> SGP4
-                    {
-                        Array<TLE> tleArray = Array<TLE>::Empty();
-                        for (auto item : aTleList)
-                        {
-                            tleArray.add(item.cast<TLE>());
-                        }
-                        return SGP4(tleArray, anOutputFrameSPtr);
-                    }
-                ),
+                init<Array<Pair<TLE, Interval>>, Shared<const Frame>>(),
                 R"doc(
-                    Construct an SGP4 model from an array of TLEs and an output frame.
-
-                    When multiple TLEs are provided, the model will use the TLE whose epoch is closest
-                    to the requested instant for state calculations.
+                    Constructor with output frame. If TEME, the runtime is faster as no frame
+                    transformations are needed. In other frames, the runtime will be slower as frame transformations are needed.
 
                     Args:
-                        tle_array (list[TLE]): An array of TLEs.
-                        output_frame (Frame): The output frame for state calculations.
-
+                        tles_with_intervals (list[tuple[TLE, Interval]]): The array of TLE-Interval pairs.
+                        output_frame (Frame): The output frame for state calculations. Defaults to TEME.
                 )doc",
-                arg("tle_array"),
-                arg("output_frame")
+                arg("tles_with_intervals"),
+                arg_v("output_frame", Frame::TEME(), "Frame.TEME()")
             )
 
             .def(
@@ -151,6 +132,26 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 
                     Returns:
                         list[TLE]: The array of TLEs.
+
+                )doc"
+            )
+
+            .def(
+                "get_validity_intervals",
+                [](const SGP4& self) -> list
+                {
+                    list result;
+                    for (const auto& interval : self.getValidityIntervals())
+                    {
+                        result.append(interval);
+                    }
+                    return result;
+                },
+                R"doc(
+                    Get the validity intervals of the `SGP4` model.
+
+                    Returns:
+                        list[Interval]: The validity intervals.
 
                 )doc"
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
@@ -190,7 +190,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
                 R"doc(
                     Calculate the state of the `SGP4` model at a given instant.
 
-                    When multiple TLEs are provided, uses the TLE whose epoch is closest to the instant.
+                    When multiple TLEs are provided, uses the TLE whose validity interval contains the instant.
+                    For array-only construction, intervals are generated from midpoints between consecutive TLE epochs.
 
                     Args:
                         instant (Instant): The instant.
@@ -208,8 +209,8 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
                 R"doc(
                     Calculate the states of the `SGP4` model at given instants.
 
-                    When multiple TLEs are provided, uses the TLE whose epoch is closest to each instant.
-
+                    When multiple TLEs are provided, uses the TLE whose validity interval contains the instant.
+                    For array-only construction, intervals are generated from midpoints between consecutive TLE epochs.
                     Args:
                         instants (list[Instant]): The instants.
 

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
@@ -60,7 +60,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
             )
 
             .def(
-                init<Array<TLE>>(),
+                init(
+                    [](const list& aTleList) -> SGP4
+                    {
+                        Array<TLE> tleArray = Array<TLE>::Empty();
+                        for (auto item : aTleList)
+                        {
+                            tleArray.add(item.cast<TLE>());
+                        }
+                        return SGP4(tleArray);
+                    }
+                ),
                 R"doc(
                     Construct an SGP4 model from an array of TLEs.
 
@@ -75,7 +85,17 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
             )
 
             .def(
-                init<Array<TLE>, Shared<const Frame>>(),
+                init(
+                    [](const list& aTleList, const Shared<const Frame>& anOutputFrameSPtr) -> SGP4
+                    {
+                        Array<TLE> tleArray = Array<TLE>::Empty();
+                        for (auto item : aTleList)
+                        {
+                            tleArray.add(item.cast<TLE>());
+                        }
+                        return SGP4(tleArray, anOutputFrameSPtr);
+                    }
+                ),
                 R"doc(
                     Construct an SGP4 model from an array of TLEs and an output frame.
 
@@ -117,12 +137,20 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 
             .def(
                 "get_tles",
-                &SGP4::getTles,
+                [](const SGP4& self) -> list
+                {
+                    list result;
+                    for (const auto& tle : self.getTles())
+                    {
+                        result.append(tle);
+                    }
+                    return result;
+                },
                 R"doc(
                     Get the array of TLEs of the `SGP4` model.
 
                     Returns:
-                        list[TLE]: The array of TLEs. Empty if constructed with a single TLE.
+                        list[TLE]: The array of TLEs.
 
                 )doc"
             )
@@ -183,7 +211,21 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 
             .def(
                 "calculate_states_at",
-                &SGP4::calculateStatesAt,
+                [](const SGP4& self, const list& anInstantList) -> list
+                {
+                    Array<Instant> instantArray = Array<Instant>::Empty();
+                    for (auto item : anInstantList)
+                    {
+                        instantArray.add(item.cast<Instant>());
+                    }
+                    const Array<State> states = self.calculateStatesAt(instantArray);
+                    list result;
+                    for (const auto& state : states)
+                    {
+                        result.append(state);
+                    }
+                    return result;
+                },
                 arg("instant_array"),
                 R"doc(
                     Calculate the states of the `SGP4` model at given instants.

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+#include <OpenSpaceToolkit/Core/Container/Array.hpp>
+
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp>
 
 #include <OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4/TLE.cpp>
@@ -8,12 +10,15 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 {
     using namespace pybind11;
 
+    using ostk::core::container::Array;
     using ostk::core::type::Shared;
 
     using ostk::physics::coordinate::Frame;
+    using ostk::physics::time::Instant;
 
     using ostk::astrodynamics::trajectory::orbit::model::SGP4;
     using ostk::astrodynamics::trajectory::orbit::model::sgp4::TLE;
+    using ostk::astrodynamics::trajectory::State;
 
     {
         class_<SGP4, ostk::astrodynamics::trajectory::orbit::Model>(
@@ -55,6 +60,38 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
             )
 
             .def(
+                init<Array<TLE>>(),
+                R"doc(
+                    Construct an SGP4 model from an array of TLEs.
+
+                    When multiple TLEs are provided, the model will use the TLE whose epoch is closest
+                    to the requested instant for state calculations.
+
+                    Args:
+                        tle_array (list[TLE]): An array of TLEs.
+
+                )doc",
+                arg("tle_array")
+            )
+
+            .def(
+                init<Array<TLE>, Shared<const Frame>>(),
+                R"doc(
+                    Construct an SGP4 model from an array of TLEs and an output frame.
+
+                    When multiple TLEs are provided, the model will use the TLE whose epoch is closest
+                    to the requested instant for state calculations.
+
+                    Args:
+                        tle_array (list[TLE]): An array of TLEs.
+                        output_frame (Frame): The output frame for state calculations.
+
+                )doc",
+                arg("tle_array"),
+                arg("output_frame")
+            )
+
+            .def(
                 "is_defined",
                 &SGP4::isDefined,
                 R"doc(
@@ -70,10 +107,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
                 "get_tle",
                 &SGP4::getTle,
                 R"doc(
-                    Get the TLE of the `SGP4` model.
+                    Get the TLE of the `SGP4` model. For multi-TLE models, returns the TLE with the earliest epoch.
 
                     Returns:
                         TLE: The TLE.
+
+                )doc"
+            )
+
+            .def(
+                "get_tles",
+                &SGP4::getTles,
+                R"doc(
+                    Get the array of TLEs of the `SGP4` model.
+
+                    Returns:
+                        list[TLE]: The array of TLEs. Empty if constructed with a single TLE.
 
                 )doc"
             )
@@ -121,11 +170,31 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
                 R"doc(
                     Calculate the state of the `SGP4` model at a given instant.
 
+                    When multiple TLEs are provided, uses the TLE whose epoch is closest to the instant.
+
                     Args:
                         instant (Instant): The instant.
 
                     Returns:
                         State: The state.
+
+                )doc"
+            )
+
+            .def(
+                "calculate_states_at",
+                &SGP4::calculateStatesAt,
+                arg("instant_array"),
+                R"doc(
+                    Calculate the states of the `SGP4` model at given instants.
+
+                    When multiple TLEs are provided, uses the TLE whose epoch is closest to each instant.
+
+                    Args:
+                        instant_array (list[Instant]): The instants.
+
+                    Returns:
+                        list[State]: The states.
 
                 )doc"
             )

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
@@ -74,10 +74,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 
                     Args:
                         tles (list[TLE]): The list of TLEs.
-                        output_frame (Frame): The output frame for state calculations. Defaults to GCRF.
+                        output_frame (Frame): The output frame for state calculations. Defaults to TEME.
                 )doc",
                 arg("tles"),
-                arg_v("output_frame", Frame::GCRF(), "Frame.GCRF()")
+                arg_v("output_frame", Frame::TEME(), "Frame.TEME()")
             )
 
             .def(
@@ -90,10 +90,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 
                     Args:
                         tles_with_intervals (list[tuple[TLE, Interval]]): The array of TLE-Interval pairs.
-                        output_frame (Frame): The output frame for state calculations. Defaults to GCRF.
+                        output_frame (Frame): The output frame for state calculations. Defaults to TEME.
                 )doc",
                 arg("tles_with_intervals"),
-                arg_v("output_frame", Frame::GCRF(), "Frame.GCRF()")
+                arg_v("output_frame", Frame::TEME(), "Frame.TEME()")
             )
 
             .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4.cpp
@@ -52,8 +52,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
             .def(
                 init<TLE, Shared<const Frame>>(),
                 R"doc(
-                    Constructor with output frame. If TEME, the runtime is faster as no frame
-                    transformations are needed. In other frames, the runtime will be slower as frame transformations are needed.
+                    If TEME, the runtime is faster as no frame transformations are needed.
 
                     Args:
                         tle (TLE): The TLE.
@@ -67,29 +66,34 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
             .def(
                 init<Array<TLE>, Shared<const Frame>>(),
                 R"doc(
-                    Constructor with output frame. If TEME, the runtime is faster as no frame
-                    transformations are needed. In other frames, the runtime will be slower as frame transformations are needed.
+                    Construct an SGP4 model from an array of TLEs and an output frame.
+                    When multiple TLEs are provided, validity intervals are automatically generated
+                    using the midpoints between consecutive TLE epochs as boundaries. The first TLE's interval
+                    extends to the far past and the last TLE's interval extends to the far future.
+                    If TEME, the runtime is faster as no frame transformations are needed
 
                     Args:
-                        tles (list[TLE]): The array of TLEs.
-                        output_frame (Frame): The output frame for state calculations. Defaults to TEME.
+                        tles (list[TLE]): The list of TLEs.
+                        output_frame (Frame): The output frame for state calculations. Defaults to GCRF.
                 )doc",
                 arg("tles"),
-                arg_v("output_frame", Frame::TEME(), "Frame.TEME()")
+                arg_v("output_frame", Frame::GCRF(), "Frame.GCRF()")
             )
 
             .def(
                 init<Array<Pair<TLE, Interval>>, Shared<const Frame>>(),
                 R"doc(
-                    Constructor with output frame. If TEME, the runtime is faster as no frame
-                    transformations are needed. In other frames, the runtime will be slower as frame transformations are needed.
+                    Construct an SGP4 model from an array of TLE-Interval pairs and an output frame.
+                    Each pair specifies a TLE and the time interval over which it is valid.
+                    When calculating states, the first TLE whose interval contains the requested instant is used.
+                    If TEME, the runtime is faster as no frame transformations are needed
 
                     Args:
                         tles_with_intervals (list[tuple[TLE, Interval]]): The array of TLE-Interval pairs.
-                        output_frame (Frame): The output frame for state calculations. Defaults to TEME.
+                        output_frame (Frame): The output frame for state calculations. Defaults to GCRF.
                 )doc",
                 arg("tles_with_intervals"),
-                arg_v("output_frame", Frame::TEME(), "Frame.TEME()")
+                arg_v("output_frame", Frame::GCRF(), "Frame.GCRF()")
             )
 
             .def(
@@ -118,35 +122,19 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 
             .def(
                 "get_tles",
-                [](const SGP4& self) -> list
-                {
-                    list result;
-                    for (const auto& tle : self.getTles())
-                    {
-                        result.append(tle);
-                    }
-                    return result;
-                },
+                &SGP4::getTles,
                 R"doc(
-                    Get the array of TLEs of the `SGP4` model.
+                    Get the list of TLEs of the `SGP4` model.
 
                     Returns:
-                        list[TLE]: The array of TLEs.
+                        list[TLE]: The list of TLEs.
 
                 )doc"
             )
 
             .def(
                 "get_validity_intervals",
-                [](const SGP4& self) -> list
-                {
-                    list result;
-                    for (const auto& interval : self.getValidityIntervals())
-                    {
-                        result.append(interval);
-                    }
-                    return result;
-                },
+                &SGP4::getValidityIntervals,
                 R"doc(
                     Get the validity intervals of the `SGP4` model.
 
@@ -212,29 +200,15 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4(pybind11
 
             .def(
                 "calculate_states_at",
-                [](const SGP4& self, const list& anInstantList) -> list
-                {
-                    Array<Instant> instantArray = Array<Instant>::Empty();
-                    for (auto item : anInstantList)
-                    {
-                        instantArray.add(item.cast<Instant>());
-                    }
-                    const Array<State> states = self.calculateStatesAt(instantArray);
-                    list result;
-                    for (const auto& state : states)
-                    {
-                        result.append(state);
-                    }
-                    return result;
-                },
-                arg("instant_array"),
+                &SGP4::calculateStatesAt,
+                arg("instants"),
                 R"doc(
                     Calculate the states of the `SGP4` model at given instants.
 
                     When multiple TLEs are provided, uses the TLE whose epoch is closest to each instant.
 
                     Args:
-                        instant_array (list[Instant]): The instants.
+                        instants (list[Instant]): The instants.
 
                     Returns:
                         list[State]: The states.

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4/TLE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4/TLE.cpp
@@ -1,7 +1,5 @@
 /// Apache License 2.0
 
-#include <sstream>
-
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.hpp>
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4_TLE(pybind11::module& aModule)
@@ -310,16 +308,6 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4_TLE(pybi
                     int: The checksum of the second line.
 
             )doc"
-        )
-
-        .def(
-            "__repr__",
-            +[](const TLE& aTle) -> String
-            {
-                std::ostringstream stream;
-                aTle.print(stream);
-                return stream.str();
-            }
         )
 
         .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4/TLE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/SGP4/TLE.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+#include <sstream>
+
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.hpp>
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4_TLE(pybind11::module& aModule)
@@ -308,6 +310,16 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_SGP4_TLE(pybi
                     int: The checksum of the second line.
 
             )doc"
+        )
+
+        .def(
+            "__repr__",
+            +[](const TLE& aTle) -> String
+            {
+                std::ostringstream stream;
+                aTle.print(stream);
+                return stream.str();
+            }
         )
 
         .def(

--- a/bindings/python/test/trajectory/orbit/models/test_sgp4.py
+++ b/bindings/python/test/trajectory/orbit/models/test_sgp4.py
@@ -4,6 +4,7 @@ import pytest
 
 from ostk.physics.coordinate import Frame
 from ostk.physics.time import Duration
+from ostk.physics.time import Interval
 
 from ostk.astrodynamics.trajectory.orbit.model import SGP4
 from ostk.astrodynamics.trajectory.orbit.model.sgp4 import TLE
@@ -45,24 +46,71 @@ class TestSGP4:
     ):
         assert SGP4(tle, Frame.TEME()) is not None
 
-    def test_constructor_with_tle_array(
+    def test_constructor_tles(
         self,
         tle: TLE,
         tle2: TLE,
     ):
         sgp4 = SGP4([tle, tle2])
         assert sgp4 is not None
-        assert sgp4.is_defined()
 
-    def test_constructor_with_tle_array_and_output_frame(
+        assert SGP4([tle, tle2], Frame.GCRF()) is not None
+
+    def test_constructor_tles_with_intervals(
         self,
         tle: TLE,
         tle2: TLE,
     ):
-        sgp4 = SGP4([tle, tle2], Frame.TEME())
+        boundary = tle.get_epoch() + Duration.hours(18.0)
+        interval1 = Interval.half_open_right(
+            tle.get_epoch() - Duration.days(1.0), boundary
+        )
+        interval2 = Interval.closed(boundary, tle2.get_epoch() + Duration.days(1.0))
+
+        sgp4 = SGP4([(tle, interval1), (tle2, interval2)])
         assert sgp4 is not None
-        assert sgp4.is_defined()
-        assert sgp4.get_output_frame() == Frame.TEME()
+
+        assert SGP4([(tle, interval1), (tle2, interval2)], Frame.GCRF()) is not None
+
+    def test_get_validity_intervals(
+        self,
+        tle: TLE,
+        tle2: TLE,
+    ):
+        sgp4 = SGP4([tle, tle2])
+        intervals = sgp4.get_validity_intervals()
+        assert intervals is not None
+        assert len(intervals) == 2
+
+    def test_get_validity_intervals_single_tle(
+        self,
+        sgp4: SGP4,
+    ):
+        intervals = sgp4.get_validity_intervals()
+        # Single TLE constructor doesn't generate intervals
+        assert len(intervals) == 0
+
+    def test_calculate_state_at_multi_tle_custom_intervals(
+        self,
+        tle: TLE,
+        tle2: TLE,
+    ):
+        # Set boundary at 18 hours (not midpoint at 12 hours)
+        boundary = tle.get_epoch() + Duration.hours(18.0)
+        interval1 = Interval.half_open_right(
+            tle.get_epoch() - Duration.days(100.0), boundary
+        )
+        interval2 = Interval.closed(boundary, tle2.get_epoch() + Duration.days(100.0))
+
+        sgp4 = SGP4([(tle, interval1), (tle2, interval2)])
+
+        # 15 hours after tle epoch should still use tle (within 18-hour boundary)
+        state = sgp4.calculate_state_at(tle.get_epoch() + Duration.hours(15.0))
+        assert state is not None
+
+        # 19 hours after tle epoch should use tle2 (past 18-hour boundary)
+        state2 = sgp4.calculate_state_at(tle.get_epoch() + Duration.hours(19.0))
+        assert state2 is not None
 
     def test_constructor_with_empty_tle_array(self):
         with pytest.raises(RuntimeError):

--- a/bindings/python/test/trajectory/orbit/models/test_sgp4.py
+++ b/bindings/python/test/trajectory/orbit/models/test_sgp4.py
@@ -95,7 +95,7 @@ class TestSGP4:
         sgp4: SGP4,
     ):
         tles = sgp4.get_tles()
-        assert len(tles) == 0
+        assert len(tles) == 1
 
     def test_get_output_frame(
         self,

--- a/bindings/python/test/trajectory/orbit/models/test_sgp4.py
+++ b/bindings/python/test/trajectory/orbit/models/test_sgp4.py
@@ -33,6 +33,11 @@ def sgp4(tle: TLE) -> SGP4:
     return SGP4(tle)
 
 
+@pytest.fixture
+def sgp4_multi(tle: TLE, tle2: TLE) -> SGP4:
+    return SGP4([tle, tle2])
+
+
 class TestSGP4:
     def test_constructor(
         self,
@@ -104,17 +109,8 @@ class TestSGP4:
 
         sgp4 = SGP4([(tle, interval1), (tle2, interval2)])
 
-        # 15 hours after tle epoch should still use tle (within 18-hour boundary)
         state = sgp4.calculate_state_at(tle.get_epoch() + Duration.hours(15.0))
         assert state is not None
-
-        # 19 hours after tle epoch should use tle2 (past 18-hour boundary)
-        state2 = sgp4.calculate_state_at(tle.get_epoch() + Duration.hours(19.0))
-        assert state2 is not None
-
-    def test_constructor_with_empty_tle_array(self):
-        with pytest.raises(RuntimeError):
-            SGP4([])
 
     def test_is_defined(
         self,
@@ -163,33 +159,30 @@ class TestSGP4:
     ):
         assert sgp4.get_revolution_number_at_epoch() is not None
 
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["sgp4", "sgp4_multi"],
+    )
     def test_calculate_state_at(
         self,
-        sgp4: SGP4,
+        fixture_name: str,
         tle: TLE,
+        request,
     ):
+        sgp4 = request.getfixturevalue(fixture_name)
         assert sgp4.calculate_state_at(tle.get_epoch()) is not None
 
-    def test_calculate_state_at_multi_tle(
-        self,
-        tle: TLE,
-        tle2: TLE,
-    ):
-        sgp4_multi = SGP4([tle, tle2])
-        sgp4_single = SGP4(tle)
-
-        # State at tle epoch should match single-TLE model
-        state_multi = sgp4_multi.calculate_state_at(tle.get_epoch())
-        state_single = sgp4_single.calculate_state_at(tle.get_epoch())
-
-        assert state_multi is not None
-        assert state_single is not None
-
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["sgp4", "sgp4_multi"],
+    )
     def test_calculate_states_at(
         self,
-        sgp4: SGP4,
+        fixture_name: str,
         tle: TLE,
+        request,
     ):
+        sgp4 = request.getfixturevalue(fixture_name)
         instants = [
             tle.get_epoch(),
             tle.get_epoch() + Duration.hours(1.0),
@@ -198,17 +191,3 @@ class TestSGP4:
         states = sgp4.calculate_states_at(instants)
         assert states is not None
         assert len(states) == 3
-
-    def test_calculate_states_at_multi_tle(
-        self,
-        tle: TLE,
-        tle2: TLE,
-    ):
-        sgp4 = SGP4([tle, tle2])
-        instants = [
-            tle.get_epoch(),
-            tle2.get_epoch(),
-        ]
-        states = sgp4.calculate_states_at(instants)
-        assert states is not None
-        assert len(states) == 2

--- a/bindings/python/test/trajectory/orbit/models/test_sgp4.py
+++ b/bindings/python/test/trajectory/orbit/models/test_sgp4.py
@@ -100,7 +100,6 @@ class TestSGP4:
         tle: TLE,
         tle2: TLE,
     ):
-        # Set boundary at 18 hours (not midpoint at 12 hours)
         boundary = tle.get_epoch() + Duration.hours(18.0)
         interval1 = Interval.half_open_right(
             tle.get_epoch() - Duration.days(100.0), boundary
@@ -190,4 +189,3 @@ class TestSGP4:
         ]
         states = sgp4.calculate_states_at(instants)
         assert states is not None
-        assert len(states) == 3

--- a/bindings/python/test/trajectory/orbit/models/test_sgp4.py
+++ b/bindings/python/test/trajectory/orbit/models/test_sgp4.py
@@ -3,6 +3,7 @@
 import pytest
 
 from ostk.physics.coordinate import Frame
+from ostk.physics.time import Duration
 
 from ostk.astrodynamics.trajectory.orbit.model import SGP4
 from ostk.astrodynamics.trajectory.orbit.model.sgp4 import TLE
@@ -14,6 +15,16 @@ def tle() -> TLE:
         "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
         "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
     )
+
+
+@pytest.fixture
+def tle2() -> TLE:
+    tle = TLE(
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    )
+    tle.set_epoch(tle.get_epoch() + Duration.days(1.0))
+    return tle
 
 
 @pytest.fixture
@@ -34,6 +45,29 @@ class TestSGP4:
     ):
         assert SGP4(tle, Frame.TEME()) is not None
 
+    def test_constructor_with_tle_array(
+        self,
+        tle: TLE,
+        tle2: TLE,
+    ):
+        sgp4 = SGP4([tle, tle2])
+        assert sgp4 is not None
+        assert sgp4.is_defined()
+
+    def test_constructor_with_tle_array_and_output_frame(
+        self,
+        tle: TLE,
+        tle2: TLE,
+    ):
+        sgp4 = SGP4([tle, tle2], Frame.TEME())
+        assert sgp4 is not None
+        assert sgp4.is_defined()
+        assert sgp4.get_output_frame() == Frame.TEME()
+
+    def test_constructor_with_empty_tle_array(self):
+        with pytest.raises(RuntimeError):
+            SGP4([])
+
     def test_is_defined(
         self,
         sgp4: SGP4,
@@ -45,6 +79,23 @@ class TestSGP4:
         sgp4: SGP4,
     ):
         assert sgp4.get_tle() is not None
+
+    def test_get_tles(
+        self,
+        tle: TLE,
+        tle2: TLE,
+    ):
+        sgp4 = SGP4([tle, tle2])
+        tles = sgp4.get_tles()
+        assert tles is not None
+        assert len(tles) == 2
+
+    def test_get_tles_single_tle(
+        self,
+        sgp4: SGP4,
+    ):
+        tles = sgp4.get_tles()
+        assert len(tles) == 0
 
     def test_get_output_frame(
         self,
@@ -70,3 +121,46 @@ class TestSGP4:
         tle: TLE,
     ):
         assert sgp4.calculate_state_at(tle.get_epoch()) is not None
+
+    def test_calculate_state_at_multi_tle(
+        self,
+        tle: TLE,
+        tle2: TLE,
+    ):
+        sgp4_multi = SGP4([tle, tle2])
+        sgp4_single = SGP4(tle)
+
+        # State at tle epoch should match single-TLE model
+        state_multi = sgp4_multi.calculate_state_at(tle.get_epoch())
+        state_single = sgp4_single.calculate_state_at(tle.get_epoch())
+
+        assert state_multi is not None
+        assert state_single is not None
+
+    def test_calculate_states_at(
+        self,
+        sgp4: SGP4,
+        tle: TLE,
+    ):
+        instants = [
+            tle.get_epoch(),
+            tle.get_epoch() + Duration.hours(1.0),
+            tle.get_epoch() + Duration.hours(2.0),
+        ]
+        states = sgp4.calculate_states_at(instants)
+        assert states is not None
+        assert len(states) == 3
+
+    def test_calculate_states_at_multi_tle(
+        self,
+        tle: TLE,
+        tle2: TLE,
+    ):
+        sgp4 = SGP4([tle, tle2])
+        instants = [
+            tle.get_epoch(),
+            tle2.get_epoch(),
+        ]
+        states = sgp4.calculate_states_at(instants)
+        assert states is not None
+        assert len(states) == 2

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
@@ -4,6 +4,7 @@
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4__
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 #include <OpenSpaceToolkit/Core/Type/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
@@ -14,6 +15,7 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 
@@ -33,6 +35,7 @@ namespace model
 {
 
 using ostk::core::container::Array;
+using ostk::core::container::Pair;
 using ostk::core::type::Integer;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
@@ -44,6 +47,7 @@ using ostk::physics::coordinate::Frame;
 
 using ostk::physics::environment::object::Celestial;
 using ostk::physics::time::Instant;
+using ostk::physics::time::Interval;
 using ostk::physics::unit::Derived;
 using ostk::physics::unit::Length;
 
@@ -82,8 +86,9 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
 
     /// @brief Construct an SGP4 model from an array of TLEs and an output frame.
     ///
-    /// @details When multiple TLEs are provided, the model will use the TLE whose epoch is closest
-    /// to the requested instant for state calculations.
+    /// @details When multiple TLEs are provided, validity intervals are automatically generated
+    /// using the midpoints between consecutive TLE epochs as boundaries. The first TLE's interval
+    /// extends to the far past and the last TLE's interval extends to the far future.
     ///
     /// @code{.cpp}
     ///     Array<TLE> tles = {TLE("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
@@ -96,6 +101,26 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @param aTleArray An array of Two-Line Element sets.
     /// @param anOutputFrameSPtr An output frame. Defaults to TEME.
     SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr = Frame::TEME());
+
+    /// @brief Construct an SGP4 model from an array of TLE-Interval pairs and an output frame.
+    ///
+    /// @details Each pair specifies a TLE and the time interval over which it is valid.
+    /// When calculating states, the first TLE whose interval contains the requested instant is used.
+    ///
+    /// @code{.cpp}
+    ///     Array<Pair<TLE, Interval>> tleIntervalPairs = {
+    ///         {tle1, Interval::Closed(startInstant1, endInstant1)},
+    ///         {tle2, Interval::Closed(startInstant2, endInstant2)}
+    ///     };
+    ///     SGP4 sgp4 = SGP4(tleIntervalPairs, Frame::TEME());
+    /// @endcode
+    ///
+    /// @param aTleIntervalArray An array of TLE-Interval pairs.
+    /// @param anOutputFrameSPtr An output frame. Defaults to TEME.
+    SGP4(
+        const Array<Pair<TLE, Interval>>& aTleIntervalArray,
+        const Shared<const Frame>& anOutputFrameSPtr = Frame::TEME()
+    );
 
     /// @brief Copy constructor.
     ///
@@ -165,6 +190,16 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @return The array of Two-Line Element sets.
     Array<TLE> getTles() const;
 
+    /// @brief Get the validity intervals associated with the TLEs.
+    ///
+    /// @code{.cpp}
+    ///     SGP4 sgp4 = SGP4(tleIntervalPairs);
+    ///     Array<Interval> intervals = sgp4.getValidityIntervals();
+    /// @endcode
+    ///
+    /// @return The array of validity intervals.
+    Array<Interval> getValidityIntervals() const;
+
     /// @brief Get the output frame of the SGP4 model.
     ///
     /// @code{.cpp}
@@ -229,13 +264,16 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     class Impl;
 
     Array<TLE> tleArray_;
+    Array<Interval> validityIntervals_;
     Shared<const Frame> outputFrameSPtr_;
 
     mutable Unique<SGP4::Impl> implUPtr_;
     mutable Size cachedTleIndex_;
 
-    Size findClosestTleIndex(const Instant& anInstant) const;
+    Size findTleIndexForInstant(const Instant& anInstant) const;
     void ensureImplForTleIndex(const Size& aTleIndex) const;
+
+    static Array<Interval> GenerateIntervalsFromEpochs(const Array<TLE>& aTleArray);
 };
 
 }  // namespace model

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
@@ -44,6 +44,7 @@ using ostk::core::type::String;
 using ostk::physics::coordinate::Frame;
 
 using ostk::physics::environment::object::Celestial;
+using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Interval;
 using ostk::physics::unit::Derived;
@@ -58,7 +59,7 @@ using ostk::astrodynamics::trajectory::State;
 class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
 {
    public:
-    /// @brief Construct an SGP4 model from a TLE.
+    /// @brief Construct an SGP4 model from a TLE. Sets the output frame to GCRF by default.
     ///
     /// @code{.cpp}
     ///     TLE tle = TLE("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
@@ -97,13 +98,15 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @endcode
     ///
     /// @param aTleArray An array of Two-Line Element sets.
-    /// @param anOutputFrameSPtr An output frame. Defaults to GCRF.
-    SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr = Frame::GCRF());
+    /// @param anOutputFrameSPtr An output frame. Defaults to TEME.
+    SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr = Frame::TEME());
 
     /// @brief Construct an SGP4 model from an array of TLE-Interval pairs and an output frame.
     ///
     /// @details Each pair specifies a TLE and the time interval over which it is valid.
     /// When calculating states, the first TLE whose interval contains the requested instant is used.
+    /// Therefore in the case an instant is within multiple TLE intervals, the first TLE whose interval contains the
+    /// instant is used.
     ///
     /// @code{.cpp}
     ///     Array<Pair<TLE, Interval>> tleIntervalPairs = {
@@ -114,10 +117,10 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @endcode
     ///
     /// @param aTleIntervalArray An array of TLE-Interval pairs.
-    /// @param anOutputFrameSPtr An output frame. Defaults to GCRF.
+    /// @param anOutputFrameSPtr An output frame. Defaults to TEME.
     SGP4(
         const Array<Pair<TLE, Interval>>& aTleIntervalArray,
-        const Shared<const Frame>& anOutputFrameSPtr = Frame::GCRF()
+        const Shared<const Frame>& anOutputFrameSPtr = Frame::TEME()
     );
 
     /// @brief Copy constructor.
@@ -266,6 +269,10 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     Shared<const Frame> outputFrameSPtr_;
 
     Array<Shared<SGP4::Impl>> implArray_;
+
+    mutable Size tleIndex_ = 0;
+
+    static const Duration epochBuffer_;
 
     Size findTleIndexForInstant(const Instant& anInstant) const;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
@@ -10,7 +10,6 @@
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Type/Size.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
-#include <OpenSpaceToolkit/Core/Type/Unique.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial.hpp>
@@ -41,7 +40,6 @@ using ostk::core::type::Real;
 using ostk::core::type::Shared;
 using ostk::core::type::Size;
 using ostk::core::type::String;
-using ostk::core::type::Unique;
 
 using ostk::physics::coordinate::Frame;
 
@@ -72,7 +70,7 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     SGP4(const TLE& aTle);
 
     /// @brief Construct an SGP4 model from a TLE and an output frame. If TEME, the runtime is faster as no frame
-    /// transformations are needed. In other frames, the runtime will be slower as frame transformations are needed.
+    /// transformations are needed.
     ///
     /// @code{.cpp}
     ///     TLE tle = TLE("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
@@ -99,8 +97,8 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @endcode
     ///
     /// @param aTleArray An array of Two-Line Element sets.
-    /// @param anOutputFrameSPtr An output frame. Defaults to TEME.
-    SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr = Frame::TEME());
+    /// @param anOutputFrameSPtr An output frame. Defaults to GCRF.
+    SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr = Frame::GCRF());
 
     /// @brief Construct an SGP4 model from an array of TLE-Interval pairs and an output frame.
     ///
@@ -116,10 +114,10 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @endcode
     ///
     /// @param aTleIntervalArray An array of TLE-Interval pairs.
-    /// @param anOutputFrameSPtr An output frame. Defaults to TEME.
+    /// @param anOutputFrameSPtr An output frame. Defaults to GCRF.
     SGP4(
         const Array<Pair<TLE, Interval>>& aTleIntervalArray,
-        const Shared<const Frame>& anOutputFrameSPtr = Frame::TEME()
+        const Shared<const Frame>& anOutputFrameSPtr = Frame::GCRF()
     );
 
     /// @brief Copy constructor.
@@ -243,7 +241,7 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
 
     /// @brief Calculate states at given instants.
     ///
-    /// @details When multiple TLEs are provided, the TLE whose epoch is closest to each instant is used.
+    /// @details When multiple TLEs are provided, the selected TLE is first one whose interval contains the instant.
     ///
     /// @param anInstantArray An array of instants at which to calculate the states.
     /// @return An array of orbital states at the given instants.
@@ -267,11 +265,9 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     Array<Interval> validityIntervals_;
     Shared<const Frame> outputFrameSPtr_;
 
-    mutable Unique<SGP4::Impl> implUPtr_;
-    mutable Size cachedTleIndex_;
+    Array<Shared<SGP4::Impl>> implArray_;
 
     Size findTleIndexForInstant(const Instant& anInstant) const;
-    void ensureImplForTleIndex(const Size& aTleIndex) const;
 
     static Array<Interval> GenerateIntervalsFromEpochs(const Array<TLE>& aTleArray);
 };

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
@@ -3,9 +3,11 @@
 #ifndef __OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4__
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4__
 
+#include <OpenSpaceToolkit/Core/Container/Array.hpp>
 #include <OpenSpaceToolkit/Core/Type/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
+#include <OpenSpaceToolkit/Core/Type/Size.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 #include <OpenSpaceToolkit/Core/Type/Unique.hpp>
 
@@ -30,9 +32,11 @@ namespace orbit
 namespace model
 {
 
+using ostk::core::container::Array;
 using ostk::core::type::Integer;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
+using ostk::core::type::Size;
 using ostk::core::type::String;
 using ostk::core::type::Unique;
 
@@ -75,6 +79,23 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @param aTle A Two-Line Element set.
     /// @param anOutputFrameSPtr An output frame.
     SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr);
+
+    /// @brief Construct an SGP4 model from an array of TLEs.
+    ///
+    /// @details When multiple TLEs are provided, the model will use the TLE whose epoch is closest
+    /// to the requested instant for state calculations.
+    ///
+    /// @param aTleArray An array of Two-Line Element sets.
+    SGP4(const Array<TLE>& aTleArray);
+
+    /// @brief Construct an SGP4 model from an array of TLEs and an output frame.
+    ///
+    /// @details When multiple TLEs are provided, the model will use the TLE whose epoch is closest
+    /// to the requested instant for state calculations.
+    ///
+    /// @param aTleArray An array of Two-Line Element sets.
+    /// @param anOutputFrameSPtr An output frame.
+    SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr);
 
     /// @brief Copy constructor.
     ///
@@ -134,6 +155,16 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @return The Two-Line Element set.
     TLE getTle() const;
 
+    /// @brief Get the array of TLEs associated with this model.
+    ///
+    /// @code{.cpp}
+    ///     SGP4 sgp4 = SGP4(tleArray);
+    ///     Array<TLE> tles = sgp4.getTles();
+    /// @endcode
+    ///
+    /// @return The array of Two-Line Element sets.
+    Array<TLE> getTles() const;
+
     /// @brief Get the output frame of the SGP4 model.
     ///
     /// @code{.cpp}
@@ -175,6 +206,14 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @return The orbital state at the given instant.
     virtual State calculateStateAt(const Instant& anInstant) const override;
 
+    /// @brief Calculate states at given instants.
+    ///
+    /// @details When multiple TLEs are provided, the TLE whose epoch is closest to each instant is used.
+    ///
+    /// @param anInstantArray An array of instants at which to calculate the states.
+    /// @return An array of orbital states at the given instants.
+    virtual Array<State> calculateStatesAt(const Array<Instant>& anInstantArray) const override;
+
     /// @brief Print the SGP4 model to an output stream.
     ///
     /// @param anOutputStream An output stream.
@@ -190,9 +229,14 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     class Impl;
 
     TLE tle_;
+    Array<TLE> tleArray_;
     Shared<const Frame> outputFrameSPtr_;
 
-    Unique<SGP4::Impl> implUPtr_;
+    mutable Unique<SGP4::Impl> implUPtr_;
+    mutable Size cachedTleIndex_;
+
+    Size findClosestTleIndex(const Instant& anInstant) const;
+    void ensureImplForTleIndex(const Size& aTleIndex) const;
 };
 
 }  // namespace model

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp
@@ -80,22 +80,22 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
     /// @param anOutputFrameSPtr An output frame.
     SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr);
 
-    /// @brief Construct an SGP4 model from an array of TLEs.
-    ///
-    /// @details When multiple TLEs are provided, the model will use the TLE whose epoch is closest
-    /// to the requested instant for state calculations.
-    ///
-    /// @param aTleArray An array of Two-Line Element sets.
-    SGP4(const Array<TLE>& aTleArray);
-
     /// @brief Construct an SGP4 model from an array of TLEs and an output frame.
     ///
     /// @details When multiple TLEs are provided, the model will use the TLE whose epoch is closest
     /// to the requested instant for state calculations.
     ///
+    /// @code{.cpp}
+    ///     Array<TLE> tles = {TLE("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+    ///                   "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537"),
+    ///                   TLE("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+    ///                   "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537")};
+    ///     SGP4 sgp4 = SGP4(tles, Frame::TEME());
+    /// @endcode
+    ///
     /// @param aTleArray An array of Two-Line Element sets.
-    /// @param anOutputFrameSPtr An output frame.
-    SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr);
+    /// @param anOutputFrameSPtr An output frame. Defaults to TEME.
+    SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr = Frame::TEME());
 
     /// @brief Copy constructor.
     ///
@@ -228,7 +228,6 @@ class SGP4 : public ostk::astrodynamics::trajectory::orbit::Model
    private:
     class Impl;
 
-    TLE tle_;
     Array<TLE> tleArray_;
     Shared<const Frame> outputFrameSPtr_;
 

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.hpp
@@ -240,6 +240,12 @@ class TLE
     /// @return Checksum of second line
     Integer getSecondLineChecksum() const;
 
+    /// @brief Print the TLE to an output stream.
+    ///
+    /// @param anOutputStream An output stream.
+    /// @param displayDecorator If true, display a decorator around the output.
+    void print(std::ostream& anOutputStream, bool displayDecorator = true) const;
+
     /// @brief Set new satellite catalogue number in the existing TLE
     ///
     /// @param aSatelliteNumber a Satellite Number

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
@@ -25,7 +25,10 @@ namespace orbit
 namespace model
 {
 
+using ostk::core::container::Pair;
+
 using ostk::physics::coordinate::Transform;
+using ostk::physics::time::Interval;
 
 class SGP4::Impl
 {
@@ -81,6 +84,7 @@ State SGP4::Impl::calculateStateAt(const Instant& anInstant) const
 SGP4::SGP4(const TLE& aTle)
     : Model(),
       tleArray_({aTle}),
+      validityIntervals_(),
       outputFrameSPtr_(Frame::GCRF()),
       implUPtr_(std::make_unique<SGP4::Impl>(aTle, outputFrameSPtr_)),
       cachedTleIndex_(0)
@@ -90,6 +94,7 @@ SGP4::SGP4(const TLE& aTle)
 SGP4::SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr)
     : Model(),
       tleArray_({aTle}),
+      validityIntervals_(),
       outputFrameSPtr_(anOutputFrameSPtr),
       implUPtr_(std::make_unique<SGP4::Impl>(aTle, outputFrameSPtr_)),
       cachedTleIndex_(0)
@@ -99,6 +104,7 @@ SGP4::SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr)
 SGP4::SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr)
     : Model(),
       tleArray_(aTleArray),
+      validityIntervals_(),
       outputFrameSPtr_(anOutputFrameSPtr),
       implUPtr_(nullptr),
       cachedTleIndex_(0)
@@ -117,12 +123,48 @@ SGP4::SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrame
         }
     );
 
+    validityIntervals_ = SGP4::GenerateIntervalsFromEpochs(tleArray_);
+
+    implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
+}
+
+SGP4::SGP4(const Array<Pair<TLE, Interval>>& aTleIntervalArray, const Shared<const Frame>& anOutputFrameSPtr)
+    : Model(),
+      tleArray_(),
+      validityIntervals_(),
+      outputFrameSPtr_(anOutputFrameSPtr),
+      implUPtr_(nullptr),
+      cachedTleIndex_(0)
+{
+    if (aTleIntervalArray.isEmpty())
+    {
+        throw ostk::core::error::RuntimeError("TLE-Interval array is empty.");
+    }
+
+    // Build parallel arrays and sort by TLE epoch
+    Array<Pair<TLE, Interval>> sortedPairs = aTleIntervalArray;
+    std::sort(
+        sortedPairs.begin(),
+        sortedPairs.end(),
+        [](const Pair<TLE, Interval>& a, const Pair<TLE, Interval>& b)
+        {
+            return a.first.getEpoch() < b.first.getEpoch();
+        }
+    );
+
+    for (const auto& pair : sortedPairs)
+    {
+        tleArray_.add(pair.first);
+        validityIntervals_.add(pair.second);
+    }
+
     implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
 }
 
 SGP4::SGP4(const SGP4& aSGP4Model)
     : Model(aSGP4Model),
       tleArray_(aSGP4Model.tleArray_),
+      validityIntervals_(aSGP4Model.validityIntervals_),
       outputFrameSPtr_(aSGP4Model.outputFrameSPtr_),
       implUPtr_(nullptr),
       cachedTleIndex_(0)
@@ -139,6 +181,7 @@ SGP4& SGP4::operator=(const SGP4& aSGP4Model)
         Model::operator=(aSGP4Model);
 
         this->tleArray_ = aSGP4Model.tleArray_;
+        this->validityIntervals_ = aSGP4Model.validityIntervals_;
         this->outputFrameSPtr_ = aSGP4Model.outputFrameSPtr_;
         this->cachedTleIndex_ = 0;
 
@@ -167,7 +210,8 @@ bool SGP4::operator==(const SGP4& aSGP4Model) const
         return false;
     }
 
-    return (this->tleArray_ == aSGP4Model.tleArray_) && (this->outputFrameSPtr_ == aSGP4Model.outputFrameSPtr_);
+    return (this->tleArray_ == aSGP4Model.tleArray_) && (this->validityIntervals_ == aSGP4Model.validityIntervals_) &&
+           (this->outputFrameSPtr_ == aSGP4Model.outputFrameSPtr_);
 }
 
 bool SGP4::operator!=(const SGP4& aSGP4Model) const
@@ -210,6 +254,16 @@ Array<TLE> SGP4::getTles() const
     }
 
     return this->tleArray_;
+}
+
+Array<Interval> SGP4::getValidityIntervals() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("SGP4");
+    }
+
+    return this->validityIntervals_;
 }
 
 Shared<const Frame> SGP4::getOutputFrame() const
@@ -267,7 +321,7 @@ State SGP4::calculateStateAt(const Instant& anInstant) const
 
     if (tleArray_.getSize() > 1)
     {
-        const Size tleIndex = this->findClosestTleIndex(anInstant);
+        const Size tleIndex = this->findTleIndexForInstant(anInstant);
         this->ensureImplForTleIndex(tleIndex);
     }
 
@@ -321,40 +375,78 @@ void SGP4::print(std::ostream& anOutputStream, bool displayDecorator) const
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 
-Size SGP4::findClosestTleIndex(const Instant& anInstant) const
+Size SGP4::findTleIndexForInstant(const Instant& anInstant) const
+{
+    for (Size i = 0; i < validityIntervals_.getSize(); ++i)
+    {
+        if (validityIntervals_[i].contains(anInstant))
+        {
+            return i;
+        }
+    }
+
+    throw ostk::core::error::RuntimeError(
+        "No TLE validity interval contains the requested instant [{}].", anInstant.toString()
+    );
+}
+
+Array<Interval> SGP4::GenerateIntervalsFromEpochs(const Array<TLE>& aTleArray)
 {
     using ostk::physics::time::Duration;
 
-    const auto it = std::lower_bound(
-        tleArray_.begin(),
-        tleArray_.end(),
-        anInstant,
-        [](const TLE& tle, const Instant& instant)
+    Array<Interval> intervals = Array<Interval>::Empty();
+    intervals.reserve(aTleArray.getSize());
+
+    if (aTleArray.getSize() == 1)
+    {
+        // Single TLE: interval spans far past to far future
+        const Instant farPast = aTleArray[0].getEpoch() - Duration::Days(36525.0);
+        const Instant farFuture = aTleArray[0].getEpoch() + Duration::Days(36525.0);
+        intervals.add(Interval::Closed(farPast, farFuture));
+        return intervals;
+    }
+
+    for (Size i = 0; i < aTleArray.getSize(); ++i)
+    {
+        Instant start = Instant::Undefined();
+        Instant end = Instant::Undefined();
+
+        if (i == 0)
         {
-            return tle.getEpoch() < instant;
+            // First TLE: start at far past
+            start = aTleArray[0].getEpoch() - Duration::Days(36525.0);
         }
-    );
+        else
+        {
+            // Midpoint between previous and current epoch
+            const Duration halfGap = Duration::Between(aTleArray[i - 1].getEpoch(), aTleArray[i].getEpoch()) / 2.0;
+            start = aTleArray[i - 1].getEpoch() + halfGap;
+        }
 
-    if (it == tleArray_.begin())
-    {
-        return 0;
+        if (i == aTleArray.getSize() - 1)
+        {
+            // Last TLE: end at far future
+            end = aTleArray[i].getEpoch() + Duration::Days(36525.0);
+        }
+        else
+        {
+            // Midpoint between current and next epoch
+            const Duration halfGap = Duration::Between(aTleArray[i].getEpoch(), aTleArray[i + 1].getEpoch()) / 2.0;
+            end = aTleArray[i].getEpoch() + halfGap;
+        }
+
+        // Use HalfOpenRight [start, end) for all except the last, which is Closed [start, end]
+        if (i < aTleArray.getSize() - 1)
+        {
+            intervals.add(Interval::HalfOpenRight(start, end));
+        }
+        else
+        {
+            intervals.add(Interval::Closed(start, end));
+        }
     }
 
-    if (it == tleArray_.end())
-    {
-        return tleArray_.getSize() - 1;
-    }
-
-    const auto prevIt = std::prev(it);
-    const Duration durationToPrev = Duration::Between(prevIt->getEpoch(), anInstant).getAbsolute();
-    const Duration durationToNext = Duration::Between(anInstant, it->getEpoch()).getAbsolute();
-
-    if (durationToPrev <= durationToNext)
-    {
-        return static_cast<Size>(std::distance(tleArray_.begin(), prevIt));
-    }
-
-    return static_cast<Size>(std::distance(tleArray_.begin(), it));
+    return intervals;
 }
 
 void SGP4::ensureImplForTleIndex(const Size& aTleIndex) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <memory>
 
 #include <sgp4/SGP4.h>
 
@@ -86,9 +87,9 @@ SGP4::SGP4(const TLE& aTle)
       tleArray_({aTle}),
       validityIntervals_(),
       outputFrameSPtr_(Frame::GCRF()),
-      implUPtr_(std::make_unique<SGP4::Impl>(aTle, outputFrameSPtr_)),
-      cachedTleIndex_(0)
+      implArray_()
 {
+    implArray_.add(std::make_shared<SGP4::Impl>(aTle, outputFrameSPtr_));
 }
 
 SGP4::SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr)
@@ -96,9 +97,9 @@ SGP4::SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr)
       tleArray_({aTle}),
       validityIntervals_(),
       outputFrameSPtr_(anOutputFrameSPtr),
-      implUPtr_(std::make_unique<SGP4::Impl>(aTle, outputFrameSPtr_)),
-      cachedTleIndex_(0)
+      implArray_()
 {
+    implArray_.add(std::make_shared<SGP4::Impl>(aTle, outputFrameSPtr_));
 }
 
 SGP4::SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr)
@@ -106,8 +107,7 @@ SGP4::SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrame
       tleArray_(aTleArray),
       validityIntervals_(),
       outputFrameSPtr_(anOutputFrameSPtr),
-      implUPtr_(nullptr),
-      cachedTleIndex_(0)
+      implArray_()
 {
     if (tleArray_.isEmpty())
     {
@@ -125,7 +125,11 @@ SGP4::SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrame
 
     validityIntervals_ = SGP4::GenerateIntervalsFromEpochs(tleArray_);
 
-    implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
+    implArray_.reserve(tleArray_.getSize());
+    for (const auto& tle : tleArray_)
+    {
+        implArray_.add(std::make_shared<SGP4::Impl>(tle, outputFrameSPtr_));
+    }
 }
 
 SGP4::SGP4(const Array<Pair<TLE, Interval>>& aTleIntervalArray, const Shared<const Frame>& anOutputFrameSPtr)
@@ -133,8 +137,7 @@ SGP4::SGP4(const Array<Pair<TLE, Interval>>& aTleIntervalArray, const Shared<con
       tleArray_(),
       validityIntervals_(),
       outputFrameSPtr_(anOutputFrameSPtr),
-      implUPtr_(nullptr),
-      cachedTleIndex_(0)
+      implArray_()
 {
     if (aTleIntervalArray.isEmpty())
     {
@@ -158,7 +161,11 @@ SGP4::SGP4(const Array<Pair<TLE, Interval>>& aTleIntervalArray, const Shared<con
         validityIntervals_.add(pair.second);
     }
 
-    implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
+    implArray_.reserve(tleArray_.getSize());
+    for (const auto& tle : tleArray_)
+    {
+        implArray_.add(std::make_shared<SGP4::Impl>(tle, outputFrameSPtr_));
+    }
 }
 
 SGP4::SGP4(const SGP4& aSGP4Model)
@@ -166,10 +173,8 @@ SGP4::SGP4(const SGP4& aSGP4Model)
       tleArray_(aSGP4Model.tleArray_),
       validityIntervals_(aSGP4Model.validityIntervals_),
       outputFrameSPtr_(aSGP4Model.outputFrameSPtr_),
-      implUPtr_(nullptr),
-      cachedTleIndex_(0)
+      implArray_(aSGP4Model.implArray_)
 {
-    implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
 }
 
 SGP4::~SGP4() {}
@@ -183,16 +188,7 @@ SGP4& SGP4::operator=(const SGP4& aSGP4Model)
         this->tleArray_ = aSGP4Model.tleArray_;
         this->validityIntervals_ = aSGP4Model.validityIntervals_;
         this->outputFrameSPtr_ = aSGP4Model.outputFrameSPtr_;
-        this->cachedTleIndex_ = 0;
-
-        if (!tleArray_.isEmpty())
-        {
-            this->implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
-        }
-        else
-        {
-            this->implUPtr_ = nullptr;
-        }
+        this->implArray_ = aSGP4Model.implArray_;
     }
 
     return *this;
@@ -228,7 +224,7 @@ std::ostream& operator<<(std::ostream& anOutputStream, const SGP4& aSGP4Model)
 
 bool SGP4::isDefined() const
 {
-    return (!this->tleArray_.isEmpty()) && (this->implUPtr_ != nullptr);
+    return (!this->tleArray_.isEmpty()) && (this->implArray_.getSize() == this->tleArray_.getSize());
 }
 
 TLE SGP4::getTle() const
@@ -319,13 +315,9 @@ State SGP4::calculateStateAt(const Instant& anInstant) const
         throw ostk::core::error::runtime::Undefined("SGP4");
     }
 
-    if (tleArray_.getSize() > 1)
-    {
-        const Size tleIndex = this->findTleIndexForInstant(anInstant);
-        this->ensureImplForTleIndex(tleIndex);
-    }
+    const Size tleIndex = (tleArray_.getSize() > 1) ? this->findTleIndexForInstant(anInstant) : 0;
 
-    return this->implUPtr_->calculateStateAt(anInstant);
+    return this->implArray_[tleIndex]->calculateStateAt(anInstant);
 }
 
 Array<State> SGP4::calculateStatesAt(const Array<Instant>& anInstantArray) const
@@ -447,15 +439,6 @@ Array<Interval> SGP4::GenerateIntervalsFromEpochs(const Array<TLE>& aTleArray)
     }
 
     return intervals;
-}
-
-void SGP4::ensureImplForTleIndex(const Size& aTleIndex) const
-{
-    if (aTleIndex != cachedTleIndex_ || implUPtr_ == nullptr)
-    {
-        cachedTleIndex_ = aTleIndex;
-        implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[aTleIndex], outputFrameSPtr_);
-    }
 }
 
 bool SGP4::operator==(const trajectory::Model& aModel) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
@@ -80,53 +80,24 @@ State SGP4::Impl::calculateStateAt(const Instant& anInstant) const
 
 SGP4::SGP4(const TLE& aTle)
     : Model(),
-      tle_(aTle),
-      tleArray_(Array<TLE>::Empty()),
+      tleArray_({aTle}),
       outputFrameSPtr_(Frame::GCRF()),
-      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_)),
+      implUPtr_(std::make_unique<SGP4::Impl>(aTle, outputFrameSPtr_)),
       cachedTleIndex_(0)
 {
 }
 
 SGP4::SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr)
     : Model(),
-      tle_(aTle),
-      tleArray_(Array<TLE>::Empty()),
+      tleArray_({aTle}),
       outputFrameSPtr_(anOutputFrameSPtr),
-      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_)),
+      implUPtr_(std::make_unique<SGP4::Impl>(aTle, outputFrameSPtr_)),
       cachedTleIndex_(0)
 {
-}
-
-SGP4::SGP4(const Array<TLE>& aTleArray)
-    : Model(),
-      tle_(TLE::Undefined()),
-      tleArray_(aTleArray),
-      outputFrameSPtr_(Frame::GCRF()),
-      implUPtr_(nullptr),
-      cachedTleIndex_(0)
-{
-    if (tleArray_.isEmpty())
-    {
-        throw ostk::core::error::RuntimeError("TLE array is empty.");
-    }
-
-    std::sort(
-        tleArray_.begin(),
-        tleArray_.end(),
-        [](const TLE& a, const TLE& b)
-        {
-            return a.getEpoch() < b.getEpoch();
-        }
-    );
-
-    tle_ = tleArray_.accessFirst();
-    implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
 }
 
 SGP4::SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr)
     : Model(),
-      tle_(TLE::Undefined()),
       tleArray_(aTleArray),
       outputFrameSPtr_(anOutputFrameSPtr),
       implUPtr_(nullptr),
@@ -146,26 +117,17 @@ SGP4::SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrame
         }
     );
 
-    tle_ = tleArray_.accessFirst();
     implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
 }
 
 SGP4::SGP4(const SGP4& aSGP4Model)
     : Model(aSGP4Model),
-      tle_(aSGP4Model.tle_),
       tleArray_(aSGP4Model.tleArray_),
       outputFrameSPtr_(aSGP4Model.outputFrameSPtr_),
       implUPtr_(nullptr),
       cachedTleIndex_(0)
 {
-    if (!tleArray_.isEmpty())
-    {
-        implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
-    }
-    else if (tle_.isDefined())
-    {
-        implUPtr_ = std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_);
-    }
+    implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
 }
 
 SGP4::~SGP4() {}
@@ -176,7 +138,6 @@ SGP4& SGP4::operator=(const SGP4& aSGP4Model)
     {
         Model::operator=(aSGP4Model);
 
-        this->tle_ = aSGP4Model.tle_;
         this->tleArray_ = aSGP4Model.tleArray_;
         this->outputFrameSPtr_ = aSGP4Model.outputFrameSPtr_;
         this->cachedTleIndex_ = 0;
@@ -184,10 +145,6 @@ SGP4& SGP4::operator=(const SGP4& aSGP4Model)
         if (!tleArray_.isEmpty())
         {
             this->implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
-        }
-        else if (tle_.isDefined())
-        {
-            this->implUPtr_ = std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_);
         }
         else
         {
@@ -210,8 +167,7 @@ bool SGP4::operator==(const SGP4& aSGP4Model) const
         return false;
     }
 
-    return (this->tle_ == aSGP4Model.tle_) && (this->tleArray_ == aSGP4Model.tleArray_) &&
-           (this->outputFrameSPtr_ == aSGP4Model.outputFrameSPtr_);
+    return (this->tleArray_ == aSGP4Model.tleArray_) && (this->outputFrameSPtr_ == aSGP4Model.outputFrameSPtr_);
 }
 
 bool SGP4::operator!=(const SGP4& aSGP4Model) const
@@ -228,7 +184,7 @@ std::ostream& operator<<(std::ostream& anOutputStream, const SGP4& aSGP4Model)
 
 bool SGP4::isDefined() const
 {
-    return (this->tle_.isDefined() || !this->tleArray_.isEmpty()) && (this->implUPtr_ != nullptr);
+    return (!this->tleArray_.isEmpty()) && (this->implUPtr_ != nullptr);
 }
 
 TLE SGP4::getTle() const
@@ -238,7 +194,12 @@ TLE SGP4::getTle() const
         throw ostk::core::error::runtime::Undefined("SGP4");
     }
 
-    return this->tle_;
+    if (this->tleArray_.getSize() > 1)
+    {
+        throw ostk::core::error::RuntimeError("Multiple TLEs exist in the model. Use getTles() instead.");
+    }
+
+    return this->tleArray_.accessFirst();
 }
 
 Array<TLE> SGP4::getTles() const
@@ -268,7 +229,12 @@ Instant SGP4::getEpoch() const
         throw ostk::core::error::runtime::Undefined("SGP4");
     }
 
-    return this->tle_.getEpoch();
+    if (this->tleArray_.getSize() > 1)
+    {
+        throw ostk::core::error::RuntimeError("Multiple TLEs exist in the model. Cannot get epoch.");
+    }
+
+    return this->tleArray_.accessFirst().getEpoch();
 }
 
 Integer SGP4::getRevolutionNumberAtEpoch() const
@@ -278,7 +244,13 @@ Integer SGP4::getRevolutionNumberAtEpoch() const
         throw ostk::core::error::runtime::Undefined("SGP4");
     }
 
-    return this->tle_.getRevolutionNumberAtEpoch();
+    if (this->tleArray_.getSize() > 1)
+    {
+        throw ostk::core::error::RuntimeError("Multiple TLEs exist in the model. Cannot get revolution number at epoch."
+        );
+    }
+
+    return this->tleArray_.accessFirst().getRevolutionNumberAtEpoch();
 }
 
 State SGP4::calculateStateAt(const Instant& anInstant) const
@@ -324,8 +296,15 @@ void SGP4::print(std::ostream& anOutputStream, bool displayDecorator) const
 {
     displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "SGP4") : void();
 
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Epoch:" << (this->isDefined() ? this->getEpoch().toString() : "Undefined");
+    if (this->isDefined() && tleArray_.getSize() == 1)
+    {
+        ostk::core::utils::Print::Line(anOutputStream) << "Epoch:" << this->getEpoch().toString();
+    }
+    else
+    {
+        ostk::core::utils::Print::Line(anOutputStream) << "Epoch:"
+                                                       << "Undefined";
+    }
 
     if (!tleArray_.isEmpty())
     {
@@ -334,7 +313,10 @@ void SGP4::print(std::ostream& anOutputStream, bool displayDecorator) const
 
     ostk::core::utils::Print::Separator(anOutputStream, "Two-Line Elements");
 
-    // tle_.print(anOutputStream, false);
+    for (const auto& tle : tleArray_)
+    {
+        tle.print(anOutputStream, false);
+    }
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
@@ -31,6 +31,8 @@ using ostk::core::container::Pair;
 using ostk::physics::coordinate::Transform;
 using ostk::physics::time::Interval;
 
+const Duration SGP4::epochBuffer_ = Duration::Days(36525.0);  // 100 years
+
 class SGP4::Impl
 {
    public:
@@ -145,20 +147,24 @@ SGP4::SGP4(const Array<Pair<TLE, Interval>>& aTleIntervalArray, const Shared<con
     }
 
     // Build parallel arrays and sort by TLE epoch
-    Array<Pair<TLE, Interval>> sortedPairs = aTleIntervalArray;
+    Array<Pair<TLE, Interval>> sortedTleIntervals = aTleIntervalArray;
     std::sort(
-        sortedPairs.begin(),
-        sortedPairs.end(),
+        sortedTleIntervals.begin(),
+        sortedTleIntervals.end(),
         [](const Pair<TLE, Interval>& a, const Pair<TLE, Interval>& b)
         {
             return a.first.getEpoch() < b.first.getEpoch();
         }
     );
 
-    for (const auto& pair : sortedPairs)
+    for (const auto& tleWithInterval : sortedTleIntervals)
     {
-        tleArray_.add(pair.first);
-        validityIntervals_.add(pair.second);
+        if (!tleWithInterval.second.contains(tleWithInterval.first.getEpoch()))
+        {
+            throw ostk::core::error::RuntimeError("TLE interval does not contain the TLE epoch.");
+        }
+        tleArray_.add(tleWithInterval.first);
+        validityIntervals_.add(tleWithInterval.second);
     }
 
     implArray_.reserve(tleArray_.getSize());
@@ -224,7 +230,7 @@ std::ostream& operator<<(std::ostream& anOutputStream, const SGP4& aSGP4Model)
 
 bool SGP4::isDefined() const
 {
-    return (!this->tleArray_.isEmpty()) && (this->implArray_.getSize() == this->tleArray_.getSize());
+    return !this->tleArray_.isEmpty();
 }
 
 TLE SGP4::getTle() const
@@ -315,9 +321,12 @@ State SGP4::calculateStateAt(const Instant& anInstant) const
         throw ostk::core::error::runtime::Undefined("SGP4");
     }
 
-    const Size tleIndex = (tleArray_.getSize() > 1) ? this->findTleIndexForInstant(anInstant) : 0;
+    if (tleArray_.getSize() > 1 && !validityIntervals_[this->tleIndex_].contains(anInstant))
+    {
+        this->tleIndex_ = this->findTleIndexForInstant(anInstant);
+    }
 
-    return this->implArray_[tleIndex]->calculateStateAt(anInstant);
+    return this->implArray_[tleIndex_]->calculateStateAt(anInstant);
 }
 
 Array<State> SGP4::calculateStatesAt(const Array<Instant>& anInstantArray) const
@@ -326,6 +335,8 @@ Array<State> SGP4::calculateStatesAt(const Array<Instant>& anInstantArray) const
     {
         throw ostk::core::error::runtime::Undefined("SGP4");
     }
+
+    // TBI: Performance can be improved by pre-calculating intervals and TLEs in a single pass.
 
     Array<State> stateArray = Array<State>::Empty();
     stateArray.reserve(anInstantArray.getSize());
@@ -392,8 +403,8 @@ Array<Interval> SGP4::GenerateIntervalsFromEpochs(const Array<TLE>& aTleArray)
     if (aTleArray.getSize() == 1)
     {
         // Single TLE: interval spans far past to far future
-        const Instant farPast = aTleArray[0].getEpoch() - Duration::Days(36525.0);
-        const Instant farFuture = aTleArray[0].getEpoch() + Duration::Days(36525.0);
+        const Instant farPast = aTleArray[0].getEpoch() - epochBuffer_;
+        const Instant farFuture = aTleArray[0].getEpoch() + epochBuffer_;
         intervals.add(Interval::Closed(farPast, farFuture));
         return intervals;
     }
@@ -406,7 +417,7 @@ Array<Interval> SGP4::GenerateIntervalsFromEpochs(const Array<TLE>& aTleArray)
         if (i == 0)
         {
             // First TLE: start at far past
-            start = aTleArray[0].getEpoch() - Duration::Days(36525.0);
+            start = aTleArray[0].getEpoch() - epochBuffer_;
         }
         else
         {
@@ -418,7 +429,7 @@ Array<Interval> SGP4::GenerateIntervalsFromEpochs(const Array<TLE>& aTleArray)
         if (i == aTleArray.getSize() - 1)
         {
             // Last TLE: end at far future
-            end = aTleArray[i].getEpoch() + Duration::Days(36525.0);
+            end = aTleArray[i].getEpoch() + epochBuffer_;
         }
         else
         {

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+#include <algorithm>
+#include <cmath>
 #include <iostream>
 
 #include <sgp4/SGP4.h>
@@ -8,6 +10,7 @@
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Transform.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.hpp>
 
@@ -36,8 +39,8 @@ class SGP4::Impl
     State calculateStateAt(const Instant& anInstant) const;
 
    private:
-    const TLE& tle_;
-    const Shared<const Frame>& outputFrameSPtr_;
+    TLE tle_;
+    Shared<const Frame> outputFrameSPtr_;
     libsgp4::SGP4 sgp4_;
 
     Shared<const Frame> temeFrameOfEpochSPtr_;
@@ -78,25 +81,91 @@ State SGP4::Impl::calculateStateAt(const Instant& anInstant) const
 SGP4::SGP4(const TLE& aTle)
     : Model(),
       tle_(aTle),
+      tleArray_(Array<TLE>::Empty()),
       outputFrameSPtr_(Frame::GCRF()),
-      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_))
+      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_)),
+      cachedTleIndex_(0)
 {
 }
 
 SGP4::SGP4(const TLE& aTle, const Shared<const Frame>& anOutputFrameSPtr)
     : Model(),
       tle_(aTle),
+      tleArray_(Array<TLE>::Empty()),
       outputFrameSPtr_(anOutputFrameSPtr),
-      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_))
+      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_)),
+      cachedTleIndex_(0)
 {
+}
+
+SGP4::SGP4(const Array<TLE>& aTleArray)
+    : Model(),
+      tle_(TLE::Undefined()),
+      tleArray_(aTleArray),
+      outputFrameSPtr_(Frame::GCRF()),
+      implUPtr_(nullptr),
+      cachedTleIndex_(0)
+{
+    if (tleArray_.isEmpty())
+    {
+        throw ostk::core::error::RuntimeError("TLE array is empty.");
+    }
+
+    std::sort(
+        tleArray_.begin(),
+        tleArray_.end(),
+        [](const TLE& a, const TLE& b)
+        {
+            return a.getEpoch() < b.getEpoch();
+        }
+    );
+
+    tle_ = tleArray_.accessFirst();
+    implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
+}
+
+SGP4::SGP4(const Array<TLE>& aTleArray, const Shared<const Frame>& anOutputFrameSPtr)
+    : Model(),
+      tle_(TLE::Undefined()),
+      tleArray_(aTleArray),
+      outputFrameSPtr_(anOutputFrameSPtr),
+      implUPtr_(nullptr),
+      cachedTleIndex_(0)
+{
+    if (tleArray_.isEmpty())
+    {
+        throw ostk::core::error::RuntimeError("TLE array is empty.");
+    }
+
+    std::sort(
+        tleArray_.begin(),
+        tleArray_.end(),
+        [](const TLE& a, const TLE& b)
+        {
+            return a.getEpoch() < b.getEpoch();
+        }
+    );
+
+    tle_ = tleArray_.accessFirst();
+    implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
 }
 
 SGP4::SGP4(const SGP4& aSGP4Model)
     : Model(aSGP4Model),
       tle_(aSGP4Model.tle_),
+      tleArray_(aSGP4Model.tleArray_),
       outputFrameSPtr_(aSGP4Model.outputFrameSPtr_),
-      implUPtr_(std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_))
+      implUPtr_(nullptr),
+      cachedTleIndex_(0)
 {
+    if (!tleArray_.isEmpty())
+    {
+        implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
+    }
+    else if (tle_.isDefined())
+    {
+        implUPtr_ = std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_);
+    }
 }
 
 SGP4::~SGP4() {}
@@ -108,9 +177,22 @@ SGP4& SGP4::operator=(const SGP4& aSGP4Model)
         Model::operator=(aSGP4Model);
 
         this->tle_ = aSGP4Model.tle_;
+        this->tleArray_ = aSGP4Model.tleArray_;
         this->outputFrameSPtr_ = aSGP4Model.outputFrameSPtr_;
+        this->cachedTleIndex_ = 0;
 
-        this->implUPtr_ = std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_);
+        if (!tleArray_.isEmpty())
+        {
+            this->implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[cachedTleIndex_], outputFrameSPtr_);
+        }
+        else if (tle_.isDefined())
+        {
+            this->implUPtr_ = std::make_unique<SGP4::Impl>(tle_, outputFrameSPtr_);
+        }
+        else
+        {
+            this->implUPtr_ = nullptr;
+        }
     }
 
     return *this;
@@ -128,7 +210,8 @@ bool SGP4::operator==(const SGP4& aSGP4Model) const
         return false;
     }
 
-    return (this->tle_ == aSGP4Model.tle_) && (this->outputFrameSPtr_ == aSGP4Model.outputFrameSPtr_);
+    return (this->tle_ == aSGP4Model.tle_) && (this->tleArray_ == aSGP4Model.tleArray_) &&
+           (this->outputFrameSPtr_ == aSGP4Model.outputFrameSPtr_);
 }
 
 bool SGP4::operator!=(const SGP4& aSGP4Model) const
@@ -145,7 +228,7 @@ std::ostream& operator<<(std::ostream& anOutputStream, const SGP4& aSGP4Model)
 
 bool SGP4::isDefined() const
 {
-    return this->tle_.isDefined() && (this->implUPtr_ != nullptr);
+    return (this->tle_.isDefined() || !this->tleArray_.isEmpty()) && (this->implUPtr_ != nullptr);
 }
 
 TLE SGP4::getTle() const
@@ -156,6 +239,16 @@ TLE SGP4::getTle() const
     }
 
     return this->tle_;
+}
+
+Array<TLE> SGP4::getTles() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("SGP4");
+    }
+
+    return this->tleArray_;
 }
 
 Shared<const Frame> SGP4::getOutputFrame() const
@@ -200,7 +293,31 @@ State SGP4::calculateStateAt(const Instant& anInstant) const
         throw ostk::core::error::runtime::Undefined("SGP4");
     }
 
+    if (tleArray_.getSize() > 1)
+    {
+        const Size tleIndex = this->findClosestTleIndex(anInstant);
+        this->ensureImplForTleIndex(tleIndex);
+    }
+
     return this->implUPtr_->calculateStateAt(anInstant);
+}
+
+Array<State> SGP4::calculateStatesAt(const Array<Instant>& anInstantArray) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("SGP4");
+    }
+
+    Array<State> stateArray = Array<State>::Empty();
+    stateArray.reserve(anInstantArray.getSize());
+
+    for (const auto& instant : anInstantArray)
+    {
+        stateArray.add(this->calculateStateAt(instant));
+    }
+
+    return stateArray;
 }
 
 void SGP4::print(std::ostream& anOutputStream, bool displayDecorator) const
@@ -208,13 +325,63 @@ void SGP4::print(std::ostream& anOutputStream, bool displayDecorator) const
     displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "SGP4") : void();
 
     ostk::core::utils::Print::Line(anOutputStream)
-        << "Epoch:" << (this->getEpoch().isDefined() ? this->getEpoch().toString() : "Undefined");
+        << "Epoch:" << (this->isDefined() ? this->getEpoch().toString() : "Undefined");
+
+    if (!tleArray_.isEmpty())
+    {
+        ostk::core::utils::Print::Line(anOutputStream) << "TLE count:" << tleArray_.getSize();
+    }
 
     ostk::core::utils::Print::Separator(anOutputStream, "Two-Line Elements");
 
     // tle_.print(anOutputStream, false);
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+}
+
+Size SGP4::findClosestTleIndex(const Instant& anInstant) const
+{
+    using ostk::physics::time::Duration;
+
+    const auto it = std::lower_bound(
+        tleArray_.begin(),
+        tleArray_.end(),
+        anInstant,
+        [](const TLE& tle, const Instant& instant)
+        {
+            return tle.getEpoch() < instant;
+        }
+    );
+
+    if (it == tleArray_.begin())
+    {
+        return 0;
+    }
+
+    if (it == tleArray_.end())
+    {
+        return tleArray_.getSize() - 1;
+    }
+
+    const auto prevIt = std::prev(it);
+    const Duration durationToPrev = Duration::Between(prevIt->getEpoch(), anInstant).getAbsolute();
+    const Duration durationToNext = Duration::Between(anInstant, it->getEpoch()).getAbsolute();
+
+    if (durationToPrev <= durationToNext)
+    {
+        return static_cast<Size>(std::distance(tleArray_.begin(), prevIt));
+    }
+
+    return static_cast<Size>(std::distance(tleArray_.begin(), it));
+}
+
+void SGP4::ensureImplForTleIndex(const Size& aTleIndex) const
+{
+    if (aTleIndex != cachedTleIndex_ || implUPtr_ == nullptr)
+    {
+        cachedTleIndex_ = aTleIndex;
+        implUPtr_ = std::make_unique<SGP4::Impl>(tleArray_[aTleIndex], outputFrameSPtr_);
+    }
 }
 
 bool SGP4::operator==(const trajectory::Model& aModel) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/TLE.cpp
@@ -75,36 +75,7 @@ bool TLE::operator!=(const TLE& aTle) const
 
 std::ostream& operator<<(std::ostream& anOutputStream, const TLE& aTle)
 {
-    ostk::core::utils::Print::Header(anOutputStream, "Two-Line Elements");
-
-    ostk::core::utils::Print::Line(anOutputStream) << "Line 1:" << aTle.getFirstLine();
-    ostk::core::utils::Print::Line(anOutputStream) << "Line 2:" << aTle.getSecondLine();
-
-    ostk::core::utils::Print::Separator(anOutputStream);
-
-    ostk::core::utils::Print::Line(anOutputStream) << "Satellite Name:" << aTle.getSatelliteName();
-    ostk::core::utils::Print::Line(anOutputStream) << "Satellite Number:" << aTle.getSatelliteNumber().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "Classification:" << aTle.getClassification();
-    ostk::core::utils::Print::Line(anOutputStream) << "International Designator:" << aTle.getInternationalDesignator();
-    ostk::core::utils::Print::Line(anOutputStream) << "Epoch:" << aTle.getEpoch().toString();
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Mean Motion First Time Der. / 2:" << aTle.getMeanMotionFirstTimeDerivativeDividedByTwo().toString();
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Mean Motion Second Time Der. / 6:" << aTle.getMeanMotionSecondTimeDerivativeDividedBySix().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "B* Drag Term:" << aTle.getBStarDragTerm().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "Ephemeris Type:" << aTle.getEphemerisType().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "Element Set Number:" << aTle.getElementSetNumber().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "Inclination:" << aTle.getInclination().toString();
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Right Ascension of the Ascending Node :" << aTle.getRaan().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "Eccentricity:" << aTle.getEccentricity().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "Argument of Periapsis:" << aTle.getAop().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "Mean Anomaly:" << aTle.getMeanAnomaly().toString();
-    ostk::core::utils::Print::Line(anOutputStream) << "Mean Motion:" << aTle.getMeanMotion().toString();
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Revolution Number at Epoch:" << aTle.getRevolutionNumberAtEpoch().toString();
-
-    ostk::core::utils::Print::Footer(anOutputStream);
+    aTle.print(anOutputStream);
 
     return anOutputStream;
 }
@@ -325,6 +296,40 @@ Integer TLE::getSecondLineChecksum() const
     }
 
     return Integer::Parse(secondLine_.getSubstring(68, 1));
+}
+
+void TLE::print(std::ostream& anOutputStream, bool displayDecorator) const
+{
+    displayDecorator ? ostk::core::utils::Print::Header(anOutputStream, "Two-Line Elements") : void();
+
+    ostk::core::utils::Print::Line(anOutputStream) << "Line 1:" << this->getFirstLine();
+    ostk::core::utils::Print::Line(anOutputStream) << "Line 2:" << this->getSecondLine();
+
+    ostk::core::utils::Print::Separator(anOutputStream);
+
+    ostk::core::utils::Print::Line(anOutputStream) << "Satellite Name:" << this->getSatelliteName();
+    ostk::core::utils::Print::Line(anOutputStream) << "Satellite Number:" << this->getSatelliteNumber().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "Classification:" << this->getClassification();
+    ostk::core::utils::Print::Line(anOutputStream) << "International Designator:" << this->getInternationalDesignator();
+    ostk::core::utils::Print::Line(anOutputStream) << "Epoch:" << this->getEpoch().toString();
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Mean Motion First Time Der. / 2:" << this->getMeanMotionFirstTimeDerivativeDividedByTwo().toString();
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Mean Motion Second Time Der. / 6:" << this->getMeanMotionSecondTimeDerivativeDividedBySix().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "B* Drag Term:" << this->getBStarDragTerm().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "Ephemeris Type:" << this->getEphemerisType().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "Element Set Number:" << this->getElementSetNumber().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "Inclination:" << this->getInclination().toString();
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Right Ascension of the Ascending Node :" << this->getRaan().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "Eccentricity:" << this->getEccentricity().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "Argument of Periapsis:" << this->getAop().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "Mean Anomaly:" << this->getMeanAnomaly().toString();
+    ostk::core::utils::Print::Line(anOutputStream) << "Mean Motion:" << this->getMeanMotion().toString();
+    ostk::core::utils::Print::Line(anOutputStream)
+        << "Revolution Number at Epoch:" << this->getRevolutionNumberAtEpoch().toString();
+
+    displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 
 void TLE::setSatelliteNumber(const Integer& aSatelliteNumber)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
@@ -32,6 +32,7 @@ using ostk::core::filesystem::File;
 using ostk::core::filesystem::Path;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
+using ostk::core::type::Size;
 
 using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
 using ostk::mathematics::geometry::d3::transformation::rotation::RotationVector;
@@ -79,6 +80,202 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, OutputFrame)
 
         const State state = sgp4.calculateStateAt(tle.getEpoch());
         EXPECT_EQ(*Frame::TEME(), *state.accessFrame());
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLEArray)
+{
+    // Single TLE in array
+    {
+        const TLE tle = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+
+        const Array<TLE> tleArray = {tle};
+
+        const SGP4 sgp4(tleArray);
+        EXPECT_TRUE(sgp4.isDefined());
+        EXPECT_EQ(Frame::GCRF(), sgp4.getOutputFrame());
+        EXPECT_EQ(1u, sgp4.getTles().getSize());
+    }
+
+    // Multiple TLEs in array
+    {
+        const TLE tle1 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle2, tle1};  // Intentionally reversed order
+
+        const SGP4 sgp4(tleArray);
+        EXPECT_TRUE(sgp4.isDefined());
+        EXPECT_EQ(2u, sgp4.getTles().getSize());
+        // Should be sorted by epoch: tle1 first
+        EXPECT_EQ(tle1.getEpoch(), sgp4.getTles()[0].getEpoch());
+        EXPECT_EQ(tle2.getEpoch(), sgp4.getTles()[1].getEpoch());
+    }
+
+    // With output frame
+    {
+        const TLE tle = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+
+        const Array<TLE> tleArray = {tle};
+
+        const SGP4 sgp4(tleArray, Frame::TEME());
+        EXPECT_TRUE(sgp4.isDefined());
+        EXPECT_EQ(Frame::TEME(), sgp4.getOutputFrame());
+    }
+
+    // Empty array throws
+    {
+        const Array<TLE> emptyTleArray = Array<TLE>::Empty();
+        EXPECT_THROW(SGP4 sgp4(emptyTleArray), ostk::core::error::RuntimeError);
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStateAt_MultiTLE)
+{
+    const TLE tle1 = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+    TLE tle2 = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+    tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+    const Array<TLE> tleArray = {tle1, tle2};
+    const SGP4 sgp4Multi(tleArray);
+
+    // State at tle1 epoch should match single-TLE SGP4 with tle1
+    {
+        const SGP4 sgp4Single(tle1);
+        const State stateMulti = sgp4Multi.calculateStateAt(tle1.getEpoch());
+        const State stateSingle = sgp4Single.calculateStateAt(tle1.getEpoch());
+
+        EXPECT_GT(
+            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        );
+        EXPECT_GT(
+            1e-9, (stateMulti.getVelocity().accessCoordinates() - stateSingle.getVelocity().accessCoordinates()).norm()
+        );
+    }
+
+    // State at tle2 epoch should match single-TLE SGP4 with tle2
+    {
+        const SGP4 sgp4Single(tle2);
+        const State stateMulti = sgp4Multi.calculateStateAt(tle2.getEpoch());
+        const State stateSingle = sgp4Single.calculateStateAt(tle2.getEpoch());
+
+        EXPECT_GT(
+            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        );
+        EXPECT_GT(
+            1e-9, (stateMulti.getVelocity().accessCoordinates() - stateSingle.getVelocity().accessCoordinates()).norm()
+        );
+    }
+
+    // State closer to tle1 should use tle1
+    {
+        const Instant instantNearTle1 =
+            tle1.getEpoch() + Duration::Hours(6.0);  // 6 hours after tle1, 18 hours before tle2
+        const SGP4 sgp4Single(tle1);
+        const State stateMulti = sgp4Multi.calculateStateAt(instantNearTle1);
+        const State stateSingle = sgp4Single.calculateStateAt(instantNearTle1);
+
+        EXPECT_GT(
+            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        );
+    }
+
+    // State closer to tle2 should use tle2
+    {
+        const Instant instantNearTle2 =
+            tle2.getEpoch() - Duration::Hours(6.0);  // 18 hours after tle1, 6 hours before tle2
+        const SGP4 sgp4Single(tle2);
+        const State stateMulti = sgp4Multi.calculateStateAt(instantNearTle2);
+        const State stateSingle = sgp4Single.calculateStateAt(instantNearTle2);
+
+        EXPECT_GT(
+            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        );
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStatesAt_MultiTLE)
+{
+    const TLE tle1 = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+    TLE tle2 = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+    tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+    const Array<TLE> tleArray = {tle1, tle2};
+    const SGP4 sgp4(tleArray);
+
+    const Array<Instant> instants = {
+        tle1.getEpoch(),
+        tle1.getEpoch() + Duration::Hours(6.0),
+        tle2.getEpoch() - Duration::Hours(6.0),
+        tle2.getEpoch(),
+    };
+
+    const Array<State> states = sgp4.calculateStatesAt(instants);
+
+    EXPECT_EQ(4u, states.getSize());
+
+    // Verify each state matches individual calculateStateAt
+    for (Size i = 0; i < instants.getSize(); ++i)
+    {
+        const State individualState = sgp4.calculateStateAt(instants[i]);
+        EXPECT_GT(
+            1e-6,
+            (states[i].getPosition().accessCoordinates() - individualState.getPosition().accessCoordinates()).norm()
+        );
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStatesAt_SingleTLE)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    const SGP4 sgp4(tle);
+
+    const Array<Instant> instants = {
+        tle.getEpoch(),
+        tle.getEpoch() + Duration::Hours(1.0),
+        tle.getEpoch() + Duration::Hours(2.0),
+    };
+
+    const Array<State> states = sgp4.calculateStatesAt(instants);
+
+    EXPECT_EQ(3u, states.getSize());
+
+    for (Size i = 0; i < instants.getSize(); ++i)
+    {
+        const State individualState = sgp4.calculateStateAt(instants[i]);
+        EXPECT_GT(
+            1e-6,
+            (states[i].getPosition().accessCoordinates() - individualState.getPosition().accessCoordinates()).norm()
+        );
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
@@ -79,9 +79,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
         const Array<TLE> tleArray = {tle_};
 
         const SGP4 sgp4(tleArray);
-        EXPECT_TRUE(sgp4_.isDefined());
-        EXPECT_EQ(Frame::GCRF(), sgp4_.getOutputFrame());
-        EXPECT_EQ(1u, sgp4_.getTles().getSize());
+        EXPECT_TRUE(sgp4.isDefined());
+        EXPECT_EQ(Frame::TEME(), sgp4.getOutputFrame());
+        EXPECT_EQ(1u, sgp4.getTles().getSize());
     }
 
     // Multiple TLEs in array
@@ -93,11 +93,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
         const Array<TLE> tleArray = {tle2, tle1};  // Intentionally reversed order
 
         const SGP4 sgp4(tleArray);
-        EXPECT_TRUE(sgp4_.isDefined());
-        EXPECT_EQ(2u, sgp4_.getTles().getSize());
+        EXPECT_TRUE(sgp4.isDefined());
+        EXPECT_EQ(2u, sgp4.getTles().getSize());
         // Should be sorted by epoch: tle1 first
-        EXPECT_EQ(tle1.getEpoch(), sgp4_.getTles()[0].getEpoch());
-        EXPECT_EQ(tle2.getEpoch(), sgp4_.getTles()[1].getEpoch());
+        EXPECT_EQ(tle1.getEpoch(), sgp4.getTles()[0].getEpoch());
+        EXPECT_EQ(tle2.getEpoch(), sgp4.getTles()[1].getEpoch());
     }
 
     // With output frame
@@ -105,8 +105,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
         const Array<TLE> tleArray = {tle_};
 
         const SGP4 sgp4(tleArray, Frame::TEME());
-        EXPECT_TRUE(sgp4_.isDefined());
-        EXPECT_EQ(Frame::TEME(), sgp4_.getOutputFrame());
+        EXPECT_TRUE(sgp4.isDefined());
+        EXPECT_EQ(Frame::TEME(), sgp4.getOutputFrame());
     }
 
     // Empty array throws
@@ -124,7 +124,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
         const Array<TLE> tleArray = {tle1, tle2};
         const SGP4 sgp4(tleArray);
 
-        const Array<Interval> intervals = sgp4_.getValidityIntervals();
+        const Array<Interval> intervals = sgp4.getValidityIntervals();
         EXPECT_EQ(2u, intervals.getSize());
 
         // Midpoint should be 12 hours after tle1 epoch
@@ -153,9 +153,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
         };
 
         const SGP4 sgp4(tleIntervalArray);
-        EXPECT_TRUE(sgp4_.isDefined());
-        EXPECT_EQ(2u, sgp4_.getTles().getSize());
-        EXPECT_EQ(2u, sgp4_.getValidityIntervals().getSize());
+        EXPECT_TRUE(sgp4.isDefined());
+        EXPECT_EQ(2u, sgp4.getTles().getSize());
+        EXPECT_EQ(2u, sgp4.getValidityIntervals().getSize());
     }
 
     // Custom intervals: 18 hours boundary instead of midpoint
@@ -178,22 +178,22 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
         // 15 hours after tle1 should still use tle1 (within 18-hour boundary)
         const Instant instantInTle1 = tle1.getEpoch() + Duration::Hours(15.0);
         const SGP4 sgp4Single1(tle1);
-        const State stateMulti = sgp4_.calculateStateAt(instantInTle1);
+        const State stateMulti = sgp4.calculateStateAt(instantInTle1);
         const State stateSingle = sgp4Single1.calculateStateAt(instantInTle1);
 
-        EXPECT_GT(
-            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        EXPECT_LT(
+            (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm(), 1e-6
         );
 
         // 19 hours after tle1 should use tle2 (past 18-hour boundary)
         const Instant instantInTle2 = tle1.getEpoch() + Duration::Hours(19.0);
         const SGP4 sgp4Single2(tle2);
-        const State stateMulti2 = sgp4_.calculateStateAt(instantInTle2);
+        const State stateMulti2 = sgp4.calculateStateAt(instantInTle2);
         const State stateSingle2 = sgp4Single2.calculateStateAt(instantInTle2);
 
-        EXPECT_GT(
-            1e-6,
-            (stateMulti2.getPosition().accessCoordinates() - stateSingle2.getPosition().accessCoordinates()).norm()
+        EXPECT_LT(
+            (stateMulti2.getPosition().accessCoordinates() - stateSingle2.getPosition().accessCoordinates()).norm(),
+            1e-6
         );
     }
 
@@ -221,8 +221,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
         };
 
         const SGP4 sgp4(tleIntervalArray);
-        EXPECT_EQ(tle1.getEpoch(), sgp4_.getTles()[0].getEpoch());
-        EXPECT_EQ(tle2.getEpoch(), sgp4_.getTles()[1].getEpoch());
+        EXPECT_EQ(tle1.getEpoch(), sgp4.getTles()[0].getEpoch());
+        EXPECT_EQ(tle2.getEpoch(), sgp4.getTles()[1].getEpoch());
+    }
+
+    // TLE interval does not contain the TLE epoch
+    {
+        const Interval interval =
+            Interval::Closed(tle_.getEpoch() - Duration::Days(1.0), tle_.getEpoch() - Duration::Days(0.5));
+        const Array<Pair<TLE, Interval>> tleIntervalArray = {{tle_, interval}};
+
+        EXPECT_THROW(SGP4 sgp4(tleIntervalArray), ostk::core::error::RuntimeError);
     }
 }
 
@@ -237,8 +246,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyConstruct
     const State state = sgp4_.calculateStateAt(tle_.getEpoch());
     const State stateCopy = sgp4Copy.calculateStateAt(tle_.getEpoch());
 
-    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm());
-    EXPECT_GT(1e-9, (state.getVelocity().accessCoordinates() - stateCopy.getVelocity().accessCoordinates()).norm());
+    EXPECT_LT((state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm(), 1e-6);
+    EXPECT_LT((state.getVelocity().accessCoordinates() - stateCopy.getVelocity().accessCoordinates()).norm(), 1e-9);
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyAssignmentOperator)
@@ -254,7 +263,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyAssignmen
     const State state = sgp4_.calculateStateAt(tle_.getEpoch());
     const State stateCopy = sgp4Copy.calculateStateAt(tle_.getEpoch());
 
-    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm());
+    EXPECT_LT((state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm(), 1e-6);
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Clone)
@@ -267,7 +276,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Clone)
     const State state = sgp4_.calculateStateAt(tle_.getEpoch());
     const State stateClone = sgp4ClonePtr->calculateStateAt(tle_.getEpoch());
 
-    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateClone.getPosition().accessCoordinates()).norm());
+    EXPECT_LT((state.getPosition().accessCoordinates() - stateClone.getPosition().accessCoordinates()).norm(), 1e-6);
 
     delete sgp4ClonePtr;
 }
@@ -333,7 +342,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetTle)
         const Array<TLE> tleArray = {tle_, tle2};
         const SGP4 sgp4(tleArray);
 
-        EXPECT_THROW(sgp4_.getTle(), ostk::core::error::RuntimeError);
+        EXPECT_THROW(sgp4.getTle(), ostk::core::error::RuntimeError);
     }
 }
 
@@ -352,7 +361,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetEpoch)
         const Array<TLE> tleArray = {tle_, tle2};
         const SGP4 sgp4(tleArray);
 
-        EXPECT_THROW(sgp4_.getEpoch(), ostk::core::error::RuntimeError);
+        EXPECT_THROW(sgp4.getEpoch(), ostk::core::error::RuntimeError);
     }
 }
 
@@ -371,7 +380,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetRevolution
         const Array<TLE> tleArray = {tle_, tle2};
         const SGP4 sgp4(tleArray);
 
-        EXPECT_THROW(sgp4_.getRevolutionNumberAtEpoch(), ostk::core::error::RuntimeError);
+        EXPECT_THROW(sgp4.getRevolutionNumberAtEpoch(), ostk::core::error::RuntimeError);
     }
 }
 
@@ -403,7 +412,7 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Print)
         const SGP4 sgp4(tleArray);
 
         std::ostringstream stream;
-        sgp4_.print(stream, true);
+        sgp4.print(stream, true);
 
         EXPECT_FALSE(stream.str().empty());
     }
@@ -422,9 +431,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, OutputFrame)
     // Constructor with TEME output frame
     {
         const SGP4 sgp4(tle_, Frame::TEME());
-        EXPECT_EQ(Frame::TEME(), sgp4_.getOutputFrame());
+        EXPECT_EQ(Frame::TEME(), sgp4.getOutputFrame());
 
-        const State state = sgp4_.calculateStateAt(tle_.getEpoch());
+        const State state = sgp4.calculateStateAt(tle_.getEpoch());
         EXPECT_EQ(*Frame::TEME(), *state.accessFrame());
     }
 }
@@ -444,11 +453,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStat
         const State stateMulti = sgp4Multi.calculateStateAt(tle1.getEpoch());
         const State stateSingle = sgp4Single.calculateStateAt(tle1.getEpoch());
 
-        EXPECT_GT(
-            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        EXPECT_LT(
+            (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm(), 1e-6
         );
-        EXPECT_GT(
-            1e-9, (stateMulti.getVelocity().accessCoordinates() - stateSingle.getVelocity().accessCoordinates()).norm()
+        EXPECT_LT(
+            (stateMulti.getVelocity().accessCoordinates() - stateSingle.getVelocity().accessCoordinates()).norm(), 1e-9
         );
     }
 
@@ -458,11 +467,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStat
         const State stateMulti = sgp4Multi.calculateStateAt(tle2.getEpoch());
         const State stateSingle = sgp4Single.calculateStateAt(tle2.getEpoch());
 
-        EXPECT_GT(
-            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        EXPECT_LT(
+            (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm(), 1e-6
         );
-        EXPECT_GT(
-            1e-9, (stateMulti.getVelocity().accessCoordinates() - stateSingle.getVelocity().accessCoordinates()).norm()
+        EXPECT_LT(
+            (stateMulti.getVelocity().accessCoordinates() - stateSingle.getVelocity().accessCoordinates()).norm(), 1e-9
         );
     }
 
@@ -474,8 +483,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStat
         const State stateMulti = sgp4Multi.calculateStateAt(instantNearTle1);
         const State stateSingle = sgp4Single.calculateStateAt(instantNearTle1);
 
-        EXPECT_GT(
-            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        EXPECT_LT(
+            (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm(), 1e-6
         );
     }
 
@@ -487,8 +496,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStat
         const State stateMulti = sgp4Multi.calculateStateAt(instantNearTle2);
         const State stateSingle = sgp4Single.calculateStateAt(instantNearTle2);
 
-        EXPECT_GT(
-            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        EXPECT_LT(
+            (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm(), 1e-6
         );
     }
 }
@@ -509,17 +518,17 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStat
         tle2.getEpoch(),
     };
 
-    const Array<State> states = sgp4_.calculateStatesAt(instants);
+    const Array<State> states = sgp4.calculateStatesAt(instants);
 
     EXPECT_EQ(4u, states.getSize());
 
     // Verify each state matches individual calculateStateAt
     for (Size i = 0; i < instants.getSize(); ++i)
     {
-        const State individualState = sgp4_.calculateStateAt(instants[i]);
-        EXPECT_GT(
-            1e-6,
-            (states[i].getPosition().accessCoordinates() - individualState.getPosition().accessCoordinates()).norm()
+        const State individualState = sgp4.calculateStateAt(instants[i]);
+        EXPECT_LT(
+            (states[i].getPosition().accessCoordinates() - individualState.getPosition().accessCoordinates()).norm(),
+            1e-6
         );
     }
 }
@@ -539,9 +548,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStat
     for (Size i = 0; i < instants.getSize(); ++i)
     {
         const State individualState = sgp4_.calculateStateAt(instants[i]);
-        EXPECT_GT(
-            1e-6,
-            (states[i].getPosition().accessCoordinates() - individualState.getPosition().accessCoordinates()).norm()
+        EXPECT_LT(
+            (states[i].getPosition().accessCoordinates() - individualState.getPosition().accessCoordinates()).norm(),
+            1e-6
         );
     }
 }
@@ -555,11 +564,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
 
         // Orbital model setup
 
-        const TLE tle = TLE::Load(
-            File::Path(
-                Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite.tle")
-            )
-        );
+        const TLE tle = TLE::Load(File::Path(
+            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite.tle")
+        ));
 
         const SGP4 sgp4Model = {tle};
 
@@ -570,11 +577,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -616,8 +621,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
             EXPECT_EQ(*Frame::GCRF(), *position_GCRF.accessFrame());
             EXPECT_EQ(*Frame::GCRF(), *velocity_GCRF.accessFrame());
 
-            EXPECT_GT(10.0, (position_GCRF.accessCoordinates() - referencePosition_GCRF).norm());
-            EXPECT_GT(1e-2, (velocity_GCRF.accessCoordinates() - referenceVelocity_GCRF).norm());
+            EXPECT_LT((position_GCRF.accessCoordinates() - referencePosition_GCRF).norm(), 10.0);
+            EXPECT_LT((velocity_GCRF.accessCoordinates() - referenceVelocity_GCRF).norm(), 1e-2);
 
             const Shared<const Frame> teme = Frame::TEME();
 
@@ -667,8 +672,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
             EXPECT_EQ(*Frame::TEME(), *position_TEME.accessFrame());
             EXPECT_EQ(*Frame::TEME(), *velocity_TEME.accessFrame());
 
-            EXPECT_GT(10.0, (position_TEME.accessCoordinates() - referencePosition_TEME).norm());
-            EXPECT_GT(1e-2, (velocity_TEME.accessCoordinates() - referenceVelocity_TEME).norm());
+            EXPECT_LT((position_TEME.accessCoordinates() - referencePosition_TEME).norm(), 10.0);
+            EXPECT_LT((velocity_TEME.accessCoordinates() - referenceVelocity_TEME).norm(), 1e-2);
 
             const Shared<const Frame> itrfFrame = Frame::ITRF();
 
@@ -680,8 +685,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
             EXPECT_EQ(*Frame::ITRF(), *position_ITRF.accessFrame());
             EXPECT_EQ(*Frame::ITRF(), *velocity_ITRF.accessFrame());
 
-            EXPECT_GT(10.0, (position_ITRF.accessCoordinates() - referencePosition_ITRF).norm());
-            EXPECT_GT(1e-2, (velocity_ITRF.accessCoordinates() - referenceVelocity_ITRF).norm());
+            EXPECT_LT((position_ITRF.accessCoordinates() - referencePosition_ITRF).norm(), 10.0);
+            EXPECT_LT((velocity_ITRF.accessCoordinates() - referenceVelocity_ITRF).norm(), 1e-2);
 
             // EXPECT_EQ(referenceRevolutionNumber.floor(), orbit.getRevolutionNumberAt(instant));
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+#include <sstream>
+
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
 #include <OpenSpaceToolkit/Core/Container/Table.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
@@ -57,6 +59,274 @@ using ostk::astrodynamics::trajectory::orbit::model::SGP4;
 using ostk::astrodynamics::trajectory::orbit::model::sgp4::TLE;
 using ostk::astrodynamics::trajectory::State;
 
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyConstructor)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    const SGP4 sgp4(tle);
+    const SGP4 sgp4Copy(sgp4);
+
+    EXPECT_TRUE(sgp4Copy.isDefined());
+    EXPECT_EQ(sgp4, sgp4Copy);
+
+    const State state = sgp4.calculateStateAt(tle.getEpoch());
+    const State stateCopy = sgp4Copy.calculateStateAt(tle.getEpoch());
+
+    EXPECT_GT(
+        1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm()
+    );
+    EXPECT_GT(
+        1e-9, (state.getVelocity().accessCoordinates() - stateCopy.getVelocity().accessCoordinates()).norm()
+    );
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyAssignmentOperator)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    const SGP4 sgp4(tle);
+    SGP4 sgp4Copy(tle, Frame::TEME());
+
+    EXPECT_NE(sgp4, sgp4Copy);
+
+    sgp4Copy = sgp4;
+
+    EXPECT_EQ(sgp4, sgp4Copy);
+
+    const State state = sgp4.calculateStateAt(tle.getEpoch());
+    const State stateCopy = sgp4Copy.calculateStateAt(tle.getEpoch());
+
+    EXPECT_GT(
+        1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm()
+    );
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Clone)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    const SGP4 sgp4(tle);
+    const SGP4* sgp4ClonePtr = sgp4.clone();
+
+    EXPECT_TRUE(sgp4ClonePtr->isDefined());
+    EXPECT_EQ(sgp4, *sgp4ClonePtr);
+
+    const State state = sgp4.calculateStateAt(tle.getEpoch());
+    const State stateClone = sgp4ClonePtr->calculateStateAt(tle.getEpoch());
+
+    EXPECT_GT(
+        1e-6, (state.getPosition().accessCoordinates() - stateClone.getPosition().accessCoordinates()).norm()
+    );
+
+    delete sgp4ClonePtr;
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, EqualityOperator)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    // Same TLE, same frame
+    {
+        const SGP4 sgp4A(tle);
+        const SGP4 sgp4B(tle);
+
+        EXPECT_TRUE(sgp4A == sgp4B);
+        EXPECT_FALSE(sgp4A != sgp4B);
+    }
+
+    // Same TLE, different frame
+    {
+        const SGP4 sgp4A(tle);
+        const SGP4 sgp4B(tle, Frame::TEME());
+
+        EXPECT_FALSE(sgp4A == sgp4B);
+        EXPECT_TRUE(sgp4A != sgp4B);
+    }
+
+    // Different TLE
+    {
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const SGP4 sgp4A(tle);
+        const SGP4 sgp4B(tle2);
+
+        EXPECT_FALSE(sgp4A == sgp4B);
+        EXPECT_TRUE(sgp4A != sgp4B);
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, StreamOperator)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    const SGP4 sgp4(tle);
+
+    std::ostringstream stream;
+    stream << sgp4;
+
+    EXPECT_FALSE(stream.str().empty());
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, IsDefined)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    const SGP4 sgp4(tle);
+    EXPECT_TRUE(sgp4.isDefined());
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetTle)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    // Single TLE
+    {
+        const SGP4 sgp4(tle);
+        EXPECT_EQ(tle, sgp4.getTle());
+    }
+
+    // Multiple TLEs should throw
+    {
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle, tle2};
+        const SGP4 sgp4(tleArray);
+
+        EXPECT_THROW(sgp4.getTle(), ostk::core::error::RuntimeError);
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetEpoch)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    // Single TLE
+    {
+        const SGP4 sgp4(tle);
+        EXPECT_EQ(tle.getEpoch(), sgp4.getEpoch());
+    }
+
+    // Multiple TLEs should throw
+    {
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle, tle2};
+        const SGP4 sgp4(tleArray);
+
+        EXPECT_THROW(sgp4.getEpoch(), ostk::core::error::RuntimeError);
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetRevolutionNumberAtEpoch)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    // Single TLE
+    {
+        const SGP4 sgp4(tle);
+        EXPECT_EQ(tle.getRevolutionNumberAtEpoch(), sgp4.getRevolutionNumberAtEpoch());
+    }
+
+    // Multiple TLEs should throw
+    {
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle, tle2};
+        const SGP4 sgp4(tleArray);
+
+        EXPECT_THROW(sgp4.getRevolutionNumberAtEpoch(), ostk::core::error::RuntimeError);
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Print)
+{
+    const TLE tle = {
+        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+    };
+
+    // Single TLE with decorator
+    {
+        const SGP4 sgp4(tle);
+
+        std::ostringstream stream;
+        sgp4.print(stream, true);
+
+        EXPECT_FALSE(stream.str().empty());
+        EXPECT_NE(std::string::npos, stream.str().find("SGP4"));
+    }
+
+    // Single TLE without decorator
+    {
+        const SGP4 sgp4(tle);
+
+        std::ostringstream stream;
+        sgp4.print(stream, false);
+
+        EXPECT_FALSE(stream.str().empty());
+    }
+
+    // Multiple TLEs
+    {
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle, tle2};
+        const SGP4 sgp4(tleArray);
+
+        std::ostringstream stream;
+        sgp4.print(stream, true);
+
+        EXPECT_FALSE(stream.str().empty());
+    }
+}
+
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, OutputFrame)
 {
     const TLE tle = {
@@ -96,7 +366,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
 
         const SGP4 sgp4(tleArray);
         EXPECT_TRUE(sgp4.isDefined());
-        EXPECT_EQ(Frame::GCRF(), sgp4.getOutputFrame());
+        EXPECT_EQ(Frame::TEME(), sgp4.getOutputFrame());
         EXPECT_EQ(1u, sgp4.getTles().getSize());
     }
 
@@ -156,7 +426,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStateA
     tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
     const Array<TLE> tleArray = {tle1, tle2};
-    const SGP4 sgp4Multi(tleArray);
+    const SGP4 sgp4Multi(tleArray, Frame::GCRF());
 
     // State at tle1 epoch should match single-TLE SGP4 with tle1
     {
@@ -226,7 +496,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStates
     tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
     const Array<TLE> tleArray = {tle1, tle2};
-    const SGP4 sgp4(tleArray);
+    const SGP4 sgp4(tleArray, Frame::GCRF());
 
     const Array<Instant> instants = {
         tle1.getEpoch(),

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
@@ -30,6 +30,7 @@
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
+using ostk::core::container::Pair;
 using ostk::core::container::Table;
 using ostk::core::filesystem::File;
 using ostk::core::filesystem::Path;
@@ -60,343 +61,52 @@ using ostk::astrodynamics::trajectory::orbit::model::SGP4;
 using ostk::astrodynamics::trajectory::orbit::model::sgp4::TLE;
 using ostk::astrodynamics::trajectory::State;
 
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyConstructor)
+class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4 : public ::testing::Test
 {
-    const TLE tle = {
+   protected:
+    const TLE tle_ = {
         "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
         "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
     };
 
-    const SGP4 sgp4(tle);
-    const SGP4 sgp4Copy(sgp4);
+    const SGP4 sgp4_ = SGP4(tle_);
+};
 
-    EXPECT_TRUE(sgp4Copy.isDefined());
-    EXPECT_EQ(sgp4, sgp4Copy);
-
-    const State state = sgp4.calculateStateAt(tle.getEpoch());
-    const State stateCopy = sgp4Copy.calculateStateAt(tle.getEpoch());
-
-    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm());
-    EXPECT_GT(1e-9, (state.getVelocity().accessCoordinates() - stateCopy.getVelocity().accessCoordinates()).norm());
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyAssignmentOperator)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    const SGP4 sgp4(tle);
-    SGP4 sgp4Copy(tle, Frame::TEME());
-
-    EXPECT_NE(sgp4, sgp4Copy);
-
-    sgp4Copy = sgp4;
-
-    EXPECT_EQ(sgp4, sgp4Copy);
-
-    const State state = sgp4.calculateStateAt(tle.getEpoch());
-    const State stateCopy = sgp4Copy.calculateStateAt(tle.getEpoch());
-
-    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm());
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Clone)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    const SGP4 sgp4(tle);
-    const SGP4* sgp4ClonePtr = sgp4.clone();
-
-    EXPECT_TRUE(sgp4ClonePtr->isDefined());
-    EXPECT_EQ(sgp4, *sgp4ClonePtr);
-
-    const State state = sgp4.calculateStateAt(tle.getEpoch());
-    const State stateClone = sgp4ClonePtr->calculateStateAt(tle.getEpoch());
-
-    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateClone.getPosition().accessCoordinates()).norm());
-
-    delete sgp4ClonePtr;
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, EqualityOperator)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    // Same TLE, same frame
-    {
-        const SGP4 sgp4A(tle);
-        const SGP4 sgp4B(tle);
-
-        EXPECT_TRUE(sgp4A == sgp4B);
-        EXPECT_FALSE(sgp4A != sgp4B);
-    }
-
-    // Same TLE, different frame
-    {
-        const SGP4 sgp4A(tle);
-        const SGP4 sgp4B(tle, Frame::TEME());
-
-        EXPECT_FALSE(sgp4A == sgp4B);
-        EXPECT_TRUE(sgp4A != sgp4B);
-    }
-
-    // Different TLE
-    {
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
-
-        const SGP4 sgp4A(tle);
-        const SGP4 sgp4B(tle2);
-
-        EXPECT_FALSE(sgp4A == sgp4B);
-        EXPECT_TRUE(sgp4A != sgp4B);
-    }
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, StreamOperator)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    const SGP4 sgp4(tle);
-
-    std::ostringstream stream;
-    stream << sgp4;
-
-    EXPECT_FALSE(stream.str().empty());
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, IsDefined)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    const SGP4 sgp4(tle);
-    EXPECT_TRUE(sgp4.isDefined());
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetTle)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    // Single TLE
-    {
-        const SGP4 sgp4(tle);
-        EXPECT_EQ(tle, sgp4.getTle());
-    }
-
-    // Multiple TLEs should throw
-    {
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
-
-        const Array<TLE> tleArray = {tle, tle2};
-        const SGP4 sgp4(tleArray);
-
-        EXPECT_THROW(sgp4.getTle(), ostk::core::error::RuntimeError);
-    }
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetEpoch)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    // Single TLE
-    {
-        const SGP4 sgp4(tle);
-        EXPECT_EQ(tle.getEpoch(), sgp4.getEpoch());
-    }
-
-    // Multiple TLEs should throw
-    {
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
-
-        const Array<TLE> tleArray = {tle, tle2};
-        const SGP4 sgp4(tleArray);
-
-        EXPECT_THROW(sgp4.getEpoch(), ostk::core::error::RuntimeError);
-    }
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetRevolutionNumberAtEpoch)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    // Single TLE
-    {
-        const SGP4 sgp4(tle);
-        EXPECT_EQ(tle.getRevolutionNumberAtEpoch(), sgp4.getRevolutionNumberAtEpoch());
-    }
-
-    // Multiple TLEs should throw
-    {
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
-
-        const Array<TLE> tleArray = {tle, tle2};
-        const SGP4 sgp4(tleArray);
-
-        EXPECT_THROW(sgp4.getRevolutionNumberAtEpoch(), ostk::core::error::RuntimeError);
-    }
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Print)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    // Single TLE with decorator
-    {
-        const SGP4 sgp4(tle);
-
-        std::ostringstream stream;
-        sgp4.print(stream, true);
-
-        EXPECT_FALSE(stream.str().empty());
-        EXPECT_NE(std::string::npos, stream.str().find("SGP4"));
-    }
-
-    // Single TLE without decorator
-    {
-        const SGP4 sgp4(tle);
-
-        std::ostringstream stream;
-        sgp4.print(stream, false);
-
-        EXPECT_FALSE(stream.str().empty());
-    }
-
-    // Multiple TLEs
-    {
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
-
-        const Array<TLE> tleArray = {tle, tle2};
-        const SGP4 sgp4(tleArray);
-
-        std::ostringstream stream;
-        sgp4.print(stream, true);
-
-        EXPECT_FALSE(stream.str().empty());
-    }
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, OutputFrame)
-{
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    // Default constructor outputs in GCRF
-    {
-        const SGP4 sgp4(tle);
-        EXPECT_EQ(Frame::GCRF(), sgp4.getOutputFrame());
-
-        const State state = sgp4.calculateStateAt(tle.getEpoch());
-        EXPECT_EQ(*Frame::GCRF(), *state.accessFrame());
-    }
-
-    // Constructor with TEME output frame
-    {
-        const SGP4 sgp4(tle, Frame::TEME());
-        EXPECT_EQ(Frame::TEME(), sgp4.getOutputFrame());
-
-        const State state = sgp4.calculateStateAt(tle.getEpoch());
-        EXPECT_EQ(*Frame::TEME(), *state.accessFrame());
-    }
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLEArray)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor)
 {
     // Single TLE in array
     {
-        const TLE tle = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-
-        const Array<TLE> tleArray = {tle};
+        const Array<TLE> tleArray = {tle_};
 
         const SGP4 sgp4(tleArray);
-        EXPECT_TRUE(sgp4.isDefined());
-        EXPECT_EQ(Frame::TEME(), sgp4.getOutputFrame());
-        EXPECT_EQ(1u, sgp4.getTles().getSize());
+        EXPECT_TRUE(sgp4_.isDefined());
+        EXPECT_EQ(Frame::GCRF(), sgp4_.getOutputFrame());
+        EXPECT_EQ(1u, sgp4_.getTles().getSize());
     }
 
     // Multiple TLEs in array
     {
-        const TLE tle1 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
+        const TLE tle1 = tle_;
+        TLE tle2 = tle_;
         tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
         const Array<TLE> tleArray = {tle2, tle1};  // Intentionally reversed order
 
         const SGP4 sgp4(tleArray);
-        EXPECT_TRUE(sgp4.isDefined());
-        EXPECT_EQ(2u, sgp4.getTles().getSize());
+        EXPECT_TRUE(sgp4_.isDefined());
+        EXPECT_EQ(2u, sgp4_.getTles().getSize());
         // Should be sorted by epoch: tle1 first
-        EXPECT_EQ(tle1.getEpoch(), sgp4.getTles()[0].getEpoch());
-        EXPECT_EQ(tle2.getEpoch(), sgp4.getTles()[1].getEpoch());
+        EXPECT_EQ(tle1.getEpoch(), sgp4_.getTles()[0].getEpoch());
+        EXPECT_EQ(tle2.getEpoch(), sgp4_.getTles()[1].getEpoch());
     }
 
     // With output frame
     {
-        const TLE tle = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-
-        const Array<TLE> tleArray = {tle};
+        const Array<TLE> tleArray = {tle_};
 
         const SGP4 sgp4(tleArray, Frame::TEME());
-        EXPECT_TRUE(sgp4.isDefined());
-        EXPECT_EQ(Frame::TEME(), sgp4.getOutputFrame());
+        EXPECT_TRUE(sgp4_.isDefined());
+        EXPECT_EQ(Frame::TEME(), sgp4_.getOutputFrame());
     }
 
     // Empty array throws
@@ -407,20 +117,14 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
 
     // Validity intervals are auto-generated
     {
-        const TLE tle1 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
+        const TLE tle1 = tle_;
+        TLE tle2 = tle_;
         tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
         const Array<TLE> tleArray = {tle1, tle2};
         const SGP4 sgp4(tleArray);
 
-        const Array<Interval> intervals = sgp4.getValidityIntervals();
+        const Array<Interval> intervals = sgp4_.getValidityIntervals();
         EXPECT_EQ(2u, intervals.getSize());
 
         // Midpoint should be 12 hours after tle1 epoch
@@ -432,22 +136,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
         EXPECT_FALSE(intervals[0].contains(midpoint));
         EXPECT_TRUE(intervals[1].contains(midpoint));
     }
-}
-
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLEIntervalArray)
-{
-    using ostk::core::container::Pair;
 
     // Basic construction with explicit intervals
     {
-        const TLE tle1 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
+        const TLE tle1 = tle_;
+        TLE tle2 = tle_;
         tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
         const Instant boundary = tle1.getEpoch() + Duration::Hours(18.0);
@@ -460,21 +153,15 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
         };
 
         const SGP4 sgp4(tleIntervalArray);
-        EXPECT_TRUE(sgp4.isDefined());
-        EXPECT_EQ(2u, sgp4.getTles().getSize());
-        EXPECT_EQ(2u, sgp4.getValidityIntervals().getSize());
+        EXPECT_TRUE(sgp4_.isDefined());
+        EXPECT_EQ(2u, sgp4_.getTles().getSize());
+        EXPECT_EQ(2u, sgp4_.getValidityIntervals().getSize());
     }
 
     // Custom intervals: 18 hours boundary instead of midpoint
     {
-        const TLE tle1 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
+        const TLE tle1 = tle_;
+        TLE tle2 = tle_;
         tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
         const Instant boundary = tle1.getEpoch() + Duration::Hours(18.0);
@@ -491,7 +178,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
         // 15 hours after tle1 should still use tle1 (within 18-hour boundary)
         const Instant instantInTle1 = tle1.getEpoch() + Duration::Hours(15.0);
         const SGP4 sgp4Single1(tle1);
-        const State stateMulti = sgp4.calculateStateAt(instantInTle1);
+        const State stateMulti = sgp4_.calculateStateAt(instantInTle1);
         const State stateSingle = sgp4Single1.calculateStateAt(instantInTle1);
 
         EXPECT_GT(
@@ -501,7 +188,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
         // 19 hours after tle1 should use tle2 (past 18-hour boundary)
         const Instant instantInTle2 = tle1.getEpoch() + Duration::Hours(19.0);
         const SGP4 sgp4Single2(tle2);
-        const State stateMulti2 = sgp4.calculateStateAt(instantInTle2);
+        const State stateMulti2 = sgp4_.calculateStateAt(instantInTle2);
         const State stateSingle2 = sgp4Single2.calculateStateAt(instantInTle2);
 
         EXPECT_GT(
@@ -518,14 +205,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
 
     // Sorted by epoch regardless of input order
     {
-        const TLE tle1 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
-        TLE tle2 = {
-            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-        };
+        const TLE tle1 = tle_;
+        TLE tle2 = tle_;
         tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
         const Interval interval1 =
@@ -540,21 +221,218 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
         };
 
         const SGP4 sgp4(tleIntervalArray);
-        EXPECT_EQ(tle1.getEpoch(), sgp4.getTles()[0].getEpoch());
-        EXPECT_EQ(tle2.getEpoch(), sgp4.getTles()[1].getEpoch());
+        EXPECT_EQ(tle1.getEpoch(), sgp4_.getTles()[0].getEpoch());
+        EXPECT_EQ(tle2.getEpoch(), sgp4_.getTles()[1].getEpoch());
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStateAt_MultiTLE)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyConstructor)
+
 {
-    const TLE tle1 = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-    TLE tle2 = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
+    const SGP4 sgp4Copy(sgp4_);
+
+    EXPECT_TRUE(sgp4Copy.isDefined());
+    EXPECT_EQ(sgp4_, sgp4Copy);
+
+    const State state = sgp4_.calculateStateAt(tle_.getEpoch());
+    const State stateCopy = sgp4Copy.calculateStateAt(tle_.getEpoch());
+
+    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm());
+    EXPECT_GT(1e-9, (state.getVelocity().accessCoordinates() - stateCopy.getVelocity().accessCoordinates()).norm());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyAssignmentOperator)
+{
+    SGP4 sgp4Copy(tle_, Frame::TEME());
+
+    EXPECT_NE(sgp4_, sgp4Copy);
+
+    sgp4Copy = sgp4_;
+
+    EXPECT_EQ(sgp4_, sgp4Copy);
+
+    const State state = sgp4_.calculateStateAt(tle_.getEpoch());
+    const State stateCopy = sgp4Copy.calculateStateAt(tle_.getEpoch());
+
+    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Clone)
+{
+    const SGP4* sgp4ClonePtr = sgp4_.clone();
+
+    EXPECT_TRUE(sgp4ClonePtr->isDefined());
+    EXPECT_EQ(sgp4_, *sgp4ClonePtr);
+
+    const State state = sgp4_.calculateStateAt(tle_.getEpoch());
+    const State stateClone = sgp4ClonePtr->calculateStateAt(tle_.getEpoch());
+
+    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateClone.getPosition().accessCoordinates()).norm());
+
+    delete sgp4ClonePtr;
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, EqualityOperator)
+{
+    // Same TLE, same frame
+    {
+        const SGP4 sgp4A(tle_);
+        const SGP4 sgp4B(tle_);
+
+        EXPECT_TRUE(sgp4A == sgp4B);
+        EXPECT_FALSE(sgp4A != sgp4B);
+    }
+
+    // Same TLE, different frame
+    {
+        const SGP4 sgp4A(tle_);
+        const SGP4 sgp4B(tle_, Frame::TEME());
+
+        EXPECT_FALSE(sgp4A == sgp4B);
+        EXPECT_TRUE(sgp4A != sgp4B);
+    }
+
+    // Different TLE
+    {
+        TLE tle2 = tle_;
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const SGP4 sgp4A(tle_);
+        const SGP4 sgp4B(tle2);
+
+        EXPECT_FALSE(sgp4A == sgp4B);
+        EXPECT_TRUE(sgp4A != sgp4B);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, StreamOperator)
+{
+    std::ostringstream stream;
+    stream << sgp4_;
+
+    EXPECT_FALSE(stream.str().empty());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, IsDefined)
+{
+    EXPECT_TRUE(sgp4_.isDefined());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetTle)
+{
+    // Single TLE
+    {
+        EXPECT_EQ(tle_, sgp4_.getTle());
+    }
+
+    // Multiple TLEs should throw
+    {
+        TLE tle2 = tle_;
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle_, tle2};
+        const SGP4 sgp4(tleArray);
+
+        EXPECT_THROW(sgp4_.getTle(), ostk::core::error::RuntimeError);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetEpoch)
+{
+    // Single TLE
+    {
+        EXPECT_EQ(tle_.getEpoch(), sgp4_.getEpoch());
+    }
+
+    // Multiple TLEs should throw
+    {
+        TLE tle2 = tle_;
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle_, tle2};
+        const SGP4 sgp4(tleArray);
+
+        EXPECT_THROW(sgp4_.getEpoch(), ostk::core::error::RuntimeError);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, GetRevolutionNumberAtEpoch)
+{
+    // Single TLE
+    {
+        EXPECT_EQ(tle_.getRevolutionNumberAtEpoch(), sgp4_.getRevolutionNumberAtEpoch());
+    }
+
+    // Multiple TLEs should throw
+    {
+        TLE tle2 = tle_;
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle_, tle2};
+        const SGP4 sgp4(tleArray);
+
+        EXPECT_THROW(sgp4_.getRevolutionNumberAtEpoch(), ostk::core::error::RuntimeError);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Print)
+{
+    // Single TLE with decorator
+    {
+        std::ostringstream stream;
+        sgp4_.print(stream, true);
+
+        EXPECT_FALSE(stream.str().empty());
+        EXPECT_NE(std::string::npos, stream.str().find("SGP4"));
+    }
+
+    // Single TLE without decorator
+    {
+        std::ostringstream stream;
+        sgp4_.print(stream, false);
+
+        EXPECT_FALSE(stream.str().empty());
+    }
+
+    // Multiple TLEs
+    {
+        TLE tle2 = tle_;
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle_, tle2};
+        const SGP4 sgp4(tleArray);
+
+        std::ostringstream stream;
+        sgp4_.print(stream, true);
+
+        EXPECT_FALSE(stream.str().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, OutputFrame)
+{
+    // Default constructor outputs in GCRF
+    {
+        EXPECT_EQ(Frame::GCRF(), sgp4_.getOutputFrame());
+
+        const State state = sgp4_.calculateStateAt(tle_.getEpoch());
+        EXPECT_EQ(*Frame::GCRF(), *state.accessFrame());
+    }
+
+    // Constructor with TEME output frame
+    {
+        const SGP4 sgp4(tle_, Frame::TEME());
+        EXPECT_EQ(Frame::TEME(), sgp4_.getOutputFrame());
+
+        const State state = sgp4_.calculateStateAt(tle_.getEpoch());
+        EXPECT_EQ(*Frame::TEME(), *state.accessFrame());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStateAt_MultiTLE)
+{
+    const TLE tle1 = tle_;
+    TLE tle2 = tle_;
     tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
     const Array<TLE> tleArray = {tle1, tle2};
@@ -615,16 +493,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStateA
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStatesAt_MultiTLE)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStatesAt_MultiTLE)
 {
-    const TLE tle1 = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-    TLE tle2 = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
+    const TLE tle1 = tle_;
+    TLE tle2 = tle_;
     tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
 
     const Array<TLE> tleArray = {tle1, tle2};
@@ -637,14 +509,14 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStates
         tle2.getEpoch(),
     };
 
-    const Array<State> states = sgp4.calculateStatesAt(instants);
+    const Array<State> states = sgp4_.calculateStatesAt(instants);
 
     EXPECT_EQ(4u, states.getSize());
 
     // Verify each state matches individual calculateStateAt
     for (Size i = 0; i < instants.getSize(); ++i)
     {
-        const State individualState = sgp4.calculateStateAt(instants[i]);
+        const State individualState = sgp4_.calculateStateAt(instants[i]);
         EXPECT_GT(
             1e-6,
             (states[i].getPosition().accessCoordinates() - individualState.getPosition().accessCoordinates()).norm()
@@ -652,28 +524,21 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStates
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStatesAt_SingleTLE)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStatesAt_SingleTLE)
 {
-    const TLE tle = {
-        "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
-        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
-    };
-
-    const SGP4 sgp4(tle);
-
     const Array<Instant> instants = {
-        tle.getEpoch(),
-        tle.getEpoch() + Duration::Hours(1.0),
-        tle.getEpoch() + Duration::Hours(2.0),
+        tle_.getEpoch(),
+        tle_.getEpoch() + Duration::Hours(1.0),
+        tle_.getEpoch() + Duration::Hours(2.0),
     };
 
-    const Array<State> states = sgp4.calculateStatesAt(instants);
+    const Array<State> states = sgp4_.calculateStatesAt(instants);
 
     EXPECT_EQ(3u, states.getSize());
 
     for (Size i = 0; i < instants.getSize(); ++i)
     {
-        const State individualState = sgp4.calculateStateAt(instants[i]);
+        const State individualState = sgp4_.calculateStateAt(instants[i]);
         EXPECT_GT(
             1e-6,
             (states[i].getPosition().accessCoordinates() - individualState.getPosition().accessCoordinates()).norm()
@@ -681,7 +546,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CalculateStates
     }
 }
 
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
 {
     {
         // Environment setup
@@ -690,9 +555,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
 
         // Orbital model setup
 
-        const TLE tle = TLE::Load(File::Path(
-            Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite.tle")
-        ));
+        const TLE tle = TLE::Load(
+            File::Path(
+                Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite.tle")
+            )
+        );
 
         const SGP4 sgp4Model = {tle};
 
@@ -703,9 +570,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Test_1)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite Orbit.csv"
-            )),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4/Test_1/Satellite Orbit.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.test.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 #include <OpenSpaceToolkit/Core/Container/Table.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
@@ -75,12 +76,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyConstructor
     const State state = sgp4.calculateStateAt(tle.getEpoch());
     const State stateCopy = sgp4Copy.calculateStateAt(tle.getEpoch());
 
-    EXPECT_GT(
-        1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm()
-    );
-    EXPECT_GT(
-        1e-9, (state.getVelocity().accessCoordinates() - stateCopy.getVelocity().accessCoordinates()).norm()
-    );
+    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm());
+    EXPECT_GT(1e-9, (state.getVelocity().accessCoordinates() - stateCopy.getVelocity().accessCoordinates()).norm());
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyAssignmentOperator)
@@ -102,9 +99,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, CopyAssignmentO
     const State state = sgp4.calculateStateAt(tle.getEpoch());
     const State stateCopy = sgp4Copy.calculateStateAt(tle.getEpoch());
 
-    EXPECT_GT(
-        1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm()
-    );
+    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateCopy.getPosition().accessCoordinates()).norm());
 }
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Clone)
@@ -123,9 +118,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Clone)
     const State state = sgp4.calculateStateAt(tle.getEpoch());
     const State stateClone = sgp4ClonePtr->calculateStateAt(tle.getEpoch());
 
-    EXPECT_GT(
-        1e-6, (state.getPosition().accessCoordinates() - stateClone.getPosition().accessCoordinates()).norm()
-    );
+    EXPECT_GT(1e-6, (state.getPosition().accessCoordinates() - stateClone.getPosition().accessCoordinates()).norm());
 
     delete sgp4ClonePtr;
 }
@@ -410,6 +403,145 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLE
     {
         const Array<TLE> emptyTleArray = Array<TLE>::Empty();
         EXPECT_THROW(SGP4 sgp4(emptyTleArray), ostk::core::error::RuntimeError);
+    }
+
+    // Validity intervals are auto-generated
+    {
+        const TLE tle1 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<TLE> tleArray = {tle1, tle2};
+        const SGP4 sgp4(tleArray);
+
+        const Array<Interval> intervals = sgp4.getValidityIntervals();
+        EXPECT_EQ(2u, intervals.getSize());
+
+        // Midpoint should be 12 hours after tle1 epoch
+        const Instant midpoint = tle1.getEpoch() + Duration::Hours(12.0);
+        EXPECT_TRUE(intervals[0].contains(tle1.getEpoch()));
+        EXPECT_TRUE(intervals[1].contains(tle2.getEpoch()));
+
+        // The boundary is at the midpoint
+        EXPECT_FALSE(intervals[0].contains(midpoint));
+        EXPECT_TRUE(intervals[1].contains(midpoint));
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_SGP4, Constructor_TLEIntervalArray)
+{
+    using ostk::core::container::Pair;
+
+    // Basic construction with explicit intervals
+    {
+        const TLE tle1 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Instant boundary = tle1.getEpoch() + Duration::Hours(18.0);
+        const Interval interval1 = Interval::Closed(tle1.getEpoch() - Duration::Days(1.0), boundary);
+        const Interval interval2 = Interval::Closed(boundary, tle2.getEpoch() + Duration::Days(1.0));
+
+        const Array<Pair<TLE, Interval>> tleIntervalArray = {
+            {tle1, interval1},
+            {tle2, interval2},
+        };
+
+        const SGP4 sgp4(tleIntervalArray);
+        EXPECT_TRUE(sgp4.isDefined());
+        EXPECT_EQ(2u, sgp4.getTles().getSize());
+        EXPECT_EQ(2u, sgp4.getValidityIntervals().getSize());
+    }
+
+    // Custom intervals: 18 hours boundary instead of midpoint
+    {
+        const TLE tle1 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Instant boundary = tle1.getEpoch() + Duration::Hours(18.0);
+        const Interval interval1 = Interval::HalfOpenRight(tle1.getEpoch() - Duration::Days(100.0), boundary);
+        const Interval interval2 = Interval::Closed(boundary, tle2.getEpoch() + Duration::Days(100.0));
+
+        const Array<Pair<TLE, Interval>> tleIntervalArray = {
+            {tle1, interval1},
+            {tle2, interval2},
+        };
+
+        const SGP4 sgp4(tleIntervalArray, Frame::GCRF());
+
+        // 15 hours after tle1 should still use tle1 (within 18-hour boundary)
+        const Instant instantInTle1 = tle1.getEpoch() + Duration::Hours(15.0);
+        const SGP4 sgp4Single1(tle1);
+        const State stateMulti = sgp4.calculateStateAt(instantInTle1);
+        const State stateSingle = sgp4Single1.calculateStateAt(instantInTle1);
+
+        EXPECT_GT(
+            1e-6, (stateMulti.getPosition().accessCoordinates() - stateSingle.getPosition().accessCoordinates()).norm()
+        );
+
+        // 19 hours after tle1 should use tle2 (past 18-hour boundary)
+        const Instant instantInTle2 = tle1.getEpoch() + Duration::Hours(19.0);
+        const SGP4 sgp4Single2(tle2);
+        const State stateMulti2 = sgp4.calculateStateAt(instantInTle2);
+        const State stateSingle2 = sgp4Single2.calculateStateAt(instantInTle2);
+
+        EXPECT_GT(
+            1e-6,
+            (stateMulti2.getPosition().accessCoordinates() - stateSingle2.getPosition().accessCoordinates()).norm()
+        );
+    }
+
+    // Empty array throws
+    {
+        const Array<Pair<TLE, Interval>> emptyArray = Array<Pair<TLE, Interval>>::Empty();
+        EXPECT_THROW(SGP4 sgp4(emptyArray), ostk::core::error::RuntimeError);
+    }
+
+    // Sorted by epoch regardless of input order
+    {
+        const TLE tle1 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        TLE tle2 = {
+            "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927",
+            "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537",
+        };
+        tle2.setEpoch(tle2.getEpoch() + Duration::Days(1.0));
+
+        const Interval interval1 =
+            Interval::Closed(tle1.getEpoch() - Duration::Days(1.0), tle1.getEpoch() + Duration::Days(0.5));
+        const Interval interval2 =
+            Interval::Closed(tle2.getEpoch() - Duration::Days(0.5), tle2.getEpoch() + Duration::Days(1.0));
+
+        // Input in reversed order
+        const Array<Pair<TLE, Interval>> tleIntervalArray = {
+            {tle2, interval2},
+            {tle1, interval1},
+        };
+
+        const SGP4 sgp4(tleIntervalArray);
+        EXPECT_EQ(tle1.getEpoch(), sgp4.getTles()[0].getEpoch());
+        EXPECT_EQ(tle2.getEpoch(), sgp4.getTles()[1].getEpoch());
     }
 }
 


### PR DESCRIPTION
This is useful when we would want to stitch a trajectory together from multiple TLEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-TLE support with automatic or explicit validity intervals, batch state calculation across multiple instants, and new accessors to list stored TLEs and intervals.
  * TLE pretty-printing output exposed.

* **Documentation**
  * Clarified selection behavior and error conditions for multi-TLE models (including closest-epoch selection).

* **Tests**
  * Expanded tests covering multi-TLE construction, interval handling, accessors, printing, and batch/state calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->