### PR TITLE
feat: switch Python viewer from cesiumpy to native CZML generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -533,7 +533,7 @@ test-unit-python-standalone: ## Run Python unit tests (standalone)
 		/bin/bash -c "cmake -DBUILD_PYTHON_BINDINGS=ON -DBUILD_UNIT_TESTS=OFF -DBUILD_VALIDATION_TESTS=OFF -DBUILD_BENCHMARK=OFF .. \
 		&& $(MAKE) -j 4 \
 		&& python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} bindings/python/OpenSpaceToolkit*Py-python-package-${test_python_version} \
-		&& python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} plotly pandas git+https://github.com/open-space-collective/cesiumpy.git#egg=cesiumpy \
+		&& python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} plotly pandas \
 		&& cd ${test_python_directory}/ostk/$(project_name)/ \
 		&& python${test_python_version} -m pytest -sv ."
 
@@ -550,7 +550,7 @@ ci-test-python: ## Run Python unit tests. Assumes the dev image has already been
 	--workdir=/app/build \
 	$(docker_development_image_repository):$(docker_image_version) \
 	/bin/bash -c "python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} --find-links /app/packages/python open_space_toolkit_${project_name} \
-	&& python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} plotly pandas git+https://github.com/open-space-collective/cesiumpy.git#egg=cesiumpy \
+	&& python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} plotly pandas \
 	&& cd ${test_python_directory}/ostk/$(project_name)/ \
 	&& python${test_python_version} -m pytest -sv ."
 

--- a/bindings/python/test/test_viewer.py
+++ b/bindings/python/test/test_viewer.py
@@ -1,5 +1,8 @@
 # Apache License 2.0
 
+import json
+
+import numpy as np
 import pytest
 
 from ostk.physics import Environment
@@ -11,15 +14,20 @@ from ostk.physics.time import Duration
 from ostk.physics.time import DateTime
 from ostk.physics.time import Time
 from ostk.physics.time import Scale
-from ostk.physics.unit import Length
 from ostk.physics.coordinate import Position
 from ostk.physics.coordinate import Frame
 
 from ostk.astrodynamics.trajectory import Orbit
 from ostk.astrodynamics.flight import Profile
+from ostk.astrodynamics import czml
 from ostk.astrodynamics.viewer import Viewer
 from ostk.astrodynamics.viewer import ConicSensor
+from ostk.astrodynamics.viewer import RectangularSensor
 from ostk.astrodynamics.viewer import _compute_celestial_angular_diameter_from_states
+from ostk.astrodynamics.viewer import _intersection_with_earth
+from ostk.astrodynamics.viewer import _quaternion_aligning_z
+from ostk.astrodynamics.viewer import _sensor_boundary_directions
+from ostk.astrodynamics.viewer import _format_duration
 
 
 @pytest.fixture
@@ -80,6 +88,14 @@ def viewer(interval: Interval) -> Viewer:
     )
 
 
