### PR TITLE
fix: propagated revolution number computation

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.cpp
@@ -26,6 +26,37 @@ static const Real Tolerance = 1e-8;
 static const Derived::Unit GravitationalParameterSIUnit =
     Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second);
 
+// Count the number of ascending-node crossings between epoch and a given instant for an analytical
+// Kepler / J2 / J4 model with a constant secular rate of the mean argument of latitude.
+//
+// The ascending node is the point where the true argument of latitude u = omega + nu = 0 (mod 2pi),
+// equivalently nu = -omega. The mean anomaly M_AN at that point fixes the satellite's phase within
+// the current revolution at epoch. The phase then advances at the rate of the mean argument of
+// latitude, which for the analytical models considered here corresponds exactly to one full
+// revolution per `orbitalPeriod` (Keplerian period for None, nodal period for J2/J4). Using
+// floor() of the phase difference gives the signed crossing count and works for both forward and
+// backward propagation from epoch.
+static Integer CalculateAscendingNodeCrossingCount(
+    const Real& aMeanAnomalyAtEpoch_rad,
+    const Real& anAop_rad,
+    const Real& anEccentricity,
+    const Real& anOrbitalPeriod_s,
+    const Real& aDurationFromEpoch_s
+)
+{
+    using ostk::physics::unit::Angle;
+
+    const Angle trueAnomalyAtNode = Angle::Radians(std::remainder(-anAop_rad, Real::TwoPi()));
+    const Angle eccentricAnomalyAtNode = COE::EccentricAnomalyFromTrueAnomaly(trueAnomalyAtNode, anEccentricity);
+    const Real meanAnomalyAtNode_rad =
+        COE::MeanAnomalyFromEccentricAnomaly(eccentricAnomalyAtNode, anEccentricity).inRadians();
+
+    const Real phaseAtEpoch_rev = (aMeanAnomalyAtEpoch_rad - meanAnomalyAtNode_rad) / Real::TwoPi();
+    const Real phaseAtInstant_rev = phaseAtEpoch_rev + aDurationFromEpoch_s / anOrbitalPeriod_s;
+
+    return phaseAtInstant_rev.floor() - phaseAtEpoch_rev.floor();
+}
+
 Kepler::Kepler(
     const COE& aClassicalOrbitalElementSet,
     const Instant& anEpoch,
@@ -424,7 +455,13 @@ Integer Kepler::CalculateNoneRevolutionNumberAt(
 
     const Duration durationFromEpoch = Duration::Between(anEpoch, anInstant);
 
-    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor();
+    return CalculateAscendingNodeCrossingCount(
+        aClassicalOrbitalElementSet.getMeanAnomaly().inRadians(),
+        aClassicalOrbitalElementSet.getAop().inRadians(),
+        aClassicalOrbitalElementSet.getEccentricity(),
+        orbitalPeriod.inSeconds(),
+        durationFromEpoch.inSeconds()
+    );
 }
 
 State Kepler::CalculateJ2StateAt(
@@ -666,7 +703,13 @@ Integer Kepler::CalculateJ2RevolutionNumberAt(
 
     const Duration durationFromEpoch = Duration::Between(anEpoch, anInstant);
 
-    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor();
+    return CalculateAscendingNodeCrossingCount(
+        aClassicalOrbitalElementSet.getMeanAnomaly().inRadians(),
+        aClassicalOrbitalElementSet.getAop().inRadians(),
+        e,
+        orbitalPeriod.inSeconds(),
+        durationFromEpoch.inSeconds()
+    );
 }
 
 State Kepler::CalculateJ4StateAt(
@@ -849,7 +892,13 @@ Integer Kepler::CalculateJ4RevolutionNumberAt(
 
     const Duration durationFromEpoch = Duration::Between(anEpoch, anInstant);
 
-    return (durationFromEpoch.inSeconds() / orbitalPeriod.inSeconds()).floor();
+    return CalculateAscendingNodeCrossingCount(
+        aClassicalOrbitalElementSet.getMeanAnomaly().inRadians(),
+        aClassicalOrbitalElementSet.getAop().inRadians(),
+        e,
+        orbitalPeriod.inSeconds(),
+        durationFromEpoch.inSeconds()
+    );
 }
 
 }  // namespace model

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
@@ -12,6 +12,7 @@
 #include <OpenSpaceToolkit/Physics/Unit/Time.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics/CentralBodyGravity.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
@@ -39,6 +40,7 @@ using ostk::physics::unit::Length;
 using ostk::physics::unit::Time;
 
 using ostk::astrodynamics::dynamics::CentralBodyGravity;
+using ostk::astrodynamics::eventcondition::RealCondition;
 using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
@@ -282,48 +284,47 @@ Integer Propagated::calculateRevolutionNumberAt(const Instant& anInstant) const
         return this->getRevolutionNumberAtEpoch();
     }
 
-    // Find the central body gravity dynamics to use its gravitational parameter for orbital period computation
-    Derived gravitationalParameter = Derived::Undefined();
-    for (const Shared<Dynamics>& dynamicsSPtr :
-         propagator_.getDynamics())  // Propagator has exactly one Central Body Gravity Dynamics, so
-                                     // graviationalParameter will be defined after the loop
-    {
-        if (const auto centralBodyGravitySPtr = std::dynamic_pointer_cast<CentralBodyGravity>(dynamicsSPtr))
-        {
-            gravitationalParameter = centralBodyGravitySPtr->getCelestial()->getGravitationalParameter();
-            break;
-        }
-    }
-
     // Determine whether to count revolution numbers in forwards or backwards time and return function if duration is 0
     const State stateAtEpoch = this->calculateStateAt(this->getEpoch());
-    const Integer durationSign = (anInstant > this->getEpoch()) ? 1 : -1;
+    const bool isForwardPropagated = anInstant > this->getEpoch();
+    const RealCondition::Criterion criterion = isForwardPropagated ? RealCondition::Criterion::PositiveCrossing : RealCondition::Criterion::NegativeCrossing;
+    const auto ascendingNodeEvaluator = [](const State& aState) -> Real
+    {
+        return aState.getPosition().accessCoordinates().z();
+    };
+    const RealCondition ascendingNodeCondition = RealCondition("ascending node", criterion, ascendingNodeEvaluator);
 
     State currentState = stateAtEpoch;
-    Instant currentInstant = stateAtEpoch.accessInstant();
     Integer revolutionNumber = this->getRevolutionNumberAtEpoch();
+
+    // TBM: Remove and simply use propagator_ once https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/628 is merged
+    const Propagator conditionCompatiblePropagator = Propagator(
+        NumericalSolver::DefaultConditional(),
+        propagator_.getDynamics()
+    );
 
     // Propagate towards desired instant a fraction of an orbit at a time in while loop, exit when arrived at desired
     // instant
     while (true)
     {
-        // Calculate orbital period at current state
-        const COE coe =
-            COE::Cartesian({currentState.getPosition(), currentState.getVelocity()}, gravitationalParameter);
-        const Duration orbitalPeriod = coe.getOrbitalPeriod(gravitationalParameter);
+        const NumericalSolver::ConditionSolution solution = conditionCompatiblePropagator.calculateStateToCondition(currentState, anInstant, ascendingNodeCondition);
 
-        // Propagate for duration of this orbital period
-        currentState = propagator_.calculateStateAt(currentState, currentInstant + (durationSign * orbitalPeriod));
-        currentInstant = currentState.accessInstant();
-
-        // If we have passed the desired instant during our progration, break from the loop
-        if (durationSign.isPositive() && currentInstant > anInstant)
+        // anInstant has been reached before the next ascending node was found, return the current revolution number
+        if (!solution.conditionIsSatisfied)
+        {
             break;
-        if (durationSign.isNegative() && currentInstant < anInstant)
-            break;
+        }
 
-        // Increase or decrease revolution number by 1
-        revolutionNumber += durationSign;
+        // Given that the condition is satisfied, the root solver should have converged
+        if (!solution.rootSolverHasConverged)
+        {
+            throw ostk::core::error::RuntimeError(
+                String::Format("Failed to find ascending node: rootSolverHasConverged: {}", solution.rootSolverHasConverged)
+            );
+        }
+
+        revolutionNumber += isForwardPropagated ? 1 : -1;
+        currentState = solution.state;
     }
 
     return revolutionNumber;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
@@ -5,15 +5,7 @@
 
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
-#include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
-#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Time.hpp>
-
-#include <OpenSpaceToolkit/Astrodynamics/Dynamics/CentralBodyGravity.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
@@ -30,22 +22,10 @@ namespace model
 
 using ostk::core::type::Size;
 
-using ostk::mathematics::object::Vector3d;
 using ostk::mathematics::object::VectorXd;
 
-using ostk::physics::environment::gravitational::Earth;
-using ostk::physics::time::Duration;
-using ostk::physics::unit::Derived;
-using ostk::physics::unit::Length;
-using ostk::physics::unit::Time;
-
-using ostk::astrodynamics::dynamics::CentralBodyGravity;
 using ostk::astrodynamics::eventcondition::RealCondition;
-using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::StateBuilder;
-
-static const Derived::Unit GravitationalParameterSIUnit =
-    Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second);
 
 Propagated::Propagated(const Propagator& aPropagator, const State& aState, const Integer& aRevolutionNumber)
     : Model(),
