### PR TITLE
fix: consider the original numerical solver maximum step size (as well as adding the python bindings for it)

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -152,6 +152,28 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                         RootSolver: The root solver.
                 )doc"
             )
+            .def(
+                "get_maximum_step_size",
+                &NumericalSolver::getMaxStepSize,
+                R"doc(
+                    Get the maximum step size.
+
+                    Returns:
+                        Real: The maximum step size in seconds, or Real.undefined() if not set.
+                )doc"
+            )
+            .def(
+                "set_maximum_step_size",
+                &NumericalSolver::setMaxStepSize,
+                R"doc(
+                    Set the maximum step size.
+
+                    Args:
+                        maximum_step_size (Real): The maximum step size in seconds. Use
+                            Real.undefined() to remove the limit.
+                )doc",
+                arg("maximum_step_size")
+            )
 
             .def(
                 "integrate_time",

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/State/NumericalSolver.cpp
@@ -169,8 +169,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_State_NumericalSolver(pyb
                     Set the maximum step size.
 
                     Args:
-                        maximum_step_size (Real): The maximum step size in seconds. Use
-                            Real.undefined() to remove the limit.
+                        maximum_step_size (Real): The maximum step size in seconds. Use Real.undefined() to remove the limit.
                 )doc",
                 arg("maximum_step_size")
             )

--- a/bindings/python/test/trajectory/state/test_numerical_solver.py
+++ b/bindings/python/test/trajectory/state/test_numerical_solver.py
@@ -159,7 +159,9 @@ class TestNumericalSolver:
         assert numerical_solver.get_observed_states() is not None
         assert numerical_solver.get_maximum_step_size().is_defined() is False
 
-    def test_set_and_get_maximum_step_size_success(self, numerical_solver: NumericalSolver):
+    def test_set_and_get_maximum_step_size_success(
+        self, numerical_solver: NumericalSolver
+    ):
         numerical_solver.set_maximum_step_size(10.0)
         assert numerical_solver.get_maximum_step_size() == 10.0
 

--- a/bindings/python/test/trajectory/state/test_numerical_solver.py
+++ b/bindings/python/test/trajectory/state/test_numerical_solver.py
@@ -7,6 +7,7 @@ import pytest
 import numpy as np
 import math
 
+from ostk.core.type import Real
 from ostk.physics.time import Instant, Duration
 from ostk.physics.coordinate import Frame
 
@@ -156,6 +157,14 @@ class TestNumericalSolver:
         assert numerical_solver.get_absolute_tolerance() == absolute_tolerance
         assert numerical_solver.get_root_solver() is not None
         assert numerical_solver.get_observed_states() is not None
+        assert numerical_solver.get_maximum_step_size().is_defined() is False
+
+    def test_set_and_get_maximum_step_size_success(self, numerical_solver: NumericalSolver):
+        numerical_solver.set_maximum_step_size(10.0)
+        assert numerical_solver.get_maximum_step_size() == 10.0
+
+        numerical_solver.set_maximum_step_size(Real.undefined())
+        assert numerical_solver.get_maximum_step_size().is_defined() is False
 
     def test_get_string_from_types(self):
         assert (

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.hpp
@@ -512,8 +512,9 @@ class Segment
     /// @param anEndInstant The end instant
     /// @param aDynamicsArray The dynamics array
     /// @param anEventCondition The event condition
-    /// @param limitMaxStepSize If true, the maximum step size will be limited to 2 minutes, or the duration of the
-    /// subsegment, whichever is smaller. Defaults to false.
+    /// @param limitMaxStepSize If true, the maximum step size will be limited to 2 minutes, the duration of the
+    /// subsegment divided by 10, or the segment numerical solver's configured maximum step size, whichever is smallest.
+    /// Defaults to false.
     /// @return The segment solution
     Segment::Solution solveWithDynamics_(
         const State& aState,

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Segment.cpp
@@ -1675,7 +1675,12 @@ Segment::Solution Segment::solveWithDynamics_(
     NumericalSolver numericalSolver = numericalSolver_;
     if (limitMaxStepSize)
     {
-        const Real maxStepSize = std::min(Real(120.0), (anEndInstant - aState.accessInstant()).inSeconds() / 10.0);
+        Real maxStepSize = std::min(Real(120.0), (anEndInstant - aState.accessInstant()).inSeconds() / 10.0);
+        const Real originalMaxStepSize = numericalSolver_.getMaxStepSize();
+        if (originalMaxStepSize.isDefined())
+        {
+            maxStepSize = std::min(maxStepSize, originalMaxStepSize);
+        }
         numericalSolver.setMaxStepSize(maxStepSize);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added getter and setter for the numerical solver's maximum step size, allowing configuration or clearing of the limit.
  * Trajectory solving now honors the solver's configured maximum step size when computing integration steps, preventing temporary overrides from exceeding that cap.

* **Tests**
  * Added tests verifying default undefined state, successful set/get behavior, and reset to undefined.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-space-collective/open-space-toolkit-astrodynamics/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->