### PR TITLE
build: remove debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,6 @@ dev_username := developer
 TARGETPLATFORM ?= linux/amd64
 $(info Target platform is $(TARGETPLATFORM))
 
-# Debug symbols toggle (on for amd64, off for arm64 builds)
-DEBUG_SYMBOLS_TOGGLE := $(shell if [ "$(TARGETPLATFORM)" = "linux/amd64" ]; then echo "ON"; else echo "OFF"; fi)
-$(info Debug symbols $(DEBUG_SYMBOLS_TOGGLE))
-
 
 pull: ## Pull all images
 
@@ -235,7 +231,7 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 		--volume="/app/build" \
 		--workdir=/app/build \
 		$(docker_development_image_repository):$(docker_image_version) \
-		/bin/bash -c "cmake -DBUILD_UNIT_TESTS=OFF -DBUILD_BENCHMARK=OFF -DBUILD_VALIDATION_TESTS=OFF -DBUILD_PYTHON_BINDINGS=OFF -DCPACK_GENERATOR=DEB -DBUILD_WITH_DEBUG_SYMBOLS=$(DEBUG_SYMBOLS_TOGGLE) .. \
+		/bin/bash -c "cmake -DBUILD_UNIT_TESTS=OFF -DBUILD_BENCHMARK=OFF -DBUILD_VALIDATION_TESTS=OFF -DBUILD_PYTHON_BINDINGS=OFF -DCPACK_GENERATOR=DEB -DBUILD_WITH_DEBUG_SYMBOLS=OFF .. \
 		&& $(MAKE) package \
 		&& mkdir -p /app/packages/cpp \
 		&& mv /app/build/*.deb /app/packages/cpp"
@@ -259,7 +255,7 @@ build-packages-python-standalone: ## Build Python packages (standalone)
 		--volume="/app/build" \
 		--workdir=/app/build \
 		$(docker_development_image_repository):$(docker_image_version) \
-		/bin/bash -c "cmake -DBUILD_UNIT_TESTS=OFF -DBUILD_VALIDATION_TESTS=OFF -DBUILD_BENCHMARK=OFF -DBUILD_PYTHON_BINDINGS=ON -DBUILD_WITH_DEBUG_SYMBOLS=$(DEBUG_SYMBOLS_TOGGLE) .. \
+		/bin/bash -c "cmake -DBUILD_UNIT_TESTS=OFF -DBUILD_VALIDATION_TESTS=OFF -DBUILD_BENCHMARK=OFF -DBUILD_PYTHON_BINDINGS=ON -DBUILD_WITH_DEBUG_SYMBOLS=OFF .. \
 		&& $(MAKE) -j 4 \
 		&& mkdir -p /app/packages/python \
 		&& mv /app/build/bindings/python/dist/*.whl /app/packages/python"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by hardcoding debug symbol settings in packaging builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->