### PR TITLE
build: fix packaging

### DIFF
--- a/bindings/python/tools/python/pyproject.toml.in
+++ b/bindings/python/tools/python/pyproject.toml.in
@@ -50,11 +50,8 @@ ext-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["ostk.astrodynamics"]
+include = ["ostk.astrodynamics", "ostk.astrodynamics.*"]
 
 [tool.setuptools.package-data]
 "ostk.astrodynamics" = ["${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}", "${LIBRARY_TARGET}.*${EXTENSION}*.so"]
 "*" = ["*/data/*"]
-
-[tool.black]
-line-length = 90


### PR DESCRIPTION
"submodules" weren't packaged. In this case, not only were stubs missing, but also the pure-python "extensions" such as `pystate`

Also removes an unnecessary `black` config in the distribution toml (was missed in earlier alignments)