### PR TITLE
feat: interpolators per coordinate subset for tabulated models

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Flight/Profile/Model/Tabulated.cpp
@@ -7,12 +7,15 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model_Tabulated(pybin
     using namespace pybind11;
 
     using ostk::core::container::Array;
+    using ostk::core::container::Map;
+    using ostk::core::type::Shared;
 
     using ostk::mathematics::curvefitting::Interpolator;
 
     using ostk::astrodynamics::flight::profile::Model;
     using ostk::astrodynamics::flight::profile::model::Tabulated;
     using ostk::astrodynamics::trajectory::State;
+    using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 
     class_<Tabulated, Model>(
         aModule,
@@ -34,6 +37,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model_Tabulated(pybin
              )doc",
             arg("states"),
             arg_v("interpolator_type", Interpolator::Type::BarycentricRational, "Interpolator.Type.BarycentricRational")
+        )
+
+        .def(
+            init<const Array<State>&, const Map<Shared<const CoordinateSubset>, Interpolator::Type>&>(),
+            R"doc(
+                Constructor with per-coordinate-subset interpolation types.
+
+                Each coordinate subset is interpolated using the interpolation type associated with it, except the
+                attitude quaternion, which is always interpolated using spherical linear interpolation (SLERP).
+
+                Args:
+                    states (Array[State]): The states of the model.
+                    interpolation_types (dict[CoordinateSubset, Interpolator.Type]): A mapping from coordinate subset to the interpolation type to use for that subset's coordinates. Every coordinate subset present in the states (other than the attitude quaternion) must have an entry. Entries for coordinate subsets not present in the states (including the attitude quaternion) are ignored.
+             )doc",
+            arg("states"),
+            arg("interpolation_types")
         )
 
         .def(
@@ -133,6 +152,26 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Flight_Profile_Model_Tabulated(pybin
                     Frame: The body frame of the model with the specified name.
              )doc",
             arg("frame_name")
+        )
+
+        .def_static(
+            "default",
+            &Tabulated::Default,
+            R"doc(
+                Construct a tabulated profile model using the default per-coordinate-subset interpolation types.
+
+                Each coordinate subset present in the states (other than the attitude quaternion, which is always
+                interpolated using SLERP) is interpolated using its default interpolation type (barycentric rational
+                for position, velocity, acceleration, angular velocity and mass; zero-order for drag coefficient,
+                surface area, mass flow rate and ballistic coefficient).
+
+                Args:
+                    states (Array[State]): The states of the model.
+
+                Returns:
+                    Tabulated: A tabulated profile model using the default interpolation types.
+             )doc",
+            arg("states")
         )
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Tabulated.cpp
@@ -7,12 +7,15 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Tabulated(pybind11:
     using namespace pybind11;
 
     using ostk::core::container::Array;
+    using ostk::core::container::Map;
+    using ostk::core::type::Shared;
 
     using ostk::mathematics::curvefitting::Interpolator;
 
     using ostk::astrodynamics::trajectory::Model;
     using ostk::astrodynamics::trajectory::model::Tabulated;
     using ostk::astrodynamics::trajectory::State;
+    using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 
     class_<Tabulated, Model>(
         aModule,
@@ -34,6 +37,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Tabulated(pybind11:
              )doc",
             arg("states"),
             arg_v("interpolation_type", Interpolator::Type::Linear, "Interpolator.Type.Linear")
+        )
+
+        .def(
+            init<const Array<State>&, const Map<Shared<const CoordinateSubset>, Interpolator::Type>&>(),
+            R"doc(
+                Constructor with per-coordinate-subset interpolation types.
+
+                Each coordinate is interpolated using the interpolation type associated with the coordinate subset
+                it belongs to.
+
+                Args:
+                    states (Array[State]): The states of the model.
+                    interpolation_types (dict[CoordinateSubset, Interpolator.Type]): A mapping from coordinate subset to the interpolation type to use for that subset's coordinates. Every coordinate subset present in the states must have an entry, and every coordinate subset in the map must be present in the states.
+             )doc",
+            arg("states"),
+            arg("interpolation_types")
         )
 
         .def(

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Tabulated.cpp
@@ -162,5 +162,24 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Tabulated(pybind11:
             arg("instants")
         )
 
+        .def_static(
+            "default",
+            &Tabulated::Default,
+            R"doc(
+                Construct a tabulated model using the default per-coordinate-subset interpolation types.
+
+                Each coordinate subset present in the states is interpolated using its default interpolation type
+                (barycentric rational for position, velocity, acceleration, attitude, angular velocity and mass;
+                zero-order for drag coefficient, surface area, mass flow rate and ballistic coefficient).
+
+                Args:
+                    states (Array[State]): The states of the model.
+
+                Returns:
+                    Tabulated: A tabulated model using the default interpolation types.
+             )doc",
+            arg("states")
+        )
+
         ;
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Tabulated.cpp
@@ -5,12 +5,15 @@
 using namespace pybind11;
 
 using ostk::core::container::Array;
+using ostk::core::container::Map;
 using ostk::core::type::Integer;
+using ostk::core::type::Shared;
 
 using ostk::mathematics::curvefitting::Interpolator;
 
 using ostk::astrodynamics::trajectory::orbit::model::Tabulated;
 using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 
 inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Tabulated(pybind11::module& aModule)
 {
@@ -41,6 +44,25 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Tabulated(pyb
                 DEFAULT_TABULATED_TRAJECTORY_INTERPOLATION_TYPE,
                 "Interpolator.Type.BarycentricRational"
             )
+        )
+
+        .def(
+            init<const Array<State>&, const Integer&, const Map<Shared<const CoordinateSubset>, Interpolator::Type>&>(),
+            R"doc(
+                Constructor with per-coordinate-subset interpolation types.
+
+                Each coordinate is interpolated using the interpolation type associated with the coordinate subset
+                it belongs to.
+
+                Args:
+                    states (list[State]): The states.
+                    initial_revolution_number (int): The initial revolution number.
+                    interpolation_types (dict[CoordinateSubset, Interpolator.Type]): A mapping from coordinate subset to the interpolation type to use for that subset's coordinates. Every coordinate subset present in the states must have an entry, and every coordinate subset in the map must be present in the states.
+
+            )doc",
+            arg("states"),
+            arg("initial_revolution_number"),
+            arg("interpolation_types")
         )
 
         .def(self == self)

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Tabulated.cpp
@@ -165,5 +165,27 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Tabulated(pyb
             arg("instants")
         )
 
+        .def_static(
+            "default",
+            &Tabulated::Default,
+            R"doc(
+                Construct a tabulated orbit model using the default per-coordinate-subset interpolation types.
+
+                Each coordinate subset present in the states is interpolated using its default interpolation type
+                (barycentric rational for position, velocity, acceleration, attitude, angular velocity and mass;
+                zero-order for drag coefficient, surface area, mass flow rate and ballistic coefficient).
+
+                Args:
+                    states (list[State]): The states.
+                    initial_revolution_number (int, optional): The initial revolution number. Defaults to 1.
+
+                Returns:
+                    Tabulated: A tabulated orbit model using the default interpolation types.
+
+            )doc",
+            arg("states"),
+            arg_v("initial_revolution_number", Integer(1), "1")
+        )
+
         ;
 }

--- a/bindings/python/test/flight/profile/model/test_tabulated_profile.py
+++ b/bindings/python/test/flight/profile/model/test_tabulated_profile.py
@@ -14,6 +14,10 @@ from ostk.physics.coordinate import Velocity
 from ostk.physics.coordinate import Frame
 
 from ostk.astrodynamics.trajectory import State
+from ostk.astrodynamics.trajectory.state import CoordinateSubset
+from ostk.astrodynamics.trajectory.state.coordinate_subset import AngularVelocity
+from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianPosition
+from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianVelocity
 from ostk.astrodynamics.flight.profile.model import Tabulated as TabulatedModel
 
 
@@ -40,6 +44,24 @@ def states() -> list[State]:
 
 
 @pytest.fixture
+def dense_states() -> list[State]:
+    # Barycentric rational interpolation (the default) requires more than two points.
+    return [
+        State(
+            instant=Instant.date_time(datetime(2020, 1, 1, 0, i, 0), Scale.UTC),
+            position=Position.meters((float(i), 2.0 * i, 3.0 * i), Frame.GCRF()),
+            velocity=Velocity.meters_per_second(
+                (4.0 * i, 5.0 * i, 6.0 * i), Frame.GCRF()
+            ),
+            attitude=Quaternion.unit(),
+            angular_velocity=(0.0, 0.0, 0.0),
+            attitude_frame=Frame.GCRF(),
+        )
+        for i in range(5)
+    ]
+
+
+@pytest.fixture
 def interpolator_type() -> Interpolator.Type:
     return Interpolator.Type.Linear
 
@@ -62,6 +84,47 @@ class TestTabulatedProfile:
     ):
         assert tabulated_model is not None
         assert isinstance(tabulated_model, TabulatedModel)
+
+    def test_constructor_with_interpolation_types(
+        self,
+        dense_states: list[State],
+    ):
+        tabulated_model: TabulatedModel = TabulatedModel(
+            states=dense_states,
+            interpolation_types={
+                CartesianPosition.default(): Interpolator.Type.BarycentricRational,
+                CartesianVelocity.default(): Interpolator.Type.BarycentricRational,
+                AngularVelocity.default(): Interpolator.Type.BarycentricRational,
+            },
+        )
+
+        assert tabulated_model.is_defined()
+
+    def test_constructor_with_interpolation_types_failure(
+        self,
+        states: list[State],
+    ):
+        # A coordinate subset present in the (reduced) states but missing from the map must raise.
+        with pytest.raises(Exception):
+            TabulatedModel(
+                states=states,
+                interpolation_types={
+                    CartesianPosition.default(): Interpolator.Type.BarycentricRational,
+                    CartesianVelocity.default(): Interpolator.Type.BarycentricRational,
+                },
+            )
+
+    def test_default(
+        self,
+        dense_states: list[State],
+    ):
+        tabulated_model: TabulatedModel = TabulatedModel.default(dense_states)
+
+        assert tabulated_model.is_defined()
+        assert (
+            tabulated_model.get_interpolator_type()
+            == Interpolator.Type.BarycentricRational
+        )
 
     def test_is_defined(
         self,

--- a/bindings/python/test/trajectory/model/test_tabulated_trajectory.py
+++ b/bindings/python/test/trajectory/model/test_tabulated_trajectory.py
@@ -15,6 +15,9 @@ from ostk.physics.coordinate import Frame
 
 from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory.model import Tabulated
+from ostk.astrodynamics.trajectory.state import CoordinateSubset
+from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianPosition
+from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianVelocity
 
 
 @pytest.fixture
@@ -257,6 +260,45 @@ class TestTabulatedTrajectory:
             )
             is not None
         )