+def packet_with_id(viewer: Viewer, packet_id: str) -> dict:
+    for packet in viewer.to_czml():
+        if packet.get("id") == packet_id:
+            return packet
+
+    raise AssertionError(f"No packet with id [{packet_id}].")
+
+
 class TestViewer:
     def test_constructor_success(self, interval: Interval):
         viewer = Viewer(
@@ -89,11 +105,31 @@ class TestViewer:
         assert viewer is not None
         assert viewer.interval == interval
 
+        packets: list[dict] = viewer.to_czml()
+
+        assert packets[0]["id"] == "document"
+        assert packets[0]["version"] == "1.0"
+        assert packets[0]["clock"]["interval"] == (
+            "2020-01-01T00:00:00.000000Z/2020-01-01T00:10:00.000000Z"
+        )
+        assert packets[0]["clock"]["range"] == "CLAMPED"
+
         rendered_html: str = viewer.render()
 
         assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
+        assert "new Cesium.Viewer" in rendered_html
+        assert "Cesium.CzmlDataSource.load" in rendered_html
+        assert "sceneModePicker: true" in rendered_html
+        assert "sceneMode: Cesium.SceneMode.SCENE3D" in rendered_html
         assert rendered_html.endswith("</script>")
+
+    def test_constructor_scene_mode_success(self, interval: Interval):
+        rendered_html: str = Viewer(interval=interval, scene_mode="2D").render()
+
+        assert "sceneMode: Cesium.SceneMode.SCENE2D" in rendered_html
+
+        with pytest.raises(ValueError):
+            Viewer(interval=interval, scene_mode="4D")
 
     def test_add_orbit_success(
         self,
@@ -106,15 +142,40 @@ class TestViewer:
             show_orbital_track=True,
         )
 
+        satellite: dict = packet_with_id(viewer, "satellite")
+
+        assert satellite["billboard"]["image"].startswith("data:image/png;base64,")
+        assert satellite["label"]["text"] == "Satellite"
+        assert satellite["position"]["interpolationAlgorithm"] == "LAGRANGE"
+        assert satellite["position"]["referenceFrame"] == "FIXED"
+        assert len(satellite["position"]["cartesian"]) == (600 // 5 + 1) * 4
+
+        # Leading/trailing orbital track: default lead/trail time is one orbital period.
+        assert satellite["path"]["leadTime"] == pytest.approx(5677.0, abs=60.0)
+        assert satellite["path"]["trailTime"] == pytest.approx(5677.0, abs=60.0)
+
         rendered_html: str = viewer.render()
 
         assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert "new Cesium.SampledProperty(Cesium.Cartesian3)" in rendered_html
-        assert " widget.entities.add({position: widget" in rendered_html
-        assert "widget.entities.add({polyline:" in rendered_html
-        assert "billboard: {image:" in rendered_html
         assert rendered_html.endswith("</script>")
+
+    def test_add_orbit_lead_trail_time_success(
+        self,
+        viewer: Viewer,
+        orbit: Orbit,
+    ):
+        viewer.add_orbit(
+            orbit=orbit,
+            step=Duration.seconds(30.0),
+            show_orbital_track=True,
+            trail_time=Duration.minutes(10.0),
+            lead_time=Duration.minutes(20.0),
+        )
+
+        satellite: dict = packet_with_id(viewer, "satellite")
+
+        assert satellite["path"]["trailTime"] == 600.0
+        assert satellite["path"]["leadTime"] == 1200.0
 
     def test_add_orbit_multiple_success(
         self,
@@ -129,15 +190,8 @@ class TestViewer:
                 name=f"Satellite {i}",
             )
 
-        rendered_html: str = viewer.render()
-
-        assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert "new Cesium.SampledProperty(Cesium.Cartesian3)" in rendered_html
-        assert " widget.entities.add({position: widget" in rendered_html
-        assert "widget.entities.add({polyline:" in rendered_html
-        assert "billboard: {image:" in rendered_html
-        assert rendered_html.endswith("</script>")
+        assert packet_with_id(viewer, "satellite_0")["label"]["text"] == "Satellite 0"
+        assert packet_with_id(viewer, "satellite_1")["label"]["text"] == "Satellite 1"
 
     def test_add_profile_success(
         self,
@@ -161,17 +215,103 @@ class TestViewer:
             show_xyz_axes=True,
         )
 
+        satellite: dict = packet_with_id(viewer, "satellite")
+
+        assert satellite["properties"]["ion_asset_id"] == 123
+        assert "unitQuaternion" in satellite["orientation"]
+        assert len(satellite["orientation"]["unitQuaternion"]) == (600 // 30 + 1) * 5
+        assert "path" in satellite
+
+        # Sensors are rendered as cone (cylinder) entities attached to the satellite.
+        star_tracker: dict = packet_with_id(viewer, "satellite_star_tracker")
+
+        assert star_tracker["cylinder"]["topRadius"] == 0.0
+        assert star_tracker["cylinder"]["length"] == pytest.approx(0.1)
+
+        for axis in ("x_axis", "y_axis", "z_axis"):
+            assert packet_with_id(viewer, f"satellite_{axis}")["cylinder"] is not None
+
         rendered_html: str = viewer.render()
 
-        assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert " widget.entities.add({position: widget" in rendered_html
-        assert "Cesium.IonResource.fromAssetId(123)" in rendered_html
-        assert "widget.entities.add({polyline:" in rendered_html
-        assert (
-            "widget.entities.add({position: widget.star_tracker_position" in rendered_html
+        assert 'entity.properties.hasProperty("ion_asset_id")' in rendered_html
+        assert "Cesium.IonResource.fromAssetId" in rendered_html
+
+    def test_add_profile_without_asset_id_warns(
+        self,
+        viewer: Viewer,
+        profile: Profile,
+    ):
+        with pytest.warns(FutureWarning):
+            viewer.add_profile(
+                profile=profile,
+                step=Duration.seconds(60.0),
+            )
+
+        satellite: dict = packet_with_id(viewer, "satellite")
+
+        assert satellite["billboard"]["image"].startswith("data:image/png;base64,")
+
+    def test_add_profile_rectangular_sensor_success(
+        self,
+        viewer: Viewer,
+        profile: Profile,
+    ):
+        viewer.add_profile(
+            profile=profile,
+            step=Duration.seconds(60.0),
+            cesium_asset_id=123,
+            sensors=[
+                RectangularSensor(
+                    name="camera",
+                    direction=(0.0, 0.0, 1.0),
+                    x_half_angle=Angle.degrees(10.0),
+                    y_half_angle=Angle.degrees(5.0),
+                    radius=Length.kilometers(600.0),
+                    color="orange",
+                ),
+            ],
         )
-        assert rendered_html.endswith("</script>")
+
+        for corner_index in range(4):
+            edge: dict = packet_with_id(viewer, f"satellite_camera_edge_{corner_index}")
+
+            assert edge["polyline"]["positions"]["references"] == [
+                "satellite#position",
+                f"satellite_camera_corner_{corner_index}#position",
+            ]
+
+    def test_add_sensor_projection_success(
+        self,
+        viewer: Viewer,
+        profile: Profile,
+    ):
+        viewer.add_sensor_projection(
+            profile=profile,
+            sensor=ConicSensor(
+                name="payload",
+                direction=(0.0, 0.0, 1.0),  # +Z is nadir for a VVLH-pointing profile
+                half_angle=Angle.degrees(30.0),
+                length=Length.meters(1.0),
+                color="red",
+            ),
+            time_step=Duration.seconds(60.0),
+        )
+
+        projection: dict = packet_with_id(viewer, "payload_projection")
+
+        assert len(projection["polygon"]["positions"]) == 10
+        assert projection["polygon"]["positions"][0]["cartesian"]
+
+        # The nadir-pointing footprint boundary must lie on the Earth ellipsoid.
+        first_footprint: list[float] = projection["polygon"]["positions"][0]["cartesian"]
+        point: np.ndarray = np.array(first_footprint[0:3])
+
+        assert np.linalg.norm(point) == pytest.approx(6.378137e6, rel=1e-2)
+
+        show_entries = projection["polygon"]["show"]
+
+        assert show_entries[0]["boolean"] is False  # default over the whole interval
+        assert all(entry["boolean"] for entry in show_entries[1:])
 
     @pytest.mark.parametrize(
         "celestial_body_name",
@@ -190,16 +330,91 @@ class TestViewer:
             celestial=environment.access_celestial_object_with_name(celestial_body_name),
         )
 
-        rendered_html: str = viewer.render()
-
-        assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert " widget.entities.add({position: widget" in rendered_html
-        assert (
-            f"widget.entities.add({{position: widget.{celestial_body_name.lower()}_direction_position"
-            in rendered_html
+        direction: dict = packet_with_id(
+            viewer, f"{celestial_body_name.lower()}_direction"
         )
-        assert rendered_html.endswith("</script>")
+
+        assert direction["polyline"]["positions"]["references"] == [
+            f"{celestial_body_name.lower()}_direction_start#position",
+            f"{celestial_body_name.lower()}_direction_end#position",
+        ]
+
+    def test_add_target_vector_success(
+        self,
+        viewer: Viewer,
+        orbits: list[Orbit],
+    ):
+        viewer.add_target_vector(
+            profile_or_trajectory=orbits[0],
+            target=orbits[1],
+            name="inter_satellite_link",
+            color="cyan",
+            time_step=Duration.seconds(60.0),
+        )
+
+        vector: dict = packet_with_id(viewer, "inter_satellite_link")
+
+        assert vector["polyline"]["arcType"] == "NONE"
+        assert vector["polyline"]["material"]["solidColor"]["color"]["rgba"] == [
+            0,
+            255,
+            255,
+            255,
+        ]
+
+        start: dict = packet_with_id(viewer, "inter_satellite_link_start")
+
+        assert len(start["position"]["cartesian"]) == (600 // 60 + 1) * 4
+
+    def test_add_accesses_success(
+        self,
+        viewer: Viewer,
+        orbit: Orbit,
+        interval: Interval,
+    ):
+        access_intervals: list[Interval] = [
+            Interval.closed(
+                start_instant=Instant.date_time(DateTime(2020, 1, 1, 0, 1, 0), Scale.UTC),
+                end_instant=Instant.date_time(DateTime(2020, 1, 1, 0, 3, 0), Scale.UTC),
+            ),
+            Interval.closed(
+                start_instant=Instant.date_time(DateTime(2020, 1, 1, 0, 6, 0), Scale.UTC),
+                end_instant=Instant.date_time(DateTime(2020, 1, 1, 0, 8, 0), Scale.UTC),
+            ),
+        ]
+
+        viewer.add_accesses(
+            accesses=access_intervals,
+            observer=orbit,
+            target=Position.meters([6378137.0, 0.0, 0.0], Frame.ITRF()),
+            name="Ground Station Access",
+            time_step=Duration.seconds(30.0),
+        )
+
+        access: dict = packet_with_id(viewer, "ground_station_access")
+
+        assert access["polyline"]["positions"]["references"] == [
+            "ground_station_access_observer#position",
+            "ground_station_access_target#position",
+        ]
+
+        show_entries: list[dict] = access["polyline"]["show"]
+
+        assert show_entries[0]["boolean"] is False
+        assert show_entries[1]["interval"] == (
+            "2020-01-01T00:01:00.000000Z/2020-01-01T00:03:00.000000Z"
+        )
+        assert show_entries[1]["boolean"] is True
+        assert len(show_entries) == 3
+
+        assert "<table" in access["description"]
+        assert "00:02:00" in access["description"]
+
+        label: dict = packet_with_id(viewer, "ground_station_access_label")
+
+        assert label["position"]["reference"] == "ground_station_access_target#position"
+        assert len(label["label"]["text"]) == 2
+        assert "Ground Station Access #1" in label["label"]["text"][0]["string"]
 
     def test_add_ground_tracks_success(
         self,
@@ -208,12 +423,13 @@ class TestViewer:
     ):
         viewer.add_ground_tracks(profile_or_trajectory=orbit)
 
-        rendered_html: str = viewer.render()
+        line: dict = packet_with_id(viewer, "line")
 
-        assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert "widget.entities.add({polyline:" in rendered_html
-        assert rendered_html.endswith("</script>")
+        assert line["polyline"]["positions"]["cartographicDegrees"]
+
+        moving_point: dict = packet_with_id(viewer, "moving_point")
+
+        assert moving_point["point"]["color"]["rgba"] == [255, 140, 0, 255]
 
     def test_add_target_success(
         self,
@@ -225,15 +441,16 @@ class TestViewer:
             color="red",
         )
 
-        rendered_html: str = viewer.render()
+        target: dict = packet_with_id(viewer, "target")
 
-        assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert (
-            "widget.entities.add({position: Cesium.Cartesian3.fromDegrees(63.43494882292201, 18.22447811510915, -6376045.535225509), point: {pixelSize: 123.0, color: Cesium.Color.RED}});"
-            in rendered_html
+        assert target["point"]["pixelSize"] == 123
+        assert target["point"]["color"]["rgba"] == [255, 0, 0, 255]
+        assert target["position"]["cartographicDegrees"][0] == pytest.approx(
+            63.43494882292201
         )
-        assert rendered_html.endswith("</script>")
+        assert target["position"]["cartographicDegrees"][1] == pytest.approx(
+            18.22447811510915
+        )
 
     def test_add_target_with_label_success(
         self,
@@ -246,19 +463,10 @@ class TestViewer:
             label="TEST",
         )
 
-        rendered_html: str = viewer.render()
+        label: dict = packet_with_id(viewer, "test_label")
 
-        assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert (
-            "widget.entities.add({position: Cesium.Cartesian3.fromDegrees(63.43494882292201, 18.22447811510915, -6376045.535225509), point: {pixelSize: 123.0, color: Cesium.Color.RED}});"
-            in rendered_html
-        )
-        assert (
-            'widget.entities.add({position: Cesium.Cartesian3.fromDegrees(63.43494882292201, 18.22447811510915, -6376045.535225509), label: {text: "TEST", fillColor: Cesium.Color.RED, scale: 123.0}});'
-            in rendered_html
-        )
-        assert rendered_html.endswith("</script>")
+        assert label["label"]["text"] == "TEST"
+        assert label["label"]["fillColor"]["rgba"] == [255, 0, 0, 255]
 
     def test_add_line_success(
         self,
@@ -269,19 +477,23 @@ class TestViewer:
                 Position.meters([1.0, 2.0, 3.0], Frame.ITRF()),
                 Position.meters([4.0, 5.0, 6.0], Frame.ITRF()),
             ],
-            size=10.0,
+            size=10,
             color="red",
         )
 
-        rendered_html: str = viewer.render()
+        line: dict = packet_with_id(viewer, "line")
 
-        assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert (
-            "widget.entities.add({polyline: {positions: Cesium.Cartesian3.fromDegreesArrayHeights([63.43494882292201, 18.22447811510915, 10.0, 51.34019174590991, 10.165199393640696, 10.0]), width: 10.0, material: Cesium.Color.RED}});"
-            in rendered_html
+        assert line["polyline"]["width"] == 10
+        assert line["polyline"]["positions"]["cartographicDegrees"] == pytest.approx(
+            [
+                63.43494882292201,
+                18.22447811510915,
+                10.0,
+                51.34019174590991,
+                10.165199393640696,
+                10.0,
+            ]
         )
-        assert rendered_html.endswith("</script>")
 
     def test_add_label_success(
         self,
@@ -290,19 +502,164 @@ class TestViewer:
         viewer.add_label(
             position=Position.meters([6671000.0, 0.0, 0.0], Frame.ITRF()),
             text="Hello, World!",
-            size=1.0,
+            size=1,
             color="red",
         )
 
-        rendered_html: str = viewer.render()
+        label: dict = packet_with_id(viewer, "hello_world_label")
 
-        assert rendered_html.startswith('<meta charset="utf-8">')
-        assert "var widget = new Cesium.Viewer" in rendered_html
-        assert (
-            'widget.entities.add({position: Cesium.Cartesian3.fromDegrees(0.0, 0.0, 292863.0000000001), label: {text: "Hello, World!", fillColor: Cesium.Color.RED, scale: 1.0}});'
-            in rendered_html
+        assert label["label"]["text"] == "Hello, World!"
+        assert label["label"]["scale"] == 1
+
+    def test_to_czml_is_json_serializable(
+        self,
+        viewer: Viewer,
+        orbit: Orbit,
+    ):
+        viewer.add_orbit(
+            orbit=orbit,
+            step=Duration.seconds(30.0),
+            show_orbital_track=True,
         )
-        assert rendered_html.endswith("</script>")
+
+        assert json.loads(json.dumps(viewer.to_czml())) == viewer.to_czml()
+
+    def test_save_czml_success(
+        self,
+        viewer: Viewer,
+        orbit: Orbit,
+        tmp_path,
+    ):
+        viewer.add_orbit(
+            orbit=orbit,
+            step=Duration.seconds(30.0),
+        )
+
+        path: str = str(tmp_path / "scenario.czml")
+        viewer.save_czml(path)
+
+        with open(path) as file:
+            packets: list[dict] = json.load(file)
+
+        assert packets[0]["id"] == "document"
+
+
+class TestCzml:
+    def test_format_instant_success(self):
+        assert (
+            czml.format_instant(
+                Instant.date_time(DateTime(2020, 1, 1, 0, 0, 0), Scale.UTC)
+            )
+            == "2020-01-01T00:00:00.000000Z"
+        )
+
+    def test_format_color_success(self):
+        assert czml.format_color("red") == {"rgba": [255, 0, 0, 255]}
+        assert czml.format_color("#00FF00") == {"rgba": [0, 255, 0, 255]}
+        assert czml.format_color("#00FF0080") == {"rgba": [0, 255, 0, 128]}
+        assert czml.format_color((1, 2, 3)) == {"rgba": [1, 2, 3, 255]}
+        assert czml.format_color([1, 2, 3, 4]) == {"rgba": [1, 2, 3, 4]}
+        assert czml.format_color(None, default="yellow") == {"rgba": [255, 255, 0, 255]}
+        assert czml.format_color("red", alpha=0.5) == {"rgba": [255, 0, 0, 128]}
+
+        with pytest.raises(ValueError):
+            czml.format_color("not-a-color")
+
+    def test_interval_booleans_success(self, interval: Interval):
+        assert czml.interval_booleans(interval, []) is False
+
+        entries = czml.interval_booleans(
+            interval,
+            [
+                Interval.closed(
+                    start_instant=Instant.date_time(
+                        DateTime(2020, 1, 1, 0, 1, 0), Scale.UTC
+                    ),
+                    end_instant=Instant.date_time(
+                        DateTime(2020, 1, 1, 0, 2, 0), Scale.UTC
+                    ),
+                )
+            ],
+        )
+
+        assert entries[0]["boolean"] is False
+        assert entries[1]["boolean"] is True
+
+
+class TestHelpers:
+    def test_intersection_with_earth_success(self):
+        # Nadir ray from 500 km above the equator hits the ellipsoid surface.
+        intersection: np.ndarray = _intersection_with_earth(
+            origin=np.array([6878137.0, 0.0, 0.0]),
+            direction=np.array([-1.0, 0.0, 0.0]),
+        )
+
+        assert intersection == pytest.approx([6378137.0, 0.0, 0.0])
+
+        # A ray pointing away from the Earth misses.
+        assert (
+            _intersection_with_earth(
+                origin=np.array([6878137.0, 0.0, 0.0]),
+                direction=np.array([1.0, 0.0, 0.0]),
+            )
+            is None
+        )
+
+    def test_quaternion_aligning_z_success(self):
+        for direction in (
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, -1.0],
+            [1.0, 2.0, 3.0],
+        ):
+            x, y, z, w = _quaternion_aligning_z(np.array(direction))
+
+            # Rotate +Z by the quaternion (Hamilton convention) and compare.
+            v = np.array([0.0, 0.0, 1.0])
+            q_vector = np.array([x, y, z])
+            rotated = (
+                v * (w**2 - q_vector @ q_vector)
+                + 2.0 * q_vector * (q_vector @ v)
+                + 2.0 * w * np.cross(q_vector, v)
+            )
+
+            expected = np.array(direction) / np.linalg.norm(direction)
+
+            assert rotated == pytest.approx(expected)
+
+    def test_sensor_boundary_directions_success(self):
+        conic_directions = _sensor_boundary_directions(
+            ConicSensor(
+                name="payload",
+                direction=(0.0, 0.0, 1.0),
+                half_angle=Angle.degrees(30.0),
+                length=Length.meters(1.0),
+                color="red",
+            )
+        )
+
+        assert len(conic_directions) == 32
+        for direction in conic_directions:
+            assert np.linalg.norm(direction) == pytest.approx(1.0)
+            assert np.arccos(direction @ np.array([0.0, 0.0, 1.0])) == pytest.approx(
+                np.deg2rad(30.0)
+            )
+
+        rectangular_directions = _sensor_boundary_directions(
+            RectangularSensor(
+                name="camera",
+                direction=(0.0, 0.0, 1.0),
+                x_half_angle=Angle.degrees(10.0),
+                y_half_angle=Angle.degrees(5.0),
+                radius=Length.kilometers(600.0),
+                color="orange",
+            )
+        )
+
+        assert len(rectangular_directions) == 16
+
+    def test_format_duration_success(self):
+        assert _format_duration(Duration.seconds(3725.0)) == "01:02:05"
 
 
 def test_compute_celestial_angular_diameter_from_states_success(

--- a/bindings/python/test/test_viewer.py
+++ b/bindings/python/test/test_viewer.py
@@ -112,7 +112,7 @@ class TestViewer:
         assert packets[0]["clock"]["interval"] == (
             "2020-01-01T00:00:00.000000Z/2020-01-01T00:10:00.000000Z"
         )
-        assert packets[0]["clock"]["range"] == "CLAMPED"
+        assert packets[0]["clock"]["range"] == "LOOP_STOP"
 
         rendered_html: str = viewer.render()
 
@@ -121,6 +121,8 @@ class TestViewer:
         assert "Cesium.CzmlDataSource.load" in rendered_html
         assert "sceneModePicker: true" in rendered_html
         assert "sceneMode: Cesium.SceneMode.SCENE3D" in rendered_html
+        # Without an Ion token, imagery comes from the CesiumJS distribution itself.
+        assert "NaturalEarthII" in rendered_html
         assert rendered_html.endswith("</script>")
 
     def test_constructor_scene_mode_success(self, interval: Interval):

--- a/bindings/python/tools/python/ostk/astrodynamics/czml.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/czml.py
@@ -1,0 +1,330 @@
+# Apache License 2.0
+
+"""
+Low-level CZML (Cesium Language) document generation utilities.
+
+CZML is a JSON-based declarative format describing time-dynamic scenes for CesiumJS:
+https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/CZML-Guide
+
+This module converts Open Space Toolkit types (Instant, Interval, Position, ...) into
+CZML properties and packets, without any third-party dependency. It is used by
+`ostk.astrodynamics.viewer.Viewer`, and can also be used directly to produce `.czml`
+files consumable by any CesiumJS application.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from ostk.physics.time import Instant
+from ostk.physics.time import Interval
+
+from .converters import coerce_to_datetime
+
+__all__ = [
+    "Document",
+    "format_color",
+    "format_instant",
+    "format_interval",
+    "sampled_cartesian",
+    "sampled_unit_quaternion",
+    "interval_booleans",
+]
+
+_COLOR_NAMES: dict[str, tuple[int, int, int]] = {
+    "black": (0, 0, 0),
+    "blue": (0, 0, 255),
+    "cyan": (0, 255, 255),
+    "darkorange": (255, 140, 0),
+    "gray": (128, 128, 128),
+    "grey": (128, 128, 128),
+    "green": (0, 128, 0),
+    "lime": (0, 255, 0),
+    "magenta": (255, 0, 255),
+    "orange": (255, 165, 0),
+    "pink": (255, 192, 203),
+    "purple": (128, 0, 128),
+    "red": (255, 0, 0),
+    "white": (255, 255, 255),
+    "yellow": (255, 255, 0),
+}
+
+
+def format_instant(instant: Instant | datetime | str) -> str:
+    """
+    Format an instant as a CZML (ISO 8601 UTC) string.
+
+    Args:
+        instant (Instant | datetime | str): The instant to format.
+
+    Returns:
+        str: The ISO 8601 string (e.g. "2020-01-01T00:00:00.000000Z").
+    """
+
+    return coerce_to_datetime(instant).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def format_interval(interval: Interval) -> str:
+    """
+    Format an interval as a CZML (ISO 8601 UTC) interval string.
+
+    Args:
+        interval (Interval): The interval to format.
+
+    Returns:
+        str: The ISO 8601 interval string (e.g. "2020-01-01T00:00:00Z/2020-01-02T00:00:00Z").
+    """
+
+    return f"{format_instant(interval.get_start())}/{format_instant(interval.get_end())}"
+
+
+def format_color(
+    color: str | tuple | list | None,
+    default: str | tuple | list = "white",
+    alpha: float | None = None,
+) -> dict:
+    """
+    Convert a color into a CZML color property.
+
+    Args:
+        color (str | tuple | list | None): A color name (e.g. "red"), a hex string
+            (e.g. "#FF0000" or "#FF0000CC"), or an RGB(A) sequence with components in [0, 255].
+        default (str | tuple | list, optional): The color to use when `color` is None.
+        alpha (float, optional): An alpha override in [0.0, 1.0]. Defaults to None (keep alpha).
+
+    Returns:
+        dict: The CZML color property (e.g. {"rgba": [255, 0, 0, 255]}).
+    """
+
+    value = color if color is not None else default
+
+    if isinstance(value, str):
+        text: str = value.strip().lower()
+
+        if text.startswith("#"):
+            text = text[1:]
+            if len(text) not in (6, 8):
+                raise ValueError(f"Invalid hex color [{value}].")
+            components: list[int] = [
+                int(text[i : i + 2], 16) for i in range(0, len(text), 2)
+            ]
+            rgba: list[int] = components + [255] * (4 - len(components))
+
+        elif text in _COLOR_NAMES:
+            rgba = [*_COLOR_NAMES[text], 255]
+
+        else:
+            raise ValueError(f"Unsupported color [{value}].")
+
+    else:
+        components = [int(component) for component in value]
+        if len(components) == 3:
+            rgba = components + [255]
+        elif len(components) == 4:
+            rgba = components
+        else:
+            raise ValueError(f"Invalid color sequence [{value}].")
+
+    if alpha is not None:
+        rgba[3] = int(round(max(0.0, min(1.0, alpha)) * 255))
+
+    return {"rgba": rgba}
+
+
+def sampled_cartesian(
+    instants: list[Instant],
+    coordinates: list,
+    interpolation_degree: int = 5,
+) -> dict:
+    """
+    Build a time-sampled CZML cartesian property (e.g. a position in the FIXED frame).
+
+    Args:
+        instants (list[Instant]): The sample instants.
+        coordinates (list): The sample cartesian coordinates, in meters, as a list of 3-element sequences.
+        interpolation_degree (int, optional): The Lagrange interpolation degree. Defaults to 5.
+
+    Returns:
+        dict: The CZML sampled property.
+    """
+
+    epoch: Instant = instants[0]
+
+    samples: list[float] = []
+    for instant, coordinate in zip(instants, coordinates):
+        samples.append(float((instant - epoch).in_seconds()))
+        samples.extend(float(component) for component in coordinate)
+
+    return {
+        "epoch": format_instant(epoch),
+        "cartesian": samples,
+        "interpolationAlgorithm": "LAGRANGE",
+        "interpolationDegree": min(interpolation_degree, max(1, len(instants) - 1)),
+        "referenceFrame": "FIXED",
+    }
+
+
+def sampled_unit_quaternion(
+    instants: list[Instant],
+    quaternions: list,
+) -> dict:
+    """
+    Build a time-sampled CZML unit quaternion property (e.g. an entity orientation).
+
+    Args:
+        instants (list[Instant]): The sample instants.
+        quaternions (list): The sample quaternions, as a list of [x, y, z, w] sequences,
+            mapping the entity body frame into the Earth-fixed frame.
+
+    Returns:
+        dict: The CZML sampled property.
+    """
+
+    epoch: Instant = instants[0]
+
+    samples: list[float] = []
+    for instant, quaternion in zip(instants, quaternions):
+        samples.append(float((instant - epoch).in_seconds()))
+        samples.extend(float(component) for component in quaternion)
+
+    return {
+        "epoch": format_instant(epoch),
+        "unitQuaternion": samples,
+        "interpolationAlgorithm": "LINEAR",
+        "interpolationDegree": 1,
+    }
+
+
+def interval_booleans(
+    interval: Interval,
+    true_intervals: list[Interval],
+) -> list[dict] | bool:
+    """
+    Build a CZML boolean property covering `interval`, true over `true_intervals` and false elsewhere.
+
+    Args:
+        interval (Interval): The overall interval to cover.
+        true_intervals (list[Interval]): The intervals over which the property is true.
+
+    Returns:
+        list[dict] | bool: The CZML interval'd boolean property.
+    """
+
+    if not true_intervals:
+        return False
+
+    entries: list[dict] = [
+        {
+            "interval": format_interval(interval),
+            "boolean": False,
+        }
+    ]
+
+    for true_interval in true_intervals:
+        entries.append(
+            {
+                "interval": format_interval(true_interval),
+                "boolean": True,
+            }
+        )
+
+    return entries
+
+
+class Document:
+    """
+    A CZML document: a clock-bearing document packet followed by entity packets.
+    """
+
+    def __init__(
+        self,
+        interval: Interval,
+        name: str = "OSTk Scenario",
+        clock_multiplier: float = 1.0,
+    ) -> None:
+        """
+        Construct a CZML Document.
+
+        Args:
+            interval (Interval): The scenario time interval.
+            name (str, optional): The document name. Defaults to "OSTk Scenario".
+            clock_multiplier (float, optional): The clock multiplier (simulated seconds per
+                wall-clock second). Defaults to 1.0.
+        """
+
+        self._interval: Interval = interval
+        self._name: str = name
+        self._clock_multiplier: float = clock_multiplier
+        self._packets: list[dict] = []
+
+    @property
+    def interval(self) -> Interval:
+        return self._interval
+
+    @property
+    def packets(self) -> list[dict]:
+        return self._packets
+
+    def add_packet(self, packet: dict) -> "Document":
+        """
+        Append a CZML packet to the document.
+
+        Args:
+            packet (dict): The CZML packet.
+
+        Returns:
+            Document: The document.
+        """
+
+        self._packets.append(packet)
+
+        return self
+
+    def to_list(self) -> list[dict]:
+        """
+        Return the document as a list of CZML packets (including the document packet).
+
+        Returns:
+            list[dict]: The CZML packets.
+        """
+
+        document_packet: dict = {
+            "id": "document",
+            "name": self._name,
+            "version": "1.0",
+            "clock": {
+                "interval": format_interval(self._interval),
+                "currentTime": format_instant(self._interval.get_start()),
+                "multiplier": self._clock_multiplier,
+                "range": "CLAMPED",
+                "step": "SYSTEM_CLOCK_MULTIPLIER",
+            },
+        }
+
+        return [document_packet, *self._packets]
+
+    def to_json(self, indent: int | None = None) -> str:
+        """
+        Serialize the document to a CZML (JSON) string.
+
+        Args:
+            indent (int, optional): The JSON indentation. Defaults to None (compact).
+
+        Returns:
+            str: The CZML string.
+        """
+
+        return json.dumps(self.to_list(), indent=indent)
+
+    def save(self, path: str, indent: int | None = 2) -> None:
+        """
+        Write the document to a `.czml` file.
+
+        Args:
+            path (str): The output file path.
+            indent (int, optional): The JSON indentation. Defaults to 2.
+        """
+
+        with open(path, "w") as file:
+            file.write(self.to_json(indent=indent))

--- a/bindings/python/tools/python/ostk/astrodynamics/czml.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/czml.py
@@ -242,6 +242,7 @@ class Document:
         interval: Interval,
         name: str = "OSTk Scenario",
         clock_multiplier: float = 1.0,
+        clock_range: str = "LOOP_STOP",
     ) -> None:
         """
         Construct a CZML Document.
@@ -251,11 +252,15 @@ class Document:
             name (str, optional): The document name. Defaults to "OSTk Scenario".
             clock_multiplier (float, optional): The clock multiplier (simulated seconds per
                 wall-clock second). Defaults to 1.0.
+            clock_range (str, optional): The clock behavior at the interval boundaries:
+                "LOOP_STOP", "CLAMPED" or "UNBOUNDED". Defaults to "LOOP_STOP" (loop back
+                to the start, so that playing never dead-ends at the interval boundary).
         """
 
         self._interval: Interval = interval
         self._name: str = name
         self._clock_multiplier: float = clock_multiplier
+        self._clock_range: str = clock_range
         self._packets: list[dict] = []
 
     @property
@@ -297,7 +302,7 @@ class Document:
                 "interval": format_interval(self._interval),
                 "currentTime": format_instant(self._interval.get_start()),
                 "multiplier": self._clock_multiplier,
-                "range": "CLAMPED",
+                "range": self._clock_range,
                 "step": "SYSTEM_CLOCK_MULTIPLIER",
             },
         }

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -779,7 +779,7 @@ class Viewer:
         )
 
         if label:
-            self.add_label(position, label, size, color)
+            self.add_label(position, label, color=color, pixel_offset=(0.0, -14.0))
 
         return self
 
@@ -873,6 +873,7 @@ class Viewer:
         text: str,
         size: int | None = None,
         color: str | None = None,
+        pixel_offset: tuple[float, float] | None = None,
     ) -> Viewer:
         """
         Add label to Viewer.
@@ -880,22 +881,29 @@ class Viewer:
         Args:
             position (Position): Label position.
             text (str): Label text.
-            size (int, optional): Label size. Defaults to None.
+            size (int, optional): Label scale (1 is the natural size). Defaults to None (1).
             color (str, optional): Label color. Defaults to None.
+            pixel_offset (tuple[float, float], optional): Screen-space offset in pixels.
+                Defaults to None.
 
         Returns:
             Viewer: The Viewer.
         """
 
+        label_property: dict = {
+            "text": text,
+            "scale": size or 1.0,
+            "fillColor": czml.format_color(color, default="white"),
+        }
+
+        if pixel_offset is not None:
+            label_property["pixelOffset"] = {"cartesian2": list(pixel_offset)}
+
         self._document.add_packet(
             {
                 "id": self._make_entity_id(f"{text}_label"),
                 "position": _static_position(position),
-                "label": {
-                    "text": text,
-                    "scale": size or 10,
-                    "fillColor": czml.format_color(color, default="white"),
-                },
+                "label": label_property,
             }
         )
 
@@ -950,10 +958,16 @@ class Viewer:
             "timeline: true",
         ]
 
+        imagery_statement: str = ""
         if self._cesium_token is None:
-            viewer_options.append(
-                "baseLayer: new Cesium.ImageryLayer(new Cesium.OpenStreetMapImageryProvider("
-                '{url: "https://tile.openstreetmap.org/"}))'
+            # Without an Ion token, use the NaturalEarthII imagery shipped with the CesiumJS
+            # distribution itself (same origin as Cesium.js, no external tile service).
+            viewer_options.append("baseLayer: false")
+            imagery_statement = (
+                'widget.scene.globe.baseColor = Cesium.Color.fromCssColorString("#0B1E33");'
+                "Cesium.TileMapServiceImageryProvider.fromUrl("
+                'Cesium.buildModuleUrl("Assets/Textures/NaturalEarthII")'
+                ").then(function (provider) { widget.imageryLayers.addImageryProvider(provider); });"
             )
 
         token_statement: str = (
@@ -986,6 +1000,7 @@ class Viewer:
             "_ostkLoadCesium(function () {\n"
             f"  {token_statement}\n"
             f'  var widget = new Cesium.Viewer("{container_id}", {{{", ".join(viewer_options)}}});\n'
+            f"  {imagery_statement}\n"
             f"  var czml = {self._document.to_json()};\n"
             "  widget.dataSources.add(Cesium.CzmlDataSource.load(czml)).then(function (dataSource) {\n"
             f"    {zoom_statement}\n"

--- a/bindings/python/tools/python/ostk/astrodynamics/viewer.py
+++ b/bindings/python/tools/python/ostk/astrodynamics/viewer.py
@@ -1,19 +1,25 @@
 # Apache License 2.0
 
+"""
+CZML-based CesiumJS viewer for Open Space Toolkit objects.
+
+The `Viewer` renders orbits, flight profiles, sensors, target vectors, ground tracks and
+access windows by generating a CZML document (https://github.com/AnalyticalGraphicsInc/czml-writer/wiki)
+displayed with CesiumJS, following the approach of Orekit's Oresium/OreCzml project
+(https://gitlab.orekit.org/orekit/oresium).
+
+The CZML document can also be exported with `Viewer.to_czml()` / `Viewer.save_czml()` for
+use in any external CesiumJS application.
+"""
+
 from __future__ import annotations
 
-import functools
-import operator
-from dataclasses import dataclass
+import re
+import uuid
 import warnings
+from dataclasses import dataclass
 
 import numpy as np
-
-try:
-    import cesiumpy
-
-except ImportError:
-    ...
 
 from ostk.mathematics.geometry.d3.transformation.rotation import Quaternion
 
@@ -26,11 +32,12 @@ from ostk.physics.coordinate import Frame
 from ostk.physics.coordinate.spherical import LLA
 
 from ostk.astrodynamics import Trajectory
+from ostk.astrodynamics import Access
 from ostk.astrodynamics.flight import Profile
 from ostk.astrodynamics.trajectory import Orbit
 from ostk.astrodynamics.trajectory import State
 
-from .converters import coerce_to_datetime
+from . import czml
 from .utilities import lla_from_position
 from .utilities import lla_from_state
 from .utilities import position_from_lla
@@ -39,6 +46,17 @@ DEFAULT_SATELLITE_IMAGE: str = (
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADJSURBVDhPnZHRDcMgEEMZjVEYpaNklIzSEfLfD4qNnXAJSFWfhO7w2Zc0Tf9QG2rXrEzSUeZLOGm47WoH95x3Hl3jEgilvDgsOQUTqsNl68ezEwn1vae6lceSEEYvvWNT/Rxc4CXQNGadho1NXoJ+9iaqc2xi2xbt23PJCDIB6TQjOC6Bho/sDy3fBQT8PrVhibU7yBFcEPaRxOoeTwbwByCOYf9VGp1BYI1BA+EeHhmfzKbBoJEQwn1yzUZtyspIQUha85MpkNIXB7GizqDEECsAAAAASUVORK5CYII="
 )
 DEFAULT_STEP_DURATION: Duration = Duration.seconds(10.0)
+DEFAULT_CESIUM_VERSION: str = "1.126"
+
+EARTH_GRAVITATIONAL_PARAMETER_M3_S2: float = 3.986004418e14
+EARTH_EQUATORIAL_RADIUS_M: float = 6378137.0
+EARTH_POLAR_RADIUS_M: float = 6356752.314245179
+
+_SCENE_MODES: dict[str, str] = {
+    "2D": "Cesium.SceneMode.SCENE2D",
+    "3D": "Cesium.SceneMode.SCENE3D",
+    "COLUMBUS": "Cesium.SceneMode.COLUMBUS_VIEW",
+}
 
 
 @dataclass
@@ -62,6 +80,10 @@ class RectangularSensor(Sensor):
 
 
 class Viewer:
+    """
+    A CesiumJS viewer, built by aggregating OSTk objects into a CZML document.
+    """
+
     def __init__(
         self,
         interval: Interval,
@@ -70,34 +92,49 @@ class Viewer:
         height: str = "800px",
         zoom_to_entity: bool = True,
         track_entity: bool = True,
+        scene_mode: str = "3D",
+        scene_mode_picker: bool = True,
+        clock_multiplier: float = 1.0,
+        name: str = "OSTk Scenario",
     ) -> None:
-        self._interval: Interval = interval
+        """
+        Construct a Viewer.
 
-        self._viewer: cesiumpy.Viewer = cesiumpy.Viewer(
-            width=width,
-            height=height,
-            clock_view_model=cesiumpy.ClockViewModel(
-                clock=cesiumpy.Clock(
-                    start_time=coerce_to_datetime(interval.get_start()),
-                    stop_time=coerce_to_datetime(interval.get_end()),
-                    clock_range=cesiumpy.Clock.Range.CLAMPED,
-                    can_animate=True,
-                    should_animate=False,
-                )
-            ),
-            fullscreen_button=False,
-            home_button=False,
-            info_box=False,
-            timeline=True,
-            navigation_help_button=False,
-            navigation_instructions_initially_visible=False,
-            scene_mode_picker=False,
-            selection_indicator=False,
-            scene3d_only=True,
-            zoom_to_entity=zoom_to_entity,
-            track_entity=track_entity,
-            default_access_token=cesium_token,
+        Args:
+            interval (Interval): The time interval of the scenario.
+            cesium_token (str, optional): The Cesium Ion access token (required for Ion imagery
+                and Ion 3D model assets). Defaults to None, in which case OpenStreetMap imagery is used.
+            width (str, optional): The CSS width of the viewer. Defaults to "1500px".
+            height (str, optional): The CSS height of the viewer. Defaults to "800px".
+            zoom_to_entity (bool, optional): Whether to zoom to the loaded scenario. Defaults to True.
+            track_entity (bool, optional): Whether to track the first satellite entity. Defaults to True.
+            scene_mode (str, optional): The initial scene mode: "3D", "2D" or "COLUMBUS". Defaults to "3D".
+            scene_mode_picker (bool, optional): Whether to show the 2D/3D scene mode picker. Defaults to True.
+            clock_multiplier (float, optional): The initial clock multiplier. Defaults to 1.0.
+            name (str, optional): The scenario name. Defaults to "OSTk Scenario".
+        """
+
+        if scene_mode not in _SCENE_MODES:
+            raise ValueError(
+                f"Scene mode [{scene_mode}] is not supported. Must be one of {list(_SCENE_MODES)}."
+            )
+
+        self._interval: Interval = interval
+        self._cesium_token: str | None = cesium_token
+        self._width: str = width
+        self._height: str = height
+        self._zoom_to_entity: bool = zoom_to_entity
+        self._track_entity: bool = track_entity
+        self._scene_mode: str = scene_mode
+        self._scene_mode_picker: bool = scene_mode_picker
+
+        self._document: czml.Document = czml.Document(
+            interval=interval,
+            name=name,
+            clock_multiplier=clock_multiplier,
         )
+        self._entity_ids: set[str] = set()
+        self._tracked_entity_id: str | None = None
 
     @property
     def interval(self) -> Interval:
@@ -111,6 +148,8 @@ class Viewer:
         show_orbital_track: bool = False,
         color: str | None = None,
         image: str | None = None,
+        trail_time: Duration | None = None,
+        lead_time: Duration | None = None,
     ) -> Viewer:
         """
         Add Orbit to Viewer.
@@ -122,56 +161,51 @@ class Viewer:
             show_orbital_track (bool, optional): Whether to show the orbital track. Defaults to False.
             color (str, optional): Color of the orbit. Defaults to None.
             image (str, optional): Logo to be added. Defaults to None.
+            trail_time (Duration, optional): Duration of the orbital track trailing the satellite.
+                Defaults to None (one orbital period).
+            lead_time (Duration, optional): Duration of the orbital track leading the satellite.
+                Defaults to None (one orbital period).
 
         Returns:
             Viewer: The Viewer.
         """
+
         instants: list[Instant] = self._interval.generate_grid(step)
-        states: list[State] = orbit.get_states_at(instants)
-        llas: list[LLA] = _generate_llas(states)
+        states: list[State] = [
+            state.in_frame(Frame.ITRF()) for state in orbit.get_states_at(instants)
+        ]
 
-        cesium_positions: cesiumpy.SampledPositionProperty = (
-            _generate_sampled_position_from_states(states)
-        )
+        entity_id: str = self._make_entity_id(name)
 
-        self._viewer.entities.add(
-            cesiumpy.Billboard(
-                name=name,
-                position=cesium_positions,
-                image=image or DEFAULT_SATELLITE_IMAGE,
-            )
-        )
-
-        self._viewer.entities.add(
-            cesiumpy.Label(
-                position=cesium_positions,
-                text=name,
-                scale=1.0,
-                fill_color=color or cesiumpy.color.WHITE,
-                pixel_offset=[0.0, 20.0],
-            )
-        )
+        packet: dict = {
+            "id": entity_id,
+            "name": name,
+            "availability": czml.format_interval(self._interval),
+            "position": _sampled_position(instants, states),
+            "billboard": {
+                "image": image or DEFAULT_SATELLITE_IMAGE,
+            },
+            "label": {
+                "text": name,
+                "scale": 1.0,
+                "fillColor": czml.format_color(color, default="white"),
+                "pixelOffset": {"cartesian2": [0.0, 20.0]},
+            },
+        }
 
         if show_orbital_track:
-            self._viewer.entities.add(
-                cesiumpy.Polyline(
-                    positions=cesiumpy.entities.cartesian.Cartesian3Array(
-                        functools.reduce(
-                            operator.iconcat,
-                            [
-                                [
-                                    float(lla.get_longitude().in_degrees()),
-                                    float(lla.get_latitude().in_degrees()),
-                                    float(lla.get_altitude().in_meters()),
-                                ]
-                                for lla in llas
-                            ],
-                            [],
-                        )
-                    ),
-                    width=1,
-                )
+            packet["path"] = self._path_property(
+                states=states,
+                step=step,
+                color=color,
+                trail_time=trail_time,
+                lead_time=lead_time,
             )
+
+        self._document.add_packet(packet)
+
+        if self._tracked_entity_id is None:
+            self._tracked_entity_id = entity_id
 
         return self
 
@@ -183,6 +217,10 @@ class Viewer:
         cesium_asset_id: int | None = None,
         sensors: list[Sensor] | None = None,
         show_xyz_axes: bool = False,
+        name: str = "Satellite",
+        color: str | None = None,
+        trail_time: Duration | None = None,
+        lead_time: Duration | None = None,
     ) -> Viewer:
         """
         Add Profile to Viewer.
@@ -191,9 +229,15 @@ class Viewer:
             profile (Profile): Profile to be added.
             step (Duration): Step between two consecutive states.
             show_orbital_track (bool, optional): Whether to show the orbital track. Defaults to False.
-            cesium_asset_id (int, optional): The Cesium asset ID. Defaults to None.
+            cesium_asset_id (int, optional): The Cesium Ion asset ID of the satellite 3D model. Defaults to None.
             sensors (list[Sensor], optional): Sensors to be added to the asset. Defaults to None.
             show_xyz_axes (bool, optional): Whether to show the XYZ axes. Defaults to False.
+            name (str, optional): Name of the satellite. Defaults to "Satellite".
+            color (str, optional): Color of the orbital track. Defaults to None.
+            trail_time (Duration, optional): Duration of the orbital track trailing the satellite.
+                Defaults to None (one orbital period).
+            lead_time (Duration, optional): Duration of the orbital track leading the satellite.
+                Defaults to None (one orbital period).
 
         Returns:
             Viewer: The Viewer.
@@ -201,16 +245,57 @@ class Viewer:
 
         if cesium_asset_id is None:
             warnings.warn(
-                "Cesium asset ID is required to render a profile. This will be a required argument in the future.",
+                "No Cesium asset ID provided: the satellite is rendered with the default billboard.",
                 FutureWarning,
                 stacklevel=2,
             )
 
         instants: list[Instant] = self._interval.generate_grid(step)
-        states: list[State] = profile.get_states_at(instants)
-        llas: list[LLA] = _generate_llas(states)
+        states: list[State] = [
+            state.in_frame(Frame.ITRF()) for state in profile.get_states_at(instants)
+        ]
 
-        sensors = sensors or []
+        entity_id: str = self._make_entity_id(name)
+
+        packet: dict = {
+            "id": entity_id,
+            "name": name,
+            "availability": czml.format_interval(self._interval),
+            "position": _sampled_position(instants, states),
+            "orientation": czml.sampled_unit_quaternion(
+                instants=instants,
+                quaternions=[_cesium_quaternion_from_state(state) for state in states],
+            ),
+            "label": {
+                "text": name,
+                "scale": 1.0,
+                "fillColor": czml.format_color(color, default="white"),
+                "pixelOffset": {"cartesian2": [0.0, 20.0]},
+            },
+        }
+
+        if cesium_asset_id is not None:
+            # Ion asset URIs cannot be referenced from pure CZML:
+            # the HTML template resolves this custom property into `entity.model` at load time.
+            packet["properties"] = {"ion_asset_id": cesium_asset_id}
+        else:
+            packet["billboard"] = {"image": DEFAULT_SATELLITE_IMAGE}
+
+        if show_orbital_track:
+            packet["path"] = self._path_property(
+                states=states,
+                step=step,
+                color=color,
+                trail_time=trail_time,
+                lead_time=lead_time,
+            )
+
+        self._document.add_packet(packet)
+
+        if self._tracked_entity_id is None:
+            self._tracked_entity_id = entity_id
+
+        sensors = list(sensors or [])
         if show_xyz_axes:
             sensors.extend(
                 [
@@ -238,38 +323,207 @@ class Viewer:
                 ]
             )
 
-        satellite = cesiumpy.Satellite(
-            position=_generate_sampled_position_from_llas(instants, llas),
-            orientation=_generate_sampled_orientation(states),
-            availability=self._get_availability(),
-            model=cesiumpy.IonResource(
-                asset_id=cesium_asset_id or 0
-            ),  # TBM: Should be made more robust
-            sensors=[_cesium_from_ostk_sensor(sensor) for sensor in sensors or []],
+        for sensor in sensors:
+            self._add_sensor(
+                satellite_entity_id=entity_id,
+                sensor=sensor,
+                instants=instants,
+                states=states,
+            )
+
+        return self
+
+    def add_sensor_projection(
+        self,
+        profile: Profile,
+        sensor: Sensor,
+        time_step: Duration | None = None,
+        color: str | None = None,
+        name: str | None = None,
+    ) -> Viewer:
+        """
+        Add the projection (footprint) of a sensor field of view onto the Earth ellipsoid.
+
+        The sensor boundary rays are cast from the satellite along the (attitude-dependent)
+        sensor directions, and their intersections with the WGS84 ellipsoid are displayed as a
+        time-varying polygon. Time steps at which the sensor does not (fully) intersect the
+        Earth are hidden.
+
+        Args:
+            profile (Profile): The satellite profile (position + attitude).
+            sensor (Sensor): The sensor whose field of view is projected.
+            time_step (Duration, optional): The duration of each step in the grid.
+                Defaults to None. If None, the default step duration is used.
+            color (str, optional): The color of the footprint. Defaults to None (sensor color).
+            name (str, optional): The name of the footprint entity. Defaults to None.
+
+        Returns:
+            Viewer: The Viewer.
+        """
+
+        time_step = time_step or DEFAULT_STEP_DURATION
+
+        instants: list[Instant] = self._interval.generate_grid(time_step)
+        states: list[State] = [
+            state.in_frame(Frame.ITRF()) for state in profile.get_states_at(instants)
+        ]
+
+        boundary_directions: list[np.ndarray] = _sensor_boundary_directions(sensor)
+
+        positions_entries: list[dict] = []
+        shown_intervals: list[Interval] = []
+
+        for index in range(len(instants) - 1):
+            state: State = states[index]
+            satellite_position: np.ndarray = np.array(
+                state.get_position().get_coordinates(), dtype=float
+            )
+            attitude: Quaternion = state.get_attitude()
+
+            footprint: list[float] = []
+            for direction_body in boundary_directions:
+                direction_ecef: np.ndarray = np.array(
+                    attitude.to_conjugate().rotate_vector(direction_body), dtype=float
+                )
+                intersection: np.ndarray | None = _intersection_with_earth(
+                    origin=satellite_position,
+                    direction=direction_ecef,
+                )
+                if intersection is None:
+                    footprint = []
+                    break
+                footprint.extend(float(component) for component in intersection)
+
+            if not footprint:
+                continue
+
+            interval: Interval = Interval.closed(
+                start_instant=instants[index],
+                end_instant=instants[index + 1],
+            )
+            shown_intervals.append(interval)
+            positions_entries.append(
+                {
+                    "interval": czml.format_interval(interval),
+                    "cartesian": footprint,
+                }
+            )
+
+        entity_id: str = self._make_entity_id(name or f"{sensor.name}_projection")
+
+        self._document.add_packet(
+            {
+                "id": entity_id,
+                "name": name or f"{sensor.name} projection",
+                "availability": czml.format_interval(self._interval),
+                "polygon": {
+                    "positions": positions_entries,
+                    "material": {
+                        "solidColor": {
+                            "color": czml.format_color(
+                                color or sensor.color, default="red", alpha=0.3
+                            ),
+                        },
+                    },
+                    "outline": True,
+                    "outlineColor": czml.format_color(
+                        color or sensor.color, default="red"
+                    ),
+                    "show": czml.interval_booleans(self._interval, shown_intervals),
+                },
+            }
         )
 
-        satellite.render(self._viewer)
+        return self
 
-        if show_orbital_track:
-            self._viewer.entities.add(
-                cesiumpy.Polyline(
-                    positions=cesiumpy.entities.cartesian.Cartesian3Array(
-                        functools.reduce(
-                            operator.iconcat,
-                            [
-                                [
-                                    float(lla.get_longitude().in_degrees()),
-                                    float(lla.get_latitude().in_degrees()),
-                                    float(lla.get_altitude().in_meters()),
-                                ]
-                                for lla in _generate_llas(states)
-                            ],
-                            [],
-                        )
-                    ),
-                    width=1,
+    def add_target_vector(
+        self,
+        profile_or_trajectory: Profile | Trajectory,
+        target: Celestial | Trajectory | Profile | Position,
+        name: str,
+        color: str | None = None,
+        time_step: Duration | None = None,
+        length: Length | None = None,
+    ) -> Viewer:
+        """
+        Add a time-varying vector (line) from a moving observer towards a target.
+
+        The target can be a celestial body (Sun, Moon, ...), another trajectory/profile
+        (e.g. another satellite), or a fixed position (e.g. a ground station).
+
+        Args:
+            profile_or_trajectory (Profile | Trajectory): The observer.
+            target (Celestial | Trajectory | Profile | Position): The target.
+            name (str): The name of the vector entity.
+            color (str, optional): The color of the vector. Defaults to None.
+            time_step (Duration, optional): The duration of each step in the grid.
+                Defaults to None. If None, the default step duration is used.
+            length (Length, optional): If provided, the vector is drawn with this fixed length
+                along the target direction, instead of joining the target itself.
+
+        Returns:
+            Viewer: The Viewer.
+        """
+
+        time_step = time_step or DEFAULT_STEP_DURATION
+        instants: list[Instant] = self._interval.generate_grid(time_step)
+
+        observer_positions: list[np.ndarray] = _sampled_itrf_positions(
+            profile_or_trajectory, instants
+        )
+        target_positions: list[np.ndarray] = _sampled_itrf_positions(target, instants)
+
+        if length is not None:
+            length_meters: float = float(length.in_meters())
+            end_positions: list[np.ndarray] = []
+            for observer_position, target_position in zip(
+                observer_positions, target_positions
+            ):
+                direction: np.ndarray = target_position - observer_position
+                end_positions.append(
+                    observer_position
+                    + direction / np.linalg.norm(direction) * length_meters
                 )
-            )
+        else:
+            end_positions = target_positions
+
+        start_id: str = self._make_entity_id(f"{name}_start")
+        end_id: str = self._make_entity_id(f"{name}_end")
+        entity_id: str = self._make_entity_id(name)
+
+        self._document.add_packet(
+            {
+                "id": start_id,
+                "availability": czml.format_interval(self._interval),
+                "position": czml.sampled_cartesian(instants, observer_positions),
+            }
+        )
+        self._document.add_packet(
+            {
+                "id": end_id,
+                "availability": czml.format_interval(self._interval),
+                "position": czml.sampled_cartesian(instants, end_positions),
+            }
+        )
+        self._document.add_packet(
+            {
+                "id": entity_id,
+                "name": name,
+                "availability": czml.format_interval(self._interval),
+                "polyline": {
+                    "positions": {
+                        "references": [f"{start_id}#position", f"{end_id}#position"],
+                    },
+                    "arcType": "NONE",
+                    "width": 2,
+                    "material": {
+                        "solidColor": {
+                            "color": czml.format_color(color, default="red"),
+                        },
+                    },
+                },
+            }
+        )
 
         return self
 
@@ -279,100 +533,166 @@ class Viewer:
         celestial: Celestial,
         time_step: Duration | None = None,
         color: str | None = None,
+        length: Length | None = None,
     ) -> Viewer:
         """
-        Add the celestial direction to the viewer.
+        Add the direction from a moving observer towards a celestial body (Sun, Moon, Earth, ...).
 
         Args:
             profile_or_trajectory (Profile | Trajectory): The profile or trajectory to be added.
-            celestial (Celestial, optional): The celestial body to be used.
-            time_step (Duration): The duration of each step in the grid.
-                Default to None. If None, the default step duration is used.
+            celestial (Celestial): The celestial body to be used.
+            time_step (Duration, optional): The duration of each step in the grid.
+                Defaults to None. If None, the default step duration is used.
             color (str, optional): The color of the celestial body direction.
-                Defaults to None. If None, the color depends on the celestial body (for the Earth, Sun and Moon).
-                Otherwise, use the default color (RED).
+                Defaults to None. If None, the color depends on the celestial body
+                (for the Earth, Sun and Moon). Otherwise, use the default color (RED).
+            length (Length, optional): If provided, the direction is drawn with this fixed
+                length instead of joining the celestial body itself.
 
         Returns:
             Viewer: The Viewer.
         """
-        time_step = time_step or DEFAULT_STEP_DURATION
-        alpha_color: float = 0.5
-        reference_frame: Frame = Frame.GCRF()
-        reference_vector: np.ndarray = np.array([0.0, 0.0, 1.0])
-        instants: list[Instant] = self._interval.generate_grid(time_step)
+
         celestial_name: str = str(celestial.access_name())
 
         if color is None:
-            if celestial_name == "Earth":
-                color = cesiumpy.color.BLUE
-            elif celestial_name == "Moon":
-                color = cesiumpy.color.GREY
-            elif celestial_name == "Sun":
-                color = cesiumpy.color.YELLOW
-            else:
-                color = cesiumpy.color.RED
+            color = {
+                "Earth": "blue",
+                "Moon": "grey",
+                "Sun": "yellow",
+            }.get(celestial_name, "red")
 
-            # Apply an alpha to the color
-            color = color.with_alpha(alpha_color)
+        return self.add_target_vector(
+            profile_or_trajectory=profile_or_trajectory,
+            target=celestial,
+            name=f"{celestial_name.lower()}_direction",
+            color=color,
+            time_step=time_step,
+            length=length,
+        )
 
-        def _create_celestial_body_direction_state(
-            satellite_state: State,
-            reference_frame: Frame = reference_frame,
-            reference_vector: np.ndarray = reference_vector,
-            celestial: Celestial = celestial,
-        ) -> State:
-            state_in_reference_frame: State = satellite_state.in_frame(reference_frame)
-            return State(
-                instant=state_in_reference_frame.get_instant(),
-                position=state_in_reference_frame.get_position(),
-                velocity=state_in_reference_frame.get_velocity(),
-                attitude=Quaternion.shortest_rotation(
-                    first_vector=_compute_celestial_direction_from_state(
-                        state=satellite_state,
-                        celestial=celestial,
-                        frame=reference_frame,
+    def add_accesses(
+        self,
+        accesses: list[Access] | list[Interval],
+        observer: Profile | Trajectory | Position | Celestial,
+        target: Profile | Trajectory | Position | Celestial,
+        name: str = "Access",
+        color: str | None = None,
+        time_step: Duration | None = None,
+        show_label: bool = True,
+    ) -> Viewer:
+        """
+        Visualize access windows between an observer and a target.
+
+        A line joining the two objects is displayed during each access window, along with an
+        optional label summarizing the current window. Clicking the line (or label) opens a
+        panel (Cesium InfoBox) listing all the provided access windows.
+
+        Args:
+            accesses (list[Access] | list[Interval]): The access windows (or bare intervals).
+            observer (Profile | Trajectory | Position | Celestial): The observer (e.g. a satellite).
+            target (Profile | Trajectory | Position | Celestial): The target (e.g. a ground station
+                or another satellite).
+            name (str, optional): The name of the access entity. Defaults to "Access".
+            color (str, optional): The color of the access line. Defaults to None (lime).
+            time_step (Duration, optional): The duration of each step in the grid.
+                Defaults to None. If None, the default step duration is used.
+            show_label (bool, optional): Whether to show a label with the current access window
+                details. Defaults to True.
+
+        Returns:
+            Viewer: The Viewer.
+        """
+
+        time_step = time_step or DEFAULT_STEP_DURATION
+
+        access_intervals: list[Interval] = [
+            access.get_interval() if isinstance(access, Access) else access
+            for access in accesses
+        ]
+
+        instants: list[Instant] = self._interval.generate_grid(time_step)
+
+        observer_positions: list[np.ndarray] = _sampled_itrf_positions(observer, instants)
+        target_positions: list[np.ndarray] = _sampled_itrf_positions(target, instants)
+
+        observer_id: str = self._make_entity_id(f"{name}_observer")
+        target_id: str = self._make_entity_id(f"{name}_target")
+        entity_id: str = self._make_entity_id(name)
+
+        self._document.add_packet(
+            {
+                "id": observer_id,
+                "availability": czml.format_interval(self._interval),
+                "position": czml.sampled_cartesian(instants, observer_positions),
+            }
+        )
+        self._document.add_packet(
+            {
+                "id": target_id,
+                "availability": czml.format_interval(self._interval),
+                "position": czml.sampled_cartesian(instants, target_positions),
+            }
+        )
+
+        description: str = _access_description_html(name, access_intervals)
+        show_property = czml.interval_booleans(self._interval, access_intervals)
+
+        self._document.add_packet(
+            {
+                "id": entity_id,
+                "name": name,
+                "availability": czml.format_interval(self._interval),
+                "description": description,
+                "polyline": {
+                    "positions": {
+                        "references": [
+                            f"{observer_id}#position",
+                            f"{target_id}#position",
+                        ],
+                    },
+                    "arcType": "NONE",
+                    "width": 2,
+                    "material": {
+                        "solidColor": {
+                            "color": czml.format_color(color, default="lime"),
+                        },
+                    },
+                    "show": show_property,
+                },
+            }
+        )
+
+        if show_label:
+            text_entries: list[dict] = [
+                {
+                    "interval": czml.format_interval(access_interval),
+                    "string": (
+                        f"{name} #{index + 1}\n"
+                        f"{czml.format_instant(access_interval.get_start())} → "
+                        f"{czml.format_instant(access_interval.get_end())}\n"
+                        f"duration: {_format_duration(access_interval.get_duration())}"
                     ),
-                    second_vector=reference_vector,
-                ),
-                angular_velocity=np.zeros(3),
-                attitude_frame=reference_frame,
-            )
+                }
+                for index, access_interval in enumerate(access_intervals)
+            ]
 
-        celestial_direction_states: list[State] = list(
-            map(
-                _create_celestial_body_direction_state,
-                profile_or_trajectory.get_states_at(instants),
+            self._document.add_packet(
+                {
+                    "id": f"{entity_id}_label",
+                    "name": f"{name} label",
+                    "availability": czml.format_interval(self._interval),
+                    "description": description,
+                    "position": {"reference": f"{target_id}#position"},
+                    "label": {
+                        "text": text_entries,
+                        "scale": 0.5,
+                        "fillColor": czml.format_color(color, default="lime"),
+                        "pixelOffset": {"cartesian2": [0.0, -40.0]},
+                        "show": show_property,
+                    },
+                }
             )
-        )
-
-        satellite = cesiumpy.Satellite(
-            position=_generate_sampled_position_from_llas(
-                instants=instants,
-                llas=_generate_llas(celestial_direction_states),
-            ),
-            orientation=_generate_sampled_orientation(celestial_direction_states),
-            availability=self._get_availability(),
-        )
-
-        _cesium_from_ostk_sensor(
-            ConicSensor(
-                name=celestial_name.lower() + "_direction",
-                direction=reference_vector,
-                # Compute the half angle from the celestial body diameter
-                half_angle=Angle.degrees(
-                    _compute_celestial_angular_diameter_from_states(
-                        celestial=celestial,
-                        states=celestial_direction_states,
-                    ).mean()
-                    / 2.0
-                ),
-                length=Length.meters(2.0),
-                color=color,
-            )
-        ).render(
-            viewer=self._viewer,
-            satellite=satellite,
-        )
 
         return self
 
@@ -394,6 +714,7 @@ class Viewer:
         Returns:
             Viewer: The Viewer.
         """
+
         time_step = time_step or DEFAULT_STEP_DURATION
 
         instants: list[Instant] = self._interval.generate_grid(time_step)
@@ -413,14 +734,14 @@ class Viewer:
         self.add_line(
             positions=ground_track_positions,
             size=1,
-            color=cesiumpy.color.GRAY,
+            color="gray",
         )
 
         if show_current_position:
             self.add_moving_point(
                 instants=instants,
                 llas=llas,
-                color=cesiumpy.color.DARKORANGE,
+                color="darkorange",
             )
 
         return self
@@ -445,12 +766,16 @@ class Viewer:
             Viewer: The Viewer.
         """
 
-        self._viewer.entities.add(
-            cesiumpy.Point(
-                position=_cesium_from_ostk_position(position),
-                pixel_size=size or 10,
-                color=color or cesiumpy.color.YELLOW,
-            )
+        self._document.add_packet(
+            {
+                "id": self._make_entity_id(label or "target"),
+                "name": label or "Target",
+                "position": _static_position(position),
+                "point": {
+                    "pixelSize": size or 10,
+                    "color": czml.format_color(color, default="yellow"),
+                },
+            }
         )
 
         if label:
@@ -476,25 +801,29 @@ class Viewer:
             Viewer: The Viewer.
         """
 
-        self._viewer.entities.add(
-            cesiumpy.Polyline(
-                positions=cesiumpy.entities.cartesian.Cartesian3Array(
-                    functools.reduce(
-                        operator.iconcat,
-                        [
-                            [
-                                float(lla.get_longitude().in_degrees()),
-                                float(lla.get_latitude().in_degrees()),
-                                10.0,
-                            ]
-                            for lla in map(lla_from_position, positions)
-                        ],
-                        [],
-                    )
-                ),
-                width=size or 1,
-                material=color or cesiumpy.color.YELLOW,
+        cartographic_degrees: list[float] = []
+        for lla in map(lla_from_position, positions):
+            cartographic_degrees.extend(
+                [
+                    float(lla.get_longitude().in_degrees()),
+                    float(lla.get_latitude().in_degrees()),
+                    10.0,
+                ]
             )
+
+        self._document.add_packet(
+            {
+                "id": self._make_entity_id("line"),
+                "polyline": {
+                    "positions": {"cartographicDegrees": cartographic_degrees},
+                    "width": size or 1,
+                    "material": {
+                        "solidColor": {
+                            "color": czml.format_color(color, default="yellow"),
+                        },
+                    },
+                },
+            }
         )
 
         return self
@@ -519,16 +848,21 @@ class Viewer:
             Viewer: The Viewer.
         """
 
-        self._viewer.entities.add(
-            cesiumpy.Point(
-                position=_generate_sampled_position_from_llas(
-                    instants=instants,
-                    llas=llas,
-                ),
-                availability=self._get_availability(),
-                color=color,
-                pixel_size=size,
-            )
+        positions: list[np.ndarray] = [
+            np.array(position_from_lla(lla).get_coordinates(), dtype=float)
+            for lla in llas
+        ]
+
+        self._document.add_packet(
+            {
+                "id": self._make_entity_id("moving_point"),
+                "availability": czml.format_interval(self._interval),
+                "position": czml.sampled_cartesian(instants, positions),
+                "point": {
+                    "pixelSize": size or 5,
+                    "color": czml.format_color(color, default="darkorange"),
+                },
+            }
         )
 
         return self
@@ -553,16 +887,39 @@ class Viewer:
             Viewer: The Viewer.
         """
 
-        self._viewer.entities.add(
-            cesiumpy.Label(
-                position=_cesium_from_ostk_position(position),
-                text=text,
-                scale=size or 10,
-                fill_color=color or cesiumpy.color.WHITE,
-            )
+        self._document.add_packet(
+            {
+                "id": self._make_entity_id(f"{text}_label"),
+                "position": _static_position(position),
+                "label": {
+                    "text": text,
+                    "scale": size or 10,
+                    "fillColor": czml.format_color(color, default="white"),
+                },
+            }
         )
 
         return self
+
+    def to_czml(self) -> list[dict]:
+        """
+        Return the scenario as a list of CZML packets.
+
+        Returns:
+            list[dict]: The CZML packets (including the document packet).
+        """
+
+        return self._document.to_list()
+
+    def save_czml(self, path: str) -> None:
+        """
+        Save the scenario as a `.czml` file, usable in any CesiumJS application.
+
+        Args:
+            path (str): The output file path.
+        """
+
+        self._document.save(path)
 
     def render(self) -> str:
         """
@@ -572,201 +929,554 @@ class Viewer:
             str: Rendered HTML string.
         """
 
-        return self._viewer.to_html()
+        container_id: str = f"cesium-container-{uuid.uuid4().hex[:8]}"
+        cesium_base_url: str = (
+            f"https://cesium.com/downloads/cesiumjs/releases/{DEFAULT_CESIUM_VERSION}/Build/Cesium"
+        )
 
-    def _get_availability(self) -> cesiumpy.TimeIntervalCollection:
-        """
-        Get the availability of the viewer.
+        viewer_options: list[str] = [
+            "animation: true",
+            "baseLayerPicker: false",
+            "fullscreenButton: false",
+            "geocoder: false",
+            "homeButton: false",
+            "infoBox: true",
+            "navigationHelpButton: false",
+            "navigationInstructionsInitiallyVisible: false",
+            f"sceneModePicker: {'true' if self._scene_mode_picker else 'false'}",
+            f"sceneMode: {_SCENE_MODES[self._scene_mode]}",
+            "selectionIndicator: false",
+            "shouldAnimate: false",
+            "timeline: true",
+        ]
 
-        Returns:
-            cesiumpy.TimeIntervalCollection: The availability of the viewer.
-        """
-        return _cesium_from_ostk_intervals(intervals=[self._interval])
+        if self._cesium_token is None:
+            viewer_options.append(
+                "baseLayer: new Cesium.ImageryLayer(new Cesium.OpenStreetMapImageryProvider("
+                '{url: "https://tile.openstreetmap.org/"}))'
+            )
+
+        token_statement: str = (
+            f'Cesium.Ion.defaultAccessToken = "{self._cesium_token}";'
+            if self._cesium_token is not None
+            else ""
+        )
+
+        zoom_statement: str = "widget.zoomTo(dataSource);" if self._zoom_to_entity else ""
+
+        track_statement: str = ""
+        if self._track_entity and self._tracked_entity_id is not None:
+            track_statement = (
+                f'var trackedEntity = dataSource.entities.getById("{self._tracked_entity_id}");'
+                "if (trackedEntity) { widget.trackedEntity = trackedEntity; }"
+            )
+
+        return (
+            '<meta charset="utf-8">\n'
+            f'<link href="{cesium_base_url}/Widgets/widgets.css" rel="stylesheet">\n'
+            f'<div id="{container_id}" style="width: {self._width}; height: {self._height};"></div>\n'
+            "<script>\n"
+            "function _ostkLoadCesium(callback) {\n"
+            "  if (window.Cesium) { callback(); return; }\n"
+            '  var script = document.createElement("script");\n'
+            f'  script.src = "{cesium_base_url}/Cesium.js";\n'
+            "  script.onload = callback;\n"
+            "  document.head.appendChild(script);\n"
+            "}\n"
+            "_ostkLoadCesium(function () {\n"
+            f"  {token_statement}\n"
+            f'  var widget = new Cesium.Viewer("{container_id}", {{{", ".join(viewer_options)}}});\n'
+            f"  var czml = {self._document.to_json()};\n"
+            "  widget.dataSources.add(Cesium.CzmlDataSource.load(czml)).then(function (dataSource) {\n"
+            f"    {zoom_statement}\n"
+            f"    {track_statement}\n"
+            "    dataSource.entities.values.forEach(function (entity) {\n"
+            '      if (entity.properties && entity.properties.hasProperty("ion_asset_id")) {\n'
+            "        Cesium.IonResource.fromAssetId(entity.properties.ion_asset_id.getValue()).then(function (resource) {\n"
+            "          entity.model = new Cesium.ModelGraphics({uri: resource, minimumPixelSize: 128, maximumScale: 20000});\n"
+            "        });\n"
+            "      }\n"
+            "    });\n"
+            "  });\n"
+            "});\n"
+            "</script>"
+        )
 
     def _repr_html_(self) -> str:
         return self.render()
 
+    def _make_entity_id(self, name: str) -> str:
+        entity_id: str = re.sub(r"[^a-z0-9_]+", "_", name.lower()).strip("_") or "entity"
 
-def _generate_llas(states: list[State]) -> list[LLA]:
-    return list(map(lla_from_state, states))
+        if entity_id in self._entity_ids:
+            suffix: int = 2
+            while f"{entity_id}_{suffix}" in self._entity_ids:
+                suffix += 1
+            entity_id = f"{entity_id}_{suffix}"
 
+        self._entity_ids.add(entity_id)
 
-def _generate_sampled_position_from_llas(
-    instants: list[Instant],
-    llas: list[LLA],
-) -> cesiumpy.SampledPositionProperty:
-    """
-    Generate a sampled position property from a list of OSTk LLAs.
+        return entity_id
 
-    Args:
-        states (list[LLA]): A list of OSTk LLAs.
+    def _path_property(
+        self,
+        states: list[State],
+        step: Duration,
+        color: str | None,
+        trail_time: Duration | None,
+        lead_time: Duration | None,
+    ) -> dict:
+        """
+        Build a CZML `path` property with leading/trailing orbital track visualization.
+        """
 
-    Returns:
-        cesiumpy.SampledPositionProperty: Sampled position property.
-    """
+        default_time_seconds: float = (
+            _orbital_period_seconds(states[0])
+            or self._interval.get_duration().in_seconds()
+        )
 
-    return cesiumpy.SampledPositionProperty(
-        samples=[
-            (
-                coerce_to_datetime(instant),
-                _cesium_from_ostk_lla(lla),
-                None,
+        trail_time_seconds: float = (
+            float(trail_time.in_seconds())
+            if trail_time is not None
+            else default_time_seconds
+        )
+        lead_time_seconds: float = (
+            float(lead_time.in_seconds())
+            if lead_time is not None
+            else default_time_seconds
+        )
+
+        return {
+            "material": {
+                "solidColor": {
+                    "color": czml.format_color(color, default="white"),
+                },
+            },
+            "width": 1,
+            "resolution": float(step.in_seconds()),
+            "leadTime": lead_time_seconds,
+            "trailTime": trail_time_seconds,
+        }
+
+    def _add_sensor(
+        self,
+        satellite_entity_id: str,
+        sensor: Sensor,
+        instants: list[Instant],
+        states: list[State],
+    ) -> None:
+        """
+        Add a body-fixed sensor visualization attached to a satellite entity.
+
+        Standard CZML has no sensor volume support (`agi_conicSensor` & co. require a CesiumJS
+        plugin), so sensors are approximated with native CZML primitives:
+
+        - `ConicSensor`: a cone (CZML cylinder) whose apex is attached to the satellite.
+        - `RectangularSensor`: the four field-of-view edge polylines.
+        """
+
+        if isinstance(sensor, ConicSensor):
+            length_meters: float = float(sensor.length.in_meters())
+            half_angle_radians: float = float(sensor.half_angle.in_radians())
+            direction_body: np.ndarray = _unit(np.asarray(sensor.direction, dtype=float))
+
+            center_positions: list[np.ndarray] = []
+            orientations: list[np.ndarray] = []
+
+            for state in states:
+                satellite_position: np.ndarray = np.array(
+                    state.get_position().get_coordinates(), dtype=float
+                )
+                direction_ecef: np.ndarray = np.array(
+                    state.get_attitude().to_conjugate().rotate_vector(direction_body),
+                    dtype=float,
+                )
+                center_positions.append(
+                    satellite_position + direction_ecef * (length_meters / 2.0)
+                )
+                # The CZML cylinder axis is the entity Z axis, with `topRadius` at +Z:
+                # align +Z with the anti-boresight so that the apex sits on the satellite.
+                orientations.append(_quaternion_aligning_z(-direction_ecef))
+
+            self._document.add_packet(
+                {
+                    "id": self._make_entity_id(f"{satellite_entity_id}_{sensor.name}"),
+                    "name": sensor.name,
+                    "availability": czml.format_interval(self._interval),
+                    "position": czml.sampled_cartesian(instants, center_positions),
+                    "orientation": czml.sampled_unit_quaternion(instants, orientations),
+                    "cylinder": {
+                        "length": length_meters,
+                        "topRadius": 0.0,
+                        "bottomRadius": length_meters * np.tan(half_angle_radians),
+                        "material": {
+                            "solidColor": {
+                                "color": czml.format_color(
+                                    sensor.color, default="red", alpha=0.3
+                                ),
+                            },
+                        },
+                        "outline": False,
+                    },
+                }
             )
-            for instant, lla in zip(instants, llas)
-        ],
-    )
+
+        elif isinstance(sensor, RectangularSensor):
+            radius_meters: float = float(sensor.radius.in_meters())
+            corner_directions: list[np.ndarray] = _rectangular_corner_directions(sensor)
+
+            for corner_index, corner_direction in enumerate(corner_directions):
+                corner_positions: list[np.ndarray] = []
+
+                for state in states:
+                    satellite_position = np.array(
+                        state.get_position().get_coordinates(), dtype=float
+                    )
+                    direction_ecef = np.array(
+                        state.get_attitude()
+                        .to_conjugate()
+                        .rotate_vector(corner_direction),
+                        dtype=float,
+                    )
+                    corner_positions.append(
+                        satellite_position + direction_ecef * radius_meters
+                    )
+
+                corner_id: str = self._make_entity_id(
+                    f"{satellite_entity_id}_{sensor.name}_corner_{corner_index}"
+                )
+
+                self._document.add_packet(
+                    {
+                        "id": corner_id,
+                        "availability": czml.format_interval(self._interval),
+                        "position": czml.sampled_cartesian(instants, corner_positions),
+                    }
+                )
+                self._document.add_packet(
+                    {
+                        "id": self._make_entity_id(
+                            f"{satellite_entity_id}_{sensor.name}_edge_{corner_index}"
+                        ),
+                        "name": sensor.name,
+                        "availability": czml.format_interval(self._interval),
+                        "polyline": {
+                            "positions": {
+                                "references": [
+                                    f"{satellite_entity_id}#position",
+                                    f"{corner_id}#position",
+                                ],
+                            },
+                            "arcType": "NONE",
+                            "width": 1,
+                            "material": {
+                                "solidColor": {
+                                    "color": czml.format_color(
+                                        sensor.color, default="orange"
+                                    ),
+                                },
+                            },
+                        },
+                    }
+                )
+
+        else:
+            raise NotImplementedError(f"{type(sensor).__name__} is not supported yet.")
 
 
-def _generate_sampled_orientation(states: list[State]) -> cesiumpy.SampledProperty:
+def _unit(vector: np.ndarray) -> np.ndarray:
+    return vector / np.linalg.norm(vector)
+
+
+def _sampled_position(instants: list[Instant], states: list[State]) -> dict:
     """
-    Generate a sampled orientation property from a list of OSTk States.
-
-    Args:
-        states (list[State]): A list of OSTk States.
-
-    Returns:
-        cesiumpy.SampledProperty: Sampled orientation property.
+    Build a CZML sampled position property from a list of OSTk States (in ITRF).
     """
 
-    return cesiumpy.SampledProperty(
-        type=cesiumpy.Quaternion,
-        samples=[
-            (
-                coerce_to_datetime(state.get_instant()),
-                _cesium_from_ostk_quaternion(state.in_frame(Frame.ITRF()).get_attitude()),
-                None,
-            )
+    return czml.sampled_cartesian(
+        instants=instants,
+        coordinates=[
+            np.array(state.get_position().get_coordinates(), dtype=float)
             for state in states
         ],
     )
 
 
-def _generate_sampled_position_from_states(
-    states: list[State],
-) -> cesiumpy.SampledPositionProperty:
+def _static_position(position: Position, instant: Instant | None = None) -> dict:
     """
-    Generate a sampled position property from a list of OSTk States.
-
-    Args:
-        states (list[State]): A list of OSTk States.
-
-    Returns:
-        cesiumpy.SampledPositionProperty: Sampled position property.
+    Build a CZML static position property from an OSTk Position.
     """
-    return _generate_sampled_position_from_positions(
-        instants=[state.get_instant() for state in states],
-        positions=[state.get_position() for state in states],
-    )
 
+    lla: LLA = lla_from_position(position, instant)
 
-def _generate_sampled_position_from_positions(
-    instants: list[Instant],
-    positions: list[Position],
-) -> cesiumpy.SampledPositionProperty:
-    """
-    Generate a sampled position property from a list of OSTk positions and instants.
-
-    Args:
-        instants (list[Instant]): A list of OSTk instants.
-        positions (list[Position]): A list of OSTk positions.
-
-    Returns:
-        cesiumpy.SampledPositionProperty: Sampled position property.
-    """
-    frame_itrf: Frame = Frame.ITRF()
-
-    return cesiumpy.SampledPositionProperty(
-        samples=[
-            (
-                coerce_to_datetime(instant),
-                _cesium_from_ostk_position(
-                    position.in_frame(instant=instant, frame=frame_itrf)
-                ),
-                None,
-            )
-            for instant, position in zip(instants, positions)
+    return {
+        "cartographicDegrees": [
+            float(lla.get_longitude().in_degrees()),
+            float(lla.get_latitude().in_degrees()),
+            float(lla.get_altitude().in_meters()),
         ],
+    }
+
+
+def _sampled_itrf_positions(
+    obj: Profile | Trajectory | Position | Celestial,
+    instants: list[Instant],
+) -> list[np.ndarray]:
+    """
+    Sample the ITRF position (in meters) of an OSTk object at the provided instants.
+    """
+
+    itrf: Frame = Frame.ITRF()
+
+    if isinstance(obj, Position):
+        return [
+            np.array(
+                obj.in_frame(instant=instant, frame=itrf).get_coordinates(), dtype=float
+            )
+            for instant in instants
+        ]
+
+    if isinstance(obj, Celestial):
+        return [
+            np.array(
+                obj.get_position_in(frame=itrf, instant=instant)
+                .in_meters()
+                .get_coordinates(),
+                dtype=float,
+            )
+            for instant in instants
+        ]
+
+    return [
+        np.array(state.get_position().get_coordinates(), dtype=float)
+        for state in (state.in_frame(itrf) for state in obj.get_states_at(instants))
+    ]
+
+
+def _cesium_quaternion_from_state(state: State) -> np.ndarray:
+    """
+    Convert an OSTk State attitude into a Cesium orientation quaternion [x, y, z, w].
+
+    OSTk attitudes are passive rotations mapping the reference frame into the body frame
+    (q_B_REF): their raw components, interpreted with Cesium's active (Hamilton) convention,
+    map the body frame into the Earth-fixed frame, which is what Cesium expects.
+    """
+
+    quaternion: Quaternion = state.get_attitude()
+
+    return np.array(
+        [
+            float(quaternion.x()),
+            float(quaternion.y()),
+            float(quaternion.z()),
+            float(quaternion.s()),
+        ]
     )
 
 
-def _cesium_from_ostk_position(
-    position: Position,
-    instant: Instant | None = None,
-) -> cesiumpy.Cartesian3:
+def _quaternion_aligning_z(direction: np.ndarray) -> np.ndarray:
     """
-    Convert OSTk Position into Cesium Cartesian3.
-
-    Args:
-        position (Position): Position to convert.
-        instant (Instant, optional): Instant at which the position is valid (required if position is not expressed in ECEF).
-
-    Returns:
-        cesiumpy.Cartesian3: Converted position.
+    Build a quaternion [x, y, z, w] rotating the +Z axis onto the provided direction.
     """
 
-    return _cesium_from_ostk_lla(lla_from_position(position, instant))
+    z_axis: np.ndarray = np.array([0.0, 0.0, 1.0])
+    target: np.ndarray = _unit(direction)
+
+    cosine: float = float(np.dot(z_axis, target))
+
+    if cosine > 1.0 - 1e-12:
+        return np.array([0.0, 0.0, 0.0, 1.0])
+
+    if cosine < -1.0 + 1e-12:
+        return np.array([1.0, 0.0, 0.0, 0.0])  # 180 degrees about X
+
+    axis: np.ndarray = _unit(np.cross(z_axis, target))
+    angle: float = float(np.arccos(cosine))
+
+    return np.array([*(axis * np.sin(angle / 2.0)), np.cos(angle / 2.0)])
 
 
-def _cesium_from_ostk_lla(
-    lla: LLA,
-) -> cesiumpy.Cartesian3:
+def _orbital_period_seconds(state: State) -> float | None:
     """
-    Convert OSTk LLA into Cesium Cartesian3.
-
-    Args:
-        lla (LLA): LLA to convert.
-
-    Returns:
-        cesiumpy.Cartesian3: Converted LLA.
+    Estimate the (Keplerian) orbital period from a state, using the vis-viva equation.
     """
 
-    return cesiumpy.Cartesian3.fromDegrees(
-        float(lla.get_longitude().in_degrees()),
-        float(lla.get_latitude().in_degrees()),
-        float(lla.get_altitude().in_meters()),
+    state_gcrf: State = state.in_frame(Frame.GCRF())
+    position: np.ndarray = np.array(
+        state_gcrf.get_position().get_coordinates(), dtype=float
+    )
+    velocity: np.ndarray = np.array(
+        state_gcrf.get_velocity().get_coordinates(), dtype=float
+    )
+
+    inverse_semi_major_axis: float = (
+        2.0 / float(np.linalg.norm(position))
+        - float(np.dot(velocity, velocity)) / EARTH_GRAVITATIONAL_PARAMETER_M3_S2
+    )
+
+    if inverse_semi_major_axis <= 0.0:
+        return None
+
+    semi_major_axis: float = 1.0 / inverse_semi_major_axis
+
+    return float(
+        2.0 * np.pi * np.sqrt(semi_major_axis**3 / EARTH_GRAVITATIONAL_PARAMETER_M3_S2)
     )
 
 
-def _cesium_from_ostk_quaternion(quaternion: Quaternion) -> cesiumpy.Quaternion:
+def _intersection_with_earth(
+    origin: np.ndarray,
+    direction: np.ndarray,
+) -> np.ndarray | None:
     """
-    Convert OSTk Quaternion into Cesium Quaternion.
-
-    Args:
-        quaternion (Quaternion): Quaternion to convert.
-
-    Returns:
-        cesiumpy.Quaternion: Converted quaternion.
+    Compute the first intersection of a ray with the WGS84 ellipsoid, or None if the ray misses.
     """
 
-    return cesiumpy.Quaternion(
-        float(quaternion.x()),
-        float(quaternion.y()),
-        float(quaternion.z()),
-        float(quaternion.s()),
+    scale: np.ndarray = np.array(
+        [
+            1.0 / EARTH_EQUATORIAL_RADIUS_M,
+            1.0 / EARTH_EQUATORIAL_RADIUS_M,
+            1.0 / EARTH_POLAR_RADIUS_M,
+        ]
     )
 
+    scaled_origin: np.ndarray = origin * scale
+    scaled_direction: np.ndarray = _unit(direction) * scale
 
-def _cesium_from_ostk_sensor(sensor: Sensor) -> cesiumpy.Sensor:
+    a: float = float(np.dot(scaled_direction, scaled_direction))
+    b: float = 2.0 * float(np.dot(scaled_origin, scaled_direction))
+    c: float = float(np.dot(scaled_origin, scaled_origin)) - 1.0
+
+    discriminant: float = b * b - 4.0 * a * c
+
+    if discriminant < 0.0:
+        return None
+
+    sqrt_discriminant: float = float(np.sqrt(discriminant))
+
+    for t in ((-b - sqrt_discriminant) / (2.0 * a), (-b + sqrt_discriminant) / (2.0 * a)):
+        if t > 0.0:
+            return origin + _unit(direction) * t
+
+    return None
+
+
+def _orthonormal_basis(axis: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Build two unit vectors orthogonal to the provided axis (deterministically).
+    """
+
+    reference: np.ndarray = (
+        np.array([1.0, 0.0, 0.0]) if abs(axis[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    )
+
+    u: np.ndarray = _unit(np.cross(axis, reference))
+    v: np.ndarray = _unit(np.cross(axis, u))
+
+    return u, v
+
+
+def _sensor_boundary_directions(
+    sensor: Sensor,
+    conic_sample_count: int = 32,
+    rectangular_edge_sample_count: int = 4,
+) -> list[np.ndarray]:
+    """
+    Sample the boundary of a sensor field of view as unit direction vectors in the body frame.
+    """
+
+    axis: np.ndarray = _unit(np.asarray(sensor.direction, dtype=float))
+
     if isinstance(sensor, ConicSensor):
-        return cesiumpy.ConicSensor(
-            name=sensor.name,
-            direction=cesiumpy.Cartesian3(*sensor.direction),
-            half_angle=float(sensor.half_angle.in_radians()),
-            length=float(sensor.length.in_meters()),
-            material=sensor.color or cesiumpy.color.RED,
-        )
+        half_angle: float = float(sensor.half_angle.in_radians())
+        u, v = _orthonormal_basis(axis)
 
-    elif isinstance(sensor, RectangularSensor):
-        return cesiumpy.RectangularSensor(
-            name=sensor.name,
-            direction=cesiumpy.Cartesian3(*sensor.direction),
-            x_half_angle=float(sensor.x_half_angle.in_radians()),
-            y_half_angle=float(sensor.y_half_angle.in_radians()),
-            radius=float(sensor.radius.in_meters()),
-            material=sensor.color or cesiumpy.color.ORANGE,
-        )
+        return [
+            _unit(
+                np.cos(half_angle) * axis
+                + np.sin(half_angle) * (np.cos(theta) * u + np.sin(theta) * v)
+            )
+            for theta in np.linspace(0.0, 2.0 * np.pi, conic_sample_count, endpoint=False)
+        ]
 
-    raise NotImplementedError("{sensor.__name__} is not supported yet.")
+    if isinstance(sensor, RectangularSensor):
+        tan_x: float = float(np.tan(float(sensor.x_half_angle.in_radians())))
+        tan_y: float = float(np.tan(float(sensor.y_half_angle.in_radians())))
+        u, v = _orthonormal_basis(axis)
+
+        corners: list[tuple[float, float]] = [
+            (+tan_x, +tan_y),
+            (+tan_x, -tan_y),
+            (-tan_x, -tan_y),
+            (-tan_x, +tan_y),
+        ]
+
+        directions: list[np.ndarray] = []
+        for corner_index in range(4):
+            start: tuple[float, float] = corners[corner_index]
+            end: tuple[float, float] = corners[(corner_index + 1) % 4]
+            for fraction in np.linspace(
+                0.0, 1.0, rectangular_edge_sample_count, endpoint=False
+            ):
+                x: float = start[0] + (end[0] - start[0]) * fraction
+                y: float = start[1] + (end[1] - start[1]) * fraction
+                directions.append(_unit(axis + x * u + y * v))
+
+        return directions
+
+    raise NotImplementedError(f"{type(sensor).__name__} is not supported yet.")
+
+
+def _rectangular_corner_directions(sensor: RectangularSensor) -> list[np.ndarray]:
+    """
+    Compute the four corner directions of a rectangular sensor field of view (body frame).
+    """
+
+    axis: np.ndarray = _unit(np.asarray(sensor.direction, dtype=float))
+    tan_x: float = float(np.tan(float(sensor.x_half_angle.in_radians())))
+    tan_y: float = float(np.tan(float(sensor.y_half_angle.in_radians())))
+    u, v = _orthonormal_basis(axis)
+
+    return [
+        _unit(axis + x * tan_x * u + y * tan_y * v)
+        for x, y in ((+1, +1), (+1, -1), (-1, -1), (-1, +1))
+    ]
+
+
+def _format_duration(duration: Duration) -> str:
+    """
+    Format a duration as HH:MM:SS.
+    """
+
+    total_seconds: int = int(round(float(duration.in_seconds())))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def _access_description_html(name: str, intervals: list[Interval]) -> str:
+    """
+    Build the HTML description (Cesium InfoBox panel) summarizing access windows.
+    """
+
+    rows: str = "".join(
+        "<tr>"
+        f"<td>{index + 1}</td>"
+        f"<td>{czml.format_instant(interval.get_start())}</td>"
+        f"<td>{czml.format_instant(interval.get_end())}</td>"
+        f"<td>{_format_duration(interval.get_duration())}</td>"
+        "</tr>"
+        for index, interval in enumerate(intervals)
+    )
+
+    return (
+        f"<h2>{name}</h2>"
+        '<table class="cesium-infoBox-defaultTable">'
+        "<tr><th>#</th><th>Start (UTC)</th><th>End (UTC)</th><th>Duration</th></tr>"
+        f"{rows}"
+        "</table>"
+    )
 
 
 def _compute_celestial_direction_from_state(
@@ -833,27 +1543,3 @@ def _compute_celestial_angular_diameter_from_states(
         )
     distances: np.ndarray = np.linalg.norm(celestial_to_observer_meters, axis=0)
     return np.rad2deg(2 * np.arcsin(celestial_radius_meters / distances))
-
-
-def _cesium_from_ostk_intervals(
-    intervals: list[Interval],
-) -> cesiumpy.TimeIntervalCollection:
-    """
-    Convert a list of OSTk intervals into Cesium TimeIntervalCollection.
-
-    Args:
-        intervals (list[Interval]): List of OSTk intervals.
-
-    Returns:
-        cesiumpy.TimeIntervalCollection: Converted intervals.
-    """
-
-    return cesiumpy.TimeIntervalCollection(
-        intervals=[
-            cesiumpy.TimeInterval(
-                start=coerce_to_datetime(interval.get_start()),
-                stop=coerce_to_datetime(interval.get_end()),
-            )
-            for interval in intervals
-        ],
-    )

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -10,6 +10,7 @@ Python API Documentation
    ostk.astrodynamics.access
    ostk.astrodynamics.converters
    ostk.astrodynamics.conjunction.message.ccsds
+   ostk.astrodynamics.czml
    ostk.astrodynamics.data
    ostk.astrodynamics.data.provider
    ostk.astrodynamics.dataframe


### PR DESCRIPTION
## Summary

Rewrites `ostk.astrodynamics.viewer` on top of a new dependency-free CZML document builder (`ostk.astrodynamics.czml`), removing the `cesiumpy` dependency entirely, following the approach of Orekit's [Oresium/OreCzml](https://gitlab.orekit.org/orekit/oresium) project.

The public `Viewer` API is preserved (`add_orbit`, `add_profile`, `add_celestial_body_direction`, `add_ground_tracks`, `add_target`, `add_line`, `add_label`, `add_moving_point`, `render()`), and the scenario can now also be exported as a portable `.czml` file for any external CesiumJS application.

## New features

- **Leading/trailing orbital track**: `add_orbit`/`add_profile` emit a CZML `path` with `leadTime`/`trailTime` (new `lead_time=`/`trail_time=` args, defaulting to one orbital period computed via vis-viva).
- **Sensor geometry projection**: new `add_sensor_projection(profile, sensor)` casts the attitude-dependent sensor boundary rays onto the WGS84 ellipsoid and renders a time-varying footprint polygon (hidden when the FOV misses the Earth).
- **Sensor rendering without plugins**: conic sensors render as a native CZML cone (cylinder with zero top radius, apex on the satellite); rectangular sensors render their four field-of-view edges. (`agi_*Sensor` CZML extensions require the unmaintained cesium-sensor-volumes plugin, so they are not used.)
- **Custom vectors to targets**: new `add_target_vector(observer, target, ...)` supporting `Celestial` (Sun, Moon, ...), other `Trajectory`/`Profile` objects (inter-satellite links), or fixed `Position`s. `add_celestial_body_direction` now delegates to it.
- **Access visualization**: new `add_accesses(accesses, observer, target)` accepting `Access` objects or bare `Interval`s — draws a line between the two objects during each window, a live label (window number, start/end, duration), and a Cesium InfoBox panel listing all windows.
- **2D/3D switching**: scene mode picker enabled by default, plus `scene_mode="3D"|"2D"|"COLUMBUS"` initial mode (previously locked to 3D-only).
- **CZML export**: `Viewer.to_czml()` / `Viewer.save_czml(path)`.

## Implementation notes

- `ostk.astrodynamics.czml` generates CZML as plain JSON — no `czml3`/`cesiumpy` dependency.
- Cesium Ion 3D model asset IDs cannot be referenced from pure CZML, so they are stored as a CZML custom property and resolved into `entity.model` by the generated HTML at load time. Exported `.czml` files fall back to a billboard in external apps.
- OSTk attitude quaternions are passive (`q_B_REF`): their raw components, interpreted with Cesium's active Hamilton convention, map body→fixed, so they are written unconjugated (verified numerically with a VVLH nadir-pointing profile). Python-side direction computations use `attitude.to_conjugate().rotate_vector(...)`, matching `Profile/Model/Tabulated.cpp`.
- Rendered HTML pins CesiumJS 1.126 and falls back to OpenStreetMap imagery when no Ion token is provided.
- `cesiumpy` removed from the Makefile Python test-dependency install; `ostk.astrodynamics.czml` added to the docs autosummary.

## Testing

- `bindings/python/test/test_viewer.py` rewritten to assert the CZML document structure (29 tests), including footprint-on-ellipsoid geometry, quaternion convention, access interval/label content, and JSON serializability.
- Verified locally with a duck-typed harness exercising every viewer method (footprint ring radius matches h·tan(half angle), cone apex placement, access show-intervals, HTML output). Full-fixture tests require the standard CI environment (OSTk data fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fkToQD7w1wA1MabZsrjE8

---
_Generated by [Claude Code](https://claude.ai/code/session_015fkToQD7w1wA1MabZsrjE8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Viewer output now generates richer CZML-based scenes, including orbits, profiles, sensors, target vectors, access lines, and moving labels.
  * Added support for orbital trail/lead display and time-varying sensor footprints.
  * Improved support for loading Cesium-based views in the browser.

* **Bug Fixes**
  * More reliable viewer tests now validate structured scene data instead of brittle HTML matching.

* **Documentation**
  * Added the new CZML module to the Python API documentation.

* **Chores**
  * Simplified Python test setup by removing an extra dependency from the standalone test flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->