### PR TITLE
feat: add option to observe dynamic contributions

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitAstrodynamicsPy/Trajectory/Propagator.cpp
@@ -22,14 +22,48 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
     using ostk::astrodynamics::trajectory::State;
     using ostk::astrodynamics::trajectory::state::NumericalSolver;
 
-    class_<Propagator>(
+    class_<Propagator> propagator(
         aModule,
         "Propagator",
         R"doc(
             A `Propagator` that propagates the provided `State` using it's `NumericalSolver` under the set `Dynamics`.
 
         )doc"
+    );
+
+    class_<Propagator::StepContributions>(
+        propagator,
+        "StepContributions",
+        R"doc(
+            Per-dynamics contributions recorded at each solver step accepted during a propagation.
+
+        )doc"
     )
+        .def_readonly(
+            "instants",
+            &Propagator::StepContributions::instants,
+            R"doc(
+                One instant per recorded step, in integration order.
+
+                Type:
+                    list[Instant]
+            )doc"
+        )
+        .def_readonly(
+            "contributions",
+            &Propagator::StepContributions::contributions,
+            R"doc(
+                Per dynamics, a matrix whose rows align with `instants` and whose columns follow the
+                dynamics' write coordinate subsets, expressed in GCRF.
+
+                Type:
+                    dict[Dynamics, np.ndarray]
+            )doc"
+        )
+
+        ;
+
+    propagator
 
         .def(
             init<const NumericalSolver&, const Array<Shared<Dynamics>>&>(),
@@ -95,6 +129,18 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
         )
 
         .def(
+            "is_contribution_observation_enabled",
+            &Propagator::isContributionObservationEnabled,
+            R"doc(
+                Check if per-dynamics step contribution recording is enabled.
+
+                Returns:
+                    bool: True if per-dynamics step contribution recording is enabled, False otherwise.
+
+            )doc"
+        )
+
+        .def(
             "access_numerical_solver",
             &Propagator::accessNumericalSolver,
             R"doc(
@@ -125,6 +171,23 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
 
                 Returns:
                     list[Dynamics]: The dynamics.
+
+            )doc"
+        )
+        .def(
+            "get_recorded_step_contributions",
+            &Propagator::getRecordedStepContributions,
+            R"doc(
+                Get the step contributions recorded during the most recent `calculate_*` call.
+
+                Empty unless recording is enabled with `set_contribution_observation_enabled`. For
+                `calculate_state_at` and `calculate_state_to_condition`, the recorded steps are the solver's
+                accepted steps (initial and final states included). For `calculate_states_at`, they are the
+                requested instants (each an accepted-step endpoint — intermediate accepted steps are not
+                recorded). Contributions are expressed in GCRF, the integration frame.
+
+                Returns:
+                    Propagator.StepContributions: The recorded step contributions.
 
             )doc"
         )
@@ -176,6 +239,23 @@ inline void OpenSpaceToolkitAstrodynamicsPy_Trajectory_Propagator(pybind11::modu
                 Args:
                     maneuver (Maneuver) The maneuver.
                     interpolation_type (Interpolator.Type, optional) The interpolation type. Defaults to Barycentric Rational.
+
+            )doc"
+        )
+
+        .def(
+            "set_contribution_observation_enabled",
+            &Propagator::setContributionObservationEnabled,
+            arg("enabled"),
+            R"doc(
+                Enable or disable per-dynamics step contribution recording (disabled by default).
+
+                When enabled, each `calculate_*` call additionally evaluates every dynamics once per recorded
+                step (one extra right-hand-side-equivalent evaluation per step) and stores the results. Memory
+                grows linearly with the number of recorded steps.
+
+                Args:
+                    enabled (bool) True to enable recording, False to disable it.
 
             )doc"
         )

--- a/bindings/python/test/trajectory/test_propagator.py
+++ b/bindings/python/test/trajectory/test_propagator.py
@@ -333,7 +333,84 @@ class TestPropagator:
 
         assert len(propagator.get_dynamics()) == 3
 
-    def test_calculate_state_at(self, propagator: Propagator, state: State):
+    def test_contribution_observation_default_disabled(
+        self,
+        propagator: Propagator,
+        state: State,
+    ):
+        assert propagator.is_contribution_observation_enabled() is False
+
+        instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 10, 0), Scale.UTC)
+
+        propagator.calculate_state_at(state, instant)
+
+        recorded = propagator.get_recorded_step_contributions()
+
+        assert isinstance(recorded, Propagator.StepContributions)
+        assert len(recorded.instants) == 0
+        assert len(recorded.contributions) == 0
+
+    def test_contribution_recording(
+        self,
+        propagator: Propagator,
+        state: State
+    ):
+        propagator.set_contribution_observation_enabled(True)
+
+        assert propagator.is_contribution_observation_enabled() is True
+
+        instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 10, 0), Scale.UTC)
+
+        propagator.calculate_state_at(state, instant)
+
+        recorded = propagator.get_recorded_step_contributions()
+
+        assert isinstance(recorded.instants, list)
+        assert len(recorded.instants) > 0
+        assert all(
+            isinstance(recorded_instant, Instant)
+            for recorded_instant in recorded.instants
+        )
+
+        assert isinstance(recorded.contributions, dict)
+        assert set(recorded.contributions.keys()) == set(propagator.get_dynamics())
+
+        for contribution in recorded.contributions.values():
+            assert isinstance(contribution, np.ndarray)
+            assert contribution.shape[0] == len(recorded.instants)
+
+        propagator.set_contribution_observation_enabled(False)
+
+        assert propagator.is_contribution_observation_enabled() is False
+
+    def test_contribution_observation_calculate_states_at(
+        self,
+        propagator: Propagator,
+        state: State,
+    ):
+        propagator.set_contribution_observation_enabled(True)
+
+        instant_array = [
+            Instant.date_time(DateTime(2018, 1, 1, 0, 10, 0), Scale.UTC),
+            Instant.date_time(DateTime(2018, 1, 1, 0, 20, 0), Scale.UTC),
+            Instant.date_time(DateTime(2018, 1, 1, 0, 30, 0), Scale.UTC),
+        ]
+
+        propagator.calculate_states_at(state, instant_array)
+
+        recorded = propagator.get_recorded_step_contributions()
+
+        assert len(recorded.instants) == 3
+        assert recorded.instants == instant_array
+
+        for contribution in recorded.contributions.values():
+            assert contribution.shape[0] == 3
+
+    def test_calculate_state_at(
+        self,
+        propagator: Propagator,
+        state: State
+    ):
         instant: Instant = Instant.date_time(DateTime(2018, 1, 1, 0, 10, 0), Scale.UTC)
 
         propagator_state = propagator.calculate_state_at(state, instant)

