### PR TITLE
feat: add utility methods to COE

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -326,6 +326,25 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
         )
 
         .def(
+            "get_argument_of_latitude_angular_rate",
+            &COE::getArgumentOfLatitudeAngularRate,
+            R"doc(
+               Get the along-track angular rate (argument of latitude angular rate) of the COE, including J2 perturbations.
+
+               Args:
+                  gravitational_parameter (Derived): The gravitational parameter of the central body.
+                  equatorial_radius (Length): The equatorial radius of the central body.
+                  j2 (float): The second zonal harmonic coefficient of the central body.
+
+               Returns:
+                  Derived: The argument of latitude angular rate of the COE.
+            )doc",
+            arg("gravitational_parameter"),
+            arg("equatorial_radius"),
+            arg("j2")
+        )
+
+        .def(
             "get_orbital_period",
             &COE::getOrbitalPeriod,
             R"doc(
@@ -660,19 +679,137 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Kepler_COE(py
             "compute_radial_distance",
             &COE::ComputeRadialDistance,
             R"doc(
-                Compute the radial distance from the semi-latus rectum and the eccentricity.
+                Compute the radial distance from the semi-major axis, the eccentricity and the true anomaly.
 
                 Args:
-                    semi_latus_rectum (float): The semi-latus rectum. In meters.
+                    semi_major_axis (float): The semi-major axis. In meters.
                     eccentricity (float): The eccentricity.
-                    true_anomaly (float): The true anomly. In degrees.
+                    true_anomaly (float): The true anomaly. In radians.
 
                 Returns:
-                    Length: The radial distance.
+                    float: The radial distance. In meters.
             )doc",
-            arg("semi_latus_rectum"),
+            arg("semi_major_axis"),
             arg("eccentricity"),
             arg("true_anomaly")
+        )
+
+        .def_static(
+            "compute_periapsis_radius",
+            &COE::ComputePeriapsisRadius,
+            R"doc(
+                Compute the periapsis radius from the semi-major axis and the eccentricity.
+
+                Args:
+                    semi_major_axis (float): The semi-major axis. In meters.
+                    eccentricity (float): The eccentricity.
+
+                Returns:
+                    float: The periapsis radius. In meters.
+            )doc",
+            arg("semi_major_axis"),
+            arg("eccentricity")
+        )
+
+        .def_static(
+            "compute_apoapsis_radius",
+            &COE::ComputeApoapsisRadius,
+            R"doc(
+                Compute the apoapsis radius from the semi-major axis and the eccentricity.
+
+                Args:
+                    semi_major_axis (float): The semi-major axis. In meters.
+                    eccentricity (float): The eccentricity.
+
+                Returns:
+                    float: The apoapsis radius. In meters.
+            )doc",
+            arg("semi_major_axis"),
+            arg("eccentricity")
+        )
+
+        .def_static(
+            "compute_mean_motion",
+            &COE::ComputeMeanMotion,
+            R"doc(
+                Compute the mean motion from the semi-major axis.
+
+                Args:
+                    semi_major_axis (float): The semi-major axis. In meters.
+                    gravitational_parameter (Derived): The gravitational parameter of the central body.
+
+                Returns:
+                    float: The mean motion. In radians per second.
+            )doc",
+            arg("semi_major_axis"),
+            arg("gravitational_parameter")
+        )
+
+        .def_static(
+            "compute_orbital_period",
+            &COE::ComputeOrbitalPeriod,
+            R"doc(
+                Compute the orbital period from the semi-major axis.
+
+                Args:
+                    semi_major_axis (float): The semi-major axis. In meters.
+                    gravitational_parameter (Derived): The gravitational parameter of the central body.
+
+                Returns:
+                    float: The orbital period. In seconds.
+            )doc",
+            arg("semi_major_axis"),
+            arg("gravitational_parameter")
+        )
+
+        .def_static(
+            "compute_nodal_precession_rate",
+            &COE::ComputeNodalPrecessionRate,
+            R"doc(
+                Compute the nodal precession rate from the orbital elements.
+
+                Args:
+                    semi_major_axis (float): The semi-major axis. In meters.
+                    eccentricity (float): The eccentricity.
+                    inclination (float): The inclination. In radians.
+                    gravitational_parameter (Derived): The gravitational parameter of the central body.
+                    equatorial_radius (float): The equatorial radius of the central body. In meters.
+                    j2 (float): The second zonal harmonic coefficient of the central body.
+
+                Returns:
+                    float: The nodal precession rate. In radians per second.
+            )doc",
+            arg("semi_major_axis"),
+            arg("eccentricity"),
+            arg("inclination"),
+            arg("gravitational_parameter"),
+            arg("equatorial_radius"),
+            arg("j2")
+        )
+
+        .def_static(
+            "compute_argument_of_latitude_angular_rate",
+            &COE::ComputeArgumentOfLatitudeAngularRate,
+            R"doc(
+                Compute the along-track angular rate (argument of latitude angular rate) including J2 perturbations.
+
+                Args:
+                    semi_major_axis (float): The semi-major axis. In meters.
+                    eccentricity (float): The eccentricity.
+                    inclination (float): The inclination. In radians.
+                    gravitational_parameter (Derived): The gravitational parameter of the central body.
+                    equatorial_radius (float): The equatorial radius of the central body. In meters.
+                    j2 (float): The second zonal harmonic coefficient of the central body.
+
+                Returns:
+                    float: The argument of latitude angular rate. In radians per second.
+            )doc",
+            arg("semi_major_axis"),
+            arg("eccentricity"),
+            arg("inclination"),
+            arg("gravitational_parameter"),
+            arg("equatorial_radius"),
+            arg("j2")
         )
 
         .def_static(

--- a/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
+++ b/bindings/python/test/trajectory/orbit/models/kepler/test_coe.py
@@ -105,6 +105,7 @@ class TestCOE:
         raan: Angle,
         aop: Angle,
         true_anomaly: Angle,
+        earth: Celestial,
     ):
         assert coe.get_semi_major_axis() == semi_major_axis
         assert coe.get_eccentricity() == eccentricity
