### PR TITLE
fix: add frame property to residual to keep it backwards compatible

### DIFF
--- a/bindings/python/test/test_utilities.py
+++ b/bindings/python/test/test_utilities.py
@@ -206,7 +206,7 @@ class TestUtility:
         assert len(dataframe) == len(residuals)
         assert list(dataframe.columns) == [
             "timestamp",
-            "frame",
+            "frame_name",
             "dr",
             "dr_x",
             "dr_y",
@@ -217,8 +217,8 @@ class TestUtility:
             "dv_z",
         ]
         assert dataframe["dr_z"].iloc[0] == pytest.approx(residuals[0].dr_z)
-        assert isinstance(residuals[0].frame, str)
-        assert dataframe["frame"].iloc[0] == residuals[0].frame
+        assert isinstance(residuals[0].frame, Frame)
+        assert dataframe["frame_name"].iloc[0] == residuals[0].frame_name
 
     def test_compute_residuals_identical_states(
         self,
@@ -240,6 +240,7 @@ class TestUtility:
             assert residual.dv_x == pytest.approx(0.0, abs=1e-10)
             assert residual.dv_y == pytest.approx(0.0, abs=1e-10)
             assert residual.dv_z == pytest.approx(0.0, abs=1e-10)
+            assert isinstance(residual.frame, Frame)
 
     def test_compute_residuals_with_local_orbital_frame_factory(
         self,

--- a/bindings/python/tools/python/ostk/astrodynamics/utilities.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/utilities.py
@@ -45,7 +45,7 @@ DEFAULT_INERTIAL_FRAME: Frame = Frame.GCRF()
 @dataclass
 class Residual:
     timestamp: datetime
-    frame: str
+    frame_name: str
     dr: float
     dr_x: float
     dr_y: float
@@ -54,6 +54,10 @@ class Residual:
     dv_x: float
     dv_y: float
     dv_z: float
+
+    @property
+    def frame(self) -> Frame:
+        return Frame.with_name(self.frame_name)
 
 
 def compute_residuals(
@@ -97,7 +101,7 @@ def compute_residuals(
         residuals.append(
             Residual(
                 timestamp=coerce_to_datetime(reference_state.get_instant()),
-                frame=str(frame.get_name()),
+                frame_name=str(frame.get_name()),
                 dr=float(np.linalg.norm(dr)),
                 dr_x=float(dr[0]),
                 dr_y=float(dr[1]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal representation of reference frame information in residuals.

* **Tests**
  * Updated residual computation and utilities test suite to reflect internal changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->