### PR TITLE
feat: add output frame option for tabulated orbit models

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Model/Tabulated.cpp
@@ -49,7 +49,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Tabulated(pybind11:
                 Args:
                     states (list[State]): The states of the model.
                     interpolation_type (Interpolator.Type): The type of interpolation to use.
-                    output_frame (Frame): The reference frame in which the computed states are expressed.
+                    output_frame (Frame): The reference frame in which the computed states are expressed. The provided states are converted to this frame and interpolation is performed in this frame.
              )doc",
             arg("states"),
             arg("interpolation_type"),
@@ -86,7 +86,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Tabulated(pybind11:
                 Args:
                     states (list[State]): The states of the model.
                     interpolation_types (dict[CoordinateSubset, Interpolator.Type]): A mapping from coordinate subset to the interpolation type to use for that subset's coordinates. Every coordinate subset present in the states must have an entry, and every coordinate subset in the map must be present in the states.
-                    output_frame (Frame): The reference frame in which the computed states are expressed.
+                    output_frame (Frame): The reference frame in which the computed states are expressed. The provided states are converted to this frame and interpolation is performed in this frame.
              )doc",
             arg("states"),
             arg("interpolation_types"),
@@ -242,7 +242,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Model_Tabulated(pybind11:
 
                 Args:
                     states (list[State]): The states of the model.
-                    output_frame (Frame): The reference frame in which the computed states are expressed.
+                    output_frame (Frame): The reference frame in which the computed states are expressed. The provided states are converted to this frame and interpolation is performed in this frame.
 
                 Returns:
                     Tabulated: A tabulated model using the default interpolation types.

--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Tabulated.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Orbit/Model/Tabulated.cpp
@@ -11,6 +11,8 @@ using ostk::core::type::Shared;
 
 using ostk::mathematics::curvefitting::Interpolator;
 
+using ostk::physics::coordinate::Frame;
+
 using ostk::astrodynamics::trajectory::orbit::model::Tabulated;
 using ostk::astrodynamics::trajectory::State;
 using ostk::astrodynamics::trajectory::state::CoordinateSubset;
@@ -47,6 +49,24 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Tabulated(pyb
         )
 
         .def(
+            init<const Array<State>&, const Integer&, const Interpolator::Type&, const Shared<const Frame>&>(),
+            R"doc(
+                Constructor with an explicit output frame.
+
+                Args:
+                    states (list[State]): The states.
+                    initial_revolution_number (int): The initial revolution number.
+                    interpolation_type (Interpolator.Type): The interpolation type.
+                    output_frame (Frame): The reference frame in which the computed states are expressed. The provided states are converted to this frame and interpolation is performed in this frame.
+
+            )doc",
+            arg("states"),
+            arg("initial_revolution_number"),
+            arg("interpolation_type"),
+            arg("output_frame")
+        )
+
+        .def(
             init<const Array<State>&, const Integer&, const Map<Shared<const CoordinateSubset>, Interpolator::Type>&>(),
             R"doc(
                 Constructor with per-coordinate-subset interpolation types.
@@ -63,6 +83,31 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Tabulated(pyb
             arg("states"),
             arg("initial_revolution_number"),
             arg("interpolation_types")
+        )
+
+        .def(
+            init<
+                const Array<State>&,
+                const Integer&,
+                const Map<Shared<const CoordinateSubset>, Interpolator::Type>&,
+                const Shared<const Frame>&>(),
+            R"doc(
+                Constructor with per-coordinate-subset interpolation types and an explicit output frame.
+
+                Each coordinate is interpolated using the interpolation type associated with the coordinate subset
+                it belongs to.
+
+                Args:
+                    states (list[State]): The states.
+                    initial_revolution_number (int): The initial revolution number.
+                    interpolation_types (dict[CoordinateSubset, Interpolator.Type]): A mapping from coordinate subset to the interpolation type to use for that subset's coordinates. Every coordinate subset present in the states must have an entry, and every coordinate subset in the map must be present in the states.
+                    output_frame (Frame): The reference frame in which the computed states are expressed. The provided states are converted to this frame and interpolation is performed in this frame.
+
+            )doc",
+            arg("states"),
+            arg("initial_revolution_number"),
+            arg("interpolation_types"),
+            arg("output_frame")
         )
 
         .def(self == self)
