### PR TITLE
fix: access is defined behavior

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -35,7 +35,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
         )
 
             .value(
-                "Undefined", Access::Type::Undefined, "Undefined (Deprecated, Accesses can only be Complete or Partial.)"
+                "Undefined",
+                Access::Type::Undefined,
+                "Undefined (Deprecated, Accesses can only be Complete or Partial.)"
             )
             .value("Complete", Access::Type::Complete, "Complete")
             .value("Partial", Access::Type::Partial, "Partial")

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -20,9 +20,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
             "Access",
             R"doc(
                 Object-to-object visibility
-                
+
                 This class encapsulates the concept of visibility access between two trajectories.
-                
+
             )doc"
         );
 
@@ -34,7 +34,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
             )doc"
         )
 
-            .value("Undefined", Access::Type::Undefined, "Undefined")
+            .value(
+                "Undefined", Access::Type::Undefined, "Undefined (Deprecated) Accesses can only be Complete or Partial."
+            )
             .value("Complete", Access::Type::Complete, "Complete")
             .value("Partial", Access::Type::Partial, "Partial")
 
@@ -46,9 +48,9 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                 init<const Access::Type&, const Instant&, const Instant&, const Instant&, const Angle&>(),
                 R"doc(
                     Constructs an Access object.
-                    
+
                     Args:
-                        type (Access.Type): Type of the access (Complete, Partial, Undefined)
+                        type (Access.Type): Type of the access (Complete, Partial)
                         acquisition_of_signal (Instant): The instant when the signal is first acquired
                         time_of_closest_approach (Instant): The time of closest approach between objects
                         loss_of_signal (Instant): The instant when the signal is lost
@@ -72,7 +74,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                 &Access::isDefined,
                 R"doc(
                     Check if the Access object is defined.
-                    
+
                     Returns:
                        bool: True if defined, False otherwise.
                  )doc"
@@ -83,7 +85,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                 &Access::isComplete,
                 R"doc(
                     Check if the access is complete.
-                    
+
                     Returns:
                         bool: True if complete, False otherwise.
                  )doc"
@@ -171,7 +173,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                 &Access::Undefined,
                 R"doc(
                     Creates an undefined Access object.
-                    
+
                     Returns:
                         Access: An undefined Access object.
                 )doc"
@@ -182,10 +184,10 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
                 &Access::StringFromType,
                 R"doc(
                     Returns a string representation of the Access type.
-    
+
                     Args:
                         type (Access.Type): The type of the access.
-                    
+
                     Returns:
                         str: A string representation of the type.
                 )doc",

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Access.cpp
@@ -35,7 +35,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Access(pybind11::module& aModule)
         )
 
             .value(
-                "Undefined", Access::Type::Undefined, "Undefined (Deprecated) Accesses can only be Complete or Partial."
+                "Undefined", Access::Type::Undefined, "Undefined (Deprecated, Accesses can only be Complete or Partial.)"
             )
             .value("Complete", Access::Type::Complete, "Complete")
             .value("Partial", Access::Type::Partial, "Partial")

--- a/bindings/python/test/test_access.py
+++ b/bindings/python/test/test_access.py
@@ -1,14 +1,10 @@
 # Apache License 2.0
 
-import pytest
-
 import numpy as np
-
-import ostk.mathematics as mathematics
-
-import ostk.physics as physics
-
 import ostk.astrodynamics as astrodynamics
+import ostk.mathematics as mathematics
+import ostk.physics as physics
+import pytest
 
 RealInterval = mathematics.object.RealInterval
 Quaternion = mathematics.geometry.d3.transformation.rotation.Quaternion

