### PR TITLE
chore: add warning for viewer

### DIFF
--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -201,7 +201,7 @@ class Viewer:
 
         if cesium_asset_id is None:
             warnings.warn(
-                "Cesium asset ID is required to render a profile. This will be a required argument in the future."
+                "Cesium asset ID is required to render a profile. This will be a required argument in the future.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import operator
 from dataclasses import dataclass
+import warnings
 
 import numpy as np
 
@@ -197,6 +198,9 @@ class Viewer:
         Returns:
             Viewer: The Viewer.
         """
+
+        if cesium_asset_id is None:
+            warnings.warn("Cesium asset ID is required to render a profile. This will be a required argument in the future.")
 
         instants: list[Instant] = self._interval.generate_grid(step)
         states: list[State] = profile.get_states_at(instants)

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -202,6 +202,8 @@ class Viewer:
         if cesium_asset_id is None:
             warnings.warn(
                 "Cesium asset ID is required to render a profile. This will be a required argument in the future."
+                FutureWarning,
+                stacklevel=2,
             )
 
         instants: list[Instant] = self._interval.generate_grid(step)

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -200,7 +200,9 @@ class Viewer:
         """
 
         if cesium_asset_id is None:
-            warnings.warn("Cesium asset ID is required to render a profile. This will be a required argument in the future.")
+            warnings.warn(
+                "Cesium asset ID is required to render a profile. This will be a required argument in the future."
+            )
 
         instants: list[Instant] = self._interval.generate_grid(step)
         states: list[State] = profile.get_states_at(instants)


### PR DESCRIPTION
To keep things backwards compatible for now, I've added a deprecation warning. Can refactor this in a future release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a runtime warning when adding a profile without a Cesium asset identifier; rendering and model display remain unchanged for now, but users are alerted that a valid asset ID will be required in a future update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->