### PR TITLE
fix: revolution number computation

### DIFF
--- a/bindings/python/test/trajectory/orbit/models/test_propagated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_propagated.py
@@ -1,25 +1,16 @@
 # Apache License 2.0
 
-import pytest
-
 import numpy as np
-
-from ostk.physics.time import Instant
-from ostk.physics.time import DateTime
-from ostk.physics.time import Scale
-from ostk.physics.coordinate import Position
-from ostk.physics.coordinate import Velocity
-from ostk.physics.coordinate import Frame
-from ostk.physics.environment.object.celestial import Earth
-
-from ostk.astrodynamics.trajectory.state import NumericalSolver
-from ostk.astrodynamics.trajectory import State
-from ostk.astrodynamics.trajectory import Orbit
-from ostk.astrodynamics.trajectory import Propagator
+import pytest
 from ostk.astrodynamics import Dynamics
-from ostk.astrodynamics.dynamics import CentralBodyGravity
-from ostk.astrodynamics.dynamics import PositionDerivative
+from ostk.astrodynamics.dynamics import CentralBodyGravity, PositionDerivative
+from ostk.astrodynamics.trajectory import Orbit, Propagator, State
 from ostk.astrodynamics.trajectory.orbit.model import Propagated
+from ostk.astrodynamics.trajectory.state import NumericalSolver
+from ostk.core.type import Integer
+from ostk.physics.coordinate import Frame, Position, Velocity
+from ostk.physics.environment.object.celestial import Earth
+from ostk.physics.time import DateTime, Instant, Scale
 
 
 @pytest.fixture
@@ -196,12 +187,16 @@ class TestPropagated:
         self,
         propagated: Propagated,
         orbit: Orbit,
-        revolution_number: int,
     ):
         instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 40, 0), Scale.UTC)
 
-        assert propagated.calculate_revolution_number_at(instant) == revolution_number + 1
-        assert orbit.get_revolution_number_at(instant) == revolution_number + 1
+        revolution_number = propagated.calculate_revolution_number_at(instant)
+        assert revolution_number is not None
+        assert isinstance(revolution_number, Integer)
+
+        revolution_number_orbit = orbit.get_revolution_number_at(instant)
+        assert revolution_number_orbit is not None
+        assert isinstance(revolution_number_orbit, Integer)
 
     def test_access_cached_state_array(
         self,

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.cpp
@@ -128,7 +128,7 @@ Integer Kepler::getRevolutionNumberAtEpoch() const
         throw ostk::core::error::runtime::Undefined("Kepler");
     }
 
-    return 1;  // [TBI] With param
+    return 1;
 }
 
 Derived Kepler::getGravitationalParameter() const
@@ -233,17 +233,20 @@ Integer Kepler::calculateRevolutionNumberAt(const Instant& anInstant) const
     switch (perturbationType_)
     {
         case Kepler::PerturbationType::None:
-            return Kepler::CalculateNoneRevolutionNumberAt(coe_, epoch_, gravitationalParameter_, anInstant);
+            return Kepler::CalculateNoneRevolutionNumberAt(coe_, epoch_, gravitationalParameter_, anInstant) +
+                   this->getRevolutionNumberAtEpoch();
 
         case Kepler::PerturbationType::J2:
             return Kepler::CalculateJ2RevolutionNumberAt(
-                coe_, epoch_, gravitationalParameter_, anInstant, equatorialRadius_, j2_
-            );
+                       coe_, epoch_, gravitationalParameter_, anInstant, equatorialRadius_, j2_
+                   ) +
+                   this->getRevolutionNumberAtEpoch();
 
         case Kepler::PerturbationType::J4:
             return Kepler::CalculateJ4RevolutionNumberAt(
-                coe_, epoch_, gravitationalParameter_, anInstant, equatorialRadius_, j2_, j4_
-            );
+                       coe_, epoch_, gravitationalParameter_, anInstant, equatorialRadius_, j2_, j4_
+                   ) +
+                   this->getRevolutionNumberAtEpoch();
 
         default:
             throw ostk::core::error::runtime::Wrong("Perturbation type", StringFromPerturbationType(perturbationType_));
