### PR TITLE
fix: qlaw targeting without sma should pass

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.cpp
@@ -132,6 +132,18 @@ QLaw::QLaw(
       stateBuilder_(Frame::GCRF(), {std::make_shared<CoordinateSubset>("QLaw Element Vector", 5)}),
       coeDomain_(aCOEDomain)
 {
+    // The semi-major axis term of the proximity quotient Q is scaled by
+    //     S_a = (1 + (Δa / (m * a_target))^n)^(1/r),
+    // which divides by the target semi-major axis. Targeting the semi-major axis (a non-zero control
+    // weight) therefore requires a strictly positive target; otherwise S_a diverges. A zero weight is
+    // allowed: in that case the semi-major axis term and its scaling factor are neutralized in
+    // computeQ() and computeAnalytical_dQ_dOE().
+    if ((parameters_.controlWeights_(0) != 0.0) && !(targetCOEVector_(0) > 0.0))
+    {
+        throw ostk::core::error::RuntimeError(
+            "Q-Law target semi-major axis must be strictly positive when the semi-major axis is targeted."
+        );
+    }
 }
 
 QLaw::~QLaw() {}
@@ -305,10 +317,21 @@ double QLaw::computeQ(const Vector5d& aCOEVector, const double& aThrustAccelerat
     const Vector5d deltaCOE = computeDeltaCOE(aCOEVector);
 
     // S_oe
+    // The semi-major axis scaling factor S_a divides by the target semi-major axis. It is only
+    // meaningful when the semi-major axis is targeted; when it is not (control weight 0), the target may
+    // be a degenerate default (e.g. 0), which would make S_a diverge and yield 0 * inf = NaN in the
+    // weighted sum below. Neutralize it to 1.0 in that case so the (zero-weighted) semi-major axis term
+    // vanishes identically.
+    const double semiMajorAxisScaling =
+        (parameters_.controlWeights_(0) == 0.0)
+            ? 1.0
+            : std::pow(
+                  1.0 + std::pow(deltaCOE[0] / (parameters_.m * targetCOEVector_[0]), parameters_.n),
+                  1.0 / parameters_.r
+              );
+
     const Vector5d scalingCOE = {
-        std::pow(
-            (1.0 + std::pow(deltaCOE[0] / (parameters_.m * targetCOEVector_[0]), parameters_.n)), 1.0 / parameters_.r
-        ),
+        semiMajorAxisScaling,
         1.0,
         1.0,
         1.0,
@@ -539,10 +562,17 @@ Vector5d QLaw::computeAnalytical_dQ_dOE(const Vector5d& aCOEVector, const double
     const double x12 = std::pow(semiMajorAxis, -3.0);
     const double x13 = eccentricity + 1.0;
     const double x14 = 1.0 / x13;
-    const double x15 = std::pow(x10 / (parameters_.m * semiMajorAxisTarget), parameters_.n);
-    const double x16 = x15 + 1.0;
+    // x15/x16/x18 build the semi-major axis scaling factor S_a (= x18), which divides by the target
+    // semi-major axis. They are only meaningful when the semi-major axis is targeted; when it is not
+    // (semiMajorAxisWeight == 0), the target may be a degenerate default (e.g. 0), making them diverge
+    // and producing 0 * inf = NaN in x19/x82 (and downstream in x72/x79). Neutralize them so the
+    // (zero-weighted) semi-major axis term and all of its partial derivatives vanish identically.
     const double x17 = 1.0 / parameters_.r;
-    const double x18 = std::pow(x16, x17);
+    const bool semiMajorAxisTargeted = (semiMajorAxisWeight != 0.0);
+    const double x15 =
+        semiMajorAxisTargeted ? std::pow(x10 / (parameters_.m * semiMajorAxisTarget), parameters_.n) : 0.0;
+    const double x16 = x15 + 1.0;
+    const double x18 = semiMajorAxisTargeted ? std::pow(x16, x17) : 1.0;
     const double x19 = semiMajorAxisWeight * x12 * x14 * x18;
     const double x20 = x11 * x19;
     const double x21 = 4.0 * x9;

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
@@ -182,14 +182,66 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Constr
 {
     EXPECT_NO_THROW(QLaw qlaw(targetCOE_, gravitationalParameter_, parameters_, QLaw::COEDomain::Osculating));
 
-    EXPECT_NO_THROW(QLaw qlaw(
-        targetCOE_, gravitationalParameter_, parameters_, QLaw::COEDomain::BrouwerLyddaneMeanLong, gradientStrategy_
-    ));
+    EXPECT_NO_THROW(
+        QLaw qlaw(
+            targetCOE_, gravitationalParameter_, parameters_, QLaw::COEDomain::BrouwerLyddaneMeanLong, gradientStrategy_
+        )
+    );
 
     EXPECT_THROW(
         QLaw qlaw(targetCOE_, gravitationalParameter_, {{}}, QLaw::COEDomain::Osculating, gradientStrategy_),
         ostk::core::error::RuntimeError
     );
+
+    {
+        // When the semi-major axis IS targeted (non-zero control weight), a non-positive target SMA would
+        // make the S_a scaling factor diverge.
+        const QLaw::Parameters parametersTargetingSMA = {
+            {
+                {COE::Element::SemiMajorAxis, {1.0, 100.0}},
+                {COE::Element::Eccentricity, {1.0, 1e-4}},
+            },
+        };
+
+        // SMA targeted + zero target SMA -> throws.
+        {
+            const COE targetCOEZeroSMA = {
+                Length::Meters(0.0),
+                0.01,
+                Angle::Degrees(0.05),
+                Angle::Degrees(0.0),
+                Angle::Degrees(0.0),
+                Angle::Degrees(0.0)
+            };
+
+            EXPECT_THROW(
+                QLaw(targetCOEZeroSMA, gravitationalParameter_, parametersTargetingSMA, QLaw::COEDomain::Osculating),
+                ostk::core::error::RuntimeError
+            );
+        }
+
+        // SMA NOT targeted + zero target SMA -> allowed (the SMA term is neutralized).
+        {
+            const COE targetCOEZeroSMA = {
+                Length::Meters(0.0),
+                0.01,
+                Angle::Degrees(0.05),
+                Angle::Degrees(0.0),
+                Angle::Degrees(0.0),
+                Angle::Degrees(0.0)
+            };
+            const QLaw::Parameters parametersWithoutSMA = {
+                {
+                    {COE::Element::Eccentricity, {1.0, 1e-4}},
+                    {COE::Element::Aop, {1.0, 1e-4}},
+                },
+            };
+
+            EXPECT_NO_THROW(
+                QLaw(targetCOEZeroSMA, gravitationalParameter_, parametersWithoutSMA, QLaw::COEDomain::Osculating)
+            );
+        }
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, GetParameters)
@@ -664,6 +716,74 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Calcul
         {
             EXPECT_NEAR(acceleration(i), accelerationExpected(i), 1e-12);
         }
+    }
+}
+
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, TargetingWithoutSemiMajorAxisYieldsFiniteGradient
+)
+{
+    // Regression test for the "NaN encountered in dQ_dOE calculation" failure
+    //
+    // When the Q-Law targets orbital elements *without* the semi-major axis (SMA), the target COE is
+    // typically built with the SMA defaulting to 0 m, while the SMA control weight is 0 because
+    // SMA is absent from the element-weights map.
+
+    // This is a ~6920 km SMA, near-circular, ~97.6 deg inclination orbit.
+    const Vector3d position = {1364745.6311035044, 6081608.288764103, -3009739.0476152804};
+    const Vector3d velocity = {368.80982226000657, -3421.284241386021, -6759.820581456799};
+
+    const Real thrustAcceleration = 0.0161 / 193.3655889361863;
+
+    // Benign, representative current COE 5-vector (excludes true anomaly). Moderate inclination /
+    // eccentricity, so the only previously-singular term was the SMA scaling.
+    const Vector5d currentCOEVector = {6.92e6, 0.01, 1.0, 0.0, 0.0};
+
+    // Eccentricity + AoP targeted, SMA NOT targeted (SMA target defaults to 0, SMA weight implicitly 0).
+    const COE targetCOEWithoutSMA = {
+        Length::Meters(0.0),   // <-- SMA defaults to 0 when not targeted
+        1.5e-4,                // eccentricity target
+        Angle::Degrees(0.0),   // inclination (not targeted)
+        Angle::Degrees(0.0),   // RAAN (not targeted)
+        Angle::Degrees(70.0),  // AoP target
+        Angle::Degrees(0.0),
+    };
+
+    const QLaw::Parameters parametersWithoutSMA = {
+        {
+            {COE::Element::Eccentricity, {1.0, 0.0}},
+            {COE::Element::Aop, {1.0, 0.0}},
+        },
+    };
+
+    // The fix must hold for both gradient strategies: the analytical partials no longer produce NaN in
+    // dQ/da and dQ/de, and the finite-difference path no longer inherits a NaN Q.
+    for (const QLaw::GradientStrategy gradientStrategy :
+         {QLaw::GradientStrategy::Analytical, QLaw::GradientStrategy::FiniteDifference})
+    {
+        const QLaw qlawWithoutSMA = {
+            targetCOEWithoutSMA,
+            gravitationalParameter_,
+            parametersWithoutSMA,
+            QLaw::COEDomain::BrouwerLyddaneMeanLong,
+            gradientStrategy,
+        };
+
+        // Q is finite (no 0 * inf in the weighted sum).
+        EXPECT_TRUE(std::isfinite(qlawWithoutSMA.computeQ(currentCOEVector, thrustAcceleration)));
+
+        // The gradient is fully finite.
+        const Vector5d dQ_dOE = qlawWithoutSMA.compute_dQ_dOE(currentCOEVector, thrustAcceleration);
+        EXPECT_TRUE(dQ_dOE.array().isFinite().all());
+
+        // End-to-end: the runtime entry point that used to throw now returns a finite acceleration.
+        Vector3d acceleration = Vector3d::Zero();
+        EXPECT_NO_THROW(
+            acceleration = qlawWithoutSMA.calculateThrustAccelerationAt(
+                Instant::J2000(), position, velocity, thrustAcceleration, Frame::GCRF()
+            )
+        );
+        EXPECT_TRUE(acceleration.array().isFinite().all());
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/GuidanceLaw/QLaw.test.cpp
@@ -182,11 +182,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics_Thruster_GuidanceLaw_QLaw, Constr
 {
     EXPECT_NO_THROW(QLaw qlaw(targetCOE_, gravitationalParameter_, parameters_, QLaw::COEDomain::Osculating));
 
-    EXPECT_NO_THROW(
-        QLaw qlaw(
-            targetCOE_, gravitationalParameter_, parameters_, QLaw::COEDomain::BrouwerLyddaneMeanLong, gradientStrategy_
-        )
-    );
+    EXPECT_NO_THROW(QLaw qlaw(
+        targetCOE_, gravitationalParameter_, parameters_, QLaw::COEDomain::BrouwerLyddaneMeanLong, gradientStrategy_
+    ));
 
     EXPECT_THROW(
         QLaw qlaw(targetCOE_, gravitationalParameter_, {{}}, QLaw::COEDomain::Osculating, gradientStrategy_),


### PR DESCRIPTION
```
const Vector5d scalingCOE = {
    std::pow(
        (1.0 + std::pow(deltaCOE[0] / (parameters_.m * targetCOEVector_[0]), parameters_.n)), 1.0 / parameters_.r
    ),
    1.0, 1.0, 1.0, 1.0,
};
// ...
return periapsisScaling * (parameters_.controlWeights_.cwiseProduct(scalingCOE)
        .cwiseProduct(deltaCOE_divided_maximalCOE.cwiseProduct(deltaCOE_divided_maximalCOE))).sum();
```

When SMA is not targeted, targetCOEVector_[0] = atarget = 0. Then deltaCOE[0] / (m · 0) = +∞, (+∞)n = +∞, and Sa = (1 + ∞)1/r = +∞. The SMA control weight is Wa = controlWeights_(0) = 0, so the SMA term of the sum is Wa · Sa · (…)2 = 0 · ∞ · (…) = NaN. A single NaN added into the sum makes the whole scalar Q = NaN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved numerical stability issues that could produce NaN/infinity when semi-major axis control is disabled.
  * Ensured semi-major axis-related gradient contributions vanish when the axis is not targeted.
  * Added runtime validation to prevent invalid semi-major axis targeting configurations.

* **Tests**
  * Expanded tests for semi-major axis targeting edge cases and regression coverage for finite outputs and gradients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->