@@ -287,7 +267,8 @@ Integer Propagated::calculateRevolutionNumberAt(const Instant& anInstant) const
     // Determine whether to count revolution numbers in forwards or backwards time and return function if duration is 0
     const State stateAtEpoch = this->calculateStateAt(this->getEpoch());
     const bool isForwardPropagated = anInstant > this->getEpoch();
-    const RealCondition::Criterion criterion = isForwardPropagated ? RealCondition::Criterion::PositiveCrossing : RealCondition::Criterion::NegativeCrossing;
+    const RealCondition::Criterion criterion =
+        isForwardPropagated ? RealCondition::Criterion::PositiveCrossing : RealCondition::Criterion::NegativeCrossing;
     const auto ascendingNodeEvaluator = [](const State& aState) -> Real
     {
         return aState.getPosition().accessCoordinates().z();
@@ -297,17 +278,17 @@ Integer Propagated::calculateRevolutionNumberAt(const Instant& anInstant) const
     State currentState = stateAtEpoch;
     Integer revolutionNumber = this->getRevolutionNumberAtEpoch();
 
-    // TBM: Remove and simply use propagator_ once https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/628 is merged
-    const Propagator conditionCompatiblePropagator = Propagator(
-        NumericalSolver::DefaultConditional(),
-        propagator_.getDynamics()
-    );
+    // TBM: Remove and simply use propagator_ once
+    // https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/628 is merged
+    const Propagator conditionCompatiblePropagator =
+        Propagator(NumericalSolver::DefaultConditional(), propagator_.getDynamics());
 
     // Propagate towards desired instant a fraction of an orbit at a time in while loop, exit when arrived at desired
     // instant
     while (true)
     {
-        const NumericalSolver::ConditionSolution solution = conditionCompatiblePropagator.calculateStateToCondition(currentState, anInstant, ascendingNodeCondition);
+        const NumericalSolver::ConditionSolution solution =
+            conditionCompatiblePropagator.calculateStateToCondition(currentState, anInstant, ascendingNodeCondition);
 
         // anInstant has been reached before the next ascending node was found, return the current revolution number
         if (!solution.conditionIsSatisfied)
@@ -318,9 +299,9 @@ Integer Propagated::calculateRevolutionNumberAt(const Instant& anInstant) const
         // Given that the condition is satisfied, the root solver should have converged
         if (!solution.rootSolverHasConverged)
         {
-            throw ostk::core::error::RuntimeError(
-                String::Format("Failed to find ascending node: rootSolverHasConverged: {}", solution.rootSolverHasConverged)
-            );
+            throw ostk::core::error::RuntimeError(String::Format(
+                "Failed to find ascending node: rootSolverHasConverged: {}", solution.rootSolverHasConverged
+            ));
         }
 
         revolutionNumber += isForwardPropagated ? 1 : -1;

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler.test.cpp
@@ -838,32 +838,44 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, CalculateRevo
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-        // Check revolution numbers for Kepler model
+        // Orbit with epoch state 1/4 of a revolution after ascending node, and 3/4 of a revolution before next
+        // ascending node epoch:                                               x passes:
+        // |------------------|------------------|------------------| expected revolution numbers:   0  0  0  0  0  0 1
+        // 1  1  1  1  1   2  2  2  2  2  2
+
+        // Check revolution numbers for keplerian model
+        EXPECT_EQ(
+            defaultRevolutionNumber - 2,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 1.5 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber - 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 1.0 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber - 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 0.5 * orbitalPeriod)
+        );
         EXPECT_EQ(defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch));
         EXPECT_EQ(
-            defaultRevolutionNumber + 1, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + orbitalPeriod)
+            defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 0.5 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber - 1, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - orbitalPeriod)
+            defaultRevolutionNumber + 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 1.0 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber + 2, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 2 * orbitalPeriod)
-        );
-        EXPECT_EQ(
-            defaultRevolutionNumber - 2, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 2 * orbitalPeriod)
+            defaultRevolutionNumber + 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 1.5 * orbitalPeriod)
         );
 