@@ -421,7 +424,7 @@ Integer Kepler::CalculateNoneRevolutionNumberAt(
 
     const Duration durationFromEpoch = Duration::Between(anEpoch, anInstant);
 
-    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor() + 1;
+    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor();
 }
 
 State Kepler::CalculateJ2StateAt(
@@ -663,7 +666,7 @@ Integer Kepler::CalculateJ2RevolutionNumberAt(
 
     const Duration durationFromEpoch = Duration::Between(anEpoch, anInstant);
 
-    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor() + 1;
+    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor();
 }
 
 State Kepler::CalculateJ4StateAt(
@@ -846,7 +849,7 @@ Integer Kepler::CalculateJ4RevolutionNumberAt(
 
     const Duration durationFromEpoch = Duration::Between(anEpoch, anInstant);
 
-    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor() + 1;
+    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor();
 }
 
 }  // namespace model

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
@@ -11,6 +11,7 @@
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Time.hpp>
 
+#include <OpenSpaceToolkit/Astrodynamics/Dynamics/CentralBodyGravity.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
@@ -37,6 +38,7 @@ using ostk::physics::unit::Derived;
 using ostk::physics::unit::Length;
 using ostk::physics::unit::Time;
 
+using ostk::astrodynamics::dynamics::CentralBodyGravity;
 using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
@@ -280,6 +282,19 @@ Integer Propagated::calculateRevolutionNumberAt(const Instant& anInstant) const
         return this->getRevolutionNumberAtEpoch();
     }
 
+    // Find the central body gravity dynamics to use its gravitational parameter for orbital period computation
+    Derived gravitationalParameter = Derived::Undefined();
+    for (const Shared<Dynamics>& dynamicsSPtr :
+         propagator_.getDynamics())  // Propagator has exactly one Central Body Gravity Dynamics, so
+                                     // graviationalParameter will be defined after the loop
+    {
+        if (const auto centralBodyGravitySPtr = std::dynamic_pointer_cast<CentralBodyGravity>(dynamicsSPtr))
+        {
+            gravitationalParameter = centralBodyGravitySPtr->getCelestial()->getGravitationalParameter();
+            break;
+        }
+    }
+
     // Determine whether to count revolution numbers in forwards or backwards time and return function if duration is 0
     const State stateAtEpoch = this->calculateStateAt(this->getEpoch());
     const Integer durationSign = (anInstant > this->getEpoch()) ? 1 : -1;
@@ -293,10 +308,9 @@ Integer Propagated::calculateRevolutionNumberAt(const Instant& anInstant) const
     while (true)
     {
         // Calculate orbital period at current state
-        const COE coe = COE::Cartesian(
-            {currentState.getPosition(), currentState.getVelocity()}, Earth::Spherical.gravitationalParameter_
-        );  // (Spherical earth has the most modern value which is the correct one)
-        const Duration orbitalPeriod = coe.getOrbitalPeriod(Earth::Spherical.gravitationalParameter_);
+        const COE coe =
+            COE::Cartesian({currentState.getPosition(), currentState.getVelocity()}, gravitationalParameter);
+        const Duration orbitalPeriod = coe.getOrbitalPeriod(gravitationalParameter);
 
         // Propagate for duration of this orbital period
         currentState = propagator_.calculateStateAt(currentState, currentInstant + (durationSign * orbitalPeriod));

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
@@ -11,6 +11,7 @@
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Time.hpp>
 
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
@@ -30,11 +31,13 @@ using ostk::core::type::Size;
 using ostk::mathematics::object::Vector3d;
 using ostk::mathematics::object::VectorXd;
 
+using ostk::physics::environment::gravitational::Earth;
 using ostk::physics::time::Duration;
 using ostk::physics::unit::Derived;
 using ostk::physics::unit::Length;
 using ostk::physics::unit::Time;
 
+using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
 static const Derived::Unit GravitationalParameterSIUnit =
@@ -272,44 +275,32 @@ Integer Propagated::calculateRevolutionNumberAt(const Instant& anInstant) const
         throw ostk::core::error::runtime::Undefined("Propagated");
     }
 
-    if (anInstant == cachedStateArray_[0].accessInstant())
+    if (anInstant == this->getEpoch())
     {
         return this->getRevolutionNumberAtEpoch();
     }
 