@@ -116,6 +117,14 @@ class TestCOE:
         assert coe.get_mean_anomaly() is not None
         assert coe.get_eccentric_anomaly() is not None
         assert coe.get_mean_motion(Earth.EGM2008.gravitational_parameter) is not None
+        assert (
+            coe.get_argument_of_latitude_angular_rate(
+                earth.get_gravitational_parameter(),
+                earth.get_equatorial_radius(),
+                earth.get_j2(),
+            )
+            is not None
+        )
         assert coe.get_orbital_period(Earth.EGM2008.gravitational_parameter) is not None
         assert coe.get_periapsis_radius() is not None
         assert coe.get_apoapsis_radius() is not None
@@ -157,6 +166,35 @@ class TestCOE:
             is not None
         )
         assert COE.compute_radial_distance(7000.0e3, 0.0, 0.0) is not None
+        assert COE.compute_periapsis_radius(7000.0e3, 0.1) is not None
+        assert COE.compute_apoapsis_radius(7000.0e3, 0.1) is not None
+        assert (
+            COE.compute_mean_motion(7000.0e3, Earth.EGM2008.gravitational_parameter)
+            is not None
+        )
+        assert (
+            COE.compute_orbital_period(7000.0e3, Earth.EGM2008.gravitational_parameter)
+            is not None
+        )
+        assert (
+            COE.compute_nodal_precession_rate(
+                7000.0e3,
+                0.1,
+                Angle.degrees(56.0).in_radians(),
+                Earth.EGM2008.gravitational_parameter,
+                6.378137e6,
+                1.08262668e-3,
+            )
+            is not None
+        )
+        assert COE.compute_argument_of_latitude_angular_rate(
+            (590.0 + 6378.137) * 1e3,
+            0.001,
+            Angle.degrees(97.0).in_radians(),
+            earth.get_gravitational_parameter(),
+            float(earth.get_equatorial_radius().in_meters()),
+            float(earth.get_j2()),
+        ) == pytest.approx(0.0010840210523878169, rel=1e-6)
 
         assert COE.compute_ltan(Angle.degrees(270.0), Instant.J2000()) is not None
         assert (

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp
@@ -221,6 +221,16 @@ class COE
         const Derived& aGravitationalParameter, const Length& anEquatorialRadius, const Real& aJ2Parameter
     ) const;
 
