### PR TITLE
test: make frame-sensitive expectations robust to time conversion resolution

### DIFF
--- a/bindings/python/test/estimator/test_tle_solver.py
+++ b/bindings/python/test/estimator/test_tle_solver.py
@@ -7,6 +7,7 @@ import pandas as pd
 from ostk.core.type import Real
 from ostk.core.type import Integer
 
+from ostk.physics.time import Duration
 from ostk.physics.coordinate import Frame
 
 from ostk.astrodynamics.solver import LeastSquaresSolver
@@ -36,9 +37,10 @@ def tle_solver(least_squares_solver: LeastSquaresSolver) -> TLESolver:
 
 @pytest.fixture
 def initial_tle() -> TLE:
+    # Approximate TLE for the observation arc below, used only as an initial guess
     return TLE(
-        "1 25544U 98067A   22253.00000622  .00000000  00000-0  71655-1 0    02",
-        "2 25544  97.5641  21.8296 0012030 155.5301 309.4836 15.14446734123455",
+        "1 25544U 98067A   24108.27550222  .00000000  00000-0  36948-2 0    05",
+        "2 25544  97.4637 232.8952 0013366 138.7208  75.4931 15.17238608123452",
     )
 
 
@@ -54,12 +56,25 @@ def initial_state_with_b_star(observations: list[State]) -> tuple[State, float]:
 
 @pytest.fixture
 def observations() -> list[State]:
-    return generate_states_from_dataframe(
+    # Same dataset and 12-hour fit span as the C++ tests. A TLE fit only converges in the sense of the
+    # solver's RMS update criterion if the arc actually constrains the estimated elements: over a very
+    # short arc the fit reaches the accuracy floor imposed by the quantization of the TLE strings after
+    # a few iterations and then oscillates around it, so whether the RMS update ever drops below the
+    # threshold comes down to where the oscillation happens to land.
+    all_observations: list[State] = generate_states_from_dataframe(
         pd.read_csv(
-            "/app/test/OpenSpaceToolkit/Astrodynamics/Estimator/OrbitDeterminationSolverData/gnss_data.csv"
+            "/app/test/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolverData/observations.csv"
         ),
         reference_frame=Frame.ITRF(),
     )
+
+    start_instant = all_observations[0].get_instant()
+
+    return [
+        observation
+        for observation in all_observations
+        if observation.get_instant() - start_instant <= Duration.hours(12.0)
+    ]
 
 
 class TestTLESolver:

--- a/bindings/python/test/estimator/test_tle_solver.py
+++ b/bindings/python/test/estimator/test_tle_solver.py
@@ -56,11 +56,6 @@ def initial_state_with_b_star(observations: list[State]) -> tuple[State, float]:
 
 @pytest.fixture
 def observations() -> list[State]:
-    # Same dataset and 12-hour fit span as the C++ tests. A TLE fit only converges in the sense of the
-    # solver's RMS update criterion if the arc actually constrains the estimated elements: over a very
-    # short arc the fit reaches the accuracy floor imposed by the quantization of the TLE strings after
-    # a few iterations and then oscillates around it, so whether the RMS update ever drops below the
-    # threshold comes down to where the oscillation happens to land.
     all_observations: list[State] = generate_states_from_dataframe(
         pd.read_csv(
             "/app/test/OpenSpaceToolkit/Astrodynamics/Estimator/TLESolverData/observations.csv"

--- a/bindings/python/test/trajectory/state/coordinate_subset/test_cartesian_position.py
+++ b/bindings/python/test/trajectory/state/coordinate_subset/test_cartesian_position.py
@@ -4,6 +4,7 @@ import pytest
 
 from ostk.physics.time import Instant
 from ostk.physics.coordinate import Frame
+from ostk.physics.coordinate import Position
 
 from ostk.astrodynamics.trajectory.state import CoordinateBroker, CoordinateSubset
 from ostk.astrodynamics.trajectory.state.coordinate_subset import CartesianPosition
@@ -98,10 +99,18 @@ class TestCartesianPosition:
         another_coordinates: list[float],
         coordinate_broker: CoordinateBroker,
     ):
+        # The expected coordinates are obtained through the equivalent Position transformation rather than
+        # hard-coded, as their exact value depends on the resolution of the Earth Rotation Angle at the instant.
+        expected_coordinates = (
+            Position.meters(coordinates, frame)
+            .in_frame(Frame.ITRF(), instant)
+            .get_coordinates()
+        )
+
         for value, expected in zip(
             cartesian_position.in_frame(
                 instant, coordinates, frame, Frame.ITRF(), coordinate_broker
             ),
-            [1238864.12746338, 6889500.39136482, -176.262107699686],
+            expected_coordinates,
         ):
             assert value == pytest.approx(expected, rel=1e-14)

--- a/bindings/python/test/trajectory/state/coordinate_subset/test_cartesian_position.py
+++ b/bindings/python/test/trajectory/state/coordinate_subset/test_cartesian_position.py
@@ -99,8 +99,6 @@ class TestCartesianPosition:
         another_coordinates: list[float],
         coordinate_broker: CoordinateBroker,
     ):
-        # The expected coordinates are obtained through the equivalent Position transformation rather than
-        # hard-coded, as their exact value depends on the resolution of the Earth Rotation Angle at the instant.
         expected_coordinates = (
             Position.meters(coordinates, frame)
             .in_frame(Frame.ITRF(), instant)

--- a/bindings/python/test/trajectory/state/coordinate_subset/test_cartesian_velocity.py
+++ b/bindings/python/test/trajectory/state/coordinate_subset/test_cartesian_velocity.py
@@ -4,6 +4,8 @@ import pytest
 
 from ostk.physics.time import Instant
 from ostk.physics.coordinate import Frame
+from ostk.physics.coordinate import Position
+from ostk.physics.coordinate import Velocity
 
 from ostk.astrodynamics.trajectory.state import CoordinateBroker, CoordinateSubset
 from ostk.astrodynamics.trajectory.state.coordinate_subset import (
@@ -106,10 +108,18 @@ class TestCartesianVelocity:
         another_coordinates: list[float],
         coordinate_broker: CoordinateBroker,
     ):
+        # The expected coordinates are obtained through the equivalent Velocity transformation rather than
+        # hard-coded, as their exact value depends on the resolution of the Earth Rotation Angle at the instant.
+        expected_coordinates = (
+            Velocity.meters_per_second(coordinates[3:6], frame)
+            .in_frame(Position.meters(coordinates[0:3], frame), Frame.ITRF(), instant)
+            .get_coordinates()
+        )
+
         for value, expected in zip(
             cartesian_velocity.in_frame(
                 instant, coordinates, frame, Frame.ITRF(), coordinate_broker
             ),
-            [-4749.36551256577, 854.163395375881, 5335.71857543495],
+            expected_coordinates,
         ):
             assert value == pytest.approx(expected, rel=1e-14)

--- a/bindings/python/test/trajectory/state/coordinate_subset/test_cartesian_velocity.py
+++ b/bindings/python/test/trajectory/state/coordinate_subset/test_cartesian_velocity.py
@@ -108,8 +108,6 @@ class TestCartesianVelocity:
         another_coordinates: list[float],
         coordinate_broker: CoordinateBroker,
     ):
-        # The expected coordinates are obtained through the equivalent Velocity transformation rather than
-        # hard-coded, as their exact value depends on the resolution of the Earth Rotation Angle at the instant.
         expected_coordinates = (
             Velocity.meters_per_second(coordinates[3:6], frame)
             .in_frame(Position.meters(coordinates[0:3], frame), Frame.ITRF(), instant)

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -304,9 +304,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetRevolutionNumberAt)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
-            )),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -362,9 +364,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassAt)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
-            )),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -512,8 +516,12 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePasses)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                                   "Satellite Passes.csv")),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                    "Satellite Passes.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -700,8 +708,12 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePassesWithModel)
             // Reference data setup
 
             const Table referenceData = Table::Load(
-                File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                                       "Satellite Passes.csv")),
+                File::Path(
+                    Path::Parse(
+                        "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                        "Satellite Passes.csv"
+                    )
+                ),
                 Table::Format::CSV,
                 true
             );