-    // Calculate gravitational parameter (Spherical earth has the most modern value which is the correct one)
-    using ostk::physics::environment::gravitational::Earth;
-
-    const Derived gravitationalParameter = Earth::Spherical.gravitationalParameter_;
-    const Real gravitationalParameter_SI = gravitationalParameter.in(GravitationalParameterSIUnit);
-
-    Position currentPosition = cachedStateArray_[0].getPosition();
-    Velocity currentVelocity = cachedStateArray_[0].getVelocity();
-
-    Vector3d currentPositionCoordinates = currentPosition.inUnit(Position::Unit::Meter).accessCoordinates();
-    Vector3d currentVelocityCoordinates = currentVelocity.inUnit(Velocity::Unit::MeterPerSecond).accessCoordinates();
-
     // Determine whether to count revolution numbers in forwards or backwards time and return function if duration is 0
-    Instant currentInstant = cachedStateArray_[0].getInstant();
-    const double durationInSecs = (anInstant - currentInstant).inSeconds();
-    if (durationInSecs == 0.0)
-    {
-        return 1;
-    }
-    Integer durationSign = (durationInSecs > 0) - (durationInSecs < 0);
+    const State stateAtEpoch = this->calculateStateAt(this->getEpoch());
+    const Integer durationSign = (anInstant > this->getEpoch()) ? 1 : -1;
+
+    State currentState = stateAtEpoch;
+    Instant currentInstant = stateAtEpoch.accessInstant();
+    Integer revolutionNumber = this->getRevolutionNumberAtEpoch();
 
     // Propagate towards desired instant a fraction of an orbit at a time in while loop, exit when arrived at desired
     // instant
-    Integer revolutionNumber = this->getRevolutionNumberAtEpoch();
     while (true)
     {
-        // Calculate orbital period
-        const double semiMajorAxis =
-            -gravitationalParameter_SI * currentPositionCoordinates.norm() /
-            (currentPositionCoordinates.norm() * std::pow(currentVelocityCoordinates.norm(), 2) -
-             2.0 * gravitationalParameter_SI);
-        const Duration orbitalPeriod =
-            Duration::Seconds(Real::TwoPi() * std::sqrt(std::pow(semiMajorAxis, 3) / gravitationalParameter_SI));
+        // Calculate orbital period at current state
+        const COE coe = COE::Cartesian(
+            {currentState.getPosition(), currentState.getVelocity()}, Earth::Spherical.gravitationalParameter_
+        );  // (Spherical earth has the most modern value which is the correct one)
+        const Duration orbitalPeriod = coe.getOrbitalPeriod(Earth::Spherical.gravitationalParameter_);
+
+        // Propagate for duration of this orbital period
+        currentState = propagator_.calculateStateAt(currentState, currentInstant + (durationSign * orbitalPeriod));
+        currentInstant = currentState.accessInstant();
 
         // If we have passed the desired instant during our progration, break from the loop
         if (durationSign.isPositive() && currentInstant > anInstant)
@@ -319,16 +310,6 @@ Integer Propagated::calculateRevolutionNumberAt(const Instant& anInstant) const
 
         // Increase or decrease revolution number by 1
         revolutionNumber += durationSign;
-
-        // Propagate for duration of this orbital period
-        const State currentState = propagator_.calculateStateAt(
-            cachedStateArray_[0], cachedStateArray_[0].accessInstant() + (durationSign * orbitalPeriod)
-        );
-
-        // Update the current instant position and velocity coordinates
-        currentPositionCoordinates = currentState.getPosition().getCoordinates();
-        currentVelocityCoordinates = currentState.getVelocity().getCoordinates();
-        currentInstant += durationSign * orbitalPeriod;
     }
 
     return revolutionNumber;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.test.cpp
@@ -2,6 +2,7 @@
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
 #include <OpenSpaceToolkit/Core/Container/Table.hpp>
+#include <OpenSpaceToolkit/Core/Type/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 
@@ -28,6 +29,7 @@ using ostk::core::container::Array;
 using ostk::core::container::Table;
 using ostk::core::filesystem::File;
 using ostk::core::filesystem::Path;
+using ostk::core::type::Integer;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
 
@@ -800,5 +802,101 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, Test_6)
             // referenceVelocity_GCRF).norm()).toString(12) << " - " << Real((velocity_ITRF.accessCoordinates() -
             // referenceVelocity_ITRF).norm()).toString(12) << std::endl;
         }