-        // Check revolution numbers for orbit
+        // Check revolution number for orbit
         EXPECT_EQ(defaultRevolutionNumber, orbit.getRevolutionNumberAt(defaultEpoch));
-        EXPECT_EQ(defaultRevolutionNumber - 1, orbit.getRevolutionNumberAt(defaultEpoch - orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber + 1, orbit.getRevolutionNumberAt(defaultEpoch + orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber + 2, orbit.getRevolutionNumberAt(defaultEpoch + 2 * orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber - 2, orbit.getRevolutionNumberAt(defaultEpoch - 2 * orbitalPeriod));
     }
 
-    // Test simple positive and negative revolution numbers for edge case initial state (at the ascending node)
+    // Test simple positive and negative revolution numbers for edge case initial state (just past the ascending node)
     {
-        const Position initialPosition = Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr);
+        const Position initialPosition = Position::Meters({7000000.0, 0.0, 1.0}, gcrfSPtr);
         const Velocity initialVelocity =
             Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr);
 
@@ -877,26 +889,87 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler, CalculateRevo
 
         const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
 
-        // Check revolution numbers for Kepler model
+        // Orbit with epoch state just after the ascending node
+        // epoch:                                           x
+        // passes:                      |------------------|------------------|------------------|
+        // expected revolution numbers:   0  0  0  0  0  0   1  1  1  1  1  1   2  2  2  2  2  2
+
+        // Check revolution numbers for keplerian model
+        EXPECT_EQ(
+            defaultRevolutionNumber - 2,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 1.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber - 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 0.9 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber - 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 0.1 * orbitalPeriod)
+        );
         EXPECT_EQ(defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch));
         EXPECT_EQ(
-            defaultRevolutionNumber + 1, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + orbitalPeriod)
+            defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 0.1 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber - 1, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - orbitalPeriod)
+            defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 0.9 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber + 2, keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 2 * orbitalPeriod)
-        );
-        EXPECT_EQ(
-            defaultRevolutionNumber - 2, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 2 * orbitalPeriod)
+            defaultRevolutionNumber + 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 1.1 * orbitalPeriod)
         );
 