--- a/include/OpenSpaceToolkit/Astrodynamics/Dynamics.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Dynamics.hpp
@@ -137,6 +137,23 @@ class Dynamics
         const Array<Context>& aContextArray, const Instant& anInstant, const Shared<const Frame>& aFrameSPtr
     );
 
+    /// @brief Compute the contribution of each dynamics context at a given instant and state vector,
+    ///        without accumulating them into a single derivative vector.
+    ///
+    /// @param aContextArray An array of dynamics contexts
+    /// @param anInstant The instant at which the contributions are evaluated
+    /// @param aStateVector The full state vector, following the coordinate broker layout shared by the contexts
+    /// @param aFrameSPtr The reference frame in which the contributions are expressed
+    ///
+    /// @return One contribution vector per context (same order as aContextArray), each following the
+    /// write coordinate subset layout of its dynamics
+    static Array<VectorXd> ComputeContributions(
+        const Array<Context>& aContextArray,
+        const Instant& anInstant,
+        const NumericalSolver::StateVector& aStateVector,
+        const Shared<const Frame>& aFrameSPtr
+    );
+
     /// @brief Get a list of dynamics from the envrionment
     ///
     /// @param anEnvironment An environment

--- a/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
+++ b/include/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.hpp
@@ -4,10 +4,12 @@
 #define __OpenSpaceToolkit_Astrodynamics_Trajectory_Propagator__
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Map.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Type/Size.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp>
+#include <OpenSpaceToolkit/Mathematics/Object/Matrix.hpp>
 
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
@@ -28,10 +30,12 @@ namespace trajectory
 {
 
 using ostk::core::container::Array;
+using ostk::core::container::Map;
 using ostk::core::type::Shared;
 using ostk::core::type::Size;
 
 using ostk::mathematics::curvefitting::Interpolator;
+using ostk::mathematics::object::MatrixXd;
 
 using ostk::physics::Environment;
 using ostk::physics::time::Instant;
@@ -49,6 +53,15 @@ using ostk::astrodynamics::trajectory::state::NumericalSolver;
 class Propagator
 {
    public:
+    /// @brief Per-dynamics contributions recorded at each solver step accepted during a propagation.
+    struct StepContributions
+    {
+        Array<Instant> instants = Array<Instant>::Empty();   ///< One instant per recorded step, in integration order
+        Map<Shared<Dynamics>, MatrixXd> contributions = {};  ///< Per dynamics: rows align with instants, columns
+                                                             ///< follow the dynamics' write coordinate subsets,
+                                                             ///< expressed in GCRF
+    };
+
     /// @brief Default integrator frame
     static const Shared<const Frame> IntegrationFrameSPtr;
 
@@ -117,6 +130,11 @@ class Propagator
     /// @return True if propagator is defined
     bool isDefined() const;
 
+    /// @brief Check if per-dynamics step contribution recording is enabled
+    ///
+    /// @return True if per-dynamics step contribution recording is enabled
+    bool isContributionObservationEnabled() const;
+
     /// @brief Access the coordinate broker
     ///
     /// @return The coordinate broker
@@ -126,6 +144,15 @@ class Propagator
     ///
     /// @return The numerical solver
     const NumericalSolver& accessNumericalSolver() const;
+
+    /// @brief Access the step contributions recorded during the most recent calculate* call.
+    ///        Empty unless recording is enabled. For calculateStateAt / calculateStateToCondition the
+    ///        recorded steps are the solver's accepted steps (initial and final states included); for
+    ///        calculateStatesAt they are the requested instants (each an accepted-step endpoint —
+    ///        intermediate accepted steps are not recorded).
+    ///
+    /// @return The recorded step contributions
+    const StepContributions& accessRecordedStepContributions() const;
 
     /// @brief Get the number of propagated coordinates
     ///
@@ -138,6 +165,13 @@ class Propagator
     /// @endcode
     /// @return An array of dynamics shared pointers
     Array<Shared<Dynamics>> getDynamics() const;
+
+    /// @brief Get the step contributions recorded during the most recent calculate* call
+    /// @code{.cpp}
+    ///              Propagator::StepContributions recorded = propagator.getRecordedStepContributions();
+    /// @endcode
+    /// @return The recorded step contributions
+    StepContributions getRecordedStepContributions() const;
 
     /// @brief Set the dynamics array
     /// @code{.cpp}
@@ -169,6 +203,16 @@ class Propagator
         const Maneuver& aManeuver,
         const Interpolator::Type& anInterpolationType = DEFAULT_MANEUVER_PROPAGATION_INTERPOLATION_TYPE
     );
+
+    /// @brief Enable or disable per-dynamics step contribution recording (disabled by default).
+    ///        When enabled, each calculate* call additionally evaluates every dynamics once per recorded
+    ///        step (one extra RHS-equivalent evaluation per step) and stores the results. Memory grows
+    ///        linearly with the number of recorded steps.
+    /// @code{.cpp}
+    ///              propagator.setContributionObservationEnabled(true);
+    /// @endcode
+    /// @param aContributionObservationEnabled True to enable recording, false to disable it
+    void setContributionObservationEnabled(const bool& aContributionObservationEnabled);
 
     /// @brief Calculate the state at an instant, given initial state
     /// @code{.cpp}
@@ -237,8 +281,15 @@ class Propagator
     Shared<CoordinateBroker> coordinatesBrokerSPtr_ = std::make_shared<CoordinateBroker>();
     Array<Dynamics::Context> dynamicsContexts_ = Array<Dynamics::Context>::Empty();
     mutable NumericalSolver numericalSolver_;
+    bool contributionObservationEnabled_ = false;
+    mutable StepContributions recordedStepContributions_ = {};
 
     void validateDynamicsSet() const;
+
+    /// @brief Evaluate and store per-dynamics contributions for the provided solver-layout states
+    ///
+    /// @param aStateArray States in the coordinate broker layout, expressed in the integration frame
+    void recordStepContributions_(const Array<State>& aStateArray) const;
 };
 
 }  // namespace trajectory