+
+    def test_constructor_with_interpolation_types(
+        self,
+        test_states: list[State],
+    ):
+        tabulated: Tabulated = Tabulated(
+            states=test_states,
+            interpolation_types={
+                CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                CartesianVelocity.default(): Interpolator.Type.Linear,
+            },
+        )
+
+        assert tabulated is not None
+        assert tabulated.is_defined()
+
+    def test_constructor_with_interpolation_types_failure(
+        self,
+        test_states: list[State],
+    ):
+        # A coordinate subset referenced in the map but absent from the states must raise.
+        with pytest.raises(Exception):
+            Tabulated(
+                states=test_states,
+                interpolation_types={
+                    CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                    CartesianVelocity.default(): Interpolator.Type.Linear,
+                    CoordinateSubset.mass(): Interpolator.Type.Linear,
+                },
+            )
+
+        # A coordinate subset present in the states but missing from the map must raise.
+        with pytest.raises(Exception):
+            Tabulated(
+                states=test_states,
+                interpolation_types={
+                    CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                },
+            )
 
     def test_get_interpolation_type(
         self,

--- a/bindings/python/test/trajectory/model/test_tabulated_trajectory.py
+++ b/bindings/python/test/trajectory/model/test_tabulated_trajectory.py
@@ -276,21 +276,26 @@ class TestTabulatedTrajectory:
         assert tabulated is not None
         assert tabulated.is_defined()
 
+    def test_constructor_with_interpolation_types_ignores_unknown_subsets(
+        self,
+        test_states: list[State],
+    ):
+        # Coordinate subsets in the map that are not present in the states are ignored (no error).
+        tabulated: Tabulated = Tabulated(
+            states=test_states,
+            interpolation_types={
+                CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                CartesianVelocity.default(): Interpolator.Type.Linear,
+                CoordinateSubset.mass(): Interpolator.Type.Linear,
+            },
+        )
+
+        assert tabulated.is_defined()
+
     def test_constructor_with_interpolation_types_failure(
         self,
         test_states: list[State],
     ):
-        # A coordinate subset referenced in the map but absent from the states must raise.
-        with pytest.raises(Exception):
-            Tabulated(
-                states=test_states,
-                interpolation_types={
-                    CartesianPosition.default(): Interpolator.Type.CubicSpline,
-                    CartesianVelocity.default(): Interpolator.Type.Linear,
-                    CoordinateSubset.mass(): Interpolator.Type.Linear,
-                },
-            )
-
         # A coordinate subset present in the states but missing from the map must raise.
         with pytest.raises(Exception):
             Tabulated(
@@ -299,6 +304,15 @@ class TestTabulatedTrajectory:
                     CartesianPosition.default(): Interpolator.Type.CubicSpline,
                 },
             )