--- a/include/OpenSpaceToolkit/Astrodynamics/Access.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Access.hpp
@@ -38,7 +38,7 @@ class Access
     enum class Type
     {
 
-        Undefined,  ///< Undefined type.
+        Undefined,  ///< Undefined type (Deprecated) Accesses can only be Complete or Partial.
         Complete,   ///< The access window is fully contained within the analysis interval.
         Partial     ///< The access window is truncated by the analysis interval boundaries.
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Access.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Access.cpp
@@ -20,20 +20,40 @@ Access::Access(
       lossOfSignal_(aLossOfSignal),
       maxElevation_(aMaxElevation)
 {
+    if (aType == Access::Type::Undefined)
+    {
+        std::cerr
+            << "[Access] Warning: Access Type [Undefined] is deprecated. Accesses can only be Complete or Partial."
+            << std::endl;
+    }
+
     if (this->isDefined())
     {
-        if (timeOfClosestApproach_ < acquisitionOfSignal_)
+        if (type_ == Access::Type::Complete)
         {
-            throw ostk::core::error::RuntimeError(
-                "TCA [{}] < AOS [{}]", timeOfClosestApproach_.toString(), acquisitionOfSignal_.toString()
-            );
+            if (timeOfClosestApproach_ < acquisitionOfSignal_)
+            {
+                throw ostk::core::error::RuntimeError(
+                    "TCA [{}] < AOS [{}]", timeOfClosestApproach_.toString(), acquisitionOfSignal_.toString()
+                );
+            }
+
+            if (lossOfSignal_ < timeOfClosestApproach_)
+            {
+                throw ostk::core::error::RuntimeError(
+                    "LOS [{}] < TCA [{}]", lossOfSignal_.toString(), timeOfClosestApproach_.toString()
+                );
+            }
         }
 
-        if (lossOfSignal_ < timeOfClosestApproach_)
+        else if (type_ == Access::Type::Partial)
         {
-            throw ostk::core::error::RuntimeError(
-                "LOS [{}] < TCA [{}]", lossOfSignal_.toString(), timeOfClosestApproach_.toString()
-            );
+            if (lossOfSignal_ < acquisitionOfSignal_)
+            {
+                throw ostk::core::error::RuntimeError(
+                    "LOS [{}] < AOS [{}]", lossOfSignal_.toString(), acquisitionOfSignal_.toString()
+                );
+            }
         }
     }
 }
@@ -89,8 +109,18 @@ std::ostream& operator<<(std::ostream& anOutputStream, const Access& anAccess)
 
 bool Access::isDefined() const
 {
-    return (type_ != Access::Type::Undefined) && acquisitionOfSignal_.isDefined() &&
-           timeOfClosestApproach_.isDefined() && lossOfSignal_.isDefined() && maxElevation_.isDefined();
+    if (type_ == Access::Type::Complete)
+    {
+        return acquisitionOfSignal_.isDefined() && timeOfClosestApproach_.isDefined() && lossOfSignal_.isDefined() &&
+               maxElevation_.isDefined();
+    }
+
+    if (type_ == Access::Type::Partial)
+    {
+        return acquisitionOfSignal_.isDefined() && lossOfSignal_.isDefined();
+    }
+
+    return false;  // TBM: Throw an error after the deprecation of Undefined type
 }
 
 bool Access::isComplete() const
@@ -176,7 +206,7 @@ Angle Access::getMaxElevation() const
 Access Access::Undefined()
 {
     return Access(
-        Access::Type::Undefined, Instant::Undefined(), Instant::Undefined(), Instant::Undefined(), Angle::Undefined()
+        Access::Type::Partial, Instant::Undefined(), Instant::Undefined(), Instant::Undefined(), Angle::Undefined()
     );
 }
 
@@ -185,6 +215,9 @@ String Access::StringFromType(const Access::Type& aType)
     switch (aType)
     {
         case Access::Type::Undefined:
+            std::cerr
+                << "[Access] Warning: Access Type [Undefined] is deprecated. Accesses can only be Complete or Partial."
+                << std::endl;
             return "Undefined";
 
         case Access::Type::Complete:

--- a/test/OpenSpaceToolkit/Astrodynamics/Access.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Access.test.cpp
@@ -11,6 +11,8 @@
 
 TEST(OpenSpaceToolkit_Astrodynamics_Access, Constructor)
 {
+    using ostk::core::type::String;
+
     using ostk::physics::time::DateTime;
     using ostk::physics::time::Instant;
     using ostk::physics::time::Scale;
@@ -18,6 +20,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, Constructor)
 
     using ostk::astrodynamics::Access;
 
+    // Complete access is valid if the TCA is after the AOS and the LOS is after the TCA
     {
         const Access::Type type = Access::Type::Complete;
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
@@ -28,6 +31,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, Constructor)
         EXPECT_NO_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation););
     }
 