--- a/src/OpenSpaceToolkit/Astrodynamics/Dynamics.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Dynamics.cpp
@@ -85,6 +85,28 @@ NumericalSolver::SystemOfEquationsWrapper Dynamics::GetSystemOfEquations(
     );
 }
 
+Array<VectorXd> Dynamics::ComputeContributions(
+    const Array<Dynamics::Context>& aContextArray,
+    const Instant& anInstant,
+    const NumericalSolver::StateVector& aStateVector,
+    const Shared<const Frame>& aFrameSPtr
+)
+{
+    Array<VectorXd> contributions = Array<VectorXd>::Empty();
+    contributions.reserve(aContextArray.getSize());
+
+    for (const Dynamics::Context& dynamicsContext : aContextArray)
+    {
+        contributions.add(dynamicsContext.dynamics->computeContribution(
+            anInstant,
+            Dynamics::extractReadState(aStateVector, dynamicsContext.readIndexes, dynamicsContext.readStateSize),
+            aFrameSPtr
+        ));
+    }
+
+    return contributions;
+}
+
 void Dynamics::DynamicalEquations(
     const NumericalSolver::StateVector& x,
     NumericalSolver::StateVector& dxdt,

--- a/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
+++ b/src/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.cpp
@@ -94,7 +94,9 @@ Propagator::Propagator(
 Propagator::Propagator(const Propagator& aPropagator)
     : coordinatesBrokerSPtr_(std::make_shared<CoordinateBroker>(*aPropagator.coordinatesBrokerSPtr_)),
       dynamicsContexts_(aPropagator.dynamicsContexts_),
-      numericalSolver_(aPropagator.numericalSolver_)
+      numericalSolver_(aPropagator.numericalSolver_),
+      contributionObservationEnabled_(aPropagator.contributionObservationEnabled_),
+      recordedStepContributions_(aPropagator.recordedStepContributions_)
 {
 }
 
@@ -105,6 +107,8 @@ Propagator& Propagator::operator=(const Propagator& aPropagator)
         coordinatesBrokerSPtr_ = std::make_shared<CoordinateBroker>(*aPropagator.coordinatesBrokerSPtr_);
         dynamicsContexts_ = aPropagator.dynamicsContexts_;
         numericalSolver_ = aPropagator.numericalSolver_;
+        contributionObservationEnabled_ = aPropagator.contributionObservationEnabled_;
+        recordedStepContributions_ = aPropagator.recordedStepContributions_;
     }
     return *this;
 }
@@ -139,6 +143,11 @@ bool Propagator::isDefined() const
     return numericalSolver_.isDefined() && coordinatesBrokerSPtr_ != nullptr && !dynamicsContexts_.isEmpty();
 }
 
+bool Propagator::isContributionObservationEnabled() const
+{
+    return contributionObservationEnabled_;
+}
+
 const Shared<CoordinateBroker>& Propagator::accessCoordinateBroker() const
 {
     if (!this->isDefined())
@@ -159,6 +168,16 @@ const NumericalSolver& Propagator::accessNumericalSolver() const
     return numericalSolver_;
 }
 
+const Propagator::StepContributions& Propagator::accessRecordedStepContributions() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Propagator");
+    }
+
+    return recordedStepContributions_;
+}
+
 Size Propagator::getNumberOfCoordinates() const
 {
     return this->accessCoordinateBroker()->getNumberOfCoordinates();
@@ -174,6 +193,11 @@ Array<Shared<Dynamics>> Propagator::getDynamics() const
     }
 
     return dynamicsArray;
+}
+
+Propagator::StepContributions Propagator::getRecordedStepContributions() const
+{
+    return this->accessRecordedStepContributions();
 }
 
 void Propagator::setDynamics(const Array<Shared<Dynamics>>& aDynamicsArray)
@@ -225,6 +249,11 @@ void Propagator::clearDynamics()
     coordinatesBrokerSPtr_ = std::make_shared<CoordinateBroker>();
 }
 
+void Propagator::setContributionObservationEnabled(const bool& aContributionObservationEnabled)
+{
+    contributionObservationEnabled_ = aContributionObservationEnabled;
+}
+
 State Propagator::calculateStateAt(const State& aState, const Instant& anInstant) const
 {
     if (!this->isDefined())
@@ -233,6 +262,8 @@ State Propagator::calculateStateAt(const State& aState, const Instant& anInstant
     }
 
     this->validateDynamicsSet();
+
+    recordedStepContributions_ = {};
 
     const StateBuilder solverStateBuilder = {Propagator::IntegrationFrameSPtr, coordinatesBrokerSPtr_};
 
@@ -245,6 +276,11 @@ State Propagator::calculateStateAt(const State& aState, const Instant& anInstant
             dynamicsContexts_, solverInputState.accessInstant(), Propagator::IntegrationFrameSPtr
         )
     );
+
+    if (contributionObservationEnabled_)
+    {
+        this->recordStepContributions_(numericalSolver_.accessObservedStates());
+    }
 
     const StateBuilder outputStateBuilder = {aState};
 