+
+    def test_default(
+        self,
+        test_states: list[State],
+    ):
+        tabulated: Tabulated = Tabulated.default(test_states)
+
+        assert tabulated.is_defined()
+        assert tabulated.get_interpolation_type() == Interpolator.Type.BarycentricRational
 
     def test_get_interpolation_type(
         self,

--- a/bindings/python/test/trajectory/orbit/models/test_tabulated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_tabulated.py
@@ -18,6 +18,9 @@ from ostk.physics import Environment
 from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory import Orbit
 from ostk.astrodynamics.trajectory.orbit.model import Tabulated
+from ostk.astrodynamics.trajectory.state import CoordinateSubset
+from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianPosition
+from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianVelocity
 
 
 @pytest.fixture
@@ -264,6 +267,53 @@ class TestTabulated:
 
         assert orbit is not None
         assert isinstance(orbit, Orbit)
+
+    def test_constructor_with_interpolation_types(
+        self,
+        test_states: list[State],
+        earth,
+    ):
+        tabulated = Tabulated(
+            states=test_states,
+            initial_revolution_number=1,
+            interpolation_types={
+                CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                CartesianVelocity.default(): Interpolator.Type.Linear,
+            },
+        )
+
+        assert tabulated is not None
+        assert tabulated.is_defined()
+
+        orbit: Orbit = Orbit(tabulated, earth)
+
+        assert isinstance(orbit, Orbit)
+
+    def test_constructor_with_interpolation_types_failure(
+        self,
+        test_states: list[State],
+    ):
+        # A coordinate subset referenced in the map but absent from the states must raise.
+        with pytest.raises(Exception):
+            Tabulated(
+                states=test_states,
+                initial_revolution_number=1,
+                interpolation_types={
+                    CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                    CartesianVelocity.default(): Interpolator.Type.Linear,
+                    CoordinateSubset.mass(): Interpolator.Type.Linear,
+                },
+            )
+
+        # A coordinate subset present in the states but missing from the map must raise.
+        with pytest.raises(Exception):
+            Tabulated(
+                states=test_states,
+                initial_revolution_number=1,
+                interpolation_types={
+                    CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                },
+            )
 
     def test_get_interpolation_type(self, test_states: list[State]):
         tabulated = Tabulated(

--- a/bindings/python/test/trajectory/orbit/models/test_tabulated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_tabulated.py
@@ -289,22 +289,27 @@ class TestTabulated:
 
         assert isinstance(orbit, Orbit)
 
+    def test_constructor_with_interpolation_types_ignores_unknown_subsets(
+        self,
+        test_states: list[State],
+    ):
+        # Coordinate subsets in the map that are not present in the states are ignored (no error).
+        tabulated = Tabulated(
+            states=test_states,
+            initial_revolution_number=1,
+            interpolation_types={
+                CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                CartesianVelocity.default(): Interpolator.Type.Linear,
+                CoordinateSubset.mass(): Interpolator.Type.Linear,
+            },
+        )
+
+        assert tabulated.is_defined()
+
     def test_constructor_with_interpolation_types_failure(
         self,
         test_states: list[State],
     ):
-        # A coordinate subset referenced in the map but absent from the states must raise.
-        with pytest.raises(Exception):
-            Tabulated(
-                states=test_states,
-                initial_revolution_number=1,
-                interpolation_types={
-                    CartesianPosition.default(): Interpolator.Type.CubicSpline,
-                    CartesianVelocity.default(): Interpolator.Type.Linear,
-                    CoordinateSubset.mass(): Interpolator.Type.Linear,
-                },
-            )
-
         # A coordinate subset present in the states but missing from the map must raise.
         with pytest.raises(Exception):
             Tabulated(
@@ -314,6 +319,18 @@ class TestTabulated:
                     CartesianPosition.default(): Interpolator.Type.CubicSpline,
                 },
             )
+
+    def test_default(
+        self,
+        test_states: list[State],
+        earth,
+    ):
+        # The initial revolution number defaults to 1.
+        tabulated = Tabulated.default(test_states)
+
+        assert tabulated.is_defined()
+        assert tabulated.get_interpolation_type() == Interpolator.Type.BarycentricRational
+        assert isinstance(Orbit(tabulated, earth), Orbit)
 
     def test_get_interpolation_type(self, test_states: list[State]):
         tabulated = Tabulated(

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.hpp
@@ -4,11 +4,13 @@
 #define __OpenSpaceToolkit_Astrodynamics_Flight_Profile_Model_Tabulated__
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Map.hpp>
 #include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 #include <OpenSpaceToolkit/Core/FileSystem/File.hpp>
 #include <OpenSpaceToolkit/Core/Type/Index.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp>
+#include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
@@ -16,6 +18,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 namespace ostk
@@ -30,12 +33,15 @@ namespace model
 {
 
 using ostk::core::container::Array;
+using ostk::core::container::Map;
 using ostk::core::container::Pair;
 using ostk::core::filesystem::File;
 using ostk::core::type::Index;
 using ostk::core::type::String;
 
 using ostk::mathematics::curvefitting::Interpolator;
+using ostk::mathematics::object::MatrixXd;
+using ostk::mathematics::object::VectorXd;
 
 using ostk::physics::coordinate::Axes;
 using ostk::physics::coordinate::Frame;
@@ -45,6 +51,7 @@ using ostk::physics::time::Interval;
 using ostk::astrodynamics::flight::profile::Model;
 using TabulatedTrajectory = ostk::astrodynamics::trajectory::model::Tabulated;
 using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
 /// @brief Tabulated profile model.
@@ -67,6 +74,26 @@ class Tabulated : public virtual Model
     Tabulated(
         const Array<State>& aStateArray,
         const Interpolator::Type& anInterpolatorType = Interpolator::Type::BarycentricRational
+    );
+
+    /// @brief Constructor with per-coordinate-subset interpolation types.
+    ///
+    /// @details Each coordinate subset is interpolated using the interpolation type associated with it, except the
+    /// attitude quaternion, which is always interpolated using spherical linear interpolation (SLERP).
+    ///
+    /// @code{.cpp}
+    ///     flight::profile::model::Tabulated tabulated = { aStateArray, interpolationTypes } ;
+    /// @endcode
+    ///
+    /// @param aStateArray An array of states
+    /// @param anInterpolationTypeMap A mapping from coordinate subset to the interpolation type to use for that
+    /// subset's coordinates. Every coordinate subset present in the states (other than the attitude quaternion) must
+    /// have an entry in the map (an error is raised otherwise). Entries for coordinate subsets that are not present in
+    /// the states are ignored; in particular, any entry for the attitude quaternion subset is ignored as attitude is
+    /// always interpolated using SLERP.
+    Tabulated(
+        const Array<State>& aStateArray,
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
     );
 
     /// @brief Clone the tabulated model
@@ -143,6 +170,20 @@ class Tabulated : public virtual Model
     /// @return Tabulated model
     static Tabulated Load(const File& aFile);
 
+    /// @brief Construct a tabulated profile model using the default per-coordinate-subset interpolation types.
+    ///
+    /// @details Each coordinate subset present in the states (other than the attitude quaternion, which is always
+    /// interpolated using SLERP) is interpolated using the type given by
+    /// trajectory::model::Tabulated::DefaultInterpolationTypes().
+    ///
+    /// @code{.cpp}
+    ///     flight::profile::model::Tabulated tabulated = flight::profile::model::Tabulated::Default(aStateArray) ;
+    /// @endcode
+    ///
+    /// @param aStateArray An array of states
+    /// @return A tabulated profile model using the default interpolation types.
+    static Tabulated Default(const Array<State>& aStateArray);
+
    protected:
     /// @brief Equal to operator for the base model
     ///
@@ -165,6 +206,17 @@ class Tabulated : public virtual Model
     StateBuilder reducedStateBuilder_;
 
     void setMembers(const Array<State>& aStateArray);
+
+    void setMembers(
+        const Array<State>& aStateArray,
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
+    );
+
+    /// @brief Sort the provided states, build the (reduced) state builders, and compute the interpolation timestamps
+    /// and reduced coordinate matrix (excluding the attitude quaternion) shared by all constructors.
+    void computeReducedInterpolationData(
+        const Array<State>& aStateArray, VectorXd& aTimestampVector, MatrixXd& aReducedCoordinateMatrix
+    );
 };
 
 }  // namespace model

--- a/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.hpp
@@ -49,7 +49,6 @@ using ostk::physics::time::Instant;
 using ostk::physics::time::Interval;
 
 using ostk::astrodynamics::flight::profile::Model;
-using TabulatedTrajectory = ostk::astrodynamics::trajectory::model::Tabulated;
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 using ostk::astrodynamics::trajectory::StateBuilder;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp
@@ -4,6 +4,7 @@
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated__
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Map.hpp>
 #include <OpenSpaceToolkit/Core/Container/Pair.hpp>
 #include <OpenSpaceToolkit/Core/FileSystem/File.hpp>
 #include <OpenSpaceToolkit/Core/Type/Index.hpp>
@@ -18,6 +19,7 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
 
 namespace ostk
 {
@@ -29,6 +31,7 @@ namespace model
 {
 
 using ostk::core::container::Array;
+using ostk::core::container::Map;
 using ostk::core::container::Pair;
 using ostk::core::filesystem::File;
 using ostk::core::type::Index;
@@ -45,6 +48,7 @@ using ostk::physics::time::Scale;
 
 using ostk::astrodynamics::trajectory::Model;
 using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 
 #define DEFAULT_TABULATED_TRAJECTORY_INTERPOLATION_TYPE Interpolator::Type::Linear
 
@@ -68,6 +72,29 @@ class Tabulated : public virtual Model
     Tabulated(
         const Array<State>& aStateArray,
         const Interpolator::Type& anInterpolationType = DEFAULT_TABULATED_TRAJECTORY_INTERPOLATION_TYPE
+    );
+
+    /// @brief Constructor with per-coordinate-subset interpolation types.
+    ///
+    ///                      Each coordinate is interpolated using the interpolation type associated with the
+    ///                      coordinate subset it belongs to.
+    ///
+    /// @code{.cpp}
+    ///     Array<State> states = { ... };
+    ///     Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+    ///         {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+    ///         {CartesianVelocity::Default(), Interpolator::Type::Linear},
+    ///     };
+    ///     Tabulated tabulated(states, interpolationTypes);
+    /// @endcode
+    ///
+    /// @param aStateArray An array of states defining the tabulated trajectory.
+    /// @param anInterpolationTypeMap A mapping from coordinate subset to the interpolation type to use for that
+    /// subset's coordinates. Every coordinate subset present in the states must have an entry in the map, and every
+    /// coordinate subset in the map must be present in the states (an error is raised otherwise).
+    Tabulated(
+        const Array<State>& aStateArray,
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
     );
 
     /// @brief Clone the tabulated model.
@@ -133,6 +160,9 @@ class Tabulated : public virtual Model
     /// @code{.cpp}
     ///     Interpolator::Type type = tabulated.getInterpolationType();
     /// @endcode
+    ///
+    /// @note When the model was constructed with per-coordinate-subset interpolation types, this returns the
+    /// interpolation type of the first coordinate.
     ///
     /// @return The interpolation type.
     Interpolator::Type getInterpolationType() const;
@@ -204,6 +234,18 @@ class Tabulated : public virtual Model
     State firstState_ = State::Undefined();
     State lastState_ = State::Undefined();
     Array<Shared<const Interpolator>> interpolators_;
+
+    /// @brief Sort the provided states by instant, cache the first and last states, and compute the interpolation
+    /// timestamps and coordinate matrix shared by all constructors.
+    ///
+    /// @param aStateArray An array of states defining the tabulated trajectory.
+    /// @param aTimestampVector [out] The timestamps (in seconds, relative to the first state) of the sorted states.
+    /// @param aCoordinateMatrix [out] The coordinates of the sorted states (one row per state, one column per
+    /// coordinate).
+    /// @return True if the model could be defined (i.e. at least two states were provided), false otherwise.
+    bool computeInterpolationData(
+        const Array<State>& aStateArray, VectorXd& aTimestampVector, MatrixXd& aCoordinateMatrix
+    );
 };
 
 }  // namespace model

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp
@@ -90,8 +90,8 @@ class Tabulated : public virtual Model
     ///
     /// @param aStateArray An array of states defining the tabulated trajectory.
     /// @param anInterpolationTypeMap A mapping from coordinate subset to the interpolation type to use for that
-    /// subset's coordinates. Every coordinate subset present in the states must have an entry in the map, and every
-    /// coordinate subset in the map must be present in the states (an error is raised otherwise).
+    /// subset's coordinates. Every coordinate subset present in the states must have an entry in the map (an error is
+    /// raised otherwise). Entries for coordinate subsets that are not present in the states are ignored.
     Tabulated(
         const Array<State>& aStateArray,
         const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
@@ -224,6 +224,29 @@ class Tabulated : public virtual Model
     /// @param aFile A file containing tabulated state data.
     /// @return A Tabulated trajectory model loaded from the file.
     static Tabulated Load(const File& aFile);
+
+    /// @brief Construct a tabulated model using the default per-coordinate-subset interpolation types.
+    ///
+    ///                      Each coordinate subset present in the states is interpolated using the type given by
+    ///                      DefaultInterpolationTypes(). The states may contain any subset of those coordinate subsets.
+    ///
+    /// @code{.cpp}
+    ///     Array<State> states = { ... };
+    ///     Tabulated tabulated = Tabulated::Default(states);
+    /// @endcode
+    ///
+    /// @param aStateArray An array of states defining the tabulated trajectory.
+    /// @return A Tabulated trajectory model using the default interpolation types.
+    static Tabulated Default(const Array<State>& aStateArray);
+
+    /// @brief Get the default interpolation type to use for each well-known coordinate subset.
+    ///
+    /// @details Position, velocity, acceleration, attitude, angular velocity and mass use barycentric rational
+    /// interpolation; drag coefficient, surface area, mass flow rate and ballistic coefficient use zero-order
+    /// interpolation.
+    ///
+    /// @return A mapping from coordinate subset to its default interpolation type.
+    static Map<Shared<const CoordinateSubset>, Interpolator::Type> DefaultInterpolationTypes();
 
    protected:
     virtual bool operator==(const Model& aModel) const override;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp
@@ -162,7 +162,7 @@ class Tabulated : public virtual Model
     /// @endcode
     ///
     /// @note When the model was constructed with per-coordinate-subset interpolation types, this returns the
-    /// interpolation type of the first coordinate.
+    /// interpolation type of the first coordinate subset.
     ///
     /// @return The interpolation type.
     Interpolator::Type getInterpolationType() const;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp
@@ -81,8 +81,8 @@ class Tabulated : public virtual trajectory::orbit::Model, public trajectory::mo
     /// @param aStateArray An array of states to tabulate.
     /// @param anInitialRevolutionNumber The revolution number at the first state epoch.
     /// @param anInterpolationTypeMap A mapping from coordinate subset to the interpolation type to use for that
-    /// subset's coordinates. Every coordinate subset present in the states must have an entry in the map, and every
-    /// coordinate subset in the map must be present in the states (an error is raised otherwise).
+    /// subset's coordinates. Every coordinate subset present in the states must have an entry in the map (an error is
+    /// raised otherwise). Entries for coordinate subsets that are not present in the states are ignored.
     Tabulated(
         const Array<State>& aStateArray,
         const Integer& anInitialRevolutionNumber,
@@ -137,6 +137,22 @@ class Tabulated : public virtual trajectory::orbit::Model, public trajectory::mo
     /// @param anOutputStream An output stream.
     /// @param displayDecorator If true, display a decorator around the output.
     virtual void print(std::ostream& anOutputStream, bool displayDecorator) const override;
+
+    /// @brief Construct a tabulated orbit model using the default per-coordinate-subset interpolation types.
+    ///
+    /// @details Each coordinate subset present in the states is interpolated using the type given by
+    /// trajectory::model::Tabulated::DefaultInterpolationTypes(). The states may contain any subset of those
+    /// coordinate subsets.
+    ///
+    /// @code{.cpp}
+    ///     Array<State> states = { ... };
+    ///     Tabulated tabulated = Tabulated::Default(states, 1);
+    /// @endcode
+    ///
+    /// @param aStateArray An array of states to tabulate.
+    /// @param anInitialRevolutionNumber The revolution number at the first state epoch. Defaults to 1.
+    /// @return A tabulated orbit model using the default interpolation types.
+    static Tabulated Default(const Array<State>& aStateArray, const Integer& anInitialRevolutionNumber = 1);
 
    protected:
     virtual bool operator==(const trajectory::Model& aModel) const override;

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp
@@ -4,7 +4,9 @@
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated__
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Map.hpp>
 #include <OpenSpaceToolkit/Core/Type/Integer.hpp>
+#include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp>
 
@@ -14,6 +16,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
 
 namespace ostk
 {
@@ -27,13 +30,16 @@ namespace model
 {
 
 using ostk::core::container::Array;
+using ostk::core::container::Map;
 using ostk::core::type::Integer;
+using ostk::core::type::Shared;
 
 using ostk::mathematics::curvefitting::Interpolator;
 
 using ostk::physics::time::Instant;
 
 using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::CoordinateSubset;
 
 /// @brief Tabulated orbit model.
 ///
@@ -56,6 +62,31 @@ class Tabulated : public virtual trajectory::orbit::Model, public trajectory::mo
         const Array<State>& aStateArray,
         const Integer& anInitialRevolutionNumber,
         const Interpolator::Type& aType = DEFAULT_TABULATED_TRAJECTORY_INTERPOLATION_TYPE
+    );
+
+    /// @brief Construct a tabulated orbit model with per-coordinate-subset interpolation types.
+    ///
+    /// @details Each coordinate is interpolated using the interpolation type associated with the coordinate subset
+    /// it belongs to.
+    ///
+    /// @code{.cpp}
+    ///     Array<State> states = { ... };
+    ///     Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+    ///         {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+    ///         {CartesianVelocity::Default(), Interpolator::Type::Linear},
+    ///     };
+    ///     Tabulated tabulated = Tabulated(states, 1, interpolationTypes);
+    /// @endcode
+    ///
+    /// @param aStateArray An array of states to tabulate.
+    /// @param anInitialRevolutionNumber The revolution number at the first state epoch.
+    /// @param anInterpolationTypeMap A mapping from coordinate subset to the interpolation type to use for that
+    /// subset's coordinates. Every coordinate subset present in the states must have an entry in the map, and every
+    /// coordinate subset in the map must be present in the states (an error is raised otherwise).
+    Tabulated(
+        const Array<State>& aStateArray,
+        const Integer& anInitialRevolutionNumber,
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
     );
 
     /// @brief Clone this tabulated orbit model.

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.cpp
@@ -135,14 +135,12 @@ State Tabulated::calculateStateAt(const Instant& anInstant) const
 
     if (anInstant < interval.accessStart() || anInstant > interval.accessEnd())
     {
-        throw ostk::core::error::RuntimeError(
-            String::Format(
-                "Provided instant [{}] is outside of interpolation range [{}, {}].",
-                anInstant.toString(),
-                interval.accessStart().toString(),
-                interval.accessEnd().toString()
-            )
-        );
+        throw ostk::core::error::RuntimeError(String::Format(
+            "Provided instant [{}] is outside of interpolation range [{}, {}].",
+            anInstant.toString(),
+            interval.accessStart().toString(),
+            interval.accessEnd().toString()
+        ));
     }
 
     VectorXd reducedCoordinates(reducedStateBuilder_.getSize());
@@ -373,12 +371,9 @@ void Tabulated::setMembers(
 
         if (interpolationTypeIt == interpolationTypeBySubsetId.end())
         {
-            throw ostk::core::error::RuntimeError(
-                String::Format(
-                    "No interpolation type was provided for the coordinate subset [{}].",
-                    coordinateSubsetSPtr->getName()
-                )
-            );
+            throw ostk::core::error::RuntimeError(String::Format(
+                "No interpolation type was provided for the coordinate subset [{}].", coordinateSubsetSPtr->getName()
+            ));
         }
 
         for (Size i = 0; i < coordinateSubsetSPtr->getSize(); ++i)

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.cpp
@@ -10,7 +10,10 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
 
 namespace ostk
 {
@@ -35,7 +38,10 @@ using DynamicProvider = ostk::physics::coordinate::frame::provider::Dynamic;
 using ostk::physics::coordinate::Transform;
 
 using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::AngularVelocity;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::AttitudeQuaternion;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
 Tabulated::Tabulated(const Array<State>& aStateArray, const Interpolator::Type& anInterpolatorType)
     : Model(),
@@ -129,12 +135,14 @@ State Tabulated::calculateStateAt(const Instant& anInstant) const
 
     if (anInstant < interval.accessStart() || anInstant > interval.accessEnd())
     {
-        throw ostk::core::error::RuntimeError(String::Format(
-            "Provided instant [{}] is outside of interpolation range [{}, {}].",
-            anInstant.toString(),
-            interval.accessStart().toString(),
-            interval.accessEnd().toString()
-        ));
+        throw ostk::core::error::RuntimeError(
+            String::Format(
+                "Provided instant [{}] is outside of interpolation range [{}, {}].",
+                anInstant.toString(),
+                interval.accessStart().toString(),
+                interval.accessEnd().toString()
+            )
+        );
     }
 
     VectorXd reducedCoordinates(reducedStateBuilder_.getSize());
@@ -297,7 +305,15 @@ void Tabulated::print(std::ostream& anOutputStream, bool displayDecorator) const
 
 Tabulated Tabulated::Default(const Array<State>& aStateArray)
 {
-    return Tabulated(aStateArray, TabulatedTrajectory::DefaultInterpolationTypes());
+    return Tabulated(
+        aStateArray,
+        {
+            {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
+            {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
+            {AngularVelocity::Default(), Interpolator::Type::BarycentricRational},
+            // AttitudeQuaternion is always interpolated using SLERP
+        }
+    );
 }
 
 bool Tabulated::operator==(const Model& aModel) const
@@ -357,9 +373,12 @@ void Tabulated::setMembers(
 
         if (interpolationTypeIt == interpolationTypeBySubsetId.end())
         {
-            throw ostk::core::error::RuntimeError(String::Format(
-                "No interpolation type was provided for the coordinate subset [{}].", coordinateSubsetSPtr->getName()
-            ));
+            throw ostk::core::error::RuntimeError(
+                String::Format(
+                    "No interpolation type was provided for the coordinate subset [{}].",
+                    coordinateSubsetSPtr->getName()
+                )
+            );
         }
 
         for (Size i = 0; i < coordinateSubsetSPtr->getSize(); ++i)

--- a/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.cpp
@@ -46,6 +46,18 @@ Tabulated::Tabulated(const Array<State>& aStateArray, const Interpolator::Type& 
     setMembers(aStateArray);
 }
 
+Tabulated::Tabulated(
+    const Array<State>& aStateArray,
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
+)
+    : Model(),
+      interpolatorType_(Interpolator::Type::BarycentricRational),
+      stateBuilder_(StateBuilder::Undefined()),
+      reducedStateBuilder_(StateBuilder::Undefined())
+{
+    setMembers(aStateArray, anInterpolationTypeMap);
+}
+
 Tabulated* Tabulated::clone() const
 {
     return new Tabulated(*this);
@@ -283,6 +295,11 @@ void Tabulated::print(std::ostream& anOutputStream, bool displayDecorator) const
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 
+Tabulated Tabulated::Default(const Array<State>& aStateArray)
+{
+    return Tabulated(aStateArray, TabulatedTrajectory::DefaultInterpolationTypes());
+}
+
 bool Tabulated::operator==(const Model& aModel) const
 {
     const Tabulated* tabulatedModelPtr = dynamic_cast<const Tabulated*>(&aModel);
@@ -297,6 +314,80 @@ bool Tabulated::operator!=(const Model& aModel) const
 
 void Tabulated::setMembers(const Array<State>& aStateArray)
 {
+    VectorXd timestamps;
+    MatrixXd coordinates;
+
+    this->computeReducedInterpolationData(aStateArray, timestamps, coordinates);
+
+    interpolators_.reserve(coordinates.cols());
+
+    for (Index i = 0; i < Size(coordinates.cols()); ++i)
+    {
+        interpolators_.add(Interpolator::GenerateInterpolator(interpolatorType_, timestamps, coordinates.col(i)));
+    }
+}
+
+void Tabulated::setMembers(
+    const Array<State>& aStateArray,
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
+)
+{
+    VectorXd timestamps;
+    MatrixXd coordinates;
+
+    this->computeReducedInterpolationData(aStateArray, timestamps, coordinates);
+
+    // Index the requested interpolation types by coordinate subset id. Entries for coordinate subsets that are not
+    // present in the (reduced) states are ignored.
+    Map<String, Interpolator::Type> interpolationTypeBySubsetId;
+
+    for (const auto& [coordinateSubsetSPtr, interpolationType] : anInterpolationTypeMap)
+    {
+        interpolationTypeBySubsetId[coordinateSubsetSPtr->getId()] = interpolationType;
+    }
+
+    // Resolve the interpolation type for each reduced coordinate. The attitude quaternion is excluded from the
+    // reduced state and is always interpolated using SLERP, so any entry for it in the map is ignored.
+    Array<Interpolator::Type> interpolationTypePerCoordinate = Array<Interpolator::Type>::Empty();
+    interpolationTypePerCoordinate.reserve(coordinates.cols());
+
+    for (const auto& coordinateSubsetSPtr : reducedStateBuilder_.getCoordinateSubsets())
+    {
+        const auto interpolationTypeIt = interpolationTypeBySubsetId.find(coordinateSubsetSPtr->getId());
+
+        if (interpolationTypeIt == interpolationTypeBySubsetId.end())
+        {
+            throw ostk::core::error::RuntimeError(String::Format(
+                "No interpolation type was provided for the coordinate subset [{}].", coordinateSubsetSPtr->getName()
+            ));
+        }
+
+        for (Size i = 0; i < coordinateSubsetSPtr->getSize(); ++i)
+        {
+            interpolationTypePerCoordinate.add(interpolationTypeIt->second);
+        }
+    }
+
+    // Report the interpolator type of the first reduced coordinate via getInterpolatorType().
+    if (!interpolationTypePerCoordinate.isEmpty())
+    {
+        interpolatorType_ = interpolationTypePerCoordinate.accessFirst();
+    }
+
+    interpolators_.reserve(coordinates.cols());
+
+    for (Index i = 0; i < Size(coordinates.cols()); ++i)
+    {
+        interpolators_.add(
+            Interpolator::GenerateInterpolator(interpolationTypePerCoordinate[i], timestamps, coordinates.col(i))
+        );
+    }
+}
+
+void Tabulated::computeReducedInterpolationData(
+    const Array<State>& aStateArray, VectorXd& aTimestampVector, MatrixXd& aReducedCoordinateMatrix
+)
+{
     if (aStateArray.getSize() < 2)
     {
         throw ostk::core::error::RuntimeError("State array must have at least length 2.");
@@ -305,9 +396,9 @@ void Tabulated::setMembers(const Array<State>& aStateArray)
     const State& firstState = aStateArray.accessFirst();
     stateBuilder_ = StateBuilder(firstState);
 
-    Array<Shared<const CoordinateSubset>> reucedCoordinateSubsets = firstState.getCoordinateSubsets();
-    reucedCoordinateSubsets.remove(AttitudeQuaternion::Default());
-    reducedStateBuilder_ = StateBuilder(firstState.accessFrame(), reucedCoordinateSubsets);
+    Array<Shared<const CoordinateSubset>> reducedCoordinateSubsets = firstState.getCoordinateSubsets();
+    reducedCoordinateSubsets.remove(AttitudeQuaternion::Default());
+    reducedStateBuilder_ = StateBuilder(firstState.accessFrame(), reducedCoordinateSubsets);
 
     // Ensure the states are sorted by instant
     stateArray_ = aStateArray;
@@ -321,21 +412,14 @@ void Tabulated::setMembers(const Array<State>& aStateArray)
         }
     );
 
-    VectorXd timestamps(stateArray_.getSize());
-    MatrixXd coordinates(stateArray_.getSize(), reducedStateBuilder_.getSize());  // Exclude quaternion
+    aTimestampVector.resize(stateArray_.getSize());
+    aReducedCoordinateMatrix.resize(stateArray_.getSize(), reducedStateBuilder_.getSize());  // Exclude quaternion
 
     for (Index i = 0; i < stateArray_.getSize(); ++i)
     {
-        timestamps(i) = (stateArray_[i].accessInstant() - firstState.accessInstant()).inSeconds();
+        aTimestampVector(i) = (stateArray_[i].accessInstant() - firstState.accessInstant()).inSeconds();
 
-        coordinates.row(i) = reducedStateBuilder_.reduce(stateArray_[i]).accessCoordinates();
-    }
-
-    interpolators_.reserve(coordinates.cols());
-
-    for (Index i = 0; i < Size(coordinates.cols()); ++i)
-    {
-        interpolators_.add(Interpolator::GenerateInterpolator(interpolatorType_, timestamps, coordinates.col(i)));
+        aReducedCoordinateMatrix.row(i) = reducedStateBuilder_.reduce(stateArray_[i]).accessCoordinates();
     }
 }
 

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
@@ -18,33 +18,12 @@ namespace model
 Tabulated::Tabulated(const Array<State>& aStateArray, const Interpolator::Type& anInterpolationType)
     : Model()
 {
-    if (aStateArray.getSize() < 2)
+    VectorXd timestamps;
+    MatrixXd coordinates;
+
+    if (!this->computeInterpolationData(aStateArray, timestamps, coordinates))
     {
         return;
-    }
-
-    Array<State> stateArray = aStateArray;
-
-    std::sort(
-        stateArray.begin(),
-        stateArray.end(),
-        [](const auto& lhs, const auto& rhs)
-        {
-            return lhs.getInstant() < rhs.getInstant();
-        }
-    );
-
-    firstState_ = aStateArray.accessFirst();
-    lastState_ = aStateArray.accessLast();
-
-    VectorXd timestamps(stateArray.getSize());
-    MatrixXd coordinates(stateArray.getSize(), firstState_.getSize());
-
-    for (Index i = 0; i < stateArray.getSize(); ++i)
-    {
-        timestamps(i) = (stateArray[i].accessInstant() - firstState_.accessInstant()).inSeconds();
-
-        coordinates.row(i) = stateArray[i].accessCoordinates();
     }
 
     interpolators_.reserve(coordinates.cols());
@@ -52,6 +31,74 @@ Tabulated::Tabulated(const Array<State>& aStateArray, const Interpolator::Type& 
     for (Index i = 0; i < Size(coordinates.cols()); ++i)
     {
         interpolators_.add(Interpolator::GenerateInterpolator(anInterpolationType, timestamps, coordinates.col(i)));
+    }
+}
+
+Tabulated::Tabulated(
+    const Array<State>& aStateArray,
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
+)
+    : Model()
+{
+    using ostk::core::type::String;
+
+    using ostk::astrodynamics::trajectory::state::CoordinateBroker;
+
+    VectorXd timestamps;
+    MatrixXd coordinates;
+
+    if (!this->computeInterpolationData(aStateArray, timestamps, coordinates))
+    {
+        return;
+    }
+
+    const Shared<const CoordinateBroker>& coordinatesBroker = firstState_.accessCoordinateBroker();
+
+    // Index the requested interpolation types by coordinate subset id, ensuring each requested subset is present in
+    // the provided states.
+    Map<String, Interpolator::Type> interpolationTypeBySubsetId;
+
+    for (const auto& [coordinateSubsetSPtr, interpolationType] : anInterpolationTypeMap)
+    {
+        if (!coordinatesBroker->hasSubset(coordinateSubsetSPtr))
+        {
+            throw ostk::core::error::RuntimeError(String::Format(
+                "The provided states do not contain the coordinate subset [{}].", coordinateSubsetSPtr->getName()
+            ));
+        }
+
+        interpolationTypeBySubsetId[coordinateSubsetSPtr->getId()] = interpolationType;
+    }
+
+    // Resolve the interpolation type for every coordinate, requiring each coordinate subset present in the states to
+    // be specified in the provided map.
+    Array<Interpolator::Type> interpolationTypePerCoordinate = Array<Interpolator::Type>::Empty();
+    interpolationTypePerCoordinate.reserve(coordinates.cols());
+
+    for (const auto& coordinateSubsetSPtr : coordinatesBroker->accessSubsets())
+    {
+        const auto interpolationTypeIt = interpolationTypeBySubsetId.find(coordinateSubsetSPtr->getId());
+
+        if (interpolationTypeIt == interpolationTypeBySubsetId.end())
+        {
+            throw ostk::core::error::RuntimeError(String::Format(
+                "No interpolation type was provided for the coordinate subset [{}].", coordinateSubsetSPtr->getName()
+            ));
+        }
+
+        for (Size i = 0; i < coordinateSubsetSPtr->getSize(); ++i)
+        {
+            interpolationTypePerCoordinate.add(interpolationTypeIt->second);
+        }
+    }
+
+    interpolators_.reserve(coordinates.cols());
+
+    for (Index i = 0; i < Size(coordinates.cols()); ++i)
+    {
+        interpolators_.add(
+            Interpolator::GenerateInterpolator(interpolationTypePerCoordinate[i], timestamps, coordinates.col(i))
+        );
     }
 }
 
@@ -67,8 +114,22 @@ bool Tabulated::operator==(const Tabulated& aTabulatedModel) const
         return false;
     }
 
-    return this->getInterpolationType() == aTabulatedModel.getInterpolationType() &&
-           firstState_ == aTabulatedModel.getFirstState() && lastState_ == aTabulatedModel.getLastState();
+    if (interpolators_.getSize() != aTabulatedModel.interpolators_.getSize())
+    {
+        return false;
+    }
+
+    // Compare the interpolation type of each coordinate, so that models with per-coordinate-subset interpolation
+    // types are correctly distinguished.
+    for (Index i = 0; i < interpolators_.getSize(); ++i)
+    {
+        if (interpolators_[i]->getInterpolationType() != aTabulatedModel.interpolators_[i]->getInterpolationType())
+        {
+            return false;
+        }
+    }
+
+    return firstState_ == aTabulatedModel.getFirstState() && lastState_ == aTabulatedModel.getLastState();
 }
 
 bool Tabulated::operator!=(const Tabulated& aTabulatedModel) const
@@ -239,6 +300,42 @@ bool Tabulated::operator==(const Model& aModel) const
 bool Tabulated::operator!=(const Model& aModel) const
 {
     return !((*this) == aModel);
+}
+
+bool Tabulated::computeInterpolationData(
+    const Array<State>& aStateArray, VectorXd& aTimestampVector, MatrixXd& aCoordinateMatrix
+)
+{
+    if (aStateArray.getSize() < 2)
+    {
+        return false;
+    }
+
+    Array<State> stateArray = aStateArray;
+
+    std::sort(
+        stateArray.begin(),
+        stateArray.end(),
+        [](const auto& lhs, const auto& rhs)
+        {
+            return lhs.getInstant() < rhs.getInstant();
+        }
+    );
+
+    firstState_ = stateArray.accessFirst();
+    lastState_ = stateArray.accessLast();
+
+    aTimestampVector.resize(stateArray.getSize());
+    aCoordinateMatrix.resize(stateArray.getSize(), firstState_.getSize());
+
+    for (Index i = 0; i < stateArray.getSize(); ++i)
+    {
+        aTimestampVector(i) = (stateArray[i].accessInstant() - firstState_.accessInstant()).inSeconds();
+
+        aCoordinateMatrix.row(i) = stateArray[i].accessCoordinates();
+    }
+
+    return true;
 }
 
 }  // namespace model

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
@@ -5,6 +5,11 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateBroker.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianAcceleration.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
 
 namespace ostk
 {
@@ -54,19 +59,12 @@ Tabulated::Tabulated(
 
     const Shared<const CoordinateBroker>& coordinatesBroker = firstState_.accessCoordinateBroker();
 
-    // Index the requested interpolation types by coordinate subset id, ensuring each requested subset is present in
-    // the provided states.
+    // Index the requested interpolation types by coordinate subset id. Entries for coordinate subsets that are not
+    // present in the states are ignored.
     Map<String, Interpolator::Type> interpolationTypeBySubsetId;
 
     for (const auto& [coordinateSubsetSPtr, interpolationType] : anInterpolationTypeMap)
     {
-        if (!coordinatesBroker->hasSubset(coordinateSubsetSPtr))
-        {
-            throw ostk::core::error::RuntimeError(String::Format(
-                "The provided states do not contain the coordinate subset [{}].", coordinateSubsetSPtr->getName()
-            ));
-        }
-
         interpolationTypeBySubsetId[coordinateSubsetSPtr->getId()] = interpolationType;
     }
 
@@ -288,6 +286,36 @@ void Tabulated::print(std::ostream& anOutputStream, bool displayDecorator) const
     }
 
     displayDecorator ? ostk::core::utils::Print::Footer(anOutputStream) : void();
+}
+
+Tabulated Tabulated::Default(const Array<State>& aStateArray)
+{
+    return Tabulated(aStateArray, Tabulated::DefaultInterpolationTypes());
+}
+
+Map<Shared<const CoordinateSubset>, Interpolator::Type> Tabulated::DefaultInterpolationTypes()
+{
+    using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+    using ostk::astrodynamics::trajectory::state::coordinatesubset::AngularVelocity;
+    using ostk::astrodynamics::trajectory::state::coordinatesubset::AttitudeQuaternion;
+    using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianAcceleration;
+    using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+    using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
+
+    static const Map<Shared<const CoordinateSubset>, Interpolator::Type> defaultInterpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
+        {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
+        {CartesianAcceleration::Default(), Interpolator::Type::BarycentricRational},
+        {AttitudeQuaternion::Default(), Interpolator::Type::BarycentricRational},
+        {AngularVelocity::Default(), Interpolator::Type::BarycentricRational},
+        {CoordinateSubset::Mass(), Interpolator::Type::BarycentricRational},
+        {CoordinateSubset::DragCoefficient(), Interpolator::Type::ZeroOrder},
+        {CoordinateSubset::SurfaceArea(), Interpolator::Type::ZeroOrder},
+        {CoordinateSubset::MassFlowRate(), Interpolator::Type::ZeroOrder},
+        {CoordinateSubset::BallisticCoefficient(), Interpolator::Type::ZeroOrder},
+    };
+
+    return defaultInterpolationTypes;
 }
 
 bool Tabulated::operator==(const Model& aModel) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
@@ -6,7 +6,6 @@
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateBroker.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.hpp>
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianAcceleration.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
@@ -19,6 +18,12 @@ namespace trajectory
 {
 namespace model
 {
+
+using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::AngularVelocity;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianAcceleration;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
 Tabulated::Tabulated(const Array<State>& aStateArray, const Interpolator::Type& anInterpolationType)
     : Model()
@@ -79,9 +84,12 @@ Tabulated::Tabulated(
 
         if (interpolationTypeIt == interpolationTypeBySubsetId.end())
         {
-            throw ostk::core::error::RuntimeError(String::Format(
-                "No interpolation type was provided for the coordinate subset [{}].", coordinateSubsetSPtr->getName()
-            ));
+            throw ostk::core::error::RuntimeError(
+                String::Format(
+                    "No interpolation type was provided for the coordinate subset [{}].",
+                    coordinateSubsetSPtr->getName()
+                )
+            );
         }
 
         for (Size i = 0; i < coordinateSubsetSPtr->getSize(); ++i)
@@ -197,12 +205,14 @@ State Tabulated::calculateStateAt(const Instant& anInstant) const
 
     if (anInstant < firstState_.accessInstant() || anInstant > lastState_.accessInstant())
     {
-        throw ostk::core::error::RuntimeError(String::Format(
-            "Provided instant [{}] is outside of interpolation range [{}, {}].",
-            anInstant.toString(),
-            firstState_.accessInstant().toString(),
-            lastState_.accessInstant().toString()
-        ));
+        throw ostk::core::error::RuntimeError(
+            String::Format(
+                "Provided instant [{}] is outside of interpolation range [{}, {}].",
+                anInstant.toString(),
+                firstState_.accessInstant().toString(),
+                lastState_.accessInstant().toString()
+            )
+        );
     }
 
     VectorXd interpolatedCoordinates(interpolators_.getSize());
@@ -295,20 +305,12 @@ Tabulated Tabulated::Default(const Array<State>& aStateArray)
 
 Map<Shared<const CoordinateSubset>, Interpolator::Type> Tabulated::DefaultInterpolationTypes()
 {
-    using ostk::astrodynamics::trajectory::state::CoordinateSubset;
-    using ostk::astrodynamics::trajectory::state::coordinatesubset::AngularVelocity;
-    using ostk::astrodynamics::trajectory::state::coordinatesubset::AttitudeQuaternion;
-    using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianAcceleration;
-    using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
-    using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
-
     static const Map<Shared<const CoordinateSubset>, Interpolator::Type> defaultInterpolationTypes = {
         {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
         {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
         {CartesianAcceleration::Default(), Interpolator::Type::BarycentricRational},
-        {AttitudeQuaternion::Default(), Interpolator::Type::BarycentricRational},
         {AngularVelocity::Default(), Interpolator::Type::BarycentricRational},
-        {CoordinateSubset::Mass(), Interpolator::Type::BarycentricRational},
+        {CoordinateSubset::Mass(), Interpolator::Type::ZeroOrder},
         {CoordinateSubset::DragCoefficient(), Interpolator::Type::ZeroOrder},
         {CoordinateSubset::SurfaceArea(), Interpolator::Type::ZeroOrder},
         {CoordinateSubset::MassFlowRate(), Interpolator::Type::ZeroOrder},

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.cpp
@@ -84,12 +84,9 @@ Tabulated::Tabulated(
 
         if (interpolationTypeIt == interpolationTypeBySubsetId.end())
         {
-            throw ostk::core::error::RuntimeError(
-                String::Format(
-                    "No interpolation type was provided for the coordinate subset [{}].",
-                    coordinateSubsetSPtr->getName()
-                )
-            );
+            throw ostk::core::error::RuntimeError(String::Format(
+                "No interpolation type was provided for the coordinate subset [{}].", coordinateSubsetSPtr->getName()
+            ));
         }
 
         for (Size i = 0; i < coordinateSubsetSPtr->getSize(); ++i)
@@ -205,14 +202,12 @@ State Tabulated::calculateStateAt(const Instant& anInstant) const
 
     if (anInstant < firstState_.accessInstant() || anInstant > lastState_.accessInstant())
     {
-        throw ostk::core::error::RuntimeError(
-            String::Format(
-                "Provided instant [{}] is outside of interpolation range [{}, {}].",
-                anInstant.toString(),
-                firstState_.accessInstant().toString(),
-                lastState_.accessInstant().toString()
-            )
-        );
+        throw ostk::core::error::RuntimeError(String::Format(
+            "Provided instant [{}] is outside of interpolation range [{}, {}].",
+            anInstant.toString(),
+            firstState_.accessInstant().toString(),
+            lastState_.accessInstant().toString()
+        ));
     }
 
     VectorXd interpolatedCoordinates(interpolators_.getSize());

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.cpp
@@ -27,6 +27,17 @@ Tabulated::Tabulated(
 {
 }
 
+Tabulated::Tabulated(
+    const Array<State>& aStateArray,
+    const Integer& anInitialRevolutionNumber,
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
+)
+    : trajectory::orbit::Model(),
+      trajectory::model::Tabulated(aStateArray, anInterpolationTypeMap),
+      initialRevolutionNumber_(anInitialRevolutionNumber)
+{
+}
+
 Tabulated* Tabulated::clone() const
 {
     return new Tabulated(*this);

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.cpp
@@ -94,6 +94,11 @@ void Tabulated::print(std::ostream& anOutputStream, bool displayDecorator) const
     trajectory::model::Tabulated::print(anOutputStream, displayDecorator);
 }
 
+Tabulated Tabulated::Default(const Array<State>& aStateArray, const Integer& anInitialRevolutionNumber)
+{
+    return Tabulated(aStateArray, anInitialRevolutionNumber, trajectory::model::Tabulated::DefaultInterpolationTypes());
+}
+
 bool Tabulated::operator==(const trajectory::Model& aModel) const
 {
     const Tabulated* tabulatedModelPtr = dynamic_cast<const Tabulated*>(&aModel);

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Tabulated.test.cpp
@@ -97,45 +97,40 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated, Construct
     {
         EXPECT_NO_THROW(Tabulated tabulated(states_););
     }
-}
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated, ConstructorWithInterpolationTypeMap)
-{
-    // The attitude quaternion entry is ignored (attitude is always interpolated using SLERP); all other reduced
-    // coordinate subsets use the type given for them.
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
-        {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
-        {AngularVelocity::Default(), Interpolator::Type::BarycentricRational},
-        {AttitudeQuaternion::Default(), Interpolator::Type::Linear},
-    };
+    {
+        // The attitude quaternion entry is ignored (attitude is always interpolated using SLERP); all other reduced
+        // coordinate subsets use the type given for them.
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
+            {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
+            {AngularVelocity::Default(), Interpolator::Type::BarycentricRational},
+            {AttitudeQuaternion::Default(), Interpolator::Type::Linear},
+        };
 
-    const Tabulated tabulatedFromMap = Tabulated(states_, interpolationTypes);
-    const Tabulated tabulatedFromType = Tabulated(states_, Interpolator::Type::BarycentricRational);
+        const Tabulated tabulatedFromMap = Tabulated(states_, interpolationTypes);
+        const Tabulated tabulatedFromType = Tabulated(states_, Interpolator::Type::BarycentricRational);
 
-    EXPECT_TRUE(tabulatedFromMap.isDefined());
+        EXPECT_TRUE(tabulatedFromMap.isDefined());
 
-    const Instant instant = Instant::DateTime(DateTime(2024, 1, 29, 0, 0, 15), Scale::UTC);
+        const Instant instant = Instant::DateTime(DateTime(2024, 1, 29, 0, 0, 15), Scale::UTC);
 
-    EXPECT_VECTORS_ALMOST_EQUAL(
-        tabulatedFromMap.calculateStateAt(instant).getCoordinates(),
-        tabulatedFromType.calculateStateAt(instant).getCoordinates(),
-        1e-12
-    );
-}
+        EXPECT_VECTORS_ALMOST_EQUAL(
+            tabulatedFromMap.calculateStateAt(instant).getCoordinates(),
+            tabulatedFromType.calculateStateAt(instant).getCoordinates(),
+            1e-12
+        );
+    }
 
-TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated,
-    ConstructorWithInterpolationTypeMap_MissingTypeForSubset
-)
-{
     // The (reduced) states contain AngularVelocity but no interpolation type is provided for it.
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
-        {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
-    };
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
+            {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
+        };
 
-    EXPECT_THROW(Tabulated(states_, interpolationTypes), ostk::core::error::RuntimeError);
+        EXPECT_THROW(Tabulated(states_, interpolationTypes), ostk::core::error::RuntimeError);
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated, Default)

--- a/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Flight/Profile/Tabulated.test.cpp
@@ -1,11 +1,19 @@
 /// Apache License 2.0
 
+#include <OpenSpaceToolkit/Core/Container/Map.hpp>
+
 #include <OpenSpaceToolkit/Astrodynamics/Flight/Profile/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AttitudeQuaternion.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
 
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
+using ostk::core::container::Map;
 using ostk::core::container::String;
 using ostk::core::type::Shared;
 
@@ -26,6 +34,11 @@ using ostk::physics::time::Scale;
 
 using ostk::astrodynamics::flight::profile::model::Tabulated;
 using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::AngularVelocity;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::AttitudeQuaternion;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
 class OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated : public ::testing::Test
 {
@@ -84,6 +97,55 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated, Construct
     {
         EXPECT_NO_THROW(Tabulated tabulated(states_););
     }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated, ConstructorWithInterpolationTypeMap)
+{
+    // The attitude quaternion entry is ignored (attitude is always interpolated using SLERP); all other reduced
+    // coordinate subsets use the type given for them.
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
+        {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
+        {AngularVelocity::Default(), Interpolator::Type::BarycentricRational},
+        {AttitudeQuaternion::Default(), Interpolator::Type::Linear},
+    };
+
+    const Tabulated tabulatedFromMap = Tabulated(states_, interpolationTypes);
+    const Tabulated tabulatedFromType = Tabulated(states_, Interpolator::Type::BarycentricRational);
+
+    EXPECT_TRUE(tabulatedFromMap.isDefined());
+
+    const Instant instant = Instant::DateTime(DateTime(2024, 1, 29, 0, 0, 15), Scale::UTC);
+
+    EXPECT_VECTORS_ALMOST_EQUAL(
+        tabulatedFromMap.calculateStateAt(instant).getCoordinates(),
+        tabulatedFromType.calculateStateAt(instant).getCoordinates(),
+        1e-12
+    );
+}
+
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated,
+    ConstructorWithInterpolationTypeMap_MissingTypeForSubset
+)
+{
+    // The (reduced) states contain AngularVelocity but no interpolation type is provided for it.
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::BarycentricRational},
+        {CartesianVelocity::Default(), Interpolator::Type::BarycentricRational},
+    };
+
+    EXPECT_THROW(Tabulated(states_, interpolationTypes), ostk::core::error::RuntimeError);
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated, Default)
+{
+    const Tabulated tabulated = Tabulated::Default(states_);
+
+    EXPECT_TRUE(tabulated.isDefined());
+    EXPECT_EQ(tabulated.getInterpolatorType(), Interpolator::Type::BarycentricRational);
+
+    EXPECT_NO_THROW(tabulated.calculateStateAt(Instant::DateTime(DateTime(2024, 1, 29, 0, 0, 15), Scale::UTC)));
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Flight_Profile_Models_Tabulated, EqualToOperator)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
@@ -1,0 +1,152 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Map.hpp>
+#include <OpenSpaceToolkit/Core/Type/Shared.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp>
+#include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
+
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
+#include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
+#include <OpenSpaceToolkit/Physics/Time/DateTime.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::container::Array;
+using ostk::core::container::Map;
+using ostk::core::type::Shared;
+using ostk::core::type::Size;
+
+using ostk::mathematics::curvefitting::Interpolator;
+using ostk::mathematics::object::VectorXd;
+
+using ostk::physics::coordinate::Frame;
+using ostk::physics::coordinate::Position;
+using ostk::physics::coordinate::Velocity;
+using ostk::physics::time::DateTime;
+using ostk::physics::time::Duration;
+using ostk::physics::time::Instant;
+using ostk::physics::time::Scale;
+
+using ostk::astrodynamics::trajectory::model::Tabulated;
+using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
+
+class OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated : public ::testing::Test
+{
+   protected:
+    void SetUp() override
+    {
+        const Instant startInstant = Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00.000"), Scale::UTC);
+
+        for (Size i = 0; i < 10; ++i)
+        {
+            states_.add(State(
+                startInstant + Duration::Minutes(static_cast<double>(i)),
+                Position::Meters({1.0 + i, 2.0 + 2.0 * i, 3.0 + 3.0 * i}, Frame::GCRF()),
+                Velocity::MetersPerSecond({4.0 + i, 5.0 + i, 6.0 + i}, Frame::GCRF())
+            ));
+        }
+    }
+
+    Array<State> states_ = Array<State>::Empty();
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap)
+{
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        {CartesianVelocity::Default(), Interpolator::Type::Linear},
+    };
+
+    const Tabulated tabulated(states_, interpolationTypes);
+
+    EXPECT_TRUE(tabulated.isDefined());
+    EXPECT_TRUE(tabulated.getInterval().isDefined());
+}
+
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_MissingSubsetInStates
+)
+{
+    // The states only contain CartesianPosition and CartesianVelocity, so referencing Mass must raise.
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        {CartesianVelocity::Default(), Interpolator::Type::Linear},
+        {CoordinateSubset::Mass(), Interpolator::Type::Linear},
+    };
+
+    EXPECT_THROW({ const Tabulated tabulated(states_, interpolationTypes); }, ostk::core::error::RuntimeError);
+}
+
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_MissingTypeForSubset
+)
+{
+    // The states contain CartesianVelocity but no interpolation type is provided for it.
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+    };
+
+    EXPECT_THROW({ const Tabulated tabulated(states_, interpolationTypes); }, ostk::core::error::RuntimeError);
+}
+
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_MatchesUniformType
+)
+{
+    // A per-subset map assigning the same type to every subset must behave identically to the single-type
+    // constructor.
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        {CartesianVelocity::Default(), Interpolator::Type::CubicSpline},
+    };
+
+    const Tabulated tabulatedFromMap(states_, interpolationTypes);
+    const Tabulated tabulatedFromType(states_, Interpolator::Type::CubicSpline);
+
+    EXPECT_TRUE(tabulatedFromMap == tabulatedFromType);
+
+    for (Size i = 0; i < states_.getSize() - 1; ++i)
+    {
+        const Instant instant = states_[i].accessInstant() + Duration::Seconds(13.0);
+
+        const VectorXd fromMapCoordinates = tabulatedFromMap.calculateStateAt(instant).getCoordinates();
+        const VectorXd fromTypeCoordinates = tabulatedFromType.calculateStateAt(instant).getCoordinates();
+
+        EXPECT_TRUE(fromMapCoordinates.isApprox(fromTypeCoordinates, 1e-12));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_DistinctTypes)
+{
+    // Distinct per-subset types must produce a model distinct from any single-type model.
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        {CartesianVelocity::Default(), Interpolator::Type::Linear},
+    };
+
+    const Tabulated tabulatedFromMap(states_, interpolationTypes);
+
+    EXPECT_TRUE(tabulatedFromMap != Tabulated(states_, Interpolator::Type::CubicSpline));
+    EXPECT_TRUE(tabulatedFromMap != Tabulated(states_, Interpolator::Type::Linear));
+
+    const State state =
+        tabulatedFromMap.calculateStateAt(states_.accessFirst().accessInstant() + Duration::Seconds(30.0));
+
+    EXPECT_TRUE(state.isDefined());
+    EXPECT_TRUE(state.getCoordinates().allFinite());
+}

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
@@ -42,6 +42,8 @@ using ostk::physics::time::Scale;
 using ostk::astrodynamics::trajectory::model::Tabulated;
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::AngularVelocity;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianAcceleration;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
 using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
@@ -159,11 +161,13 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, DefaultInterpo
 {
     const Map<Shared<const CoordinateSubset>, Interpolator::Type> defaultTypes = Tabulated::DefaultInterpolationTypes();
 
-    EXPECT_EQ(defaultTypes.size(), Size(10));
+    EXPECT_EQ(defaultTypes.size(), Size(9));
 
     EXPECT_EQ(defaultTypes.at(CartesianPosition::Default()), Interpolator::Type::BarycentricRational);
     EXPECT_EQ(defaultTypes.at(CartesianVelocity::Default()), Interpolator::Type::BarycentricRational);
-    EXPECT_EQ(defaultTypes.at(CoordinateSubset::Mass()), Interpolator::Type::BarycentricRational);
+    EXPECT_EQ(defaultTypes.at(CartesianAcceleration::Default()), Interpolator::Type::BarycentricRational);
+    EXPECT_EQ(defaultTypes.at(AngularVelocity::Default()), Interpolator::Type::BarycentricRational);
+    EXPECT_EQ(defaultTypes.at(CoordinateSubset::Mass()), Interpolator::Type::ZeroOrder);
     EXPECT_EQ(defaultTypes.at(CoordinateSubset::DragCoefficient()), Interpolator::Type::ZeroOrder);
     EXPECT_EQ(defaultTypes.at(CoordinateSubset::SurfaceArea()), Interpolator::Type::ZeroOrder);
     EXPECT_EQ(defaultTypes.at(CoordinateSubset::MassFlowRate()), Interpolator::Type::ZeroOrder);

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
@@ -79,20 +79,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWit
 }
 
 TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_MissingSubsetInStates
-)
-{
-    // The states only contain CartesianPosition and CartesianVelocity, so referencing Mass must raise.
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-        {CartesianVelocity::Default(), Interpolator::Type::Linear},
-        {CoordinateSubset::Mass(), Interpolator::Type::Linear},
-    };
-
-    EXPECT_THROW({ const Tabulated tabulated(states_, interpolationTypes); }, ostk::core::error::RuntimeError);
-}
-
-TEST_F(
     OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_MissingTypeForSubset
 )
 {
@@ -149,4 +135,45 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWit
 
     EXPECT_TRUE(state.isDefined());
     EXPECT_TRUE(state.getCoordinates().allFinite());
+}
+
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_IgnoresUnknownSubsets
+)
+{
+    // Coordinate subsets in the map that are not present in the states are ignored (no error).
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        {CartesianVelocity::Default(), Interpolator::Type::Linear},
+        {CoordinateSubset::Mass(), Interpolator::Type::BarycentricRational},
+        {CoordinateSubset::DragCoefficient(), Interpolator::Type::ZeroOrder},
+    };
+
+    const Tabulated tabulated(states_, interpolationTypes);
+
+    EXPECT_TRUE(tabulated.isDefined());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, Default)
+{
+    const Tabulated tabulated = Tabulated::Default(states_);
+
+    EXPECT_TRUE(tabulated.isDefined());
+    // Position is interpolated using barycentric rational by default.
+    EXPECT_EQ(tabulated.getInterpolationType(), Interpolator::Type::BarycentricRational);
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, DefaultInterpolationTypes)
+{
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> defaultTypes = Tabulated::DefaultInterpolationTypes();
+
+    EXPECT_EQ(defaultTypes.size(), Size(10));
+
+    EXPECT_EQ(defaultTypes.at(CartesianPosition::Default()), Interpolator::Type::BarycentricRational);
+    EXPECT_EQ(defaultTypes.at(CartesianVelocity::Default()), Interpolator::Type::BarycentricRational);
+    EXPECT_EQ(defaultTypes.at(CoordinateSubset::Mass()), Interpolator::Type::BarycentricRational);
+    EXPECT_EQ(defaultTypes.at(CoordinateSubset::DragCoefficient()), Interpolator::Type::ZeroOrder);
+    EXPECT_EQ(defaultTypes.at(CoordinateSubset::SurfaceArea()), Interpolator::Type::ZeroOrder);
+    EXPECT_EQ(defaultTypes.at(CoordinateSubset::MassFlowRate()), Interpolator::Type::ZeroOrder);
+    EXPECT_EQ(defaultTypes.at(CoordinateSubset::BallisticCoefficient()), Interpolator::Type::ZeroOrder);
 }

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
@@ -18,6 +18,8 @@
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/AngularVelocity.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianAcceleration.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Tabulated.test.cpp
@@ -65,93 +65,85 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated : public ::testi
     Array<State> states_ = Array<State>::Empty();
 };
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap)
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, Constructor)
 {
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-        {CartesianVelocity::Default(), Interpolator::Type::Linear},
-    };
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+            {CartesianVelocity::Default(), Interpolator::Type::Linear},
+        };
 
