### PR TITLE
feat: improve residual computation utilities

### DIFF
--- a/bindings/python/test/test_utilities.py
+++ b/bindings/python/test/test_utilities.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+import pandas as pd
 import pytest
 
 from ostk.mathematics.curve_fitting import Interpolator
@@ -189,6 +190,36 @@ class TestUtility:
         for i in range(1, 11):
             assert isinstance(output[i], float)
 
+    def test_residual_as_dataframe(
+        self,
+        candidate_states: list[State],
+        reference_states: list[State],
+    ) -> None:
+        residuals = utilities.compute_residuals(
+            candidate_states=candidate_states,
+            reference_states=reference_states,
+        )
+
+        dataframe = pd.DataFrame(residuals)
+
+        assert isinstance(dataframe, pd.DataFrame)
+        assert len(dataframe) == len(residuals)
+        assert list(dataframe.columns) == [
+            "timestamp",
+            "frame",
+            "dr",
+            "dr_x",
+            "dr_y",
+            "dr_z",
+            "dv",
+            "dv_x",
+            "dv_y",
+            "dv_z",
+        ]
+        assert dataframe["dr_z"].iloc[0] == pytest.approx(residuals[0].dr_z)
+        assert isinstance(residuals[0].frame, str)
+        assert dataframe["frame"].iloc[0] == residuals[0].frame
+
     def test_compute_residuals_identical_states(
         self,
         candidate_states: list[State],
@@ -336,3 +367,84 @@ class TestUtility:
             assert isinstance(entry.timestamp, datetime)
             assert isinstance(entry.dr, float)
             assert isinstance(entry.dv, float)
+
+    def test_compute_residuals_for_orbit_multiple_candidate_orbits(
+        self,
+        orbit: Orbit,
+        reference_states: list[State],
+    ) -> None:
+        result = utilities.compute_residuals_for_orbit(
+            candidate_orbit=[orbit, orbit],
+            reference_states=reference_states,
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        for residuals in result:
+            assert isinstance(residuals, list)
+            assert len(residuals) == len(reference_states)
+            for entry in residuals:
+                assert isinstance(entry, utilities.Residual)
+                assert isinstance(entry.timestamp, datetime)
+
+    def test_compute_residuals_for_orbit_single_candidate_orbit_backwards_compatible(
+        self,
+        orbit: Orbit,
+        reference_states: list[State],
+    ) -> None:
+        single_result = utilities.compute_residuals_for_orbit(
+            candidate_orbit=orbit,
+            reference_states=reference_states,
+        )
+        list_result = utilities.compute_residuals_for_orbit(
+            candidate_orbit=[orbit],
+            reference_states=reference_states,
+        )
+
+        assert isinstance(single_result, list)
+        assert isinstance(single_result[0], utilities.Residual)
+        assert len(list_result) == 1
+        assert single_result == list_result[0]
+
+    def test_compute_residuals_for_orbits_multiple_candidate_orbits(
+        self,
+        orbit: Orbit,
+        reference_states: list[State],
+    ) -> None:
+        result = utilities.compute_residuals_for_orbits(
+            candidate_orbit=[orbit, orbit],
+            reference_orbit=orbit,
+            instants=[state.get_instant() for state in reference_states],
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        for residuals in result:
+            assert isinstance(residuals, list)
+            assert len(residuals) == len(reference_states)
+            for entry in residuals:
+                assert isinstance(entry, utilities.Residual)
+                assert isinstance(entry.timestamp, datetime)
+
+    def test_compute_residuals_for_orbits_single_candidate_orbit_backwards_compatible(
+        self,
+        orbit: Orbit,
+        reference_states: list[State],
+    ) -> None:
+        instants = [state.get_instant() for state in reference_states]
+
+        single_result = utilities.compute_residuals_for_orbits(
+            candidate_orbit=orbit,
+            reference_orbit=orbit,
+            instants=instants,
+        )
+        list_result = utilities.compute_residuals_for_orbits(
+            candidate_orbit=[orbit],
+            reference_orbit=orbit,
+            instants=instants,
+        )
+
+        assert isinstance(single_result, list)
+        assert isinstance(single_result[0], utilities.Residual)
+        assert len(list_result) == 1
+        assert single_result == list_result[0]

--- a/bindings/python/tools/python/ostk/astrodynamics/utilities.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/utilities.py
@@ -45,7 +45,7 @@ DEFAULT_INERTIAL_FRAME: Frame = Frame.GCRF()
 @dataclass
 class Residual:
     timestamp: datetime
-    frame: Frame
+    frame: str
     dr: float
     dr_x: float
     dr_y: float
@@ -97,7 +97,7 @@ def compute_residuals(
         residuals.append(
             Residual(
                 timestamp=coerce_to_datetime(reference_state.get_instant()),
-                frame=frame,
+                frame=str(frame.get_name()),
                 dr=float(np.linalg.norm(dr)),
                 dr_x=float(dr[0]),
                 dr_y=float(dr[1]),
@@ -113,58 +113,66 @@ def compute_residuals(
 
 
 def compute_residuals_for_orbit(
-    candidate_orbit: Orbit,
+    candidate_orbit: Orbit | list[Orbit],
     reference_states: list[State],
     local_orbital_frame_factory_or_frame: (
         LocalOrbitalFrameFactory | Frame
     ) = DEFAULT_INERTIAL_FRAME,
-) -> list[Residual]:
+) -> list[Residual] | list[list[Residual]]:
     """
-    Compute position and velocity residuals for an orbit against a list of reference states.
+    Compute position and velocity residuals for one or more candidate orbits against a list of reference states.
 
     Args:
-        candidate_orbit (Orbit): Candidate Orbit used to generate states at the instants of the reference states.
+        candidate_orbit (Orbit | list[Orbit]): Candidate Orbit, or list of candidate Orbits, used to generate states at the instants of the reference states.
         reference_states (list[State]): List of reference States to compare against.
         local_orbital_frame_factory_or_frame (LocalOrbitalFrameFactory | Frame, optional): The local orbital frame factory to use. Defaults to Frame.GCRF().
 
     Returns:
-        list[Residual]: List of Residuals.
+        list[Residual] | list[list[Residual]]: List of Residuals if a single candidate Orbit is provided, or a list of lists of Residuals (one per candidate Orbit) if multiple candidate Orbits are provided.
     """
-    instants: list[Instant] = [state.get_instant() for state in reference_states]
-    candidate_states: list[State] = candidate_orbit.get_states_at(instants)
-
-    return compute_residuals(
-        candidate_states=candidate_states,
-        reference_states=reference_states,
-        local_orbital_frame_factory_or_frame=local_orbital_frame_factory_or_frame,
+    is_single_orbit: bool = isinstance(candidate_orbit, Orbit)
+    candidate_orbits: list[Orbit] = (
+        [candidate_orbit] if is_single_orbit else list(candidate_orbit)
     )
+
+    instants: list[Instant] = [state.get_instant() for state in reference_states]
+
+    residuals_per_orbit: list[list[Residual]] = [
+        compute_residuals(
+            candidate_states=orbit.get_states_at(instants),
+            reference_states=reference_states,
+            local_orbital_frame_factory_or_frame=local_orbital_frame_factory_or_frame,
+        )
+        for orbit in candidate_orbits
+    ]
+
+    return residuals_per_orbit[0] if is_single_orbit else residuals_per_orbit
 
 
 def compute_residuals_for_orbits(
-    candidate_orbit: Orbit,
+    candidate_orbit: Orbit | list[Orbit],
     reference_orbit: Orbit,
     instants: list[Instant],
     local_orbital_frame_factory_or_frame: (
         LocalOrbitalFrameFactory | Frame
     ) = DEFAULT_INERTIAL_FRAME,
-) -> list[Residual]:
+) -> list[Residual] | list[list[Residual]]:
     """
-    Compare two orbits at the provided instants and compute position and velocity residuals.
+    Compare one or more candidate orbits against a reference orbit at the provided instants and compute position and velocity residuals.
 
     Args:
-        candidate_orbit (Orbit): Candidate Orbit.
+        candidate_orbit (Orbit | list[Orbit]): Candidate Orbit, or list of candidate Orbits.
         reference_orbit (Orbit): Reference Orbit.
         instants (list[Instant]): List of instants to generate states at.
         local_orbital_frame_factory_or_frame (LocalOrbitalFrameFactory | Frame, optional): The local orbital frame factory to use. Defaults to Frame.GCRF().
 
     Returns:
-        list[Residual]: List of Residuals.
+        list[Residual] | list[list[Residual]]: List of Residuals if a single candidate Orbit is provided, or a list of lists of Residuals (one per candidate Orbit) if multiple candidate Orbits are provided.
     """
-    candidate_states: list[State] = candidate_orbit.get_states_at(instants)
     reference_states: list[State] = reference_orbit.get_states_at(instants)
 
-    return compute_residuals(
-        candidate_states=candidate_states,
+    return compute_residuals_for_orbit(
+        candidate_orbit=candidate_orbit,
         reference_states=reference_states,
         local_orbital_frame_factory_or_frame=local_orbital_frame_factory_or_frame,
     )


### PR DESCRIPTION
Expand the compute_residuals_* methods to allow a list of orbits. Additionally, allow the residual to be easily converted to a pandas dataframe for plotting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded residuals test coverage including DataFrame conversion validation and multiple candidate orbit scenarios
  * Added backward compatibility tests ensuring single-orbit inputs produce consistent results

* **Improvements**
  * Enhanced residuals computation to support processing multiple candidate orbits
  * Simplified frame field representation for improved data accessibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-space-collective/open-space-toolkit-astrodynamics/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->