@@ -262,6 +298,8 @@ NumericalSolver::ConditionSolution Propagator::calculateStateToCondition(
 
     this->validateDynamicsSet();
 
+    recordedStepContributions_ = {};
+
     const Instant& startInstant = aState.accessInstant();
 
     const StateBuilder solverStateBuilder = {Propagator::IntegrationFrameSPtr, coordinatesBrokerSPtr_};
@@ -274,6 +312,11 @@ NumericalSolver::ConditionSolution Propagator::calculateStateToCondition(
         Dynamics::GetSystemOfEquations(dynamicsContexts_, startInstant, Propagator::IntegrationFrameSPtr),
         anEventCondition
     );
+
+    if (contributionObservationEnabled_)
+    {
+        this->recordStepContributions_(numericalSolver_.accessObservedStates());
+    }
 
     const StateBuilder outputStateBuilder = {aState};
 
@@ -317,6 +360,8 @@ Array<State> Propagator::calculateStatesAt(const State& aState, const Array<Inst
     }
 
     this->validateDynamicsSet();
+
+    recordedStepContributions_ = {};
 
     const StateBuilder solverStateBuilder = {Propagator::IntegrationFrameSPtr, coordinatesBrokerSPtr_};
 
@@ -369,12 +414,19 @@ Array<State> Propagator::calculateStatesAt(const State& aState, const Array<Inst
         std::reverse(backwardPropagatedStates.begin(), backwardPropagatedStates.end());
     }
 
-    Array<State> outputStates;
-    outputStates.reserve(backwardPropagatedStates.getSize() + forwardPropagatedStates.getSize());
+    const Array<State> solverOutputStates = backwardPropagatedStates + forwardPropagatedStates;
 
-    for (const State& solverOutputState : backwardPropagatedStates + forwardPropagatedStates)
+    Array<State> outputStates;
+    outputStates.reserve(solverOutputStates.getSize());
+
+    for (const State& solverOutputState : solverOutputStates)
     {
         outputStates.add(outputStateBuilder.expand(solverOutputState.inFrame(aState.accessFrame()), aState));
+    }
+
+    if (contributionObservationEnabled_)
+    {
+        this->recordStepContributions_(solverOutputStates);
     }
 
     return outputStates;
@@ -452,6 +504,43 @@ void Propagator::validateDynamicsSet() const
     if (thrusterIt != dynamicsMap.end() && thrusterIt->second.getSize() > 1)
     {
         throw ostk::core::error::RuntimeError("Propagator can have at most one Thruster Dynamics.");
+    }
+}
+
+void Propagator::recordStepContributions_(const Array<State>& aStateArray) const
+{
+    const Size stepCount = aStateArray.getSize();
+
+    recordedStepContributions_.instants.reserve(stepCount);
+
+    for (const Dynamics::Context& dynamicsContext : dynamicsContexts_)
+    {
+        Size writeSize = 0;
+        for (const Pair<Index, Size>& writeInfo : dynamicsContext.writeIndexes)
+        {
+            writeSize += writeInfo.second;
+        }
+
+        recordedStepContributions_.contributions.emplace(
+            dynamicsContext.dynamics, MatrixXd::Zero(stepCount, writeSize)
+        );
+    }
+
+    for (Index stepIndex = 0; stepIndex < stepCount; ++stepIndex)
+    {
+        const State& state = aStateArray[stepIndex];
+
+        recordedStepContributions_.instants.add(state.accessInstant());
+
+        const Array<VectorXd> contributions = Dynamics::ComputeContributions(
+            dynamicsContexts_, state.accessInstant(), state.accessCoordinates(), Propagator::IntegrationFrameSPtr
+        );
+
+        for (Index contextIndex = 0; contextIndex < dynamicsContexts_.getSize(); ++contextIndex)
+        {
+            recordedStepContributions_.contributions.at(dynamicsContexts_[contextIndex].dynamics).row(stepIndex) =
+                contributions[contextIndex];
+        }
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Dynamics.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Dynamics.test.cpp
@@ -4,7 +4,14 @@
 
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 
+#include <OpenSpaceToolkit/Physics/Environment/Object/Celestial.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
+
 #include <OpenSpaceToolkit/Astrodynamics/Dynamics.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Dynamics/CentralBodyGravity.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Dynamics/PositionDerivative.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianPosition.hpp>
+#include <OpenSpaceToolkit/Astrodynamics/Trajectory/State/CoordinateSubset/CartesianVelocity.hpp>
 
 #include <Global.test.hpp>
 
@@ -19,11 +26,17 @@ using ostk::mathematics::object::VectorXd;
 
 using ostk::physics::coordinate::Frame;
 using ostk::physics::Environment;
+using ostk::physics::environment::object::Celestial;
+using ostk::physics::environment::object::celestial::Earth;
 using ostk::physics::time::Instant;
 
 using ostk::astrodynamics::Dynamics;
+using ostk::astrodynamics::dynamics::CentralBodyGravity;
+using ostk::astrodynamics::dynamics::PositionDerivative;
 using ostk::astrodynamics::trajectory::state::CoordinateBroker;
 using ostk::astrodynamics::trajectory::state::CoordinateSubset;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianPosition;
+using ostk::astrodynamics::trajectory::state::coordinatesubset::CartesianVelocity;
 using ostk::astrodynamics::trajectory::state::NumericalSolver;
 
 class DynamicsMock : public Dynamics
@@ -49,8 +62,34 @@ class DynamicsMock : public Dynamics
 class OpenSpaceToolkit_Astrodynamics_Dynamics : public ::testing::Test
 {
    protected:
+    /// @brief Build a dynamics context, registering the dynamics' coordinate subsets into the provided broker
+    ///        (mirrors what Propagator::addDynamics does)
+    static Dynamics::Context BuildContext(
+        const Shared<Dynamics>& aDynamicsSPtr, const Shared<CoordinateBroker>& aCoordinateBrokerSPtr
+    )
+    {
+        Array<Pair<Index, Size>> readInfo = Array<Pair<Index, Size>>::Empty();
+        for (const Shared<const CoordinateSubset>& subset : aDynamicsSPtr->getReadCoordinateSubsets())
+        {
+            const Pair<Index, Size> indexAndSize = {aCoordinateBrokerSPtr->addSubset(subset), subset->getSize()};
+            readInfo.add(indexAndSize);
+        }
+
+        Array<Pair<Index, Size>> writeInfo = Array<Pair<Index, Size>>::Empty();
+        for (const Shared<const CoordinateSubset>& subset : aDynamicsSPtr->getWriteCoordinateSubsets())
+        {
+            const Pair<Index, Size> indexAndSize = {aCoordinateBrokerSPtr->addSubset(subset), subset->getSize()};
+            writeInfo.add(indexAndSize);
+        }
+
+        return {aDynamicsSPtr, readInfo, writeInfo};
+    }
+
     const String defaultName_ = "Test";
     const DynamicsMock defaultDynamics_ = {defaultName_};
+
+    const Shared<const Frame> gcrfSPtr_ = Frame::GCRF();
+    const Instant defaultInstant_ = Instant::J2000();
 };
 
 TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics, StreamOperator)
@@ -79,6 +118,120 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics, Getters)
 {
     {
         EXPECT_EQ(defaultName_, defaultDynamics_.getName());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Dynamics, ComputeContributions)
+{
+    const Shared<Celestial> earthSPtr = std::make_shared<Celestial>(Earth::Spherical());
+
+    const Shared<Dynamics> positionDerivativeSPtr = std::make_shared<PositionDerivative>();
+    const Shared<Dynamics> centralBodyGravitySPtr = std::make_shared<CentralBodyGravity>(earthSPtr);
+
+    const Shared<CoordinateBroker> coordinateBrokerSPtr = std::make_shared<CoordinateBroker>();
+
+    const Array<Dynamics::Context> contexts = {
+        BuildContext(positionDerivativeSPtr, coordinateBrokerSPtr),
+        BuildContext(centralBodyGravitySPtr, coordinateBrokerSPtr),
+    };
+
+    const Index positionIndex = coordinateBrokerSPtr->getSubsetIndex(CartesianPosition::Default());
+    const Index velocityIndex = coordinateBrokerSPtr->getSubsetIndex(CartesianVelocity::Default());
+    const Size stateSize = coordinateBrokerSPtr->getNumberOfCoordinates();
+
+    VectorXd position(3);
+    position << 7000000.0, 0.0, 0.0;
+
+    VectorXd velocity(3);
+    velocity << 0.0, 7546.05, 0.0;
+
+    NumericalSolver::StateVector stateVector = NumericalSolver::StateVector::Zero(stateSize);
+    stateVector.segment(positionIndex, 3) = position;
+    stateVector.segment(velocityIndex, 3) = velocity;
+
+    const Array<VectorXd> contributions =
+        Dynamics::ComputeContributions(contexts, defaultInstant_, stateVector, gcrfSPtr_);
+
+    // Each contribution is exactly what the dynamics returns when called with the manually reduced state
+    {
+        ASSERT_EQ(2, contributions.getSize());
+
+        const VectorXd expectedPositionDerivativeContribution =
+            positionDerivativeSPtr->computeContribution(defaultInstant_, velocity, gcrfSPtr_);
+        const VectorXd expectedCentralBodyGravityContribution =
+            centralBodyGravitySPtr->computeContribution(defaultInstant_, position, gcrfSPtr_);
+
+        ASSERT_EQ(expectedPositionDerivativeContribution.size(), contributions[0].size());
+        ASSERT_EQ(expectedCentralBodyGravityContribution.size(), contributions[1].size());
+
+        for (Index i = 0; i < 3; ++i)
+        {
+            EXPECT_EQ(expectedPositionDerivativeContribution(i), contributions[0](i));
+            EXPECT_EQ(expectedCentralBodyGravityContribution(i), contributions[1](i));
+        }
+    }
+
+    // Scatter-adding the contributions reproduces the summed system of equations
+    {
+        NumericalSolver::StateVector dxdt = NumericalSolver::StateVector::Zero(stateSize);
+
+        Dynamics::GetSystemOfEquations(contexts, defaultInstant_, gcrfSPtr_)(stateVector, dxdt, 0.0);
+
+        NumericalSolver::StateVector scatteredContributions = NumericalSolver::StateVector::Zero(stateSize);
+
+        for (Index contextIndex = 0; contextIndex < contexts.getSize(); ++contextIndex)
+        {
+            Index offset = 0;
+
+            for (const Pair<Index, Size>& writeInfo : contexts[contextIndex].writeIndexes)
+            {
+                scatteredContributions.segment(writeInfo.first, writeInfo.second) +=
+                    contributions[contextIndex].segment(offset, writeInfo.second);
+                offset += writeInfo.second;
+            }
+        }
+
+        for (Index i = 0; i < stateSize; ++i)
+        {
+            EXPECT_EQ(dxdt(i), scatteredContributions(i));
+        }
+    }
+
+    // Empty context array
+    {
+        EXPECT_TRUE(
+            Dynamics::ComputeContributions(Array<Dynamics::Context>::Empty(), defaultInstant_, stateVector, gcrfSPtr_)
+                .isEmpty()
+        );
+    }
+
+    // Dynamics declaring no read coordinate subsets
+    {
+        const Shared<DynamicsMock> dynamicsMockSPtr = std::make_shared<DynamicsMock>("Read Nothing");
+        const Shared<const CoordinateSubset> customSubsetSPtr = std::make_shared<CoordinateSubset>("Custom", 1);
+
+        VectorXd mockContribution(1);
+        mockContribution << 42.0;
+
+        EXPECT_CALL(*dynamicsMockSPtr, getReadCoordinateSubsets())
+            .WillRepeatedly(::testing::Return(Array<Shared<const CoordinateSubset>>::Empty()));
+        EXPECT_CALL(*dynamicsMockSPtr, getWriteCoordinateSubsets())
+            .WillRepeatedly(::testing::Return(Array<Shared<const CoordinateSubset>> {customSubsetSPtr}));
+        EXPECT_CALL(*dynamicsMockSPtr, computeContribution(::testing::_, ::testing::_, ::testing::_))
+            .WillRepeatedly(::testing::Return(mockContribution));
+
+        const Shared<CoordinateBroker> mockCoordinateBrokerSPtr = std::make_shared<CoordinateBroker>();
+        const Array<Dynamics::Context> mockContexts = {BuildContext(dynamicsMockSPtr, mockCoordinateBrokerSPtr)};
+
+        const NumericalSolver::StateVector mockStateVector =
+            NumericalSolver::StateVector::Zero(mockCoordinateBrokerSPtr->getNumberOfCoordinates());
+
+        const Array<VectorXd> mockContributions =
+            Dynamics::ComputeContributions(mockContexts, defaultInstant_, mockStateVector, gcrfSPtr_);
+
+        ASSERT_EQ(1, mockContributions.getSize());
+        ASSERT_EQ(1, mockContributions[0].size());
+        EXPECT_EQ(42.0, mockContributions[0](0));
     }
 }
 

--- a/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
+++ b/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Propagator.test.cpp
@@ -902,8 +902,12 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Calcula
     /// Test full state results against reference trajectory
     // Reference data setup
     const Table referenceData = Table::Load(
-        File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
-                               "Propagated/CalculateStatesAt_StateValidation.csv")),
+        File::Path(
+            Path::Parse(
+                "/app/test/OpenSpaceToolkit/Astrodynamics/Trajectory/Orbit/Model/"
+                "Propagated/CalculateStatesAt_StateValidation.csv"
+            )
+        ),
         Table::Format::CSV,
         true
     );