-    const Tabulated tabulated(states_, interpolationTypes);
+        const Tabulated tabulated(states_, interpolationTypes);
 
-    EXPECT_TRUE(tabulated.isDefined());
-    EXPECT_TRUE(tabulated.getInterval().isDefined());
-}
+        EXPECT_TRUE(tabulated.isDefined());
+        EXPECT_TRUE(tabulated.getInterval().isDefined());
+    }
 
-TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_MissingTypeForSubset
-)
-{
-    // The states contain CartesianVelocity but no interpolation type is provided for it.
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-    };
+    // Coordinate subsets in the map that are not present in the states are ignored (no error).
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+            {CartesianVelocity::Default(), Interpolator::Type::Linear},
+            {CoordinateSubset::Mass(), Interpolator::Type::BarycentricRational},
+            {CoordinateSubset::DragCoefficient(), Interpolator::Type::ZeroOrder},
+        };
 
-    EXPECT_THROW({ const Tabulated tabulated(states_, interpolationTypes); }, ostk::core::error::RuntimeError);
-}
+        const Tabulated tabulated(states_, interpolationTypes);
 
-TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_MatchesUniformType
-)
-{
+        EXPECT_TRUE(tabulated.isDefined());
+    }
+
     // A per-subset map assigning the same type to every subset must behave identically to the single-type
     // constructor.
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-        {CartesianVelocity::Default(), Interpolator::Type::CubicSpline},
-    };
-
-    const Tabulated tabulatedFromMap(states_, interpolationTypes);
-    const Tabulated tabulatedFromType(states_, Interpolator::Type::CubicSpline);
-
-    EXPECT_TRUE(tabulatedFromMap == tabulatedFromType);
-
-    for (Size i = 0; i < states_.getSize() - 1; ++i)
     {
-        const Instant instant = states_[i].accessInstant() + Duration::Seconds(13.0);
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+            {CartesianVelocity::Default(), Interpolator::Type::CubicSpline},
+        };
 
