### PR TITLE
fix: correct BrouwerLyddaneMeanShort retrograde and negative-eccentricity paths

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMeanShort.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMeanShort.cpp
@@ -95,6 +95,23 @@ COE BrouwerLyddaneMeanShort::toCOE() const
         }
     }
 
+    // Re-wrap angles to [0, 2*pi) after the pseudo-state and negative-eccentricity shifts (matches GMAT).
+    raanp = mod(raanp, Real::TwoPi());
+    if (raanp < 0.0)
+    {
+        raanp += Real::TwoPi();
+    }
+    aopp = mod(aopp, Real::TwoPi());
+    if (aopp < 0.0)
+    {
+        aopp += Real::TwoPi();
+    }
+    meanAnomalyp = mod(meanAnomalyp, Real::TwoPi());
+    if (meanAnomalyp < 0.0)
+    {
+        meanAnomalyp += Real::TwoPi();
+    }
+
     if (eccp > 0.99)
     {
         throw ostk::core::error::RuntimeError(
@@ -130,7 +147,10 @@ COE BrouwerLyddaneMeanShort::toCOE() const
     //-------------------------------------I
     // COMPUTE TRUE ANOMALY(DOUBLE PRIMED) I
     //-------------------------------------I
-    const Real tap = COE::TrueAnomalyFromMeanAnomaly(anomaly_, eccentricity_, 1e-15).inRadians(0.0, Real::TwoPi());
+    // Use the locally-shifted mean anomaly and eccentricity (after the negative-ecc
+    // recovery branch), not the unmodified class members. Matches GMAT.
+    const Real tap =
+        COE::TrueAnomalyFromMeanAnomaly(Angle::Radians(meanAnomalyp), eccp, 1e-15).inRadians(0.0, Real::TwoPi());
 
     const Real rp = p / (1.0 + eccp * std::cos(tap));
     const Real adr = smap / rp;
@@ -264,6 +284,15 @@ COE BrouwerLyddaneMeanShort::toCOE() const
     if (aop < 0.0)
     {
         aop += Real::TwoPi();
+    }
+
+    // Reverse the pseudo-state remap applied to retrograde inputs (matches GMAT
+    // BrouwerMeanShortToOsculatingElements). Without this the output for inputs
+    // with mean inclination > 175 deg is reflected to a prograde frame.
+    if (pseudoState != 0)
+    {
+        inc = Real::Pi() - inc;
+        raan = Real::TwoPi() - raan;
     }
 
     return COE::FromSIVector(

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMeanShort.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMeanShort.test.cpp
@@ -254,7 +254,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddane
 // Regression: retrograde inputs (mean inc > 175 deg) trigger the GMAT "pseudo-state"
 // remap (inc -> pi - inc, raan -> -raan) at the top of toCOE(); the reverse must be
 // applied at the end. Without it the output is reflected to a prograde frame.
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddaneMeanShort, ToCOE_RetrogradePseudoStateReverse)
+TEST(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddaneMeanShort,
+    ToCOE_RetrogradePseudoStateReverse
+)
 {
     const BrouwerLyddaneMeanShort retrograde({
         Length::Kilometers(7192.16),
@@ -278,7 +281,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddane
 // and angle-dependent formulas must use the *shifted* values, and angles must be
 // re-wrapped to [0, 2*pi) afterwards. Feeding the algebraically-equivalent positive
 // form should yield the same osculating state.
-TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddaneMeanShort, ToCOE_NegativeEccentricityRecovery)
+TEST(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddaneMeanShort,
+    ToCOE_NegativeEccentricityRecovery
+)
 {
     const BrouwerLyddaneMeanShort negEcc({
         Length::Kilometers(7192.16),

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMeanShort.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/BrouwerLyddaneMeanShort.test.cpp
@@ -250,3 +250,65 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddane
         EXPECT_NO_THROW(BrouwerLyddaneMeanShort::Undefined());
     }
 }
+
+// Regression: retrograde inputs (mean inc > 175 deg) trigger the GMAT "pseudo-state"
+// remap (inc -> pi - inc, raan -> -raan) at the top of toCOE(); the reverse must be
+// applied at the end. Without it the output is reflected to a prograde frame.
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddaneMeanShort, ToCOE_RetrogradePseudoStateReverse)
+{
+    const BrouwerLyddaneMeanShort retrograde({
+        Length::Kilometers(7192.16),
+        0.025,
+        Angle::Degrees(177.0),
+        Angle::Degrees(120.0),
+        Angle::Degrees(80.0),
+        Angle::Degrees(40.0),
+    });
+
+    const COE coe = retrograde.toCOE();
+
+    // The osculating inclination differs from the mean only by small J2/J3 corrections.
+    // It must remain retrograde (close to 177 deg), NOT be flipped to ~3 deg.
+    EXPECT_NEAR(177.0, coe.getInclination().inDegrees(), 0.1);
+    EXPECT_NEAR(120.0, coe.getRaan().inDegrees(), 0.5);
+}
+
+// Regression: when the input mean eccentricity is negative, OSTk's recovery branch
+// applies (e -> -e, M -> M - pi, AOP -> AOP + pi). The downstream true-anomaly solver
+// and angle-dependent formulas must use the *shifted* values, and angles must be
+// re-wrapped to [0, 2*pi) afterwards. Feeding the algebraically-equivalent positive
+// form should yield the same osculating state.
+TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_BrouwerLyddaneMeanShort, ToCOE_NegativeEccentricityRecovery)
+{
+    const BrouwerLyddaneMeanShort negEcc({
+        Length::Kilometers(7192.16),
+        -0.025,
+        Angle::Degrees(30.0),
+        Angle::Degrees(120.0),
+        Angle::Degrees(80.0),
+        Angle::Degrees(40.0),
+    });
+
+    // Equivalent state with positive eccentricity: e -> -e, AOP += pi, MA -= pi.
+    const BrouwerLyddaneMeanShort posEcc({
+        Length::Kilometers(7192.16),
+        0.025,
+        Angle::Degrees(30.0),
+        Angle::Degrees(120.0),
+        Angle::Degrees(80.0 + 180.0),
+        Angle::Degrees(40.0 - 180.0 + 360.0),
+    });
+
+    testing::internal::CaptureStdout();
+    const COE coeNeg = negEcc.toCOE();
+    testing::internal::GetCapturedStdout();  // discard the "apoapsis as periapsis" warning
+
+    const COE coePos = posEcc.toCOE();
+
+    EXPECT_NEAR(coePos.getSemiMajorAxis().inMeters(), coeNeg.getSemiMajorAxis().inMeters(), 1e-3);
+    EXPECT_NEAR(coePos.getEccentricity(), coeNeg.getEccentricity(), 1e-9);
+    EXPECT_NEAR(coePos.getInclination().inDegrees(), coeNeg.getInclination().inDegrees(), 1e-7);
+    EXPECT_NEAR(coePos.getRaan().inDegrees(), coeNeg.getRaan().inDegrees(), 1e-6);
+    EXPECT_NEAR(coePos.getAop().inDegrees(), coeNeg.getAop().inDegrees(), 1e-6);
+    EXPECT_NEAR(coePos.getMeanAnomaly().inDegrees(), coeNeg.getMeanAnomaly().inDegrees(), 1e-6);
+}


### PR DESCRIPTION
## Summary

Fixes three bugs in `BrouwerLyddaneMeanShort::toCOE()` that were present in the GMAT port. The Long variant already handled all three cases correctly; this PR brings Short into line.

### Bug 1 — Missing `pseudoState` reverse-transform
For mean inclination > 175° the code remaps `inc → π − inc, raan → −raan` on entry and sets a `pseudoState` flag, but the flag was never read again. GMAT applies `inc → 180° − inc, raan → 360° − raan` at the end (StateConversionUtil.cpp:3900-3904); the Long variant already does this (BrouwerLyddaneMeanLong.cpp:374-378). Outputs for retrograde mean inputs were reflected to a prograde frame — inc off by ~174°, raan off by ~120° in the regression case below.

### Bug 2 — `TrueAnomalyFromMeanAnomaly` called with unmodified class members
Line 133 used `anomaly_` / `eccentricity_` (the class fields) rather than the locally-shifted `meanAnomalyp` / `eccp` (after the negative-eccentricity recovery branch). For negative-eccentricity inputs this fed the iterative solver values inconsistent with the rest of the downstream formula, producing wrong osculating AOP / MA. GMAT uses the shifted locals (StateConversionUtil.cpp:3794).

### Bug 3 — Missing 2π re-wrap after the negative-eccentricity shift
After `e → −e, M → M − π, AOP → AOP + π` the angles were not re-wrapped to `[0, 2π)`. GMAT re-mods all three angles after both the pseudo-state and negative-eccentricity transforms (StateConversionUtil.cpp:3770-3785).

## Numerical impact (before this PR)

| Test | Element | Wrong by |
|---|---|---|
| Retrograde input (inc=177°, raan=120°) | inc | ~174° |
| Retrograde input | raan | ~120° |
| Negative-eccentricity input (e=−0.025) | aop | ~1.85° |
| Negative-eccentricity input | ma | ~1.5° |

After this PR, both regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve retrograde inclinations instead of converting them to prograde equivalents.
  * Correct recovery for negative-eccentricity inputs, including proper transformations of anomaly and argument.
  * Normalize angular elements immediately after state adjustments to ensure consistent outputs.

* **Tests**
  * Added regression tests covering retrograde handling and negative-eccentricity recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-space-collective/open-space-toolkit-astrodynamics/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->