### PR TITLE
chore: don't overwrite devcontainer venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,7 @@ start-development-no-link: build-development-image-non-root ## Start development
 		-it \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
+		--volume="/app/bindings/python/.venv" \
 		--volume="$(HOME)/.ssh:/home/$(dev_username)/.ssh:ro" \
 		--volume="$(HOME)/.gitconfig:/home/$(dev_username)/.gitconfig:ro" \
 		--workdir=/app/build \


### PR DESCRIPTION
The dev image creates a venv here at build-time, but when running `make dev`, the volume mount overwrites it. Adding the venv as an "anonymous volume" prevents this.