-        const VectorXd fromMapCoordinates = tabulatedFromMap.calculateStateAt(instant).getCoordinates();
-        const VectorXd fromTypeCoordinates = tabulatedFromType.calculateStateAt(instant).getCoordinates();
+        const Tabulated tabulatedFromMap(states_, interpolationTypes);
+        const Tabulated tabulatedFromType(states_, Interpolator::Type::CubicSpline);
 
-        EXPECT_TRUE(fromMapCoordinates.isApprox(fromTypeCoordinates, 1e-12));
+        EXPECT_TRUE(tabulatedFromMap == tabulatedFromType);
+
+        for (Size i = 0; i < states_.getSize() - 1; ++i)
+        {
+            const Instant instant = states_[i].accessInstant() + Duration::Seconds(13.0);
+
+            const VectorXd fromMapCoordinates = tabulatedFromMap.calculateStateAt(instant).getCoordinates();
+            const VectorXd fromTypeCoordinates = tabulatedFromType.calculateStateAt(instant).getCoordinates();
+
+            EXPECT_TRUE(fromMapCoordinates.isApprox(fromTypeCoordinates, 1e-12));
+        }
     }
-}
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_DistinctTypes)
-{
+    // The states contain CartesianVelocity but no interpolation type is provided for it.
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        };
+
+        EXPECT_THROW({ const Tabulated tabulated(states_, interpolationTypes); }, ostk::core::error::RuntimeError);
+    }
+
     // Distinct per-subset types must produce a model distinct from any single-type model.
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-        {CartesianVelocity::Default(), Interpolator::Type::Linear},
-    };
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+            {CartesianVelocity::Default(), Interpolator::Type::Linear},
+        };
 