@@ -900,8 +912,12 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                                   "Satellite Passes.csv")),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                    "Satellite Passes.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -964,8 +980,12 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
-                                   "Satellite Passes.csv")),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
+                    "Satellite Passes.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -1028,8 +1048,12 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
-                                   "Satellite Passes.csv")),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
+                    "Satellite Passes.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -1235,27 +1259,35 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassesWithinInterval)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                                   "Satellite Passes.csv")),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                    "Satellite Passes.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
 
         // Pass test
 
-        const Array<Pass> passes = orbit.getPassesWithinInterval(Interval::Closed(
-            Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
-            Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
-        ));
+        const Array<Pass> passes = orbit.getPassesWithinInterval(
+            Interval::Closed(
+                Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
+                Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
+            )
+        );
 
         EXPECT_TRUE(passes.getSize() > 0);
         EXPECT_EQ(passes.getSize() - 1, referenceData.getRowCount());
 
         // Test regenerating with cached passes
-        EXPECT_NO_THROW(orbit.getPassesWithinInterval(Interval::Closed(
-            Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
-            Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
-        )));
+        EXPECT_NO_THROW(orbit.getPassesWithinInterval(
+            Interval::Closed(
+                Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
+                Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
+            )
+        ));
 
         for (const auto &referenceRow : referenceData)
         {
@@ -1446,10 +1478,14 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetOrbitalFrame)
             const Angle angularTolerance = std::get<1>(testCase);
             const Angle angularVelocityTolerance = std::get<2>(testCase);
 
-            const File referenceDataFile = File::Path(Path::Parse(String::Format(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/GetOrbitalFrame/{}_GCRF.csv",
-                Orbit::StringFromFrameType(frameType)
-            )));
+            const File referenceDataFile = File::Path(
+                Path::Parse(
+                    String::Format(
+                        "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/GetOrbitalFrame/{}_GCRF.csv",
+                        Orbit::StringFromFrameType(frameType)
+                    )
+                )
+            );
 
             const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
 
@@ -1586,7 +1622,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(0.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 1.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 1.csv")
              ),
              1e-3,
              1e-6,
@@ -1596,7 +1633,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(45.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 2.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 2.csv")
              ),
              1e-3,
              1e-6,
@@ -1606,7 +1644,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(90.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 3.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 3.csv")
              ),
              1e-3,
              1e-6,
@@ -1616,7 +1655,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(135.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 4.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 4.csv")
              ),
              1e-3,
              1e-6,
@@ -1626,7 +1666,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(180.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 5.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 5.csv")
              ),
              1e-3,
              1e-6,
@@ -1636,7 +1677,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(0.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 6.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 6.csv")
              ),
              1e-3,
              1e-6,
@@ -1646,7 +1688,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(45.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 7.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 7.csv")
              ),
              1e-3,
              1e-6,
@@ -1656,7 +1699,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(90.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 8.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 8.csv")
              ),
              1e-3,
              1e-6,
@@ -1666,7 +1710,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(135.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 9.csv")
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 9.csv")
              ),
              1e-3,
              1e-6,
@@ -1676,8 +1721,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(180.0),
-             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 10.csv"
-             )),
+             File::Path(
+                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 10.csv")
+             ),
              1e-3,
              1e-6,
              1e-1,
@@ -1870,9 +1916,11 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, CircularEquatorial)
             {"Scenario 1",
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
-             File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/CircularEquatorial/Scenario 1.csv"
-             )),
+             File::Path(
+                 Path::Parse(
+                     "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/CircularEquatorial/Scenario 1.csv"
+                 )
+             ),
              1e-3,
              1e-6,
              1e-1,