+    /// @brief Get the along-track angular rate (argument of latitude angular rate) including J2 perturbations
+    ///
+    /// @param aGravitationalParameter A gravitational parameter
+    /// @param anEquatorialRadius An equatorial radius
+    /// @param aJ2Parameter A J2 parameter
+    /// @return Argument of latitude angular rate
+    Derived getArgumentOfLatitudeAngularRate(
+        const Derived& aGravitationalParameter, const Length& anEquatorialRadius, const Real& aJ2Parameter
+    ) const;
+
     /// @brief Get Orbital period
     ///
     /// @param aGravitationalParameter A gravitational parameter
@@ -441,6 +451,72 @@ class COE
     /// @param trueAnomaly True anomaly in radians.
     /// @return Radial distance in meters.
     static Real ComputeRadialDistance(const Real& aSemiMajorAxis, const Real& anEccentricity, const Real& trueAnomaly);
+
+    /// @brief Compute the periapsis radius of the orbit.
+    ///
+    /// @param aSemiMajorAxis Semi-major axis of the orbit in meters.
+    /// @param anEccentricity Eccentricity of the orbit.
+    /// @return Periapsis radius in meters.
+    static Real ComputePeriapsisRadius(const Real& aSemiMajorAxis, const Real& anEccentricity);
+
+    /// @brief Compute the apoapsis radius of the orbit.
+    ///
+    /// @param aSemiMajorAxis Semi-major axis of the orbit in meters.
+    /// @param anEccentricity Eccentricity of the orbit.
+    /// @return Apoapsis radius in meters.
+    static Real ComputeApoapsisRadius(const Real& aSemiMajorAxis, const Real& anEccentricity);
+
+    /// @brief Compute the mean motion of the orbit.
+    ///
+    /// @param aSemiMajorAxis Semi-major axis of the orbit in meters.
+    /// @param aGravitationalParameter Gravitational parameter.
+    /// @return Mean motion in radians per second.
+    static Real ComputeMeanMotion(const Real& aSemiMajorAxis, const Derived& aGravitationalParameter);
+
+    /// @brief Compute the orbital period of the orbit.
+    ///
+    /// @param aSemiMajorAxis Semi-major axis of the orbit in meters.
+    /// @param aGravitationalParameter Gravitational parameter.
+    /// @return Orbital period in seconds.
+    static Real ComputeOrbitalPeriod(const Real& aSemiMajorAxis, const Derived& aGravitationalParameter);
+
+    /// @brief Compute the nodal precession rate of the orbit.
+    ///
+    /// @param aSemiMajorAxis Semi-major axis of the orbit in meters.
+    /// @param anEccentricity Eccentricity of the orbit.
+    /// @param anInclination Inclination of the orbit in radians.
+    /// @param aGravitationalParameter Gravitational parameter.
+    /// @param anEquatorialRadius Equatorial radius of the central body in meters.
+    /// @param aJ2Parameter Second zonal harmonic coefficient.
+    /// @return Nodal precession rate in radians per second.
+    static Real ComputeNodalPrecessionRate(
+        const Real& aSemiMajorAxis,
+        const Real& anEccentricity,
+        const Real& anInclination,
+        const Derived& aGravitationalParameter,
+        const Real& anEquatorialRadius,
+        const Real& aJ2Parameter
+    );
+
+    /// @brief Compute the along-track angular rate (argument of latitude angular rate) including J2 perturbations.
+    ///
+    /// Sums the unperturbed mean motion with the secular J2 rates of the mean anomaly and the argument of periapsis.
+    ///
+    /// @param aSemiMajorAxis Semi-major axis of the orbit in meters.
+    /// @param anEccentricity Eccentricity of the orbit.
+    /// @param anInclination Inclination of the orbit in radians.
+    /// @param aGravitationalParameter Gravitational parameter.
+    /// @param anEquatorialRadius Equatorial radius of the central body in meters.
+    /// @param aJ2Parameter Second zonal harmonic coefficient.
+    /// @return Argument of latitude angular rate in radians per second.
+    static Real ComputeArgumentOfLatitudeAngularRate(
+        const Real& aSemiMajorAxis,
+        const Real& anEccentricity,
+        const Real& anInclination,
+        const Derived& aGravitationalParameter,
+        const Real& anEquatorialRadius,
+        const Real& aJ2Parameter
+    );
 
     /// @brief Compute Mean Local Time of the Ascending Node (MLTAN) from the RAAN and instant
     ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.cpp
