### PR TITLE
feat: add Brouwer-Lyddane Mean Short Event Conditions

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition.cpp
@@ -5,6 +5,7 @@
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/AngularCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/BooleanCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanLongCondition.cpp>
+#include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanShortCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/COECondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/InstantCondition.cpp>
 #include <OpenSpaceToolkitAstrodynamicsPy/EventCondition/LogicalCondition.cpp>
@@ -291,4 +292,5 @@ inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition(pybind11::module& aMo
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_COECondition(event_condition);
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_LogicalCondition(event_condition);
     OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanLongCondition(event_condition);
+    OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanShortCondition(event_condition);
 }

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanShortCondition.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/EventCondition/BrouwerLyddaneMeanShortCondition.cpp
@@ -1,0 +1,396 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanShortCondition.hpp>
+
+using namespace pybind11;
+
+using ostk::core::container::Pair;
+using ostk::core::type::Shared;
+
+using ostk::physics::coordinate::Frame;
+using ostk::physics::unit::Angle;
+using ostk::physics::unit::Derived;
+
+using ostk::astrodynamics::EventCondition;
+using ostk::astrodynamics::eventcondition::AngularCondition;
+using ostk::astrodynamics::eventcondition::BrouwerLyddaneMeanShortCondition;
+
+inline void OpenSpaceToolkitAstrodynamicsPy_EventCondition_BrouwerLyddaneMeanShortCondition(pybind11::module& aModule)
+{
+    {
+        class_<BrouwerLyddaneMeanShortCondition>(
+            aModule,
+            "BrouwerLyddaneMeanShortCondition",
+            R"doc(
+                A Brouwer-Lyddane Mean Short Event Condition.
+
+            )doc"
+        )
+
+            .def_static(
+                "semi_major_axis",
+                &BrouwerLyddaneMeanShortCondition::SemiMajorAxis,
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the semi-major axis.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        semi_major_axis (EventConditionTarget): The semi-major axis.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("semi_major_axis"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "eccentricity",
+                &BrouwerLyddaneMeanShortCondition::Eccentricity,
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the eccentricity.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        eccentricity (EventConditionTarget): The eccentricity.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("eccentricity"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "inclination",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanShortCondition::Inclination),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the inclination.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        inclination (EventConditionTarget): The inclination.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("inclination"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "inclination",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanShortCondition::Inclination
+                ),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the inclination being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "aop",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanShortCondition::Aop),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the argument of perigee.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        aop (EventConditionTarget): The argument of perigee.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("aop"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "aop",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanShortCondition::Aop
+                ),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the argument of perigee being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "raan",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanShortCondition::Raan),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the right ascension of the ascending node.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        raan (EventConditionTarget): The right ascension of the ascending node.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("raan"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "raan",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanShortCondition::Raan
+                ),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the right ascension of the ascending node being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "true_anomaly",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanShortCondition::TrueAnomaly),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the true anomaly.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        true_anomaly (EventConditionTarget): The true anomaly.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("true_anomaly"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "true_anomaly",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanShortCondition::TrueAnomaly
+                ),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the true anomaly being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "mean_anomaly",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanShortCondition::MeanAnomaly),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the mean anomaly.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        mean_anomaly (EventConditionTarget): The mean anomaly.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("mean_anomaly"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "mean_anomaly",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanShortCondition::MeanAnomaly
+                ),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the mean anomaly being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "eccentric_anomaly",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanShortCondition::EccentricAnomaly),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the eccentric anomaly.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        eccentric_anomaly (EventConditionTarget): The eccentric anomaly.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("eccentric_anomaly"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "eccentric_anomaly",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanShortCondition::EccentricAnomaly
+                ),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the eccentric anomaly being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "argument_of_latitude",
+                overload_cast<
+                    const AngularCondition::Criterion&,
+                    const Shared<const Frame>&,
+                    const EventCondition::Target&,
+                    const Derived&>(&BrouwerLyddaneMeanShortCondition::ArgumentOfLatitude),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the argument of latitude.
+
+                    Args:
+                        criterion (Criterion): The criterion.
+                        frame (Frame): The reference frame.
+                        argument_of_latitude (EventConditionTarget): The argument of latitude.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("criterion"),
+                arg("frame"),
+                arg("argument_of_latitude"),
+                arg("gravitational_parameter")
+            )
+
+            .def_static(
+                "argument_of_latitude",
+                overload_cast<const Shared<const Frame>&, const Pair<Angle, Angle>&, const Derived&>(
+                    &BrouwerLyddaneMeanShortCondition::ArgumentOfLatitude
+                ),
+                R"doc(
+                    Create a Brouwer-Lyddane Mean Short condition based on the argument of latitude being within a range.
+
+                    Args:
+                        frame (Frame): The reference frame.
+                        target_range (tuple[Angle, Angle]): A tuple of two angles defining the range.
+                        gravitational_parameter (Derived): The gravitational parameter.
+
+                    Returns:
+                        BrouwerLyddaneMeanShortCondition: The Brouwer-Lyddane Mean Short condition.
+                )doc",
+                arg("frame"),
+                arg("target_range"),
+                arg("gravitational_parameter")
+            )
+
+            ;
+    }
+}

