### PR TITLE
fix: frame comparison checks

### DIFF
--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics/Tabulated.cpp
@@ -58,7 +58,7 @@ Tabulated::Tabulated(
         );
     }
 
-    if (aFrameSPtr != DefaultContributionFrameSPtr)
+    if ((*aFrameSPtr) != (*DefaultContributionFrameSPtr))
     {
         throw ostk::core::error::RuntimeError("Contributions must be expressed in an inertial frame.");
     }
@@ -182,7 +182,7 @@ VectorXd Tabulated::computeContribution(
 {
     // TBM: Allow frame conversion through `CoordinateSubset.inFrame` method, once we have a `CartesianAcceleration`
     // class
-    if (aFrameSPtr != frameSPtr_)
+    if ((*aFrameSPtr) != (*frameSPtr_))
     {
         throw ostk::core::error::RuntimeError("Contribution Frame conversion to non-inertial not yet supported.");
     }

--- a/src/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolver.cpp
@@ -95,7 +95,7 @@ TLESolver::TLESolver(
       elementSetNumber_(0),
       tleStateBuilder_(StateBuilder::Undefined())
 {
-    if (anEstimationFrameSPtr != Frame::TEME())
+    if ((*anEstimationFrameSPtr) != (*Frame::TEME()))
     {
         std::cerr
             << "[TLESolver] Warning: The 'estimationFrame' parameter is deprecated. Solving is done natively in TEME."

--- a/src/OpenSpaceToolkit/Astrodynamics/Solvers/LeastSquaresSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Solvers/LeastSquaresSolver.cpp
@@ -245,7 +245,7 @@ LeastSquaresSolver::Analysis LeastSquaresSolver::solve(
     const Array<Shared<const CoordinateSubset>> observationStateSubsets =
         observationStateBuilder.getCoordinateSubsets();
 
-    if (estimationStateFrame != observationStateBuilder.getFrame())
+    if ((*estimationStateFrame) != (*observationStateBuilder.getFrame()))
     {
         throw ostk::core::error::RuntimeError("Initial guess state and observation state must have the same frame.");
     }
@@ -256,7 +256,7 @@ LeastSquaresSolver::Analysis LeastSquaresSolver::solve(
         {
             throw ostk::core::error::RuntimeError("All observations must have the same coordinate subsets.");
         }
-        if (observation.getFrame() != observationStateBuilder.getFrame())
+        if ((*observation.getFrame()) != (*observationStateBuilder.getFrame()))
         {
             throw ostk::core::error::RuntimeError("All observations must have the same frame.");
         }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Model/Static.cpp
@@ -18,7 +18,7 @@ Static::Static(const Position& aPosition)
     : Model(),
       position_(aPosition)
 {
-    if (aPosition.accessFrame() != Frame::ITRF())
+    if ((*aPosition.accessFrame()) != (*Frame::ITRF()))
     {
         throw ostk::core::error::runtime::Wrong("Position Frame", aPosition.accessFrame()->getName());
     }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/SGP4.cpp
@@ -213,7 +213,7 @@ bool SGP4::operator==(const SGP4& aSGP4Model) const
     }
 
     return (this->tleArray_ == aSGP4Model.tleArray_) && (this->validityIntervals_ == aSGP4Model.validityIntervals_) &&
-           (this->outputFrameSPtr_ == aSGP4Model.outputFrameSPtr_);
+           ((*this->outputFrameSPtr_) == (*aSGP4Model.outputFrameSPtr_));
 }
 
 bool SGP4::operator!=(const SGP4& aSGP4Model) const

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State.cpp
@@ -77,7 +77,7 @@ State::State(const Instant& anInstant, const Position& aPosition, const Velocity
         throw ostk::core::error::runtime::Undefined("Velocity");
     }
 
-    if (aPosition.accessFrame() != aVelocity.accessFrame())
+    if ((*aPosition.accessFrame()) != (*aVelocity.accessFrame()))
     {
         throw ostk::core::error::runtime::Wrong("Position-Velocity Frames");
     }
@@ -131,7 +131,8 @@ State::State(
         throw ostk::core::error::runtime::Undefined("Angular Velocity");
     }
 
-    if ((aPosition.accessFrame() != aVelocity.accessFrame()) || (aPosition.accessFrame() != anAttitudeReferenceFrame))
+    if (((*aPosition.accessFrame()) != (*aVelocity.accessFrame())) ||
+        ((*aPosition.accessFrame()) != (*anAttitudeReferenceFrame)))
     {
         throw ostk::core::error::runtime::Wrong("Position-Velocity-Attitude Frames");
     }
@@ -186,7 +187,7 @@ bool State::operator==(const State& aState) const
         return false;
     }
 
-    if (this->frameSPtr_ != aState.frameSPtr_)
+    if ((*this->frameSPtr_) != (*aState.frameSPtr_))
     {
         return false;
     }
@@ -229,12 +230,12 @@ State State::operator+(const State& aState) const
         throw ostk::core::error::runtime::Wrong("Instant");
     }
 
-    if (this->frameSPtr_ != aState.frameSPtr_)
+    if ((*this->frameSPtr_) != (*aState.frameSPtr_))
     {
         throw ostk::core::error::runtime::Wrong("Frame");
     }
 
-    if (this->coordinatesBrokerSPtr_ != aState.coordinatesBrokerSPtr_)
+    if (*this->coordinatesBrokerSPtr_ != *aState.coordinatesBrokerSPtr_)
     {
         throw ostk::core::error::runtime::Wrong("Coordinate Subsets");
     }
@@ -274,7 +275,7 @@ State State::operator-(const State& aState) const
         throw ostk::core::error::runtime::Wrong("Instant");
     }
 
-    if (this->frameSPtr_ != aState.frameSPtr_)
+    if ((*this->frameSPtr_) != (*aState.frameSPtr_))
     {
         throw ostk::core::error::runtime::Wrong("Frame");
     }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianAcceleration.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianAcceleration.cpp
@@ -42,7 +42,7 @@ VectorXd CartesianAcceleration::inFrame(
     const Shared<const CoordinateBroker>& aCoordinateBrokerSPtr
 ) const
 {
-    if (fromFrame == toFrame)
+    if ((*fromFrame) == (*toFrame))
     {
         return aCoordinateBrokerSPtr->extractCoordinate(aFullCoordinatesVector, *this);
     }

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.cpp
@@ -43,7 +43,7 @@ bool StateBuilder::operator==(const StateBuilder& aStateBuilder) const
         return false;
     }
 
-    if (this->frameSPtr_ != aStateBuilder.frameSPtr_)
+    if ((*this->frameSPtr_) != (*aStateBuilder.frameSPtr_))
     {
         return false;
     }


### PR DESCRIPTION
We should be comparing the actual objects and not the addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved frame and state equality comparisons throughout the astrodynamics module. Updated validation checks to use proper object value comparisons instead of pointer identity checks, enhancing reliability of frame compatibility validation in trajectory computations, state operations, and coordinate transformations across all affected components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->