@@ -1936,9 +1984,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
         VectorXd comparisonVector(6);
         comparisonVector << 7462233.829725, -41498548.350819, 0.000000, 3026.125690, 544.155360, 0.536630;
 
-        const double positionError = (comparisonVector - ascendingNodeVector).norm();
+        const double coordinatesError = (comparisonVector - ascendingNodeVector).norm();
 
-        EXPECT_GT(tolerance, positionError);
+        EXPECT_GT(tolerance, coordinatesError);
     }
 
     // Test longitude alignement for a certain longitude

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -1908,6 +1908,12 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, CircularEquatorial)
 
 TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
 {
+    // The reference states below are aligned with a geodetic longitude, so they depend on the Earth Rotation Angle
+    // at epoch. The tolerance is therefore set to a value that is still negligible in terms of longitude alignment
+    // (1 cm at geosynchronous radius is 2.4e-10 rad) rather than to the print precision of the reference values,
+    // so that it absorbs the sub-centimeter differences caused by the resolution of the underlying time conversions.
+    const double tolerance = 1e-2;
+
     // Test longitude alignement for a certain longitude
     {
         // Environment setup
@@ -1932,7 +1938,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
 
         const double positionError = (comparisonVector - ascendingNodeVector).norm();
 
-        EXPECT_GT(1e-6, positionError);
+        EXPECT_GT(tolerance, positionError);
     }
 
     // Test longitude alignement for a certain longitude
@@ -1959,7 +1965,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
 
         const double positionError = (comparisonVector - ascendingNodeVector).norm();
 
-        EXPECT_GT(1e-6, positionError);
+        EXPECT_GT(tolerance, positionError);
     }
 
     // Test longitude alignement for a certain longitude
@@ -1986,7 +1992,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GeoSynchronous)
 
         const double positionError = (comparisonVector - ascendingNodeVector).norm();
 
-        EXPECT_GT(1e-6, positionError);
+        EXPECT_GT(tolerance, positionError);
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit.test.cpp
@@ -304,11 +304,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetRevolutionNumberAt)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -364,11 +362,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassAt)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/Satellite Passes.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -516,12 +512,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePasses)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
@@ -708,12 +700,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, ComputePassesWithModel)
             // Reference data setup
 
             const Table referenceData = Table::Load(
-                File::Path(
-                    Path::Parse(
-                        "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                        "Satellite Passes.csv"
-                    )
-                ),
+                File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                       "Satellite Passes.csv")),
                 Table::Format::CSV,
                 true
             );
@@ -912,12 +900,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
@@ -980,12 +964,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_2/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
@@ -1048,12 +1028,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassWithRevolutionNumbe
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_4/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
@@ -1259,35 +1235,27 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetPassesWithinInterval)
         // Reference data setup
 
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
-                    "Satellite Passes.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Kepler/Test_1/"
+                                   "Satellite Passes.csv")),
             Table::Format::CSV,
             true
         );
 
         // Pass test
 
-        const Array<Pass> passes = orbit.getPassesWithinInterval(
-            Interval::Closed(
-                Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
-                Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
-            )
-        );
+        const Array<Pass> passes = orbit.getPassesWithinInterval(Interval::Closed(
+            Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
+            Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
+        ));
 
         EXPECT_TRUE(passes.getSize() > 0);
         EXPECT_EQ(passes.getSize() - 1, referenceData.getRowCount());
 
         // Test regenerating with cached passes
-        EXPECT_NO_THROW(orbit.getPassesWithinInterval(
-            Interval::Closed(
-                Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
-                Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
-            )
-        ));
+        EXPECT_NO_THROW(orbit.getPassesWithinInterval(Interval::Closed(
+            Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
+            Instant::DateTime(DateTime::Parse("2018-01-01 23:00:00"), Scale::UTC)
+        )));
 
         for (const auto &referenceRow : referenceData)
         {
@@ -1478,14 +1446,10 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, GetOrbitalFrame)
             const Angle angularTolerance = std::get<1>(testCase);
             const Angle angularVelocityTolerance = std::get<2>(testCase);
 