@@ -105,6 +150,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Tabulated(pyb
 
                 Returns:
                     int: The revolution number.
+
+            )doc"
+        )
+
+        .def(
+            "get_frame",
+            &Tabulated::getFrame,
+            R"doc(
+                Get the reference frame in which the computed states are expressed.
+
+                Returns:
+                    Frame: The output reference frame.
 
             )doc"
         )
@@ -167,7 +224,7 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Tabulated(pyb
 
         .def_static(
             "default",
-            &Tabulated::Default,
+            overload_cast<const Array<State>&, const Integer&>(&Tabulated::Default),
             R"doc(
                 Construct a tabulated orbit model using the default per-coordinate-subset interpolation types.
 
@@ -185,6 +242,31 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Orbit_Model_Tabulated(pyb
             )doc",
             arg("states"),
             arg_v("initial_revolution_number", Integer(1), "1")
+        )
+
+        .def_static(
+            "default",
+            overload_cast<const Array<State>&, const Integer&, const Shared<const Frame>&>(&Tabulated::Default),
+            R"doc(
+                Construct a tabulated orbit model using the default per-coordinate-subset interpolation types and an
+                explicit output frame.
+
+                Each coordinate subset present in the states is interpolated using its default interpolation type
+                (barycentric rational for position, velocity, acceleration, attitude, angular velocity and mass;
+                zero-order for drag coefficient, surface area, mass flow rate and ballistic coefficient).
+
+                Args:
+                    states (list[State]): The states.
+                    initial_revolution_number (int): The initial revolution number.
+                    output_frame (Frame): The reference frame in which the computed states are expressed. The provided states are converted to this frame and interpolation is performed in this frame.
+
+                Returns:
+                    Tabulated: A tabulated orbit model using the default interpolation types.
+
+            )doc",
+            arg("states"),
+            arg("initial_revolution_number"),
+            arg("output_frame")
         )
 
         ;

--- a/bindings/python/test/trajectory/model/test_tabulated_trajectory.py
+++ b/bindings/python/test/trajectory/model/test_tabulated_trajectory.py
@@ -1,23 +1,15 @@
 # Apache License 2.0
 
-import pytest
-
 import numpy as np
-
-from ostk.mathematics.curve_fitting import Interpolator
-
-from ostk.physics.time import Instant
-from ostk.physics.time import DateTime
-from ostk.physics.time import Scale
-from ostk.physics.coordinate import Position
-from ostk.physics.coordinate import Velocity
-from ostk.physics.coordinate import Frame
-
+import pytest
 from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory.model import Tabulated
 from ostk.astrodynamics.trajectory.state import CoordinateSubset
-from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianPosition
-from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianVelocity
+from ostk.astrodynamics.trajectory.state.coordinate_subset import (
+    CartesianPosition, CartesianVelocity)
+from ostk.mathematics.curve_fitting import Interpolator
+from ostk.physics.coordinate import Frame, Position, Velocity
+from ostk.physics.time import DateTime, Instant, Scale
 
 
 @pytest.fixture
@@ -321,12 +313,6 @@ class TestTabulatedTrajectory:
         interpolation_type: Interpolator.Type,
     ):
         assert tabulated.get_interpolation_type() == Interpolator.Type.CubicSpline
-
-    def test_get_frame_default(
-        self,
-        tabulated: Tabulated,
-    ):
-        assert tabulated.get_frame() == Frame.GCRF()
 
     @pytest.mark.parametrize(
         "frame",

--- a/bindings/python/test/trajectory/model/test_tabulated_trajectory.py
+++ b/bindings/python/test/trajectory/model/test_tabulated_trajectory.py
@@ -6,7 +6,9 @@ from ostk.astrodynamics.trajectory import State
 from ostk.astrodynamics.trajectory.model import Tabulated
 from ostk.astrodynamics.trajectory.state import CoordinateSubset
 from ostk.astrodynamics.trajectory.state.coordinate_subset import (
-    CartesianPosition, CartesianVelocity)
+    CartesianPosition,
+    CartesianVelocity,
+)
 from ostk.mathematics.curve_fitting import Interpolator
 from ostk.physics.coordinate import Frame, Position, Velocity
 from ostk.physics.time import DateTime, Instant, Scale

--- a/bindings/python/test/trajectory/orbit/models/test_tabulated.py
+++ b/bindings/python/test/trajectory/orbit/models/test_tabulated.py
@@ -1,26 +1,18 @@
 # Apache License 2.0
 