+    // Complete access is not valid if the TCA is before the AOS
     {
         const Access::Type type = Access::Type::Complete;
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC);
@@ -35,9 +39,23 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, Constructor)
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC);
         const Angle maxElevation = Angle::Degrees(54.3);
 
-        EXPECT_ANY_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation););
+        EXPECT_THROW(
+            try {
+                Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation);
+            } catch (const ostk::core::error::RuntimeError& e) {
+                EXPECT_EQ(
+                    String::Format(
+                        "TCA [{}] < AOS [{}]", timeOfClosestApproach.toString(), acquisitionOfSignal.toString()
+                    ),
+                    e.getMessage()
+                );
+                throw;
+            },
+            ostk::core::error::RuntimeError
+        );
     }
 
+    // Complete access is not valid if the LOS is before the TCA
     {
         const Access::Type type = Access::Type::Complete;
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
@@ -45,7 +63,51 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, Constructor)
         const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC);
         const Angle maxElevation = Angle::Degrees(54.3);
 
-        EXPECT_ANY_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation););
+        EXPECT_THROW(
+            try {
+                Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation);
+            } catch (const ostk::core::error::RuntimeError& e) {
+                EXPECT_EQ(
+                    String::Format("LOS [{}] < TCA [{}]", lossOfSignal.toString(), timeOfClosestApproach.toString()),
+                    e.getMessage()
+                );
+                throw;
+            },
+            ostk::core::error::RuntimeError
+        );
+    }
+
+    // Partial access is valid if even if only the acquisition of signal and loss of signal are defined
+    {
+        const Access::Type type = Access::Type::Partial;
+        const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Instant timeOfClosestApproach = Instant::Undefined();
+        const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC);
+        const Angle maxElevation = Angle::Undefined();
+
+        EXPECT_NO_THROW(Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation););
+    }
+
+    // Partial access is not valid if the loss of signal is before the acquisition of signal
+    {
+        const Access::Type type = Access::Type::Partial;
+        const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC);
+        const Instant timeOfClosestApproach = Instant::Undefined();
+        const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Angle maxElevation = Angle::Undefined();
+
+        EXPECT_THROW(
+            try {
+                Access access(type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation);
+            } catch (const ostk::core::error::RuntimeError& e) {
+                EXPECT_EQ(
+                    String::Format("LOS [{}] < AOS [{}]", lossOfSignal.toString(), acquisitionOfSignal.toString()),
+                    e.getMessage()
+                );
+                throw;
+            },
+            ostk::core::error::RuntimeError
+        );
     }
 }
 
@@ -260,6 +322,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, IsDefined)
 
     using ostk::astrodynamics::Access;
 