--- a/bindings/python/test/event_condition/test_brouwer_lyddane_mean_short_condition.py
+++ b/bindings/python/test/event_condition/test_brouwer_lyddane_mean_short_condition.py
@@ -1,0 +1,135 @@
+# Apache License 2.0
+
+import pytest
+
+from ostk.physics.environment.gravitational import Earth
+from ostk.physics.unit import Derived, Length, Angle
+from ostk.physics.coordinate import Frame
+
+from ostk.astrodynamics import EventCondition
+from ostk.astrodynamics.event_condition import (
+    BrouwerLyddaneMeanShortCondition,
+    AngularCondition,
+    RealCondition,
+)
+
+
+@pytest.fixture
+def criterion() -> AngularCondition.Criterion:
+    return AngularCondition.Criterion.AnyCrossing
+
+
+@pytest.fixture
+def gravitational_parameter() -> Derived:
+    return Earth.spherical.gravitational_parameter
+
+
+@pytest.fixture
+def frame() -> Frame:
+    return Frame.GCRF()
+
+
+class TestBrouwerLyddaneMeanShortCondition:
+    @pytest.mark.parametrize(
+        "static_constructor,target,criterion",
+        (
+            (
+                BrouwerLyddaneMeanShortCondition.semi_major_axis,
+                EventCondition.Target(Length.meters(7e6)),
+                RealCondition.Criterion.PositiveCrossing,
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.eccentricity,
+                EventCondition.Target(0.1),
+                RealCondition.Criterion.PositiveCrossing,
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.inclination,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.aop,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.raan,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.true_anomaly,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.mean_anomaly,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.eccentric_anomaly,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.argument_of_latitude,
+                EventCondition.Target(Angle.degrees(0.0)),
+                AngularCondition.Criterion.PositiveCrossing,
+            ),
+        ),
+    )
+    def test_static_constructors(
+        self,
+        static_constructor,
+        target,
+        criterion,
+        frame: Frame,
+        gravitational_parameter: Derived,
+    ):
+        condition = static_constructor(criterion, frame, target, gravitational_parameter)
+        assert condition is not None
+
+    @pytest.mark.parametrize(
+        "static_constructor,target_range",
+        (
+            (
+                BrouwerLyddaneMeanShortCondition.inclination,
+                (Angle.degrees(10.0), Angle.degrees(20.0)),
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.aop,
+                (Angle.degrees(0.0), Angle.degrees(90.0)),
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.raan,
+                (Angle.degrees(0.0), Angle.degrees(90.0)),
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.true_anomaly,
+                (Angle.degrees(0.0), Angle.degrees(90.0)),
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.mean_anomaly,
+                (Angle.degrees(0.0), Angle.degrees(90.0)),
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.eccentric_anomaly,
+                (Angle.degrees(0.0), Angle.degrees(90.0)),
+            ),
+            (
+                BrouwerLyddaneMeanShortCondition.argument_of_latitude,
+                (Angle.degrees(0.0), Angle.degrees(90.0)),
+            ),
+        ),
+    )
+    def test_static_constructors_within_range(
+        self,
+        static_constructor,
+        target_range,
+        frame: Frame,
+        gravitational_parameter: Derived,
+    ):
+        condition = static_constructor(frame, target_range, gravitational_parameter)
+        assert condition is not None