-        // Check revolution numbers for orbit
+        // Check revolution number for orbit
         EXPECT_EQ(defaultRevolutionNumber, orbit.getRevolutionNumberAt(defaultEpoch));
-        EXPECT_EQ(defaultRevolutionNumber - 1, orbit.getRevolutionNumberAt(defaultEpoch - orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber + 1, orbit.getRevolutionNumberAt(defaultEpoch + orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber + 2, orbit.getRevolutionNumberAt(defaultEpoch + 2 * orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber - 2, orbit.getRevolutionNumberAt(defaultEpoch - 2 * orbitalPeriod));
+    }
+
+    // Test simple positive and negative revolution numbers for edge case initial state (just before the ascending node)
+    {
+        const Position initialPosition = Position::Meters({7000000.0, 0.0, -1.0}, gcrfSPtr);
+        const Velocity initialVelocity =
+            Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr);
+
+        const COE coe = COE::Cartesian({initialPosition, initialVelocity}, gravitationalParameter);
+        const Duration orbitalPeriod = coe.getOrbitalPeriod(gravitationalParameter);
+
+        // Setup Kepler model and orbit
+        const Kepler keplerianModel = {
+            coe, defaultEpoch, gravitationalParameter, equatorialRadius, J2, J4, Kepler::PerturbationType::None
+        };
+
+        const Orbit orbit = {keplerianModel, environment.accessCelestialObjectWithName("Earth")};
+
+        // Orbit with epoch state just before the ascending node
+        // epoch:                                         x
+        // passes:                      |------------------|------------------|------------------|
+        // expected revolution numbers:   0  0  0  0  0  0   1  1  1  1  1  1   2  2  2  2  2  2
+
+        // Check revolution numbers for keplerian model
+        EXPECT_EQ(
+            defaultRevolutionNumber - 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 1.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 0.9 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch - 0.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(defaultRevolutionNumber, keplerianModel.calculateRevolutionNumberAt(defaultEpoch));
+        EXPECT_EQ(
+            defaultRevolutionNumber + 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 0.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber + 1,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 0.9 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber + 2,
+            keplerianModel.calculateRevolutionNumberAt(defaultEpoch + 1.1 * orbitalPeriod)
+        );
+
+        // Check revolution number for orbit
+        EXPECT_EQ(defaultRevolutionNumber, orbit.getRevolutionNumberAt(defaultEpoch));
     }
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
@@ -498,10 +498,10 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
 
         const Orbit orbit = {propagatedModel, earthSpherical_};
 
-        // Orbit with epoch state 1/4 of a revolution after ascending node, and 3/4 of a revolution before next ascending node
-        // epoch:                                               x
-        // passes:                      |------------------|------------------|------------------|
-        // expected revolution numbers:   0  0  0  0  0  0   1  1  1  1  1  1   2  2  2  2  2  2
+        // Orbit with epoch state 1/4 of a revolution after ascending node, and 3/4 of a revolution before next
+        // ascending node epoch:                                               x passes:
+        // |------------------|------------------|------------------| expected revolution numbers:   0  0  0  0  0  0 1
+        // 1  1  1  1  1   2  2  2  2  2  2
 
         // Check revolution numbers for propagated model
         EXPECT_EQ(
@@ -509,17 +509,20 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
             propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 1.5 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 1.0 * orbitalPeriod)
+            defaultRevolutionNumber_ - 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 1.0 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.5 * orbitalPeriod)
+            defaultRevolutionNumber_ - 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.5 * orbitalPeriod)
         );
         EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
         EXPECT_EQ(
             defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 0.5 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 1.0 * orbitalPeriod)