+    }
+}
+
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, CalculateRevolutionNumberAt)
+{
+    const Shared<const Frame> gcrfSPtr = Frame::GCRF();
+
+    const Environment environment = Environment::Default();
+
+    const Instant defaultEpoch = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC);
+
+    // Kepler's revolution number at epoch is hardcoded to 1
+    const Integer defaultRevolutionNumber = 1;
+
+    const Derived gravitationalParameter = Earth::Spherical.gravitationalParameter_;
+    const Length equatorialRadius = Earth::Spherical.equatorialRadius_;
+    const Real J2 = Earth::Spherical.J2_;
+    const Real J4 = Earth::Spherical.J4_;
+
+    // Test simple positive and negative revolution numbers for non-edge case initial state (far away from the ascending
+    // node)
+    {
+        const Position initialPosition = Position::Meters({0.0, 0.0, 7000000.0}, gcrfSPtr);
+        const Velocity initialVelocity =
+            Velocity::MetersPerSecond({5335.865450622126, 5335.865450622126, 0.0}, gcrfSPtr);
+
+        const COE coe = COE::Cartesian({initialPosition, initialVelocity}, gravitationalParameter);
+        const Duration orbitalPeriod = coe.getOrbitalPeriod(gravitationalParameter);
+
+        // Setup Kepler model and orbit
+        const Kepler keplerianModel = {
+            coe, defaultEpoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
+
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        // Check revolution numbers for Kepler model
+        EXPECT_EQ(defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch));
+        EXPECT_EQ(
+            defaultRevolutionNumber + 1, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber - 1, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber + 2, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 2 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber - 2, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 2 * orbitalPeriod)
+        );
+
+        // Check revolution numbers for orbit
+        EXPECT_EQ(defaultRevolutionNumber, orbit.getRevolutionNumberAt(defaultEpoch));
+        EXPECT_EQ(defaultRevolutionNumber - 1, orbit.getRevolutionNumberAt(defaultEpoch - orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber + 1, orbit.getRevolutionNumberAt(defaultEpoch + orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber + 2, orbit.getRevolutionNumberAt(defaultEpoch + 2 * orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber - 2, orbit.getRevolutionNumberAt(defaultEpoch - 2 * orbitalPeriod));
+    }
+
+    // Test simple positive and negative revolution numbers for edge case initial state (at the ascending node)
+    {
+        const Position initialPosition = Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr);
+        const Velocity initialVelocity =
+            Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr);
+
+        const COE coe = COE::Cartesian({initialPosition, initialVelocity}, gravitationalParameter);
+        const Duration orbitalPeriod = coe.getOrbitalPeriod(gravitationalParameter);
+
+        // Setup Kepler model and orbit
+        const Kepler keplerianModel = {
+            coe, defaultEpoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
+
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        // Check revolution numbers for Kepler model
+        EXPECT_EQ(defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch));
+        EXPECT_EQ(
+            defaultRevolutionNumber + 1, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber - 1, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber + 2, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 2 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber - 2, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 2 * orbitalPeriod)
+        );
+
+        // Check revolution numbers for orbit
+        EXPECT_EQ(defaultRevolutionNumber, orbit.getRevolutionNumberAt(defaultEpoch));
+        EXPECT_EQ(defaultRevolutionNumber - 1, orbit.getRevolutionNumberAt(defaultEpoch - orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber + 1, orbit.getRevolutionNumberAt(defaultEpoch + orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber + 2, orbit.getRevolutionNumberAt(defaultEpoch + 2 * orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber - 2, orbit.getRevolutionNumberAt(defaultEpoch - 2 * orbitalPeriod));
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
@@ -25,6 +25,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/PositionDerivative.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp>
@@ -64,6 +65,7 @@ using ostk::astrodynamics::dynamics::CentralBodyGravity;
 using ostk::astrodynamics::dynamics::PositionDerivative;
 using ostk::astrodynamics::flight::system::SatelliteSystem;
 using ostk::astrodynamics::trajectory::Orbit;
+using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::orbit::model::Propagated;
 using ostk::astrodynamics::trajectory::Propagator;
 using ostk::astrodynamics::trajectory::State;
@@ -472,34 +474,101 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
         );
     }
 
-    // Test basic positive and negative revolution numbers
+    // Test simple positive and negative revolution numbers for non-edge case initial state (far away from the ascending
+    // node)
     {
+        const State initialStateAtPole = {
+            defaultInstant_,
+            Position::Meters({0.0, 0.0, 7000000.0}, gcrfSPtr_),
+            Velocity::MetersPerSecond({5335.865450622126, 5335.865450622126, 0.0}, gcrfSPtr_)
+        };
+
         // Setup Propagated model and orbit
         const Propagated propagatedModel = {
             propagator_,
-            defaultState_,
+            initialStateAtPole,
             defaultRevolutionNumber_,
         };
 
+        const COE coe = COE::Cartesian(
+            {initialStateAtPole.getPosition(), initialStateAtPole.getVelocity()},
+            EarthGravitationalModel::Spherical.gravitationalParameter_
+        );  // (Spherical earth has the most modern value which is the correct one)
+        const Duration orbitalPeriod = coe.getOrbitalPeriod(EarthGravitationalModel::Spherical.gravitationalParameter_);
+
         const Orbit orbit = {propagatedModel, earthSpherical_};
 
-        // Calculate revolution number at instant
-        const Instant instant = defaultInstant_;
-        const Instant instant_before1 = Instant::DateTime(DateTime(2018, 1, 1, 22, 0, 0), Scale::UTC);
-        const Instant instant_after1 = Instant::DateTime(DateTime(2018, 1, 2, 1, 0, 0), Scale::UTC);
-        const Instant instant_after2 = Instant::DateTime(DateTime(2018, 1, 2, 2, 0, 0), Scale::UTC);
-
         // Check revolution numbers for propagated model
-        EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(instant));
-        EXPECT_EQ(defaultRevolutionNumber_ - 2, propagatedModel.calculateRevolutionNumberAt(instant_before1));
-        EXPECT_EQ(defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(instant_after1));
-        EXPECT_EQ(defaultRevolutionNumber_ + 2, propagatedModel.calculateRevolutionNumberAt(instant_after2));
+        EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 2,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 2 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 2,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 2 * orbitalPeriod)
+        );
 
         // Check revolution numbers for orbit