-    const Tabulated tabulatedFromMap(states_, interpolationTypes);
+        const Tabulated tabulatedFromMap(states_, interpolationTypes);
 
-    EXPECT_TRUE(tabulatedFromMap != Tabulated(states_, Interpolator::Type::CubicSpline));
-    EXPECT_TRUE(tabulatedFromMap != Tabulated(states_, Interpolator::Type::Linear));
+        EXPECT_TRUE(tabulatedFromMap != Tabulated(states_, Interpolator::Type::CubicSpline));
+        EXPECT_TRUE(tabulatedFromMap != Tabulated(states_, Interpolator::Type::Linear));
 
-    const State state =
-        tabulatedFromMap.calculateStateAt(states_.accessFirst().accessInstant() + Duration::Seconds(30.0));
+        const State state =
+            tabulatedFromMap.calculateStateAt(states_.accessFirst().accessInstant() + Duration::Seconds(30.0));
 
-    EXPECT_TRUE(state.isDefined());
-    EXPECT_TRUE(state.getCoordinates().allFinite());
-}
-
-TEST_F(
-    OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, ConstructorWithInterpolationTypeMap_IgnoresUnknownSubsets
-)
-{
-    // Coordinate subsets in the map that are not present in the states are ignored (no error).
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-        {CartesianVelocity::Default(), Interpolator::Type::Linear},
-        {CoordinateSubset::Mass(), Interpolator::Type::BarycentricRational},
-        {CoordinateSubset::DragCoefficient(), Interpolator::Type::ZeroOrder},
-    };
-
-    const Tabulated tabulated(states_, interpolationTypes);
-
-    EXPECT_TRUE(tabulated.isDefined());
+        EXPECT_TRUE(state.isDefined());
+        EXPECT_TRUE(state.getCoordinates().allFinite());
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Model_Tabulated, Default)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
@@ -1,7 +1,9 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Map.hpp>
 #include <OpenSpaceToolkit/Core/Container/Table.hpp>