-import pytest
-
 import numpy as np
-
-from ostk.mathematics.curve_fitting import Interpolator
-
-from ostk.physics.time import Instant
-from ostk.physics.time import DateTime
-from ostk.physics.time import Scale
-from ostk.physics.time import Duration
-from ostk.physics.coordinate import Position
-from ostk.physics.coordinate import Velocity
-from ostk.physics.coordinate import Frame
-from ostk.physics import Environment
-
-from ostk.astrodynamics.trajectory import State
-from ostk.astrodynamics.trajectory import Orbit
+import pytest
+from ostk.astrodynamics.trajectory import Orbit, State
 from ostk.astrodynamics.trajectory.orbit.model import Tabulated
 from ostk.astrodynamics.trajectory.state import CoordinateSubset
-from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianPosition
-from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianVelocity
+from ostk.astrodynamics.trajectory.state.coordinate_subset import (
+    CartesianPosition,
+    CartesianVelocity,
+)
+from ostk.mathematics.curve_fitting import Interpolator
+from ostk.physics import Environment
+from ostk.physics.coordinate import Frame, Position, Velocity
+from ostk.physics.time import DateTime, Duration, Instant, Scale
 
 
 @pytest.fixture
@@ -340,6 +332,88 @@ class TestTabulated:
         )
 
         assert tabulated.get_interpolation_type() == Interpolator.Type.CubicSpline
+
+    @pytest.mark.parametrize(
+        "frame",
+        (
+            (Frame.GCRF()),
+            (Frame.ITRF()),
+        ),
+    )
+    def test_constructor_with_frame(
+        self,
+        test_states: list[State],
+        frame: Frame,
+    ):
+        tabulated = Tabulated(
+            states=test_states,
+            initial_revolution_number=1,
+            interpolation_type=Interpolator.Type.Linear,
+            output_frame=frame,
+        )
+
+        assert tabulated.is_defined()
+        assert tabulated.get_frame() == frame
+        assert tabulated.get_revolution_number_at_epoch() == 1
+        assert (
+            tabulated.calculate_state_at(test_states[0].get_instant()).get_frame()
+            == frame
+        )
+
+    def test_constructor_with_interpolation_types_and_frame(
+        self,
+        test_states: list[State],
+    ):
+        tabulated = Tabulated(
+            states=test_states,
+            initial_revolution_number=1,
+            interpolation_types={
+                CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                CartesianVelocity.default(): Interpolator.Type.Linear,
+            },
+            output_frame=Frame.ITRF(),
+        )
+
+        assert tabulated.get_frame() == Frame.ITRF()
+
+    def test_constructor_with_null_frame_failure(
+        self,
+        test_states: list[State],
+    ):
+        # A null output frame is rejected by both explicit-frame constructors.
+        with pytest.raises(Exception):
+            Tabulated(
+                states=test_states,
+                initial_revolution_number=1,
+                interpolation_type=Interpolator.Type.Linear,
+                output_frame=None,
+            )
+
+        with pytest.raises(Exception):
+            Tabulated(
+                states=test_states,
+                initial_revolution_number=1,
+                interpolation_types={
+                    CartesianPosition.default(): Interpolator.Type.CubicSpline,
+                    CartesianVelocity.default(): Interpolator.Type.Linear,
+                },
+                output_frame=None,
+            )
+
+    def test_default_with_frame(
+        self,
+        test_states: list[State],
+    ):
+        assert Tabulated.default(test_states).get_frame() == Frame.GCRF()
+
+        tabulated = Tabulated.default(
+            test_states,
+            initial_revolution_number=2,
+            output_frame=Frame.ITRF(),
+        )
+
+        assert tabulated.get_frame() == Frame.ITRF()
+        assert tabulated.get_revolution_number_at_epoch() == 2
 
     @pytest.mark.parametrize(
         "interpolation_type,error_tolerance",

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.hpp
@@ -10,6 +10,7 @@
 
 #include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp>
 
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
 #include <OpenSpaceToolkit/Astrodynamics/Trajectory/Model.hpp>
@@ -36,6 +37,7 @@ using ostk::core::type::Shared;
 
 using ostk::mathematics::curvefitting::Interpolator;
 
+using ostk::physics::coordinate::Frame;
 using ostk::physics::time::Instant;
 
 using ostk::astrodynamics::trajectory::State;
@@ -64,6 +66,25 @@ class Tabulated : public virtual trajectory::orbit::Model, public trajectory::mo
         const Interpolator::Type& aType = DEFAULT_TABULATED_TRAJECTORY_INTERPOLATION_TYPE
     );
 