@@ -217,7 +217,7 @@ Length COE::getPeriapsisRadius() const
         throw ostk::core::error::runtime::Undefined("COE");
     }
 
-    return this->semiMajorAxis_ * (1.0 - this->eccentricity_);
+    return Length::Meters(COE::ComputePeriapsisRadius(semiMajorAxis_.inMeters(), eccentricity_));
 }
 
 Length COE::getApoapsisRadius() const
@@ -227,7 +227,7 @@ Length COE::getApoapsisRadius() const
         throw ostk::core::error::runtime::Undefined("COE");
     }
 
-    return this->semiMajorAxis_ * (1.0 + this->eccentricity_);
+    return Length::Meters(COE::ComputeApoapsisRadius(semiMajorAxis_.inMeters(), eccentricity_));
 }
 
 Length COE::getSemiLatusRectum() const
@@ -281,28 +281,46 @@ Derived COE::getMeanMotion(const Derived& aGravitationalParameter) const
         throw ostk::core::error::runtime::Undefined("COE");
     }
 
-    const Real semiMajorAxis_m = semiMajorAxis_.inMeters();
-
-    const Real gravitationalParameter_SI = aGravitationalParameter.in(GravitationalParameterSIUnit);
-
-    return Derived(
-        std::sqrt(gravitationalParameter_SI / (semiMajorAxis_m * semiMajorAxis_m * semiMajorAxis_m)),
-        angularVelocitySIUnit
-    );
+    return Derived(COE::ComputeMeanMotion(semiMajorAxis_.inMeters(), aGravitationalParameter), angularVelocitySIUnit);
 }
 
 Derived COE::getNodalPrecessionRate(
     const Derived& aGravitationalParameter, const Length& anEquatorialRadius, const Real& aJ2Parameter
 ) const
 {
-    const Real omega = this->getMeanMotion(aGravitationalParameter).in(angularVelocitySIUnit);
+    return Derived(
+        COE::ComputeNodalPrecessionRate(
+            this->semiMajorAxis_.inMeters(),
+            this->eccentricity_,
+            this->inclination_.inRadians(),
+            aGravitationalParameter,
+            anEquatorialRadius.inMeters(),
+            aJ2Parameter
+        ),
+        angularVelocitySIUnit
+    );
+}
 
-    const Real omega_p =
-        -(3.0 / 2.0) * std::pow(anEquatorialRadius.inMeters(), 2.0) * aJ2Parameter * omega *
-        std::cos(this->inclination_.inRadians()) /
-        std::pow(this->semiMajorAxis_.inMeters() * (1.0 - (this->eccentricity_ * this->eccentricity_)), 2.0);
+Derived COE::getArgumentOfLatitudeAngularRate(
+    const Derived& aGravitationalParameter, const Length& anEquatorialRadius, const Real& aJ2Parameter
+) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("COE");
+    }
 