+#include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp>
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
@@ -11,10 +13,14 @@
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
 
 #include <Global.test.hpp>
 
 using ostk::core::container::Array;
+using ostk::core::container::Map;
 using ostk::core::container::Table;
 using ostk::core::container::Tuple;
 using ostk::core::filesystem::File;
@@ -22,6 +28,7 @@ using ostk::core::filesystem::Path;
 using ostk::core::type::Index;
 using ostk::core::type::Integer;
 using ostk::core::type::Real;
+using ostk::core::type::Shared;
 using ostk::core::type::Size;
 using ostk::core::type::String;
 
@@ -41,6 +48,9 @@ using ostk::astrodynamics::trajectory::Orbit;
 using ostk::astrodynamics::trajectory::orbit::Model;
 using ostk::astrodynamics::trajectory::orbit::model::Tabulated;
 using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 
 class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated : public ::testing::Test
 {
@@ -110,6 +120,44 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Construc
     Environment environment = Environment::Default();
 
     const Orbit orbit = {tabulated, environment.accessCelestialObjectWithName("Earth")};
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, ConstructorWithInterpolationTypeMap)
+{
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        {CartesianVelocity::Default(), Interpolator::Type::Linear},
+    };
+
+    const Tabulated tabulated(states_, 0, interpolationTypes);
+
+    EXPECT_TRUE(tabulated.isDefined());
+    EXPECT_TRUE(tabulated.getRevolutionNumberAtEpoch() == 0);
+
+    Environment environment = Environment::Default();
+
+    const Orbit orbit = {tabulated, environment.accessCelestialObjectWithName("Earth")};
+
+    EXPECT_TRUE(orbit.isDefined());
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, ConstructorWithInterpolationTypeMap_Failure)
+{
+    // Referencing a coordinate subset that is not present in the states must raise.
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> missingSubsetInStates = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        {CartesianVelocity::Default(), Interpolator::Type::Linear},
+        {CoordinateSubset::Mass(), Interpolator::Type::Linear},
+    };
+
+    EXPECT_THROW({ const Tabulated tabulated(states_, 0, missingSubsetInStates); }, ostk::core::error::RuntimeError);
+
+    // Omitting the interpolation type for a coordinate subset present in the states must raise.
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> missingTypeForSubset = {
+        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+    };
+
+    EXPECT_THROW({ const Tabulated tabulated(states_, 0, missingTypeForSubset); }, ostk::core::error::RuntimeError);
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, GetInterval)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
@@ -11,7 +11,6 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 
-#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
@@ -44,7 +43,6 @@ using ostk::physics::time::Duration;
 using ostk::physics::time::Instant;
 using ostk::physics::time::Scale;
 
