### PR TITLE
perf: reduce per-step allocation overhead in the propagation loop

### DIFF
--- a/include/OpenSpaceToolkit/Astrodynamics/Dynamics.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Dynamics.hpp
@@ -66,6 +66,7 @@ class Dynamics
         Array<Pair<Index, Size>> readIndexes;
         Array<Pair<Index, Size>> writeIndexes;
         Size readStateSize;
+        mutable VectorXd readStateBuffer;  ///< Scratch buffer reused across derivative evaluations
     };
 
     /// @brief Constructor
@@ -156,8 +157,11 @@ class Dynamics
         const Shared<const Frame>& aFrameSPtr
     );
 
-    static VectorXd extractReadState(
-        const NumericalSolver::StateVector& x, const Array<Pair<Index, Size>>& readInfo, const Size readSize
+    static void extractReadState(
+        const NumericalSolver::StateVector& x,
+        const Array<Pair<Index, Size>>& readInfo,
+        const Size readSize,
+        VectorXd& aReadState
     );
 
     static void applyContribution(

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.hpp
@@ -13,6 +13,7 @@
 #include <OpenSpaceToolkit/Astrodynamics/EventCondition.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/RootSolver.hpp>
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/State.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/StateBuilder.hpp>
 
 namespace ostk
 {
@@ -29,6 +30,7 @@ using ostk::physics::time::Instant;
 
 using ostk::astrodynamics::RootSolver;
 using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::StateBuilder;
 using MathNumericalSolver = ostk::mathematics::solver::NumericalSolver;
 
 /// @brief Define an astrodynamics state contextual Numerical Solver. This class inherits from the OSTk Mathematics
@@ -243,9 +245,12 @@ class NumericalSolver : public MathNumericalSolver
 
    private:
     RootSolver rootSolver_;
-    Array<State> observedStates_;
+    mutable Array<State> observedStates_;
     std::function<void(const State&)> stateLogger_;
     Real maxStepSize_ = Real::Undefined();
+    StateBuilder observedStateBuilder_ = StateBuilder::Undefined();
+    Instant observedStatesStartInstant_ = Instant::Undefined();
+    mutable bool observedStatesAreUpToDate_ = true;
 
     /// @brief Constructor
     ///
@@ -273,6 +278,12 @@ class NumericalSolver : public MathNumericalSolver
     ///
     /// @param aState The state to observe
     void observeState(const State& aState);
+
+    /// @brief Build the observed State objects from the observed state vectors of the underlying
+    ///        solver, if they have not been built yet. State construction is deferred until the
+    ///        observed states are actually accessed, to avoid building one State per accepted
+    ///        integration step when only the final state is needed.
+    void buildObservedStates() const;
 
     /// @brief Integrate with controlled stepper using the unified dense-output refinement.
     ///

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics.cpp
@@ -40,6 +40,8 @@ Dynamics::Context::Context(
     {
         this->readStateSize += pair.second;
     }
+
+    this->readStateBuffer = VectorXd::Zero(this->readStateSize);
 }
 
 Dynamics::Dynamics(const String& aName)
@@ -100,33 +102,39 @@ void Dynamics::DynamicalEquations(
 
     for (const Dynamics::Context& dynamicsContext : aContextArray)
     {
-        const VectorXd contribution = dynamicsContext.dynamics->computeContribution(
-            nextInstant,
-            Dynamics::extractReadState(x, dynamicsContext.readIndexes, dynamicsContext.readStateSize),
-            aFrameSPtr
+        Dynamics::extractReadState(
+            x, dynamicsContext.readIndexes, dynamicsContext.readStateSize, dynamicsContext.readStateBuffer
         );
+
+        const VectorXd contribution =
+            dynamicsContext.dynamics->computeContribution(nextInstant, dynamicsContext.readStateBuffer, aFrameSPtr);
 
         Dynamics::applyContribution(dxdt, contribution, dynamicsContext.writeIndexes);
     }
 }
 
-VectorXd Dynamics::extractReadState(
-    const NumericalSolver::StateVector& x, const Array<Pair<Index, Size>>& readInfo, const Size readSize
+void Dynamics::extractReadState(
+    const NumericalSolver::StateVector& x,
+    const Array<Pair<Index, Size>>& readInfo,
+    const Size readSize,
+    VectorXd& aReadState
 )
 {
+    if (aReadState.size() != static_cast<Eigen::Index>(readSize))
+    {
+        aReadState.resize(readSize);
+    }
+
     Index offset = 0;
-    VectorXd reducedState = VectorXd(readSize);
 
     for (const Pair<Index, Size>& pair : readInfo)
     {
         const Index subsetOffset = pair.first;
         const Size subsetSize = pair.second;
 
-        reducedState.segment(offset, subsetSize) = x.segment(subsetOffset, subsetSize);
+        aReadState.segment(offset, subsetSize) = x.segment(subsetOffset, subsetSize);
         offset += subsetSize;
     }
-
-    return reducedState;
 }
 
 void Dynamics::applyContribution(

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/State/NumericalSolver.cpp
@@ -124,6 +124,8 @@ const Array<State>& NumericalSolver::accessObservedStates() const
         throw ostk::core::error::runtime::Undefined("NumericalSolver");
     }
 
+    this->buildObservedStates();
+
     return observedStates_;
 }
 
@@ -163,6 +165,10 @@ Array<State> NumericalSolver::integrateTime(
     const NumericalSolver::SystemOfEquationsWrapper& aSystemOfEquations
 )
 {
+    // Materialize any pending observed states before the underlying solver clears the observed
+    // state vectors they are built from.
+    this->buildObservedStates();
+
     const Array<Real> durationArray = anInstantArray.map<Real>(
         [&aState](const Instant& anInstant) -> Real
         {
@@ -194,7 +200,7 @@ State NumericalSolver::integrateTime(
     const State& aState, const Instant& anEndTime, const NumericalSolver::SystemOfEquationsWrapper& aSystemOfEquations
 )
 {
-    observedStates_ = {};
+    observedStates_.clear();
 
     const StateBuilder stateBuilder = {aState};
 
@@ -202,10 +208,10 @@ State NumericalSolver::integrateTime(
         aState.accessCoordinates(), (anEndTime - aState.accessInstant()).inSeconds(), aSystemOfEquations
     );
 
-    for (const auto& state : MathNumericalSolver::getObservedStateVectors())
-    {
-        observedStates_.add(stateBuilder.build(aState.accessInstant() + Duration::Seconds(state.second), state.first));
-    }
+    // Defer building the observed State objects until they are actually accessed
+    observedStateBuilder_ = stateBuilder;
+    observedStatesStartInstant_ = aState.accessInstant();
+    observedStatesAreUpToDate_ = false;
 
     return stateBuilder.build(anEndTime, solution.first);
 }
@@ -233,6 +239,7 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTime(
     }
 
     observedStates_ = {aState};
+    observedStatesAreUpToDate_ = true;
 
     const Real aDurationInSeconds = (anInstant - aState.accessInstant()).inSeconds();
 
@@ -365,6 +372,29 @@ void NumericalSolver::observeState(const State& aState)
     }
 }
 
+void NumericalSolver::buildObservedStates() const
+{
+    if (observedStatesAreUpToDate_)
+    {
+        return;
+    }
+
+    const Array<MathNumericalSolver::Solution>& observedStateVectors =
+        MathNumericalSolver::accessObservedStateVectors();
+
+    observedStates_.clear();
+    observedStates_.reserve(observedStateVectors.getSize());
+
+    for (const MathNumericalSolver::Solution& solution : observedStateVectors)
+    {
+        observedStates_.add(observedStateBuilder_.build(
+            observedStatesStartInstant_ + Duration::Seconds(solution.second), solution.first
+        ));
+    }
+
+    observedStatesAreUpToDate_ = true;
+}
+
 namespace
 {
 
@@ -426,7 +456,8 @@ NumericalSolver::ConditionSolution NumericalSolver::integrateTimeWithStepperImpl
     double aSignedTimeStep
 )
 {
-    observedStates_ = {};
+    observedStates_.clear();
+    observedStatesAreUpToDate_ = true;
 
     const StateBuilder stateBuilder = {aState};
 


### PR DESCRIPTION
## Summary

Two hot-loop cleanups on the astrodynamics side of numerical propagation. No public API change, and numerical results are **bit-identical** to `main` (verified, see below).

### 1. Reuse read-state scratch buffers in `Dynamics::DynamicalEquations`

Previously, every derivative evaluation heap-allocated a fresh `VectorXd` per dynamics (`extractReadState`), i.e. with RK4 that is 4 stages x N dynamics small Eigen allocations per step. The reduced read state is now written into a scratch buffer owned by `Dynamics::Context`. Since `Dynamics::GetSystemOfEquations` binds a *copy* of the context array into the system-of-equations wrapper, each propagation gets its own buffers — nothing is shared between propagators or with the `Dynamics` objects themselves, so a `Dynamics` instance shared by two propagators stays safe.

### 2. Defer observed-`State` construction in `NumericalSolver::integrateTime`

`integrateTime(State, Instant, ...)` used to build one full `State` object (Instant arithmetic + coordinate vector copy + shared_ptr churn) per accepted integration step — 17k+ States for a 1-day RK4/5s propagation — plus a full by-value copy of the underlying solver's observed state vectors, even when the caller (`Propagator::calculateStateAt`) only needs the final state. Construction is now deferred until `accessObservedStates()` / `getObservedStates()` is actually called, and builds from a `const&` to the underlying solver's observed state vectors instead of a copy. Consumers (e.g. `Segment`) observe identical behavior, including the existing quirk that the multi-instant `integrateTime` overload leaves previously observed states in place (they are materialized before the underlying solver clears its raw data). The conditional/event-condition path is unchanged (still eager, `stateLogger` behavior preserved).

## Measured numbers

Release build, EGM96 10x10 `CentralBodyGravity` + `PositionDerivative`, RK4 fixed 5 s step (17,280 steps/day), interleaved A/B runs on the same machine:

| Benchmark | main | this PR |
|---|---|---|
| 1-day propagation (median of 3) | 991 ms | 950 ms |
| 7-day propagation (median of 3) | 4.76 s | 4.65 s |
| Loop overhead, `PositionDerivative`-only 1-day (isolates the glue) | 1.05 µs/step | 0.78 µs/step (-26%) |
| Derivative-evaluation glue, 5 dynamics | 0.222 µs/eval | 0.173 µs/eval (-22%) |

**Result identity:** final positions of the 1-day and 7-day benchmark propagations match `main` exactly at µm precision, and an FNV-64 checksum over the raw coordinate bits of a 2-h EGM96 360x360 trajectory (121 states) is identical between `main` and this branch.

## Profiling context (why the win is modest)

Instrumenting the 1-day benchmark shows ~98.5% of wall time is spent *inside* `Dynamics::computeContribution` (physics-side gravity-model evaluation + GCRF/ITRF transforms for fresh instants); the astrodynamics-side loop glue is only ~1 µs/step. This PR removes most of that glue. The remaining per-accepted-step `VectorXd` copy into `observedStateVectors_` lives in the mathematics repo's `NumericalSolver::observeNumericalIntegration` (called unconditionally by the odeint observer even for `LogType::NoLog`) and cannot be avoided from the astrodynamics side.

## Testing

- `--gtest_filter="*Propagator*:*NumericalSolver*:*Dynamics*:*Segment*:*Sequence*:*Maneuver*:*Thruster*"`: **337/337 pass**
- Full test binary: **1072 pass, 2 skipped** (expected Release skips), 2 failures — `Trajectory_Orbit.GeoSynchronous` and `Validation_SelfValidation.GravityModel` — both **pre-existing** in this environment and unrelated to this change: they fail identically (same error values / bit-identical trajectory checksum) when run against a `main`-built library, and are driven by the locally installed physics library, not this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)