-    return Derived(omega_p, angularVelocitySIUnit);
+    return Derived(
+        COE::ComputeArgumentOfLatitudeAngularRate(
+            this->semiMajorAxis_.inMeters(),
+            this->eccentricity_,
+            this->inclination_.inRadians(),
+            aGravitationalParameter,
+            anEquatorialRadius.inMeters(),
+            aJ2Parameter
+        ),
+        angularVelocitySIUnit
+    );
 }
 
 Duration COE::getOrbitalPeriod(const Derived& aGravitationalParameter) const
@@ -317,7 +335,7 @@ Duration COE::getOrbitalPeriod(const Derived& aGravitationalParameter) const
         throw ostk::core::error::runtime::Undefined("COE");
     }
 
-    return Duration::Seconds(Real::TwoPi() / this->getMeanMotion(aGravitationalParameter).in(angularVelocitySIUnit));
+    return Duration::Seconds(COE::ComputeOrbitalPeriod(semiMajorAxis_.inMeters(), aGravitationalParameter));
 }
 
 COE::CartesianState COE::getCartesianState(
@@ -1052,6 +1070,70 @@ Real COE::ComputeAngularMomentum(const Real& aSemiLatusRectum, const Derived& aG
     const Real mu_SI = aGravitationalParameter.in(GravitationalParameterSIUnit);
 
     return std::sqrt(mu_SI * aSemiLatusRectum);
+}
+
+Real COE::ComputePeriapsisRadius(const Real& aSemiMajorAxis, const Real& anEccentricity)
+{
+    return aSemiMajorAxis * (1.0 - anEccentricity);
+}
+
+Real COE::ComputeApoapsisRadius(const Real& aSemiMajorAxis, const Real& anEccentricity)
+{
+    return aSemiMajorAxis * (1.0 + anEccentricity);
+}
+
+Real COE::ComputeMeanMotion(const Real& aSemiMajorAxis, const Derived& aGravitationalParameter)
+{
+    const Real mu_SI = aGravitationalParameter.in(GravitationalParameterSIUnit);
+
+    return std::sqrt(mu_SI / (aSemiMajorAxis * aSemiMajorAxis * aSemiMajorAxis));
+}
+
+Real COE::ComputeOrbitalPeriod(const Real& aSemiMajorAxis, const Derived& aGravitationalParameter)
+{
+    return Real::TwoPi() / COE::ComputeMeanMotion(aSemiMajorAxis, aGravitationalParameter);
+}
+
+Real COE::ComputeNodalPrecessionRate(
+    const Real& aSemiMajorAxis,
+    const Real& anEccentricity,
+    const Real& anInclination,
+    const Derived& aGravitationalParameter,
+    const Real& anEquatorialRadius,
+    const Real& aJ2Parameter
+)
+{
+    const Real meanMotion = COE::ComputeMeanMotion(aSemiMajorAxis, aGravitationalParameter);
+
+    return -(3.0 / 2.0) * std::pow(anEquatorialRadius, 2.0) * aJ2Parameter * meanMotion * std::cos(anInclination) /
+           std::pow(aSemiMajorAxis * (1.0 - (anEccentricity * anEccentricity)), 2.0);
+}
+
+Real COE::ComputeArgumentOfLatitudeAngularRate(
+    const Real& aSemiMajorAxis,
+    const Real& anEccentricity,
+    const Real& anInclination,
+    const Derived& aGravitationalParameter,
+    const Real& anEquatorialRadius,
+    const Real& aJ2Parameter
+)
+{
+    const Real meanMotion = COE::ComputeMeanMotion(aSemiMajorAxis, aGravitationalParameter);
+    const Real semiLatusRectum = COE::ComputeSemiLatusRectum(aSemiMajorAxis, anEccentricity);
+
+    const Real commonFactor =
+        (3.0 / 4.0) * meanMotion * aJ2Parameter * std::pow(anEquatorialRadius / semiLatusRectum, 2.0);
+
+    const Real sinInclinationSquared = std::pow(std::sin(anInclination), 2.0);
+
+    // Secular rate of change of the argument of periapsis
+    const Real aopRate = commonFactor * (4.0 - 5.0 * sinInclinationSquared);
+
+    // Secular rate of change of the mean anomaly
+    const Real meanAnomalyRate =
+        -commonFactor * std::sqrt(1.0 - (anEccentricity * anEccentricity)) * (3.0 * sinInclinationSquared - 2.0);
+
+    return meanMotion + meanAnomalyRate + aopRate;
 }
 
 Time COE::ComputeMeanLTAN(const Angle& raan, const Instant& anInstant, const Sun& aSun)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.test.cpp
@@ -635,6 +635,178 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetCart
     }
 }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, ComputePeriapsisRadius)