-using ostk::astrodynamics::trajectory::Orbit;
 using ostk::astrodynamics::trajectory::orbit::Model;
 using ostk::astrodynamics::trajectory::orbit::model::Tabulated;
 using ostk::astrodynamics::trajectory::State;
@@ -73,9 +71,11 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated : public :
         referenceStates_.clear();
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated/Satellite Orbit.csv"
-            )),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated/Satellite Orbit.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -115,49 +115,43 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated : public :
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Constructor)
 {
-    const Tabulated tabulated(states_, 0, Interpolator::Type::Linear);
+    {
+        const Tabulated tabulated(states_, 0, Interpolator::Type::Linear);
 
-    Environment environment = Environment::Default();
+        EXPECT_TRUE(tabulated.isDefined());
+    }
 
-    const Orbit orbit = {tabulated, environment.accessCelestialObjectWithName("Earth")};
-}
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+            {CartesianVelocity::Default(), Interpolator::Type::Linear},
+        };
 
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, ConstructorWithInterpolationTypeMap)
-{
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-        {CartesianVelocity::Default(), Interpolator::Type::Linear},
-    };
+        const Tabulated tabulated(states_, 0, interpolationTypes);
 
-    const Tabulated tabulated(states_, 0, interpolationTypes);
+        EXPECT_TRUE(tabulated.isDefined());
+        EXPECT_TRUE(tabulated.getRevolutionNumberAtEpoch() == 0);
+    }
 
-    EXPECT_TRUE(tabulated.isDefined());
-    EXPECT_TRUE(tabulated.getRevolutionNumberAtEpoch() == 0);
-
-    Environment environment = Environment::Default();
-
-    const Orbit orbit = {tabulated, environment.accessCelestialObjectWithName("Earth")};
-
-    EXPECT_TRUE(orbit.isDefined());
-}
-
-TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, ConstructorWithInterpolationTypeMap_Failure)
-{
     // Coordinate subsets in the map that are not present in the states are ignored (no error).
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> unknownSubsetInStates = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-        {CartesianVelocity::Default(), Interpolator::Type::Linear},
-        {CoordinateSubset::Mass(), Interpolator::Type::Linear},
-    };
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> unknownSubsetInStates = {
+            {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+            {CartesianVelocity::Default(), Interpolator::Type::Linear},
+            {CoordinateSubset::Mass(), Interpolator::Type::Linear},
+        };
 
-    EXPECT_NO_THROW({ const Tabulated tabulated(states_, 0, unknownSubsetInStates); });
+        EXPECT_NO_THROW({ const Tabulated tabulated(states_, 0, unknownSubsetInStates); });
+    }
 
     // Omitting the interpolation type for a coordinate subset present in the states must raise.
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> missingTypeForSubset = {
-        {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
-    };
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> missingTypeForSubset = {
+            {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
+        };
 
-    EXPECT_THROW({ const Tabulated tabulated(states_, 0, missingTypeForSubset); }, ostk::core::error::RuntimeError);
+        EXPECT_THROW({ const Tabulated tabulated(states_, 0, missingTypeForSubset); }, ostk::core::error::RuntimeError);
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Default)
@@ -170,12 +164,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Default)
 
     // The initial revolution number defaults to 1.
     EXPECT_TRUE(Tabulated::Default(states_).getRevolutionNumberAtEpoch() == 1);
-
-    Environment environment = Environment::Default();
-
-    const Orbit orbit = {tabulated, environment.accessCelestialObjectWithName("Earth")};
-
-    EXPECT_TRUE(orbit.isDefined());
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, GetInterval)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
@@ -143,14 +143,14 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Construc
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, ConstructorWithInterpolationTypeMap_Failure)
 {
-    // Referencing a coordinate subset that is not present in the states must raise.
-    const Map<Shared<const CoordinateSubset>, Interpolator::Type> missingSubsetInStates = {
+    // Coordinate subsets in the map that are not present in the states are ignored (no error).
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type> unknownSubsetInStates = {
         {CartesianPosition::Default(), Interpolator::Type::CubicSpline},
         {CartesianVelocity::Default(), Interpolator::Type::Linear},
         {CoordinateSubset::Mass(), Interpolator::Type::Linear},
     };
 
-    EXPECT_THROW({ const Tabulated tabulated(states_, 0, missingSubsetInStates); }, ostk::core::error::RuntimeError);
+    EXPECT_NO_THROW({ const Tabulated tabulated(states_, 0, unknownSubsetInStates); });
 
     // Omitting the interpolation type for a coordinate subset present in the states must raise.
     const Map<Shared<const CoordinateSubset>, Interpolator::Type> missingTypeForSubset = {
@@ -158,6 +158,24 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Construc
     };
 
     EXPECT_THROW({ const Tabulated tabulated(states_, 0, missingTypeForSubset); }, ostk::core::error::RuntimeError);
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Default)
+{
+    const Tabulated tabulated = Tabulated::Default(states_, 0);
+
+    EXPECT_TRUE(tabulated.isDefined());
+    EXPECT_TRUE(tabulated.getRevolutionNumberAtEpoch() == 0);
+    EXPECT_EQ(tabulated.getInterpolationType(), Interpolator::Type::BarycentricRational);
+
+    // The initial revolution number defaults to 1.
+    EXPECT_TRUE(Tabulated::Default(states_).getRevolutionNumberAtEpoch() == 1);
+
+    Environment environment = Environment::Default();
+
+    const Orbit orbit = {tabulated, environment.accessCelestialObjectWithName("Earth")};
+
+    EXPECT_TRUE(orbit.isDefined());
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, GetInterval)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
@@ -71,11 +71,9 @@ class OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated : public :
         referenceStates_.clear();
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated/Satellite Orbit.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated/Satellite Orbit.csv"
+            )),
             Table::Format::CSV,
             true
         );


### PR DESCRIPTION
- Tabulated trajectory, orbit, and profile models now support per-coordinate-subset interpolation configuration 
- Default static constructor using sensible per-subset interpolation choices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for per-coordinate-subset interpolation type configuration in tabulated trajectory, orbit, and flight profile models, enabling distinct interpolation methods for position, velocity, and other coordinate subsets.
  * Introduced `Default()` static factory methods for convenient model construction using optimized interpolation defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->