+    /// @brief Construct a tabulated orbit model from an array of states, with an explicit output frame.
+    ///
+    /// @code{.cpp}
+    ///     Array<State> states = { ... };
+    ///     Tabulated tabulated = Tabulated(states, 1, Interpolator::Type::Linear, Frame::ITRF());
+    /// @endcode
+    ///
+    /// @param aStateArray An array of states to tabulate.
+    /// @param anInitialRevolutionNumber The revolution number at the first state epoch.
+    /// @param aType The interpolation type to use between tabulated states.
+    /// @param aFrameSPtr The reference frame in which the computed states are expressed. The provided states are
+    /// converted to this frame and interpolation is performed in this frame.
+    Tabulated(
+        const Array<State>& aStateArray,
+        const Integer& anInitialRevolutionNumber,
+        const Interpolator::Type& aType,
+        const Shared<const Frame>& aFrameSPtr
+    );
+
     /// @brief Construct a tabulated orbit model with per-coordinate-subset interpolation types.
     ///
     /// @details Each coordinate is interpolated using the interpolation type associated with the coordinate subset
@@ -87,6 +108,23 @@ class Tabulated : public virtual trajectory::orbit::Model, public trajectory::mo
         const Array<State>& aStateArray,
         const Integer& anInitialRevolutionNumber,
         const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
+    );
+
+    /// @brief Construct a tabulated orbit model with per-coordinate-subset interpolation types and an explicit
+    /// output frame.
+    ///
+    /// @param aStateArray An array of states to tabulate.
+    /// @param anInitialRevolutionNumber The revolution number at the first state epoch.
+    /// @param anInterpolationTypeMap A mapping from coordinate subset to the interpolation type to use for that
+    /// subset's coordinates. Every coordinate subset present in the states must have an entry in the map (an error is
+    /// raised otherwise). Entries for coordinate subsets that are not present in the states are ignored.
+    /// @param aFrameSPtr The reference frame in which the computed states are expressed. The provided states are
+    /// converted to this frame and interpolation is performed in this frame.
+    Tabulated(
+        const Array<State>& aStateArray,
+        const Integer& anInitialRevolutionNumber,
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap,
+        const Shared<const Frame>& aFrameSPtr
     );
 
     /// @brief Clone this tabulated orbit model.
@@ -153,6 +191,22 @@ class Tabulated : public virtual trajectory::orbit::Model, public trajectory::mo
     /// @param anInitialRevolutionNumber The revolution number at the first state epoch. Defaults to 1.
     /// @return A tabulated orbit model using the default interpolation types.
     static Tabulated Default(const Array<State>& aStateArray, const Integer& anInitialRevolutionNumber = 1);
+
+    /// @brief Construct a tabulated orbit model using the default per-coordinate-subset interpolation types and an
+    /// explicit output frame.
+    ///
+    /// @code{.cpp}
+    ///     Array<State> states = { ... };
+    ///     Tabulated tabulated = Tabulated::Default(states, 1, Frame::ITRF());
+    /// @endcode
+    ///
+    /// @param aStateArray An array of states to tabulate.
+    /// @param anInitialRevolutionNumber The revolution number at the first state epoch.
+    /// @param aFrameSPtr The reference frame in which the computed states are expressed.
+    /// @return A tabulated orbit model using the default interpolation types.
+    static Tabulated Default(
+        const Array<State>& aStateArray, const Integer& anInitialRevolutionNumber, const Shared<const Frame>& aFrameSPtr
+    );
 
    protected:
     virtual bool operator==(const trajectory::Model& aModel) const override;

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.cpp
@@ -21,8 +21,18 @@ Tabulated::Tabulated(
     const Integer& anInitialRevolutionNumber,
     const Interpolator::Type& anInterpolationType
 )
+    : Tabulated(aStateArray, anInitialRevolutionNumber, anInterpolationType, Frame::GCRF())
+{
+}
+
+Tabulated::Tabulated(
+    const Array<State>& aStateArray,
+    const Integer& anInitialRevolutionNumber,
+    const Interpolator::Type& anInterpolationType,
+    const Shared<const Frame>& aFrameSPtr
+)
     : trajectory::orbit::Model(),