-            const File referenceDataFile = File::Path(
-                Path::Parse(
-                    String::Format(
-                        "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/GetOrbitalFrame/{}_GCRF.csv",
-                        Orbit::StringFromFrameType(frameType)
-                    )
-                )
-            );
+            const File referenceDataFile = File::Path(Path::Parse(String::Format(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/GetOrbitalFrame/{}_GCRF.csv",
+                Orbit::StringFromFrameType(frameType)
+            )));
 
             const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
 
@@ -1622,8 +1586,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(0.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 1.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 1.csv")
              ),
              1e-3,
              1e-6,
@@ -1633,8 +1596,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(45.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 2.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 2.csv")
              ),
              1e-3,
              1e-6,
@@ -1644,8 +1606,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(90.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 3.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 3.csv")
              ),
              1e-3,
              1e-6,
@@ -1655,8 +1616,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(135.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 4.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 4.csv")
              ),
              1e-3,
              1e-6,
@@ -1666,8 +1626,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
              Angle::Degrees(180.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 5.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 5.csv")
              ),
              1e-3,
              1e-6,
@@ -1677,8 +1636,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(0.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 6.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 6.csv")
              ),
              1e-3,
              1e-6,
@@ -1688,8 +1646,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(45.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 7.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 7.csv")
              ),
              1e-3,
              1e-6,
@@ -1699,8 +1656,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(90.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 8.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 8.csv")
              ),
              1e-3,
              1e-6,
@@ -1710,8 +1666,7 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(135.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 9.csv")
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 9.csv")
              ),
              1e-3,
              1e-6,
@@ -1721,9 +1676,8 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, Circular)
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(5000.0),
              Angle::Degrees(180.0),
-             File::Path(
-                 Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 10.csv")
-             ),
+             File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Circular/Scenario 10.csv"
+             )),
              1e-3,
              1e-6,
              1e-1,
@@ -1916,11 +1870,9 @@ TEST(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit, CircularEquatorial)
             {"Scenario 1",
              Instant::DateTime(DateTime::Parse("2018-01-01 00:00:00"), Scale::UTC),
              Length::Kilometers(500.0),
-             File::Path(
-                 Path::Parse(
-                     "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/CircularEquatorial/Scenario 1.csv"
-                 )
-             ),
+             File::Path(Path::Parse(
+                 "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/CircularEquatorial/Scenario 1.csv"
+             )),
              1e-3,
              1e-6,
              1e-1,

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
@@ -191,11 +191,9 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_Two
     {
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/STK_TwoBody_2hr_run.csv"
-                )
-            ),
+            File::Path(Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/STK_TwoBody_2hr_run.csv"
+            )),
             Table::Format::CSV,
             true
         );
@@ -307,12 +305,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_EGM
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                    "Propagated/STK_EGM2008_100x100_2hr_run.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                                   "Propagated/STK_EGM2008_100x100_2hr_run.csv")),
             Table::Format::CSV,
             true
         );
@@ -390,12 +384,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_WGS
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                    "Propagated/STK_WGS84EGM96_70x70_2hr_run.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                                   "Propagated/STK_WGS84EGM96_70x70_2hr_run.csv")),
             Table::Format::CSV,
             true
         );
@@ -473,12 +463,8 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_EGM
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(
-                Path::Parse(
-                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                    "Propagated/STK_WGS84_70x70_2hr_run.csv"
-                )
-            ),
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                                   "Propagated/STK_WGS84_70x70_2hr_run.csv")),
             Table::Format::CSV,
             true
         );

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
@@ -259,8 +259,15 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_Two
             ASSERT_EQ(*Frame::GCRF(), *positionGCRF.accessFrame());
             ASSERT_EQ(*Frame::GCRF(), *velocityGCRF.accessFrame());
 
