### PR TITLE
feat: add Propagated to Tabulated method

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Propagated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Propagated.cpp
@@ -13,6 +13,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Propagated(py
     using ostk::physics::time::Instant;
 
     using ostk::astrodynamics::trajectory::orbit::model::Propagated;
+    using ostk::astrodynamics::trajectory::orbit::model::Tabulated;
     using ostk::astrodynamics::trajectory::Propagator;
     using ostk::astrodynamics::trajectory::State;
 
@@ -187,6 +188,22 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Propagated(py
 
                     Args:
                         state_array (list[State]): The state array.
+
+                )doc"
+            )
+
+            .def(
+                "to_tabulated",
+                &Propagated::toTabulated,
+                arg("instants"),
+                R"doc(
+                    Compute the states at the given instants and construct a Tabulated orbit model from them.
+
+                    Args:
+                        instants (list[Instant]): An array of at least 4 instants to compute the states at.
+
+                    Returns:
+                        Tabulated: The Tabulated orbit model.
 
                 )doc"
             )

--- a/bindings/python/test/trajectory/orbit/models/test_propagated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_propagated.py
@@ -5,12 +5,12 @@ import pytest
 from ostk.astrodynamics import Dynamics
 from ostk.astrodynamics.dynamics import CentralBodyGravity, PositionDerivative
 from ostk.astrodynamics.trajectory import Orbit, Propagator, State
-from ostk.astrodynamics.trajectory.orbit.model import Propagated
+from ostk.astrodynamics.trajectory.orbit.model import Propagated, Tabulated
 from ostk.astrodynamics.trajectory.state import NumericalSolver
 from ostk.core.type import Integer
 from ostk.physics.coordinate import Frame, Position, Velocity
 from ostk.physics.environment.object.celestial import Earth
-from ostk.physics.time import DateTime, Instant, Scale
+from ostk.physics.time import DateTime, Duration, Instant, Scale
 
 
 @pytest.fixture
@@ -227,3 +227,18 @@ class TestPropagated:
 
         with pytest.raises(Exception) as e:
             propagated.set_cached_state_array([])
+
+    def test_to_tabulated(
+        self,
+        propagated: Propagated,
+        state: State,
+    ):
+        instant_array = [
+            state.get_instant() + Duration.minutes(offset) for offset in range(4)
+        ]
+
+        tabulated = propagated.to_tabulated(instant_array)
+
+        assert tabulated is not None
+        assert isinstance(tabulated, Tabulated)
+        assert tabulated.is_defined()

--- a/bindings/python/test/trajectory/orbit/models/test_propagated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_propagated.py
@@ -234,7 +234,7 @@ class TestPropagated:
         state: State,
     ):
         instant_array = [
-            state.get_instant() + Duration.minutes(offset) for offset in range(4)
+            state.get_instant() + Duration.minutes(float(offset)) for offset in range(4)
         ]
 
         tabulated = propagated.to_tabulated(instant_array)

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.hpp
@@ -10,6 +10,7 @@
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp>
@@ -31,7 +32,10 @@ using ostk::core::type::Real;
 
 using ostk::physics::time::Instant;
 
+using ostk::mathematics::curvefitting::Interpolator;
+
 using ostk::astrodynamics::trajectory::orbit::Model;
+using ostk::astrodynamics::trajectory::orbit::model::Tabulated;
 using ostk::astrodynamics::trajectory::Propagator;
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::state::NumericalSolver;
@@ -176,6 +180,12 @@ class Propagated : public ostk::astrodynamics::trajectory::orbit::Model
     /// @param anOutputStream An output stream
     /// @param (optional) displayDecorators If true, display decorators
     virtual void print(std::ostream& anOutputStream, bool displayDecorator = true) const override;
+
+    /// @brief Compute the states at the given instants and construct a Tabulated orbit model from them.
+    ///
+    /// @param anInstantArray An array of at least 4 instants to compute the states at.
+    /// @return The Tabulated orbit model
+    Tabulated toTabulated(const Array<Instant>& anInstantArray) const;
 
    protected:
     /// @brief Equal to operator

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.cpp
@@ -42,6 +42,8 @@ using ostk::astrodynamics::dynamics::CentralBodyGravity;
 using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
 using ostk::astrodynamics::trajectory::StateBuilder;
 
+using ostk::astrodynamics::trajectory::orbit::model::Tabulated;
+
 static const Derived::Unit GravitationalParameterSIUnit =
     Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second);
 
@@ -431,6 +433,13 @@ void Propagated::sanitizeCachedArray() const
             )
         );
     }
+}
+
+Tabulated Propagated::toTabulated(const Array<Instant>& anInstantArray) const
+{
+    const Array<State> propagatedStates = this->calculateStatesAt(anInstantArray);
+
+    return Tabulated::Default(propagatedStates, this->initialRevolutionNumber_);
 }
 
 }  // namespace model

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated.test.cpp
@@ -806,3 +806,23 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, Propaga
         ASSERT_EQ(estimatedState, states[1]);
     }
 }
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagated, ToTabulated)
+{
+    using ostk::astrodynamics::trajectory::orbit::model::Tabulated;
+
+    {
+        const Propagated propagatedModel = {propagator_, defaultState_};
+
+        const Tabulated tabulatedModel = propagatedModel.toTabulated(
+            {defaultInstant_,
+             defaultInstant_ + Duration::Minutes(1.0),
+             defaultInstant_ + Duration::Minutes(2.0),
+             defaultInstant_ + Duration::Minutes(3.0)}
+        );
+
+        ASSERT_EQ(
+            tabulatedModel.getInterval(), Interval::Closed(defaultInstant_, defaultInstant_ + Duration::Minutes(3.0))
+        );
+    }
+}


### PR DESCRIPTION
Add a helper to convert a Propagated orbit model into a Tabulated one, so that it can be "reused" more easily for a given timespan. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `to_tabulated()` method to convert Propagated orbit models to Tabulated orbit models by sampling at specified time instants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->