-      trajectory::model::Tabulated(aStateArray, anInterpolationType),
+      trajectory::model::Tabulated(aStateArray, anInterpolationType, aFrameSPtr),
       initialRevolutionNumber_(anInitialRevolutionNumber)
 {
 }
@@ -32,8 +42,18 @@ Tabulated::Tabulated(
     const Integer& anInitialRevolutionNumber,
     const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap
 )
+    : Tabulated(aStateArray, anInitialRevolutionNumber, anInterpolationTypeMap, Frame::GCRF())
+{
+}
+
+Tabulated::Tabulated(
+    const Array<State>& aStateArray,
+    const Integer& anInitialRevolutionNumber,
+    const Map<Shared<const CoordinateSubset>, Interpolator::Type>& anInterpolationTypeMap,
+    const Shared<const Frame>& aFrameSPtr
+)
     : trajectory::orbit::Model(),
-      trajectory::model::Tabulated(aStateArray, anInterpolationTypeMap),
+      trajectory::model::Tabulated(aStateArray, anInterpolationTypeMap, aFrameSPtr),
       initialRevolutionNumber_(anInitialRevolutionNumber)
 {
 }
@@ -97,6 +117,15 @@ void Tabulated::print(std::ostream& anOutputStream, bool displayDecorator) const
 Tabulated Tabulated::Default(const Array<State>& aStateArray, const Integer& anInitialRevolutionNumber)
 {
     return Tabulated(aStateArray, anInitialRevolutionNumber, trajectory::model::Tabulated::DefaultInterpolationTypes());
+}
+
+Tabulated Tabulated::Default(
+    const Array<State>& aStateArray, const Integer& anInitialRevolutionNumber, const Shared<const Frame>& aFrameSPtr
+)
+{
+    return Tabulated(
+        aStateArray, anInitialRevolutionNumber, trajectory::model::Tabulated::DefaultInterpolationTypes(), aFrameSPtr
+    );
 }
 
 bool Tabulated::operator==(const trajectory::Model& aModel) const

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Tabulated.test.cpp
@@ -150,6 +150,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Construc
 
         EXPECT_THROW({ const Tabulated tabulated(states_, 0, missingTypeForSubset); }, ostk::core::error::RuntimeError);
     }
+
+    // The output frame is set by the constructor.
+    {
+        const Tabulated tabulated(states_, 0, Interpolator::Type::Linear, Frame::ITRF());
+
+        EXPECT_TRUE(tabulated.isDefined());
+        EXPECT_EQ(tabulated.getFrame(), Frame::ITRF());
+        EXPECT_TRUE(tabulated.getRevolutionNumberAtEpoch() == 0);
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Default)
@@ -162,6 +171,101 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, Default)
 
     // The initial revolution number defaults to 1.
     EXPECT_TRUE(Tabulated::Default(states_).getRevolutionNumberAtEpoch() == 1);