-            ASSERT_GT(2e-7, positionErrorGCRF);
-            ASSERT_GT(2e-10, velocityErrorGCRF);
+            // These bounds sit on the floating-point noise floor of the propagation, not on any physical
+            // difference with the reference data: even in GCRF, the gravitational field is evaluated in the
+            // Earth-fixed frame, so the round-off of the GCRF <-> ITRF round trip accumulates over the ~1400
+            // integration steps. Any change to the resolution of the underlying time conversions re-rolls that
+            // noise, so the bounds are set an order of magnitude above the observed maxima (6.8e-7 m, 7.2e-10 m/s)
+            // and remain several orders of magnitude below a physically meaningful difference.
+
+            ASSERT_GT(5e-6, positionErrorGCRF);
+            ASSERT_GT(5e-9, velocityErrorGCRF);
 
             // ITRF Compare
             const Position position_ITRF = (propagatedStateArray[i].inFrame(itrfSPtr)).getPosition();

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Validation/Propagator.cross.validation.cpp
@@ -191,9 +191,11 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_Two
     {
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse(
-                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/STK_TwoBody_2hr_run.csv"
-            )),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/Propagated/STK_TwoBody_2hr_run.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -259,13 +261,6 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_Two
             ASSERT_EQ(*Frame::GCRF(), *positionGCRF.accessFrame());
             ASSERT_EQ(*Frame::GCRF(), *velocityGCRF.accessFrame());
 
-            // These bounds sit on the floating-point noise floor of the propagation, not on any physical
-            // difference with the reference data: even in GCRF, the gravitational field is evaluated in the
-            // Earth-fixed frame, so the round-off of the GCRF <-> ITRF round trip accumulates over the ~1400
-            // integration steps. Any change to the resolution of the underlying time conversions re-rolls that
-            // noise, so the bounds are set an order of magnitude above the observed maxima (6.8e-7 m, 7.2e-10 m/s)
-            // and remain several orders of magnitude below a physically meaningful difference.
-
             ASSERT_GT(5e-6, positionErrorGCRF);
             ASSERT_GT(5e-9, velocityErrorGCRF);
 
@@ -312,8 +307,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_EGM
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                                   "Propagated/STK_EGM2008_100x100_2hr_run.csv")),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                    "Propagated/STK_EGM2008_100x100_2hr_run.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -391,8 +390,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_WGS
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                                   "Propagated/STK_WGS84EGM96_70x70_2hr_run.csv")),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                    "Propagated/STK_WGS84EGM96_70x70_2hr_run.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );
@@ -470,8 +473,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Validation_CrossValidation, ForceModel_EGM
 
         // Reference data setup
         const Table referenceData = Table::Load(
-            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                                   "Propagated/STK_WGS84_70x70_2hr_run.csv")),
+            File::Path(
+                Path::Parse(
+                    "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                    "Propagated/STK_WGS84_70x70_2hr_run.csv"
+                )
+            ),
             Table::Format::CSV,
             true
         );


### PR DESCRIPTION
## Summary

`ostk-physics` [#378](https://github.com/open-space-collective/open-space-toolkit-physics/pull/378) computed Julian dates arithmetically from `Instant`'s internal nanosecond count instead of round-tripping through a calendar date and a ~2.4e6-magnitude double, and had the CIRF/TIRF/ITRF providers use those accessors directly. It had to be reverted in [#390](https://github.com/open-space-collective/open-space-toolkit-physics/pull/390) because it broke tests here.

The change removes ~20-40 µs of quantization noise from the Modified Julian Date that feeds the Earth Rotation Angle, which shifts every Earth-fixed frame transformation by up to a few millimetres and re-rolls the floating-point noise of any propagation whose force model is evaluated in the Earth-fixed frame. Nothing in this repository was wrong, but four expectations were pinned tightly enough — or conditioned poorly enough — to notice. This PR makes them robust so #378 can be re-landed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved TLE solver coverage with time-span filtering and updated reference data.
  * Updated coordinate transformation tests to calculate expected positions and velocities through frame conversions.
  * Adjusted geosynchronous orbit and two-body propagation validation tolerances to account for expected numerical precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->