--- a/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanShortCondition.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanShortCondition.hpp
@@ -1,0 +1,290 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkit_Astrodynamics_EventConditions_BrouwerLyddaneMeanShortCondition__
+#define __OpenSpaceToolkit_Astrodynamics_EventConditions_BrouwerLyddaneMeanShortCondition__
+
+#include <OpenSpaceToolkit/Core/Type/Real.hpp>
+#include <OpenSpaceToolkit/Core/Type/Shared.hpp>
+#include <OpenSpaceToolkit/Core/Type/String.hpp>
+
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/AngularCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/RealCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/BrouwerLyddaneMean/BrouwerLyddaneMeanShort.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
+
+namespace ostk
+{
+namespace astrodynamics
+{
+namespace eventcondition
+{
+
+using ostk::core::container::Pair;
+using ostk::core::type::Real;
+using ostk::core::type::Shared;
+using ostk::core::type::String;
+
+using ostk::physics::coordinate::Frame;
+using ostk::physics::unit::Angle;
+using ostk::physics::unit::Derived;
+
+using ostk::astrodynamics::EventCondition;
+using ostk::astrodynamics::eventcondition::AngularCondition;
+using ostk::astrodynamics::eventcondition::RealCondition;
+using ostk::astrodynamics::trajectory::orbit::model::blm::BrouwerLyddaneMeanShort;
+using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
+using ostk::astrodynamics::trajectory::State;
+
+/// @brief A Brouwer-Lyddane Short Mean orbital elements based event condition
+class BrouwerLyddaneMeanShortCondition
+{
+   public:
+    /// @brief Semi-Major Axis based constructor
+    ///
+    /// @code{.cpp}
+    ///     RealCondition condition = BrouwerLyddaneMeanShortCondition::SemiMajorAxis(
+    ///         RealCondition::Criterion::AnyCrossing,
+    ///         Frame::GCRF(),
+    ///         EventCondition::Target(7000000.0),
+    ///         gravitationalParameter
+    ///     ) ;
+    /// @endcode
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static RealCondition SemiMajorAxis(
+        const RealCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Eccentricity based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static RealCondition Eccentricity(
+        const RealCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Inclination based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition Inclination(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Inclination based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition Inclination(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Argument of Periapsis based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition Aop(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Argument of Periapsis based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition Aop(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Right Ascension of Ascending Node based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition Raan(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Right Ascension of Ascending Node based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition Raan(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief True Anomaly based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition TrueAnomaly(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief True Anomaly based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition TrueAnomaly(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Mean Anomaly based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition MeanAnomaly(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Mean Anomaly based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition MeanAnomaly(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Eccentric Anomaly based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition EccentricAnomaly(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Eccentric Anomaly based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition EccentricAnomaly(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Argument of Latitude based constructor
+    ///
+    /// @param aCriterion The criterion used to resolve the Event Condition
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTarget A Target
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition ArgumentOfLatitude(
+        const AngularCondition::Criterion& aCriterion,
+        const Shared<const Frame>& aFrameSPtr,
+        const EventCondition::Target& aTarget,
+        const Derived& aGravitationalParameter
+    );
+
+    /// @brief Argument of Latitude based constructor
+    ///
+    /// @param aFrameSPtr A frame in which the element is to be computed
+    /// @param aTargetRange A Target Range
+    /// @param aGravitationalParameter A gravitational parameter
+    ///
+    /// @return BrouwerLyddaneMeanShortCondition object
+    static AngularCondition ArgumentOfLatitude(
+        const Shared<const Frame>& aFrameSPtr,
+        const Pair<Angle, Angle>& aTargetRange,
+        const Derived& aGravitationalParameter
+    );
+
+   private:
+    static std::function<Real(const State&)> GenerateEvaluator(
+        const COE::Element& anElement, const Shared<const Frame>& aFrameSPtr, const Derived& aGravitationalParameter
+    );
+};
+
+}  // namespace eventcondition
+}  // namespace astrodynamics
+}  // namespace ostk
+
+#endif

--- a/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLydanneMeanShortCondition.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLydanneMeanShortCondition.cpp
@@ -1,0 +1,283 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Utility.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanShortCondition.hpp>
+
+namespace ostk
+{
+namespace astrodynamics
+{
+namespace eventcondition
+{
+
+RealCondition BrouwerLyddaneMeanShortCondition::SemiMajorAxis(
+    const RealCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return RealCondition(
+        "Semi-Major Axis",
+        aCriterion,
+        GenerateEvaluator(COE::Element::SemiMajorAxis, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    );
+}
+
+RealCondition BrouwerLyddaneMeanShortCondition::Eccentricity(
+    const RealCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return RealCondition(
+        "Eccentricity",
+        aCriterion,
+        GenerateEvaluator(COE::Element::Eccentricity, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    );
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::Inclination(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "Inclination",
+        aCriterion,
+        GenerateEvaluator(COE::Element::Inclination, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::Inclination(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "Inclination", GenerateEvaluator(COE::Element::Inclination, aFrameSPtr, aGravitationalParameter), aTargetRange
+    );
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::Aop(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "Argument of Periapsis",
+        aCriterion,
+        GenerateEvaluator(COE::Element::Aop, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::Aop(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "Argument of Periapsis", GenerateEvaluator(COE::Element::Aop, aFrameSPtr, aGravitationalParameter), aTargetRange
+    );
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::Raan(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "Right Ascension of Ascending Node",
+        aCriterion,
+        GenerateEvaluator(COE::Element::Raan, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::Raan(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "Right Ascension of Ascending Node",
+        GenerateEvaluator(COE::Element::Raan, aFrameSPtr, aGravitationalParameter),
+        aTargetRange
+    );
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::TrueAnomaly(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "True Anomaly",
+        aCriterion,
+        GenerateEvaluator(COE::Element::TrueAnomaly, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::TrueAnomaly(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "True Anomaly", GenerateEvaluator(COE::Element::TrueAnomaly, aFrameSPtr, aGravitationalParameter), aTargetRange
+    );
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::MeanAnomaly(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "Mean Anomaly",
+        aCriterion,
+        GenerateEvaluator(COE::Element::MeanAnomaly, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::MeanAnomaly(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "Mean Anomaly", GenerateEvaluator(COE::Element::MeanAnomaly, aFrameSPtr, aGravitationalParameter), aTargetRange
+    );
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::EccentricAnomaly(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "Eccentric Anomaly",
+        aCriterion,
+        GenerateEvaluator(COE::Element::EccentricAnomaly, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::EccentricAnomaly(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "Eccentric Anomaly",
+        GenerateEvaluator(COE::Element::EccentricAnomaly, aFrameSPtr, aGravitationalParameter),
+        aTargetRange
+    );
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::ArgumentOfLatitude(
+    const AngularCondition::Criterion& aCriterion,
+    const Shared<const Frame>& aFrameSPtr,
+    const EventCondition::Target& aTarget,
+    const Derived& aGravitationalParameter
+)
+{
+    return {
+        "Argument of Latitude",
+        aCriterion,
+        GenerateEvaluator(COE::Element::ArgumentOfLatitude, aFrameSPtr, aGravitationalParameter),
+        aTarget
+    };
+}
+
+AngularCondition BrouwerLyddaneMeanShortCondition::ArgumentOfLatitude(
+    const Shared<const Frame>& aFrameSPtr,
+    const Pair<Angle, Angle>& aTargetRange,
+    const Derived& aGravitationalParameter
+)
+{
+    return AngularCondition::WithinRange(
+        "Argument of Latitude",
+        GenerateEvaluator(COE::Element::ArgumentOfLatitude, aFrameSPtr, aGravitationalParameter),
+        aTargetRange
+    );
+}
+
+std::function<Real(const State&)> BrouwerLyddaneMeanShortCondition::GenerateEvaluator(
+    const COE::Element& anElement, const Shared<const Frame>& aFrameSPtr, const Derived& aGravitationalParameter
+)
+{
+    return [anElement, aFrameSPtr, aGravitationalParameter](const State& aState) -> Real
+    {
+        try
+        {
+            // Transform state to the target frame if necessary
+            const State stateInTargetFrame = aState.inFrame(aFrameSPtr);
+
+            // Compute the COE set from the position and velocity
+            const BrouwerLyddaneMeanShort orbitalElements = BrouwerLyddaneMeanShort::Cartesian(
+                {stateInTargetFrame.getPosition(), stateInTargetFrame.getVelocity()}, aGravitationalParameter
+            );
+
+            // Return the requested element value
+            switch (anElement)
+            {
+                case COE::Element::SemiMajorAxis:
+                    return orbitalElements.getSemiMajorAxis().inMeters();
+                case COE::Element::Eccentricity:
+                    return orbitalElements.getEccentricity();
+                case COE::Element::Inclination:
+                    return orbitalElements.getInclination().inRadians(0.0, Real::TwoPi());
+                case COE::Element::Aop:
+                    return orbitalElements.getAop().inRadians(0.0, Real::TwoPi());
+                case COE::Element::Raan:
+                    return orbitalElements.getRaan().inRadians(0.0, Real::TwoPi());
+                case COE::Element::TrueAnomaly:
+                    return orbitalElements.getTrueAnomaly().inRadians(0.0, Real::TwoPi());
+                case COE::Element::MeanAnomaly:
+                    return orbitalElements.getMeanAnomaly().inRadians(0.0, Real::TwoPi());
+                case COE::Element::EccentricAnomaly:
+                    return orbitalElements.getEccentricAnomaly().inRadians(0.0, Real::TwoPi());
+                case COE::Element::ArgumentOfLatitude:
+                    return orbitalElements.getArgumentOfLatitude().inRadians(0.0, Real::TwoPi());
+                default:
+                    throw ostk::core::error::runtime::Wrong("Element");
+            }
+        }
+        catch (const std::exception& e)
+        {
+            throw ostk::core::error::RuntimeError("Cannot evaluate Brouwer-Lyddane Mean Short: [{}].", e.what());
+        }
+    };
+}
+
+}  // namespace eventcondition
+}  // namespace astrodynamics
+}  // namespace ostk

--- a/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanShortCondition.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanShortCondition.test.cpp
@@ -1,0 +1,440 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Container/Tuple.hpp>
+#include <OpenSpaceToolkit/Core/Type/Real.hpp>
+#include <OpenSpaceToolkit/Core/Type/Shared.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
+
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
+
+#include <OpenSpaceToolkit/Astrodynamics/EventCondition/BrouwerLyddaneMeanShortCondition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/COE.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateBroker.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::container::Array;
+using ostk::core::container::Pair;
+using ostk::core::container::Tuple;
+using ostk::core::type::Real;
+using ostk::core::type::Shared;
+using ostk::core::type::String;
+
+using ostk::mathematics::object::VectorXd;
+
+using ostk::physics::coordinate::Frame;
+using ostk::physics::coordinate::Position;
+using ostk::physics::coordinate::Velocity;
+using ostk::physics::environment::gravitational::Earth;
+using ostk::physics::time::Instant;
+using ostk::physics::unit::Angle;
+using ostk::physics::unit::Derived;
+using ostk::physics::unit::Length;
+
+using ostk::astrodynamics::EventCondition;
+using ostk::astrodynamics::eventcondition::AngularCondition;
+using ostk::astrodynamics::eventcondition::BrouwerLyddaneMeanShortCondition;
+using ostk::astrodynamics::eventcondition::RealCondition;
+using ostk::astrodynamics::trajectory::orbit::model::blm::BrouwerLyddaneMeanShort;
+using ostk::astrodynamics::trajectory::orbit::model::kepler::COE;
+using ostk::astrodynamics::trajectory::State;
+using ostk::astrodynamics::trajectory::state::CoordinateBroker;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
+
+class OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition
+    : public ::testing::TestWithParam<Tuple<COE::Element, Real, Real>>
+{
+    void SetUp() override
+    {
+        Position currentPosition = Position::Undefined();
+        Position previousPosition = Position::Undefined();
+        Velocity currentVelocity = Velocity::Undefined();
+        Velocity previousVelocity = Velocity::Undefined();
+
+        std::tie(currentPosition, currentVelocity) =
+            BrouwerLyddaneMeanShort(
+                Length::Kilometers(551.0) + Earth::EGM2008.equatorialRadius_,
+                0.00021,
+                Angle::Degrees(16.0),
+                Angle::Degrees(1.0),
+                Angle::Degrees(1.0),
+                Angle::Degrees(1.0)
+            )
+                .getCartesianState(Earth::EGM2008.gravitationalParameter_, defaultFrame_);
+
+        std::tie(previousPosition, previousVelocity) =
+            BrouwerLyddaneMeanShort(
+                Length::Kilometers(549.0) + Earth::EGM2008.equatorialRadius_,
+                0.00019,
+                Angle::Degrees(15.0),
+                Angle::Degrees(359.0),
+                Angle::Degrees(359.0),
+                Angle::Degrees(359.0)
+            )
+                .getCartesianState(Earth::EGM2008.gravitationalParameter_, defaultFrame_);
+
+        currentState_ = {defaultInstant_, currentPosition, currentVelocity};
+        previousState_ = {defaultInstant_, previousPosition, previousVelocity};
+    }
+
+   protected:
+    const Derived gravitationalParameter_ = Earth::Spherical.gravitationalParameter_;
+    const Instant defaultInstant_ = Instant::J2000();
+    const Shared<const Frame> defaultFrame_ = Frame::GCRF();
+    State currentState_ = State::Undefined();
+    State previousState_ = State::Undefined();
+};
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, SemiMajorAxis)
+{
+    RealCondition condition = BrouwerLyddaneMeanShortCondition::SemiMajorAxis(
+        RealCondition::Criterion::PositiveCrossing,
+        defaultFrame_,
+        Length::Meters(550000.0) + Earth::EGM2008.equatorialRadius_,
+        gravitationalParameter_
+    );
+
+    EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, Eccentricity)
+{
+    const Real target = 0.0002;
+
+    {
+        RealCondition condition = BrouwerLyddaneMeanShortCondition::Eccentricity(
+            RealCondition::Criterion::PositiveCrossing, defaultFrame_, target, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        RealCondition condition = BrouwerLyddaneMeanShortCondition::Eccentricity(
+            RealCondition::Criterion::NegativeCrossing, defaultFrame_, target, gravitationalParameter_
+        );
+
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        RealCondition condition = BrouwerLyddaneMeanShortCondition::Eccentricity(
+            RealCondition::Criterion::AnyCrossing, defaultFrame_, target, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, Inclination)
+{
+    const Angle targetAngle = Angle::Degrees(15.5);
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Inclination(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Inclination(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Inclination(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's inclination (16 deg) but not the previous state's (15 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(15.5), Angle::Degrees(17.0)};
+
+        AngularCondition condition =
+            BrouwerLyddaneMeanShortCondition::Inclination(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, Aop)
+{
+    const Angle targetAngle = Angle::Degrees(0.0);
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Aop(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Aop(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Aop(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's AoP (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+
+        AngularCondition condition =
+            BrouwerLyddaneMeanShortCondition::Aop(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, Raan)
+{
+    const Angle targetAngle = Angle::Degrees(0.0);
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Raan(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Raan(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::Raan(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's RAAN (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+
+        AngularCondition condition =
+            BrouwerLyddaneMeanShortCondition::Raan(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, TrueAnomaly)
+{
+    const Angle targetAngle = Angle::Degrees(0.0);
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::TrueAnomaly(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::TrueAnomaly(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::TrueAnomaly(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's true anomaly (1 deg) but not the previous state's (359 deg)
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+
+        AngularCondition condition =
+            BrouwerLyddaneMeanShortCondition::TrueAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, MeanAnomaly)
+{
+    const Angle targetAngle = Angle::Degrees(0.0);
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::MeanAnomaly(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::MeanAnomaly(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::MeanAnomaly(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's mean anomaly (approximately 1 deg) but not the previous state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+
+        AngularCondition condition =
+            BrouwerLyddaneMeanShortCondition::MeanAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, EccentricAnomaly)
+{
+    const Angle targetAngle = Angle::Degrees(0.0);
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::EccentricAnomaly(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::EccentricAnomaly(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::EccentricAnomaly(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's eccentric anomaly (approximately 1 deg) but not the previous state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+
+        AngularCondition condition =
+            BrouwerLyddaneMeanShortCondition::EccentricAnomaly(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_EventCondition_BrouwerLyddaneMeanShortCondition, ArgumentOfLatitude)
+{
+    const Angle targetAngle = Angle::Degrees(0.0);
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::PositiveCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::NegativeCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+        EXPECT_FALSE(condition.isSatisfied(currentState_, previousState_));
+    }
+
+    {
+        AngularCondition condition = BrouwerLyddaneMeanShortCondition::ArgumentOfLatitude(
+            AngularCondition::Criterion::AnyCrossing, defaultFrame_, targetAngle, gravitationalParameter_
+        );
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_TRUE(condition.isSatisfied(previousState_, currentState_));
+    }
+
+    {
+        // Range that includes the current state's argument of latitude (approximately 1 deg) but not the previous
+        // state's
+        const Pair<Angle, Angle> targetRange = {Angle::Degrees(0.5), Angle::Degrees(10.0)};
+
+        AngularCondition condition =
+            BrouwerLyddaneMeanShortCondition::ArgumentOfLatitude(defaultFrame_, targetRange, gravitationalParameter_);
+
+        EXPECT_TRUE(condition.isSatisfied(currentState_, previousState_));
+        EXPECT_FALSE(condition.isSatisfied(previousState_, currentState_));
+    }
+}


### PR DESCRIPTION
Adding BLMS event conditions, analogous to the BLML ones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new orbital event condition in Python and C++.
  * Exposed checks for semi-major axis, eccentricity, and multiple angular orbital elements.
  * Added range-based angle conditions for more flexible event detection.

* **Tests**
  * Added coverage for the new event condition across scalar and angular cases.
  * Verified expected behavior for crossing directions and angle wraparound scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->