@@ -1201,6 +1205,359 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Calcula
     }
 }
 
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, ContributionObservation)
+{
+    const State state = {
+        Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC),
+        Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr_),
+        Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_),
+    };
+
+    // Observation is disabled by default and records nothing
+    {
+        Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
+
+        EXPECT_FALSE(propagator.isContributionObservationEnabled());
+
+        propagator.calculateStateAt(state, state.accessInstant() + Duration::Minutes(10.0));
+
+        EXPECT_TRUE(propagator.accessRecordedStepContributions().instants.isEmpty());
+        EXPECT_TRUE(propagator.accessRecordedStepContributions().contributions.empty());
+        EXPECT_TRUE(propagator.getRecordedStepContributions().instants.isEmpty());
+    }
+
+    // An undefined propagator has no recorded contributions to access
+    {
+        EXPECT_THROW(Propagator::Undefined().accessRecordedStepContributions(), ostk::core::error::runtime::Undefined);
+        EXPECT_THROW(Propagator::Undefined().getRecordedStepContributions(), ostk::core::error::runtime::Undefined);
+    }
+
+    // Setter round-trip
+    {
+        Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
+
+        propagator.setContributionObservationEnabled(true);
+        EXPECT_TRUE(propagator.isContributionObservationEnabled());
+
+        propagator.setContributionObservationEnabled(false);
+        EXPECT_FALSE(propagator.isContributionObservationEnabled());
+    }
+
+    // Zero-duration propagation does not throw
+    {
+        Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
+        propagator.setContributionObservationEnabled(true);
+
+        EXPECT_NO_THROW(propagator.calculateStateAt(state, state.accessInstant()));
+
+        const Propagator::StepContributions& recorded = propagator.accessRecordedStepContributions();
+
+        for (const auto& dynamicsContributionPair : recorded.contributions)
+        {
+            EXPECT_EQ(recorded.instants.getSize(), Size(dynamicsContributionPair.second.rows()));
+        }
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, ContributionObservation_CalculateStateAt)
+{
+    const State state = {
+        Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC),
+        Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr_),
+        Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_),
+    };
+
+    const Instant endInstant = state.accessInstant() + Duration::Minutes(90.0);
+
+    Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
+    propagator.setContributionObservationEnabled(true);
+
+    propagator.calculateStateAt(state, endInstant);
+
+    const Propagator::StepContributions& recorded = propagator.accessRecordedStepContributions();
+    const Array<State>& observedStates = propagator.accessNumericalSolver().accessObservedStates();
+
+    // Recorded instants are exactly the solver's accepted steps
+    {
+        ASSERT_FALSE(observedStates.isEmpty());
+        ASSERT_EQ(observedStates.getSize(), recorded.instants.getSize());
+
+        for (Size i = 0; i < observedStates.getSize(); ++i)
+        {
+            EXPECT_EQ(observedStates[i].accessInstant(), recorded.instants[i]);
+        }
+
+        EXPECT_LT(std::abs((recorded.instants.accessLast() - endInstant).inSeconds()), 1e-9);
+    }
+
+    // One entry per dynamics, with the expected shape
+    {
+        const Array<Shared<Dynamics>> dynamicsArray = propagator.getDynamics();
+
+        ASSERT_EQ(dynamicsArray.getSize(), recorded.contributions.size());
+
+        for (const Shared<Dynamics>& dynamicsSPtr : dynamicsArray)
+        {
+            ASSERT_EQ(1, recorded.contributions.count(dynamicsSPtr));
+
+            const MatrixXd& dynamicsContributions = recorded.contributions.at(dynamicsSPtr);
+
+            EXPECT_EQ(recorded.instants.getSize(), Size(dynamicsContributions.rows()));
+            EXPECT_EQ(3, dynamicsContributions.cols());
+        }
+    }
+
+    // Recorded values are exactly what the dynamics return at the accepted states
+    {
+        const Shared<Dynamics> positionDerivativeSPtr = propagator.getDynamics()[0];
+        const Shared<Dynamics> centralBodyGravitySPtr = propagator.getDynamics()[1];
+
+        const MatrixXd& positionDerivativeContributions = recorded.contributions.at(positionDerivativeSPtr);
+        const MatrixXd& centralBodyGravityContributions = recorded.contributions.at(centralBodyGravitySPtr);
+
+        for (Size i = 0; i < observedStates.getSize(); ++i)
+        {
+            const State& observedState = observedStates[i];
+
+            const VectorXd position = observedState.extractCoordinate(CartesianPosition::Default());
+            const VectorXd velocity = observedState.extractCoordinate(CartesianVelocity::Default());
+
+            const VectorXd expectedCentralBodyGravityContribution =
+                centralBodyGravitySPtr->computeContribution(observedState.accessInstant(), position, gcrfSPtr_);
+
+            for (Size j = 0; j < 3; ++j)
+            {
+                EXPECT_EQ(velocity(j), positionDerivativeContributions(i, j));
+                EXPECT_EQ(expectedCentralBodyGravityContribution(j), centralBodyGravityContributions(i, j));
+            }
+        }
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, ContributionObservation_CalculateStatesAt)
+{
+    const State state = {
+        Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC),
+        Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr_),
+        Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_),
+    };
+
+    // Mixed backward + forward request, spanning the initial instant
+    const Array<Instant> instantArray = {
+        state.accessInstant() - Duration::Minutes(20.0),
+        state.accessInstant() - Duration::Minutes(10.0),
+        state.accessInstant(),
+        state.accessInstant() + Duration::Minutes(10.0),
+        state.accessInstant() + Duration::Minutes(20.0),
+    };
+
+    Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
+    propagator.setContributionObservationEnabled(true);
+
+    const Array<State> outputStates = propagator.calculateStatesAt(state, instantArray);
+
+    const Propagator::StepContributions& recorded = propagator.accessRecordedStepContributions();
+
+    ASSERT_EQ(instantArray.getSize(), recorded.instants.getSize());
+
+    for (Size i = 0; i < instantArray.getSize(); ++i)
+    {
+        EXPECT_EQ(instantArray[i], recorded.instants[i]);
+    }
+
+    const Shared<Dynamics> positionDerivativeSPtr = propagator.getDynamics()[0];
+    const Shared<Dynamics> centralBodyGravitySPtr = propagator.getDynamics()[1];
+
+    const MatrixXd& positionDerivativeContributions = recorded.contributions.at(positionDerivativeSPtr);
+    const MatrixXd& centralBodyGravityContributions = recorded.contributions.at(centralBodyGravitySPtr);
+
+    for (Size i = 0; i < outputStates.getSize(); ++i)
+    {
+        const State& outputState = outputStates[i];
+
+        const VectorXd position = outputState.extractCoordinate(CartesianPosition::Default());
+        const VectorXd velocity = outputState.extractCoordinate(CartesianVelocity::Default());
+
+        const VectorXd expectedCentralBodyGravityContribution =
+            centralBodyGravitySPtr->computeContribution(outputState.accessInstant(), position, gcrfSPtr_);
+
+        for (Size j = 0; j < 3; ++j)
+        {
+            EXPECT_EQ(velocity(j), positionDerivativeContributions(i, j));
+            EXPECT_EQ(expectedCentralBodyGravityContribution(j), centralBodyGravityContributions(i, j));
+        }
+    }
+}
+
+TEST_F(
+    OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, ContributionObservation_CalculateStateToCondition
+)
+{
+    const State state = {
+        Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC),
+        Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr_),
+        Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_),
+    };
+
+    const Instant endInstant = state.accessInstant() + Duration::Minutes(60.0);
+
+    const InstantCondition condition = {
+        InstantCondition::Criterion::StrictlyPositive,
+        state.accessInstant() + Duration::Seconds(60.0),
+    };
+
+    Propagator propagator = {defaultRKD5_, defaultDynamics_};
+    propagator.setContributionObservationEnabled(true);
+
+    const NumericalSolver::ConditionSolution conditionSolution =
+        propagator.calculateStateToCondition(state, endInstant, condition);
+
+    ASSERT_TRUE(conditionSolution.conditionIsSatisfied);
+
+    const Propagator::StepContributions& recorded = propagator.accessRecordedStepContributions();
+
+    ASSERT_FALSE(recorded.instants.isEmpty());
+
+    EXPECT_EQ(state.accessInstant(), recorded.instants.accessFirst());
+    EXPECT_EQ(conditionSolution.state.accessInstant(), recorded.instants.accessLast());
+
+    for (Size i = 1; i < recorded.instants.getSize(); ++i)
+    {
+        EXPECT_TRUE(recorded.instants[i] > recorded.instants[i - 1]);
+    }
+
+    for (const auto& dynamicsContributionPair : recorded.contributions)
+    {
+        EXPECT_EQ(recorded.instants.getSize(), Size(dynamicsContributionPair.second.rows()));
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, ContributionObservation_Reset)
+{
+    const State state = {
+        Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC),
+        Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr_),
+        Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_),
+    };
+
+    Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
+    propagator.setContributionObservationEnabled(true);
+
+    propagator.calculateStateAt(state, state.accessInstant() + Duration::Minutes(90.0));
+
+    const Size longPropagationStepCount = propagator.accessRecordedStepContributions().instants.getSize();
+
+    const Instant shortEndInstant = state.accessInstant() + Duration::Minutes(5.0);
+
+    propagator.calculateStateAt(state, shortEndInstant);
+
+    // Only the second call is reflected
+    {
+        const Propagator::StepContributions& recorded = propagator.accessRecordedStepContributions();
+
+        EXPECT_LT(recorded.instants.getSize(), longPropagationStepCount);
+        EXPECT_LT(std::abs((recorded.instants.accessLast() - shortEndInstant).inSeconds()), 1e-9);
+
+        for (const auto& dynamicsContributionPair : recorded.contributions)
+        {
+            EXPECT_EQ(recorded.instants.getSize(), Size(dynamicsContributionPair.second.rows()));
+        }
+    }
+
+    // Disabling recording clears the previous results on the next call
+    {
+        propagator.setContributionObservationEnabled(false);
+
+        propagator.calculateStateAt(state, shortEndInstant);
+
+        EXPECT_TRUE(propagator.accessRecordedStepContributions().instants.isEmpty());
+        EXPECT_TRUE(propagator.accessRecordedStepContributions().contributions.empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, ContributionObservation_BackwardPropagation)
+{
+    const State state = {
+        Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC),
+        Position::Meters({7000000.0, 0.0, 0.0}, gcrfSPtr_),
+        Velocity::MetersPerSecond({0.0, 5335.865450622126, 5335.865450622126}, gcrfSPtr_),
+    };
+
+    Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
+    propagator.setContributionObservationEnabled(true);
+
+    propagator.calculateStateAt(state, state.accessInstant() - Duration::Minutes(30.0));
+
+    const Propagator::StepContributions& recorded = propagator.accessRecordedStepContributions();
+
+    ASSERT_GT(recorded.instants.getSize(), 1);
+
+    for (Size i = 1; i < recorded.instants.getSize(); ++i)
+    {
+        EXPECT_TRUE(recorded.instants[i] < recorded.instants[i - 1]);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, ContributionObservation_WithDrag)
+{
+    const Shared<Celestial> earthSPtr = std::make_shared<Celestial>(Earth::FromModels(
+        std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::Spherical),
+        std::make_shared<EarthMagneticModel>(EarthMagneticModel::Type::Undefined),
+        std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
+    ));
+
+    const Shared<Dynamics> positionDerivativeSPtr = std::make_shared<PositionDerivative>();
+    const Shared<Dynamics> centralBodyGravitySPtr = std::make_shared<CentralBodyGravity>(earthSPtr);
+    const Shared<Dynamics> atmosphericDragSPtr = std::make_shared<AtmosphericDrag>(earthSPtr);
+
+    Propagator propagator = {
+        defaultNumericalSolver_,
+        {positionDerivativeSPtr, centralBodyGravitySPtr, atmosphericDragSPtr},
+    };
+    propagator.setContributionObservationEnabled(true);
+
+    VectorXd coordinates(9);
+    coordinates << 7000000.0, 0.0, 0.0, 0.0, 5335.865450622126, 5335.865450622126, 100.0, 1.0, 2.1;
+
+    const State state = {
+        Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC),
+        coordinates,
+        gcrfSPtr_,
+        {
+            CartesianPosition::Default(),
+            CartesianVelocity::Default(),
+            CoordinateSubset::Mass(),
+            CoordinateSubset::SurfaceArea(),
+            CoordinateSubset::DragCoefficient(),
+        },
+    };
+
+    EXPECT_EQ(9, propagator.getNumberOfCoordinates());
+
+    propagator.calculateStateAt(state, state.accessInstant() + Duration::Minutes(10.0));
+
+    const Propagator::StepContributions& recorded = propagator.accessRecordedStepContributions();
+
+    ASSERT_EQ(3, recorded.contributions.size());
+    ASSERT_FALSE(recorded.instants.isEmpty());
+
+    const MatrixXd& positionDerivativeContributions = recorded.contributions.at(positionDerivativeSPtr);
+    const MatrixXd& centralBodyGravityContributions = recorded.contributions.at(centralBodyGravitySPtr);
+    const MatrixXd& atmosphericDragContributions = recorded.contributions.at(atmosphericDragSPtr);
+
+    for (const MatrixXd& dynamicsContributions :
+         {positionDerivativeContributions, centralBodyGravityContributions, atmosphericDragContributions})
+    {
+        EXPECT_EQ(recorded.instants.getSize(), Size(dynamicsContributions.rows()));
+        EXPECT_EQ(3, dynamicsContributions.cols());
+        EXPECT_TRUE(dynamicsContributions.allFinite());
+    }
+
+    // Drag opposes the velocity and is dominated by gravity
+    EXPECT_LT(atmosphericDragContributions.row(0).norm(), centralBodyGravityContributions.row(0).norm());
+    EXPECT_GT(atmosphericDragContributions.row(0).norm(), 0.0);
+}
+
 TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Default)
 {
     {
@@ -1347,12 +1704,16 @@ TEST_F(OpenSpaceToolkit_Astrodynamics_Trajectory_Orbit_Model_Propagator, Validat
         // Wrong number of AtmosphericDrags
         {
             Propagator propagator = {defaultNumericalSolver_, defaultDynamics_};
-            propagator.addDynamics(std::make_shared<AtmosphericDrag>(std::make_shared<Celestial>(Earth::AtmosphericOnly(
-                std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
-            ))));
-            propagator.addDynamics(std::make_shared<AtmosphericDrag>(std::make_shared<Celestial>(Earth::AtmosphericOnly(
-                std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
-            ))));
+            propagator.addDynamics(
+                std::make_shared<AtmosphericDrag>(std::make_shared<Celestial>(Earth::AtmosphericOnly(
+                    std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
+                )))
+            );
+            propagator.addDynamics(
+                std::make_shared<AtmosphericDrag>(std::make_shared<Celestial>(Earth::AtmosphericOnly(
+                    std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::Exponential)
+                )))
+            );
 
             EXPECT_THROW(
                 {


### PR DESCRIPTION
Adds the ability to record the dynamics contributions when propagating. Unfortunately there's no way to save each individual dynamic without re-evaluating it (as we use Boost ODEInt and it evaluates the entire system of equations which is the sum of the dynamic contributions).
This is the next best thing. Open to suggestions on naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional recording of per-dynamics contributions during propagation.
  * Added access to recorded integration instants and contribution data.
  * Added controls to enable, disable, and check contribution observation.
  * Added support for calculating individual dynamics contributions independently.

* **Bug Fixes**
  * Improved portability of reference data paths.

* **Tests**
  * Added comprehensive coverage for contribution recording, propagation directions, resets, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->