+
+    // The output frame is set by the default constructor.
+    {
+        const Tabulated tabulatedITRF = Tabulated::Default(states_, 0, Frame::ITRF());
+
+        EXPECT_EQ(tabulatedITRF.getFrame(), Frame::ITRF());
+        EXPECT_TRUE(tabulatedITRF.getRevolutionNumberAtEpoch() == 0);
+        EXPECT_EQ(tabulatedITRF.getInterpolationType(), Interpolator::Type::BarycentricRational);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, OutputFrame)
+{
+    const Instant queryInstant = states_.accessFirst().accessInstant() + Duration::Seconds(30.0);
+
+    // The default output frame is GCRF (backward-compatible behavior).
+    {
+        const Tabulated tabulated(states_, 0, Interpolator::Type::Linear);
+
+        EXPECT_EQ(tabulated.getFrame(), Frame::GCRF());
+        EXPECT_EQ(tabulated.calculateStateAt(queryInstant).getFrame(), Frame::GCRF());
+    }
+
+    // An explicitly requested output frame is honored by calculateStateAt.
+    {
+        const Tabulated tabulatedGCRF(states_, 0, Interpolator::Type::Linear, Frame::GCRF());
+        const Tabulated tabulatedITRF(states_, 0, Interpolator::Type::Linear, Frame::ITRF());
+
+        EXPECT_EQ(tabulatedITRF.getFrame(), Frame::ITRF());
+        EXPECT_EQ(tabulatedGCRF.getFrame(), Frame::GCRF());
+
+        const State stateGCRF = tabulatedGCRF.calculateStateAt(queryInstant);
+        const State stateITRF = tabulatedITRF.calculateStateAt(queryInstant);
+
+        EXPECT_EQ(stateITRF.getFrame(), Frame::ITRF());
+
+        // Interpolation happens directly in the output frame: at a tabulated node the ITRF result matches the
+        // input state expressed in ITRF (linear interpolation reproduces the nodes exactly).
+        const State nodeState = states_[3];
+        EXPECT_TRUE(tabulatedITRF.calculateStateAt(nodeState.accessInstant())
+                        .getCoordinates()
+                        .isApprox(nodeState.inFrame(Frame::ITRF()).getCoordinates(), 1e-8));
+
+        // Away from the nodes, interpolating in ITRF and converting back to GCRF no longer recovers the GCRF
+        // interpolation, because interpolation is performed in the output frame rather than the native frame.
+        EXPECT_FALSE(stateITRF.inFrame(Frame::GCRF()).getCoordinates().isApprox(stateGCRF.getCoordinates(), 1e-8));
+    }
+
+    // The per-coordinate-subset constructor also honors the output frame.
+    {
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::Linear},
+            {CartesianVelocity::Default(), Interpolator::Type::Linear},
+        };
+
+        const Tabulated tabulated(states_, 0, interpolationTypes, Frame::ITRF());
+
+        EXPECT_EQ(tabulated.getFrame(), Frame::ITRF());
+        EXPECT_EQ(tabulated.calculateStateAt(queryInstant).getFrame(), Frame::ITRF());
+    }
+
+    // Default() honors the output frame.
+    {
+        EXPECT_EQ(Tabulated::Default(states_, 0).getFrame(), Frame::GCRF());
+        EXPECT_EQ(Tabulated::Default(states_, 0, Frame::ITRF()).getFrame(), Frame::ITRF());
+    }
+
+    // Models that differ only by their output frame are not equal.
+    {
+        const Tabulated tabulatedGCRF(states_, 0, Interpolator::Type::Linear, Frame::GCRF());
+        const Tabulated tabulatedITRF(states_, 0, Interpolator::Type::Linear, Frame::ITRF());
+
+        EXPECT_TRUE(tabulatedGCRF != tabulatedITRF);
+        EXPECT_FALSE(tabulatedGCRF == tabulatedITRF);
+    }
+
+    // A null output frame is rejected by both explicit-frame constructors.
+    {
+        const Shared<const Frame> nullFrameSPtr = nullptr;
+
+        EXPECT_THROW(
+            { const Tabulated tabulated(states_, 0, Interpolator::Type::Linear, nullFrameSPtr); },
+            ostk::core::error::runtime::Undefined
+        );
+
+        const Map<Shared<const CoordinateSubset>, Interpolator::Type> interpolationTypes = {
+            {CartesianPosition::Default(), Interpolator::Type::Linear},
+            {CartesianVelocity::Default(), Interpolator::Type::Linear},
+        };
+
+        EXPECT_THROW(
+            { const Tabulated tabulated(states_, 0, interpolationTypes, nullFrameSPtr); },
+            ostk::core::error::runtime::Undefined
+        );
+    }
 }
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Tabulated, GetInterval)


### PR DESCRIPTION
These extra changes were forgetting as part of this MR https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/688, and are needed to fully realise the downstream access generation speed up for users using OSTkOrbits or OSTkTabulatedOrbits.

The implementation was exactly the same as it was for the TrajectoryModel:
- backwards compatible (default Frame is GCRF)
- no ABI break (new constructor added instead of modifying existing constructor signatures

The one tiny difference is that the `TabulatedOrbit::Default()` constructor couldn't have a defaultable `initialRevolutionNumber` like the `TabulatedTrajectory::Default()` had because its not the last argument and when you make it the last argument it results in the the compiler not being able to resolve ambiguous calls to the existing two argument `TabulatedOrbit::Default()` constructor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting an explicit output reference frame when creating tabulated orbit models.
  - Added frame-aware default creation options for uniform and per-coordinate interpolation.
  - Added access to the model’s configured output frame.
  - States are converted to the selected frame before interpolation.
- **Bug Fixes**
  - Improved frame selection and validation, including rejection of invalid or missing frames.
  - Ensured default frame behavior remains consistent when no output frame is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->