+            defaultRevolutionNumber_ + 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 1.0 * orbitalPeriod)
         );
         EXPECT_EQ(
             defaultRevolutionNumber_ + 1,
@@ -528,7 +531,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
 
         // Check revolution number for orbit
         EXPECT_EQ(defaultRevolutionNumber_, orbit.getRevolutionNumberAt(defaultInstant_));
-
     }
 
     // Test simple positive and negative revolution numbers for edge case initial state (just past the ascending node)
@@ -565,10 +567,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
             propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 1.1 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.9 * orbitalPeriod)
+            defaultRevolutionNumber_ - 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.9 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.1 * orbitalPeriod)
+            defaultRevolutionNumber_ - 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.1 * orbitalPeriod)
         );
         EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
         EXPECT_EQ(
@@ -578,7 +582,65 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
             defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 0.9 * orbitalPeriod)
         );
         EXPECT_EQ(
-            defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 1.1 * orbitalPeriod)
+            defaultRevolutionNumber_ + 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 1.1 * orbitalPeriod)
+        );
+
+        // Check revolution number for orbit
+        EXPECT_EQ(defaultRevolutionNumber_, orbit.getRevolutionNumberAt(defaultInstant_));
+    }
+
+    // Test simple positive and negative revolution numbers for edge case initial state (just before the ascending node)
+    {
+        const State initialStateAtAscendingNode = {
+            defaultInstant_,
+            Position::Meters({7000000.0, 0.0, -1.0}, gcrfSPtr_),
+            Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_)
+        };
+
+        // Setup Propagated model and orbit
+        const Propagated propagatedModel = {
+            propagator_,
+            initialStateAtAscendingNode,
+            defaultRevolutionNumber_,
+        };
+
+        const COE coe = COE::Cartesian(
+            {initialStateAtAscendingNode.getPosition(), initialStateAtAscendingNode.getVelocity()},
+            EarthGravitationalModel::Spherical.gravitationalParameter_
+        );  // (Spherical earth has the most modern value which is the correct one)
+        const Duration orbitalPeriod = coe.getOrbitalPeriod(EarthGravitationalModel::Spherical.gravitationalParameter_);
+
+        const Orbit orbit = {propagatedModel, earthSpherical_};
+
+        // Orbit with epoch state just before the ascending node
+        // epoch:                                         x
+        // passes:                      |------------------|------------------|------------------|
+        // expected revolution numbers:   0  0  0  0  0  0   1  1  1  1  1  1   2  2  2  2  2  2
+
+        // Check revolution numbers for propagated model
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 1.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.9 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 0.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 0.9 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 2,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 1.1 * orbitalPeriod)
         );
 
         // Check revolution number for orbit

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
@@ -498,36 +498,44 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
 
         const Orbit orbit = {propagatedModel, earthSpherical_};
 
+        // Orbit with epoch state 1/4 of a revolution after ascending node, and 3/4 of a revolution before next ascending node
+        // epoch:                                               x
+        // passes:                      |------------------|------------------|------------------|
+        // expected revolution numbers:   0  0  0  0  0  0   1  1  1  1  1  1   2  2  2  2  2  2
+
         // Check revolution numbers for propagated model