+    // Complete access is defined if the acquisition of signal, time of closest approach, loss of signal and max
+    // elevation are all defined
     {
         const Access::Type type = Access::Type::Complete;
         const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
@@ -270,6 +334,97 @@ TEST(OpenSpaceToolkit_Astrodynamics_Access, IsDefined)
         const Access access = {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
 
         EXPECT_TRUE(access.isDefined());
+    }
+
+    // Complete access is not defined if the time of closest approach is undefined
+    {
+        const Access::Type type = Access::Type::Complete;
+        const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Instant timeOfClosestApproach = Instant::Undefined();
+        const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC);
+        const Angle maxElevation = Angle::Degrees(54.3);
+
+        const Access access = {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+
+        EXPECT_FALSE(access.isDefined());
+    }
+
+    // Complete access is not defined if the loss of signal is undefined
+    {
+        const Access::Type type = Access::Type::Complete;
+        const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC);
+        const Instant lossOfSignal = Instant::Undefined();
+        const Angle maxElevation = Angle::Degrees(54.3);
+
+        const Access access = {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+
+        EXPECT_FALSE(access.isDefined());
+    }
+
+    // Complete access is not defined if the acquisition of signal is undefined
+    {
+        const Access::Type type = Access::Type::Complete;
+        const Instant acquisitionOfSignal = Instant::Undefined();
+        const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC);
+        const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC);
+        const Angle maxElevation = Angle::Degrees(54.3);
+
+        const Access access = {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+
+        EXPECT_FALSE(access.isDefined());
+    }
+
+    // Complete access is not defined if the max elevation is undefined
+    {
+        const Access::Type type = Access::Type::Complete;
+        const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Instant timeOfClosestApproach = Instant::DateTime(DateTime(2018, 1, 1, 0, 1, 0), Scale::UTC);
+        const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC);
+        const Angle maxElevation = Angle::Undefined();
+
+        const Access access = {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+
+        EXPECT_FALSE(access.isDefined());
+    }
+
+    // Partial access is defined even if only the acquisition of signal and loss of signal are defined
+    {
+        const Access::Type type = Access::Type::Partial;
+        const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Instant timeOfClosestApproach = Instant::Undefined();
+        const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC);
+        const Angle maxElevation = Angle::Undefined();
+
+        const Access access = {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+
+        EXPECT_TRUE(access.isDefined());
+    }
+
+    // Partial access is not defined if the acquisition of signal is undefined
+    {
+        const Access::Type type = Access::Type::Partial;
+        const Instant acquisitionOfSignal = Instant::Undefined();
+        const Instant timeOfClosestApproach = Instant::Undefined();
+        const Instant lossOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 2, 0), Scale::UTC);
+        const Angle maxElevation = Angle::Undefined();
+
+        const Access access = {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+
+        EXPECT_FALSE(access.isDefined());
+    }
+
+    // Partial access is not defined if the loss of signal is undefined
+    {
+        const Access::Type type = Access::Type::Partial;
+        const Instant acquisitionOfSignal = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+        const Instant timeOfClosestApproach = Instant::Undefined();
+        const Instant lossOfSignal = Instant::Undefined();
+        const Angle maxElevation = Angle::Undefined();
+
+        const Access access = {type, acquisitionOfSignal, timeOfClosestApproach, lossOfSignal, maxElevation};
+
+        EXPECT_FALSE(access.isDefined());
     }
 
     {


### PR DESCRIPTION
I realized that the isDefined behavior for accesses didn't really make sense in its current implementation (it didn't correctly reflect the validity of `Partial` accesses, so I fixed it by:
- Deprecating the `Undefined` access type (to be removed in a future version) - we don't need this enum, we can simply improved the logic is the `isDefined` function to understand whether an access is defined or not
- Improved the logic in the `isDefined` function to:
	- mark a `Complete` access as defined when its AOS, LOS, TCA, and maxEl are all defined
	- mark a `Partial` access as defined only when its AOS and LOS are defined, it doesn't need a maxEl or TCA, because our access generation logic can produce these kinds of accesses (those that are clipped by the access analysis timespan)
- Split the check in the access contrustor to:
	- Raise for `Partial` Access' whose LOS is before AOS
	- Only raise for `Complete` Access' whose LOS is before TCA or TCA is before AOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * The "Undefined" access type is deprecated; use Complete or Partial instead.

* **Behavior Changes**
  * Validation is now type-specific: Complete requires all time fields and max elevation; Partial requires only acquisition and loss times.
  * Undefined cases now emit a deprecation warning and are treated as Partial.

* **Documentation**
  * Updated docstrings to reflect deprecation and allowed values.

* **Tests**
  * Expanded tests to assert type-specific validation and clearer error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->