-        EXPECT_EQ(defaultRevolutionNumber_, orbit.getRevolutionNumberAt(instant));
-        EXPECT_EQ(defaultRevolutionNumber_ - 2, orbit.getRevolutionNumberAt(instant_before1));
-        EXPECT_EQ(defaultRevolutionNumber_ + 1, orbit.getRevolutionNumberAt(instant_after1));
-        EXPECT_EQ(defaultRevolutionNumber_ + 2, orbit.getRevolutionNumberAt(instant_after2));
+        EXPECT_EQ(defaultRevolutionNumber_, orbit.getRevolutionNumberAt(defaultInstant_));
+        EXPECT_EQ(defaultRevolutionNumber_ - 1, orbit.getRevolutionNumberAt(defaultInstant_ - orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber_ + 1, orbit.getRevolutionNumberAt(defaultInstant_ + orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber_ + 2, orbit.getRevolutionNumberAt(defaultInstant_ + 2 * orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber_ - 2, orbit.getRevolutionNumberAt(defaultInstant_ - 2 * orbitalPeriod));
+    }
+
+    // Test simple positive and negative revolution numbers for edge case initial state (at the ascending node)
+    {
+        const State initialStateAtAscendingNode = {
+            defaultInstant_,
+            Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr_),
+            Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_)
+        };
+
+        // Setup Propagated model and orbit
+        const Propagated propagatedModel = {
+            propagator_,
+            initialStateAtAscendingNode,
+            defaultRevolutionNumber_,
+        };
+
+        const COE coe = COE::Cartesian(
+            {initialStateAtAscendingNode.getPosition(), initialStateAtAscendingNode.getVelocity()},
+            EarthGravitationalModel::Spherical.gravitationalParameter_
+        );  // (Spherical earth has the most modern value which is the correct one)
+        const Duration orbitalPeriod = coe.getOrbitalPeriod(EarthGravitationalModel::Spherical.gravitationalParameter_);
+
+        const Orbit orbit = {propagatedModel, earthSpherical_};
+
+        // Check revolution numbers for propagated model
+        EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 2,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 2 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 2,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 2 * orbitalPeriod)
+        );
+
+        // Check revolution numbers for orbit
+        EXPECT_EQ(defaultRevolutionNumber_, orbit.getRevolutionNumberAt(defaultInstant_));
+        EXPECT_EQ(defaultRevolutionNumber_ - 1, orbit.getRevolutionNumberAt(defaultInstant_ - orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber_ + 1, orbit.getRevolutionNumberAt(defaultInstant_ + orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber_ + 2, orbit.getRevolutionNumberAt(defaultInstant_ + 2 * orbitalPeriod));
+        EXPECT_EQ(defaultRevolutionNumber_ - 2, orbit.getRevolutionNumberAt(defaultInstant_ - 2 * orbitalPeriod));
     }
 
     // Test accuracy of calculateRevolutionNumber at by checking that it returns results accurate to the force model
@@ -518,8 +587,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
         const State state = {startInstant, defaultPosition_, defaultVelocity_};
 
         // Setup Propagated model and orbit
-        const Propagated propagatedModel_twobody = {propagator_, state, 0};
-        const Propagated propagatedModel_fullgrav = {{defaultNumericalSolver_, dynamics}, state, 0};
+        const Integer initialRevolutionNumber = 0;
+        const Propagated propagatedModel_twobody = {propagator_, state, initialRevolutionNumber};
+        const Propagated propagatedModel_fullgrav = {
+            {defaultNumericalSolver_, dynamics}, state, initialRevolutionNumber
+        };
 
         // Calculate gravitational parameter
         const Derived gravitationalParameter = EarthGravitationalModel::Spherical.gravitationalParameter_;
@@ -549,12 +621,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
         const Integer revolutionNumber_twobody = propagatedModel_twobody.calculateRevolutionNumberAt(endInstant);
         const Integer revolutionNumber_fullgrav = propagatedModel_fullgrav.calculateRevolutionNumberAt(endInstant);
 
-        // Check that revolution numbers for two body are exact, for full grav are 1 higher due to losses (which are
-        // gains in negative time), and that they are not equal
-        EXPECT_EQ(-propagationRevolutions - 1, revolutionNumber_twobody);
-        EXPECT_EQ(-propagationRevolutions, revolutionNumber_fullgrav);
-
-        EXPECT_FALSE(revolutionNumber_twobody == revolutionNumber_fullgrav);
+        EXPECT_EQ(initialRevolutionNumber - propagationRevolutions, revolutionNumber_twobody);
+        EXPECT_EQ(initialRevolutionNumber - propagationRevolutions, revolutionNumber_fullgrav);
+        EXPECT_EQ(revolutionNumber_twobody, revolutionNumber_fullgrav);
     }
 }
 