+{
+    {
+        EXPECT_DOUBLE_EQ(
+            defaultSemiMajorAxis_.inMeters() * (1.0 - defaultEccentricity_),
+            COE::ComputePeriapsisRadius(defaultSemiMajorAxis_.inMeters(), defaultEccentricity_)
+        );
+    }
+
+    {
+        EXPECT_DOUBLE_EQ(
+            coe_.getPeriapsisRadius().inMeters(),
+            COE::ComputePeriapsisRadius(defaultSemiMajorAxis_.inMeters(), defaultEccentricity_)
+        );
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, ComputeApoapsisRadius)
+{
+    {
+        EXPECT_DOUBLE_EQ(
+            defaultSemiMajorAxis_.inMeters() * (1.0 + defaultEccentricity_),
+            COE::ComputeApoapsisRadius(defaultSemiMajorAxis_.inMeters(), defaultEccentricity_)
+        );
+    }
+
+    {
+        EXPECT_DOUBLE_EQ(
+            coe_.getApoapsisRadius().inMeters(),
+            COE::ComputeApoapsisRadius(defaultSemiMajorAxis_.inMeters(), defaultEccentricity_)
+        );
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, ComputeMeanMotion)
+{
+    {
+        const Real semiMajorAxis_m = defaultSemiMajorAxis_.inMeters();
+        const Real mu = Earth::EGM2008.gravitationalParameter_.in(Derived::Unit::MeterCubedPerSecondSquared());
+
+        EXPECT_DOUBLE_EQ(
+            std::sqrt(mu / (semiMajorAxis_m * semiMajorAxis_m * semiMajorAxis_m)),
+            COE::ComputeMeanMotion(semiMajorAxis_m, Earth::EGM2008.gravitationalParameter_)
+        );
+    }
+
+    {
+        EXPECT_DOUBLE_EQ(
+            coe_.getMeanMotion(Earth::EGM2008.gravitationalParameter_).in(Derived::Unit::RadianPerSecond()),
+            COE::ComputeMeanMotion(defaultSemiMajorAxis_.inMeters(), Earth::EGM2008.gravitationalParameter_)
+        );
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, ComputeOrbitalPeriod)
+{
+    {
+        EXPECT_DOUBLE_EQ(
+            Real::TwoPi() /
+                COE::ComputeMeanMotion(defaultSemiMajorAxis_.inMeters(), Earth::EGM2008.gravitationalParameter_),
+            COE::ComputeOrbitalPeriod(defaultSemiMajorAxis_.inMeters(), Earth::EGM2008.gravitationalParameter_)
+        );
+    }
+
+    {
+        // The instance getter round-trips through Duration (integer nanoseconds), so compare with a
+        // tolerance well above sub-nanosecond rounding.
+        EXPECT_NEAR(
+            coe_.getOrbitalPeriod(Earth::EGM2008.gravitationalParameter_).inSeconds(),
+            COE::ComputeOrbitalPeriod(defaultSemiMajorAxis_.inMeters(), Earth::EGM2008.gravitationalParameter_),
+            1e-6
+        );
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, ComputeNodalPrecessionRate)
+{
+    {
+        const COE coe = {
+            Earth::EGM2008.equatorialRadius_ + Length::Kilometers(800.0),
+            0.0,
+            Angle::Degrees(56.0),
+            Angle::Degrees(0.0),
+            Angle::Degrees(0.0),
+            Angle::Degrees(0.0),
+        };
+
+        EXPECT_DOUBLE_EQ(
+            coe.getNodalPrecessionRate(
+                   Earth::EGM2008.gravitationalParameter_, Length::Meters(6.378137e6), 1.08262668e-3
+            )
+                .in(Derived::Unit::RadianPerSecond()),
+            COE::ComputeNodalPrecessionRate(
+                (Earth::EGM2008.equatorialRadius_ + Length::Kilometers(800.0)).inMeters(),
+                0.0,
+                Angle::Degrees(56.0).inRadians(),
+                Earth::EGM2008.gravitationalParameter_,
+                6.378137e6,
+                1.08262668e-3
+            )
+        );
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, ComputeArgumentOfLatitudeAngularRate)
+{
+    const auto earthSPtr = Environment::Default().accessCelestialObjectWithName("Earth");
+
+    const Length semiMajorAxis = Length::Kilometers(590.0 + 6378.137);
+    const Real eccentricity = 0.001;
+    const Angle inclination = Angle::Degrees(97.0);
+
+    const Real expectedRate = 0.0010840210523878169;
+
+    {
+        const Real rate = COE::ComputeArgumentOfLatitudeAngularRate(
+            semiMajorAxis.inMeters(),
+            eccentricity,
+            inclination.inRadians(),
+            earthSPtr->getGravitationalParameter(),
+            earthSPtr->getEquatorialRadius().inMeters(),
+            earthSPtr->getJ2()
+        );
+
+        EXPECT_NEAR(rate, expectedRate, std::abs(expectedRate) * 1e-6);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetArgumentOfLatitudeAngularRate)
+{
+    const auto earthSPtr = Environment::Default().accessCelestialObjectWithName("Earth");
+
+    const Derived gravitationalParameter = earthSPtr->getGravitationalParameter();
+    const Length equatorialRadius = earthSPtr->getEquatorialRadius();
+    const Real j2 = earthSPtr->getJ2();
+
+    const COE coe = {
+        Length::Kilometers(590.0 + 6378.137),
+        0.001,
+        Angle::Degrees(97.0),
+        Angle::Zero(),
+        Angle::Zero(),
+        Angle::Zero(),
+    };
+
+    const Real expectedRate = 0.0010840210523878169;
+
+    {
+        const Derived rate = coe.getArgumentOfLatitudeAngularRate(gravitationalParameter, equatorialRadius, j2);
+
+        EXPECT_NEAR(rate.in(Derived::Unit::RadianPerSecond()), expectedRate, std::abs(expectedRate) * 1e-6);
+
+        // The getter must match the static computation.
+        EXPECT_DOUBLE_EQ(
+            rate.in(Derived::Unit::RadianPerSecond()),
+            COE::ComputeArgumentOfLatitudeAngularRate(
+                coe.getSemiMajorAxis().inMeters(),
+                coe.getEccentricity(),
+                coe.getInclination().inRadians(),
+                gravitationalParameter,
+                equatorialRadius.inMeters(),
+                j2
+            )
+        );
+    }
+
+    {
+        EXPECT_ANY_THROW(COE::Undefined().getArgumentOfLatitudeAngularRate(gravitationalParameter, equatorialRadius, j2)
+        );
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Kepler_COE, GetVector)
 {
     {


### PR DESCRIPTION
Adds some utility methods to COE (that existed in the getters but not in the static compute methods).
Also adds the AoL angular rate computation method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added static calculation methods for orbital characteristics including periapsis and apoapsis radius, mean motion, orbital period, nodal precession rate, and argument-of-latitude angular rate with J2 perturbation effects.

* **Refactor**
  * Refactored existing orbital calculation methods to delegate to new centralized static helper functions, improving consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->