-        EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
-        EXPECT_EQ(
-            defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + orbitalPeriod)
-        );
-        EXPECT_EQ(
-            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - orbitalPeriod)
-        );
-        EXPECT_EQ(
-            defaultRevolutionNumber_ + 2,
-            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 2 * orbitalPeriod)
-        );
         EXPECT_EQ(
             defaultRevolutionNumber_ - 2,
-            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 2 * orbitalPeriod)
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 1.5 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 1.0 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.5 * orbitalPeriod)
+        );
+        EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
+        EXPECT_EQ(
+            defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 0.5 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 1.0 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 1,
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 1.5 * orbitalPeriod)
         );
 
-        // Check revolution numbers for orbit
+        // Check revolution number for orbit
         EXPECT_EQ(defaultRevolutionNumber_, orbit.getRevolutionNumberAt(defaultInstant_));
-        EXPECT_EQ(defaultRevolutionNumber_ - 1, orbit.getRevolutionNumberAt(defaultInstant_ - orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber_ + 1, orbit.getRevolutionNumberAt(defaultInstant_ + orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber_ + 2, orbit.getRevolutionNumberAt(defaultInstant_ + 2 * orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber_ - 2, orbit.getRevolutionNumberAt(defaultInstant_ - 2 * orbitalPeriod));
+
     }
 
-    // Test simple positive and negative revolution numbers for edge case initial state (at the ascending node)
+    // Test simple positive and negative revolution numbers for edge case initial state (just past the ascending node)
     {
         const State initialStateAtAscendingNode = {
             defaultInstant_,
-            Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr_),
+            Position::Meters({7000000.0, 0.0, 1.0}, gcrfSPtr_),
             Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_)
         };
 
@@ -546,29 +554,35 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Calcula
 
         const Orbit orbit = {propagatedModel, earthSpherical_};
 
+        // Orbit with epoch state just past the ascending node
+        // epoch:                                           x
+        // passes:                      |------------------|------------------|------------------|
+        // expected revolution numbers:   0  0  0  0  0  0   1  1  1  1  1  1   2  2  2  2  2  2
+
         // Check revolution numbers for propagated model
-        EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
-        EXPECT_EQ(
-            defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + orbitalPeriod)
-        );
-        EXPECT_EQ(
-            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - orbitalPeriod)
-        );
-        EXPECT_EQ(
-            defaultRevolutionNumber_ + 2,
-            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 2 * orbitalPeriod)
-        );
         EXPECT_EQ(
             defaultRevolutionNumber_ - 2,
-            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 2 * orbitalPeriod)
+            propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 1.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.9 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ - 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ - 0.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_));
+        EXPECT_EQ(
+            defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 0.1 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 0.9 * orbitalPeriod)
+        );
+        EXPECT_EQ(
+            defaultRevolutionNumber_ + 1, propagatedModel.calculateRevolutionNumberAt(defaultInstant_ + 1.1 * orbitalPeriod)
         );
 
-        // Check revolution numbers for orbit
+        // Check revolution number for orbit
         EXPECT_EQ(defaultRevolutionNumber_, orbit.getRevolutionNumberAt(defaultInstant_));
-        EXPECT_EQ(defaultRevolutionNumber_ - 1, orbit.getRevolutionNumberAt(defaultInstant_ - orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber_ + 1, orbit.getRevolutionNumberAt(defaultInstant_ + orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber_ + 2, orbit.getRevolutionNumberAt(defaultInstant_ + 2 * orbitalPeriod));
-        EXPECT_EQ(defaultRevolutionNumber_ - 2, orbit.getRevolutionNumberAt(defaultInstant_ - 2 * orbitalPeriod));
     }
 
     // Test accuracy of calculateRevolutionNumber at by checking that it returns results accurate to the force model


### PR DESCRIPTION
The previous "fix" that I put out still suffers from the same problem as before: namely that it was propagating one whole orbital period before checking if it had encountered a new pass (aka crossed the ascending node) or not. 

Since the propagated model's revolution number computation relies on numerical integration, the only way to properly do it, is to check if you have crossed the next ascending node before incrementing the revolution number counter, using a condition propagator.

I have buffed up the test to actually query the revolution number in non-orbital period increments starting from the epoch to ensure that we don't run into the previous issue again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved revolution-number calculations for propagated orbital models by advancing directly to relevant node crossings, improving accuracy and robustness around edge cases.
  * Updated Kepler-family revolution-number logic to use signed node-crossing counts instead of simple period-based flooring.
* **Tests**
  * Refreshed revolution-number expectations with finer-grained timing offsets and revised node-related edge-case scenarios to better validate transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->