### PR DESCRIPTION
Fixes the off-by-one bug in the `PropagatedModel.calculateRevolutionNumberAt()` method.

Bug: The break check uses strict inequalities (>, <), but it is performed before revolutionNumber += durationSign and before currentInstant += durationSign * orbitalPeriod for the current iteration. As a result, when the loop reaches a currentInstant that is exactly equal to requesting instant, the predicate is still false, so the code increments the revolution counter one extra time and only breaks on the next iteration after overshooting by a full orbital period.
Result: 
- When asking for a rev number before epoch, you would get the true rev number minus one
- When asking for a rev number before epoch, you would get the true rev number plus one

New logic:
- Start from the epoch state
- compute the orbital period, jump back or forwards by one revolution
- break with the current rev number of we are past the requested instant
- otherwise increment/decrement the rev number

Note:
- Additionally, I also avoid repropagating all the way from the epoch state to the currentState each time the loop runs, because that is computationally slower than just propagating from the previously propagated state. 
- I also generalized the logic in the Kepler model to use the `getRevlutionNumberAtEpoch()` instead of assuming it is always 1, even though it is hardcoded to that



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed revolution-number origin and epoch handling so orbital revolution counts are consistent across models and propagation methods, including edge cases near node crossings.
  * Updated propagation logic to compute periods from the current orbit state for more reliable stepping.

* **Tests**
  * Expanded and refactored tests to use period-based validation, cover edge cases, and assert valid integer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->